### PR TITLE
fix(ruby): refresh OAuth token per-request instead of baking it once (FER-11562)

### DIFF
--- a/generators/ruby-v2/base/src/asIs/internal/http/raw_client.Template.rb
+++ b/generators/ruby-v2/base/src/asIs/internal/http/raw_client.Template.rb
@@ -23,10 +23,14 @@ module <%= gem_namespace %>
         # @param max_retries [Integer] The number of times to retry a failed request, defaults to <%= defaultMaxRetries %>.
         # @param timeout [Float] The timeout for the request, defaults to 60.0 seconds.
         # @param headers [Hash] The headers for the request.
-        def initialize(base_url:, max_retries: <%= defaultMaxRetries %>, timeout: 60.0, headers: {})
+        # @param auth_provider [Object, nil] An optional auth provider responding to
+        #   `auth_headers`. When present its headers are resolved on every request so
+        #   token-based schemes (e.g. OAuth) can refresh an expired token mid-session.
+        def initialize(base_url:, max_retries: <%= defaultMaxRetries %>, timeout: 60.0, headers: {}, auth_provider: nil)
           @base_url = base_url
           @max_retries = max_retries
           @timeout = timeout
+          @auth_provider = auth_provider
           @default_headers = <% if (!omitFernHeaders) { %>{
             "X-Fern-Language": "Ruby",
             "X-Fern-SDK-Name": "<%= sdkName %>",
@@ -94,6 +98,9 @@ module <%= gem_namespace %>
         # @return [HTTP::Response] The HTTP response.
         def send(request)
           url = build_url(request)
+          # Resolve auth headers once per request (not per retry) so token-based
+          # providers refresh at most once here; static providers are cheap.
+          auth_headers = resolve_auth_headers
           attempt = 0
           response = nil
 
@@ -101,8 +108,9 @@ module <%= gem_namespace %>
             http_request = build_http_request(
               url:,
               method: request.method,
-              headers: request.encode_headers(protected_keys: @default_headers.keys),
-              body: request.encode_body
+              headers: request.encode_headers(protected_keys: @default_headers.keys + auth_headers.keys),
+              body: request.encode_body,
+              auth_headers: auth_headers
             )
 
             conn = connect(url)
@@ -215,12 +223,27 @@ module <%= gem_namespace %>
                 "HTTP is only allowed for localhost. Use HTTPS or pass a localhost URL."
         end
 
+        # Resolves the auth headers to send with the next request. Delegates to the
+        # configured auth provider (if any) on every call so that token-based
+        # providers (e.g. OAuth client-credentials) can refresh an expired token
+        # before the request is sent. Returns an empty hash when no provider is set,
+        # which keeps the api-key / basic / bearer / no-auth paths unchanged.
+        # @return [Hash] The auth headers for the current request.
+        def resolve_auth_headers
+          return {} if @auth_provider.nil?
+
+          @auth_provider.auth_headers
+        end
+
         # @param url [URI::Generic] The url to the resource.
         # @param method [String] The HTTP method to use.
         # @param headers [Hash] The headers for the request.
         # @param body [String, nil] The body for the request.
+        # @param auth_headers [Hash] The auth headers resolved for this request. These
+        #   take precedence over the static default headers but not over per-request
+        #   headers, mirroring the previous baked-header precedence.
         # @return [HTTP::Request] The HTTP request.
-        def build_http_request(url:, method:, headers: {}, body: nil)
+        def build_http_request(url:, method:, headers: {}, body: nil, auth_headers: {})
           request = Net::HTTPGenericRequest.new(
             method,
             !body.nil?,
@@ -228,7 +251,7 @@ module <%= gem_namespace %>
             url
           )
 
-          request_headers = @default_headers.merge(headers)
+          request_headers = @default_headers.merge(auth_headers).merge(headers)
           request_headers.each { |name, value| request[name] = value }
           request.body = body if body
 

--- a/generators/ruby-v2/base/src/asIs/test/unit/internal/http/test_raw_client.Template.rb
+++ b/generators/ruby-v2/base/src/asIs/test/unit/internal/http/test_raw_client.Template.rb
@@ -54,4 +54,71 @@ describe <%= gem_namespace %>::Internal::Http::RawClient do
       assert client.should_retry?(make_response(502), 2)
     end
   end
+
+  # A minimal auth provider whose `auth_headers` returns a *different* token on
+  # each call, simulating a token that is refreshed on expiry.
+  class RefreshingAuthProvider
+    def initialize
+      @count = 0
+    end
+
+    def auth_headers
+      @count += 1
+      { "Authorization" => "Bearer TOKEN_#{@count}" }
+    end
+  end
+
+  describe "#resolve_auth_headers" do
+    it "returns an empty hash when no auth provider is configured" do
+      client = <%= gem_namespace %>::Internal::Http::RawClient.new(base_url: "https://example.com")
+
+      assert_equal({}, client.resolve_auth_headers)
+    end
+
+    it "consults the auth provider on every call so an expired token is refreshed" do
+      client = <%= gem_namespace %>::Internal::Http::RawClient.new(
+        base_url: "https://example.com",
+        auth_provider: RefreshingAuthProvider.new
+      )
+
+      assert_equal({ "Authorization" => "Bearer TOKEN_1" }, client.resolve_auth_headers)
+      assert_equal({ "Authorization" => "Bearer TOKEN_2" }, client.resolve_auth_headers)
+    end
+  end
+
+  describe "#build_http_request auth header precedence" do
+    let(:client) do
+      <%= gem_namespace %>::Internal::Http::RawClient.new(
+        base_url: "https://example.com",
+        headers: { "Authorization" => "Bearer STATIC" }
+      )
+    end
+
+    it "lets resolved auth headers override the static default headers" do
+      request = client.build_http_request(
+        url: URI.parse("https://example.com"),
+        method: "GET",
+        auth_headers: { "Authorization" => "Bearer FRESH" }
+      )
+
+      assert_equal("Bearer FRESH", request["Authorization"])
+    end
+
+    it "lets per-request headers take precedence over auth headers" do
+      request = client.build_http_request(
+        url: URI.parse("https://example.com"),
+        method: "GET",
+        headers: { "Authorization" => "Bearer PER_REQUEST" },
+        auth_headers: { "Authorization" => "Bearer FRESH" }
+      )
+
+      assert_equal("Bearer PER_REQUEST", request["Authorization"])
+    end
+
+    it "defaults auth headers to empty, leaving the default headers unchanged" do
+      request = client.build_http_request(url: URI.parse("https://example.com"), method: "GET")
+
+      assert_equal("Bearer STATIC", request["Authorization"])
+    end
+  end
 end

--- a/generators/ruby-v2/sdk/changes/unreleased/fix-oauth-token-refresh.yml
+++ b/generators/ruby-v2/sdk/changes/unreleased/fix-oauth-token-refresh.yml
@@ -1,0 +1,10 @@
+# yaml-language-server: $schema=../../../../../fern-changes-yml.schema.json
+
+- summary: |
+    Fix OAuth (and inferred-auth) access tokens never being refreshed on expiry. The token was
+    resolved once at client construction and baked into the `RawClient`'s static default headers, so
+    every subsequent request kept sending the original (eventually stale) token until the client was
+    reconstructed. The `RawClient` now receives the auth provider and resolves its `auth_headers` on
+    every request, so the provider's existing refresh logic runs before each call. Api-key/basic/
+    bearer/no-auth flows are unaffected (no provider is passed, so header resolution is a no-op).
+  type: fix

--- a/generators/ruby-v2/sdk/src/root-client/RootClientGenerator.ts
+++ b/generators/ruby-v2/sdk/src/root-client/RootClientGenerator.ts
@@ -263,22 +263,21 @@ export class RootClientGenerator extends FileGenerator<RubyFile, SdkCustomConfig
                     writer.writeLine(`,`);
                 }
                 if (hasBasicAuth) {
-                    writer.write(`headers: headers`);
+                    writer.writeLine(`headers: headers,`);
                 } else {
                     writer.write(`headers: `);
                     writer.writeNode(this.getRawClientHeaders());
+                    writer.writeLine(`,`);
                 }
-                if (hasAuthProvider && anyAuthMultiScheme) {
-                    // Under `any`-composed multi-scheme auth the provider is only
-                    // instantiated when its creds were supplied. Merge its headers at
-                    // runtime only when it exists; when creds are absent `@auth_provider`
-                    // is nil and we fall back to the other scheme's header
-                    // (api-key/basic/etc.) without touching the token endpoint.
-                    writer.writeLine(`.merge(@auth_provider.nil? ? {} : @auth_provider.auth_headers),`);
-                } else if (hasAuthProvider) {
-                    writer.writeLine(`.merge(@auth_provider.auth_headers),`);
-                } else {
-                    writer.writeLine(",");
+                if (hasAuthProvider) {
+                    // Pass the auth provider into the RawClient so its `auth_headers`
+                    // are resolved on EVERY request rather than baked once here. This
+                    // lets token-based providers (OAuth client-credentials, inferred
+                    // auth) refresh an expired token mid-session. When the provider's
+                    // credentials were not supplied (e.g. an `any`-composed scheme
+                    // where another scheme's creds were given) `@auth_provider` is nil,
+                    // and the RawClient simply resolves no auth headers.
+                    writer.writeLine(`auth_provider: @auth_provider,`);
                 }
                 writer.writeLine(`max_retries: max_retries`);
                 writer.dedent();

--- a/seed/ruby-sdk-v2/accept-header/lib/seed/internal/http/raw_client.rb
+++ b/seed/ruby-sdk-v2/accept-header/lib/seed/internal/http/raw_client.rb
@@ -21,10 +21,14 @@ module Seed
         # @param max_retries [Integer] The number of times to retry a failed request, defaults to 2.
         # @param timeout [Float] The timeout for the request, defaults to 60.0 seconds.
         # @param headers [Hash] The headers for the request.
-        def initialize(base_url:, max_retries: 2, timeout: 60.0, headers: {})
+        # @param auth_provider [Object, nil] An optional auth provider responding to
+        #   `auth_headers`. When present its headers are resolved on every request so
+        #   token-based schemes (e.g. OAuth) can refresh an expired token mid-session.
+        def initialize(base_url:, max_retries: 2, timeout: 60.0, headers: {}, auth_provider: nil)
           @base_url = base_url
           @max_retries = max_retries
           @timeout = timeout
+          @auth_provider = auth_provider
           @default_headers = {
             "X-Fern-Language": "Ruby",
             "X-Fern-SDK-Name": "seed",
@@ -36,6 +40,9 @@ module Seed
         # @return [HTTP::Response] The HTTP response.
         def send(request)
           url = build_url(request)
+          # Resolve auth headers once per request (not per retry) so token-based
+          # providers refresh at most once here; static providers are cheap.
+          auth_headers = resolve_auth_headers
           attempt = 0
           response = nil
 
@@ -43,8 +50,9 @@ module Seed
             http_request = build_http_request(
               url:,
               method: request.method,
-              headers: request.encode_headers(protected_keys: @default_headers.keys),
-              body: request.encode_body
+              headers: request.encode_headers(protected_keys: @default_headers.keys + auth_headers.keys),
+              body: request.encode_body,
+              auth_headers: auth_headers
             )
 
             conn = connect(url)
@@ -157,12 +165,27 @@ module Seed
                 "HTTP is only allowed for localhost. Use HTTPS or pass a localhost URL."
         end
 
+        # Resolves the auth headers to send with the next request. Delegates to the
+        # configured auth provider (if any) on every call so that token-based
+        # providers (e.g. OAuth client-credentials) can refresh an expired token
+        # before the request is sent. Returns an empty hash when no provider is set,
+        # which keeps the api-key / basic / bearer / no-auth paths unchanged.
+        # @return [Hash] The auth headers for the current request.
+        def resolve_auth_headers
+          return {} if @auth_provider.nil?
+
+          @auth_provider.auth_headers
+        end
+
         # @param url [URI::Generic] The url to the resource.
         # @param method [String] The HTTP method to use.
         # @param headers [Hash] The headers for the request.
         # @param body [String, nil] The body for the request.
+        # @param auth_headers [Hash] The auth headers resolved for this request. These
+        #   take precedence over the static default headers but not over per-request
+        #   headers, mirroring the previous baked-header precedence.
         # @return [HTTP::Request] The HTTP request.
-        def build_http_request(url:, method:, headers: {}, body: nil)
+        def build_http_request(url:, method:, headers: {}, body: nil, auth_headers: {})
           request = Net::HTTPGenericRequest.new(
             method,
             !body.nil?,
@@ -170,7 +193,7 @@ module Seed
             url
           )
 
-          request_headers = @default_headers.merge(headers)
+          request_headers = @default_headers.merge(auth_headers).merge(headers)
           request_headers.each { |name, value| request[name] = value }
           request.body = body if body
 

--- a/seed/ruby-sdk-v2/accept-header/test/unit/internal/http/test_raw_client.rb
+++ b/seed/ruby-sdk-v2/accept-header/test/unit/internal/http/test_raw_client.rb
@@ -54,4 +54,71 @@ describe Seed::Internal::Http::RawClient do
       assert client.should_retry?(make_response(502), 2)
     end
   end
+
+  # A minimal auth provider whose `auth_headers` returns a *different* token on
+  # each call, simulating a token that is refreshed on expiry.
+  class RefreshingAuthProvider
+    def initialize
+      @count = 0
+    end
+
+    def auth_headers
+      @count += 1
+      { "Authorization" => "Bearer TOKEN_#{@count}" }
+    end
+  end
+
+  describe "#resolve_auth_headers" do
+    it "returns an empty hash when no auth provider is configured" do
+      client = Seed::Internal::Http::RawClient.new(base_url: "https://example.com")
+
+      assert_equal({}, client.resolve_auth_headers)
+    end
+
+    it "consults the auth provider on every call so an expired token is refreshed" do
+      client = Seed::Internal::Http::RawClient.new(
+        base_url: "https://example.com",
+        auth_provider: RefreshingAuthProvider.new
+      )
+
+      assert_equal({ "Authorization" => "Bearer TOKEN_1" }, client.resolve_auth_headers)
+      assert_equal({ "Authorization" => "Bearer TOKEN_2" }, client.resolve_auth_headers)
+    end
+  end
+
+  describe "#build_http_request auth header precedence" do
+    let(:client) do
+      Seed::Internal::Http::RawClient.new(
+        base_url: "https://example.com",
+        headers: { "Authorization" => "Bearer STATIC" }
+      )
+    end
+
+    it "lets resolved auth headers override the static default headers" do
+      request = client.build_http_request(
+        url: URI.parse("https://example.com"),
+        method: "GET",
+        auth_headers: { "Authorization" => "Bearer FRESH" }
+      )
+
+      assert_equal("Bearer FRESH", request["Authorization"])
+    end
+
+    it "lets per-request headers take precedence over auth headers" do
+      request = client.build_http_request(
+        url: URI.parse("https://example.com"),
+        method: "GET",
+        headers: { "Authorization" => "Bearer PER_REQUEST" },
+        auth_headers: { "Authorization" => "Bearer FRESH" }
+      )
+
+      assert_equal("Bearer PER_REQUEST", request["Authorization"])
+    end
+
+    it "defaults auth headers to empty, leaving the default headers unchanged" do
+      request = client.build_http_request(url: URI.parse("https://example.com"), method: "GET")
+
+      assert_equal("Bearer STATIC", request["Authorization"])
+    end
+  end
 end

--- a/seed/ruby-sdk-v2/alias-extends/lib/seed/internal/http/raw_client.rb
+++ b/seed/ruby-sdk-v2/alias-extends/lib/seed/internal/http/raw_client.rb
@@ -21,10 +21,14 @@ module Seed
         # @param max_retries [Integer] The number of times to retry a failed request, defaults to 2.
         # @param timeout [Float] The timeout for the request, defaults to 60.0 seconds.
         # @param headers [Hash] The headers for the request.
-        def initialize(base_url:, max_retries: 2, timeout: 60.0, headers: {})
+        # @param auth_provider [Object, nil] An optional auth provider responding to
+        #   `auth_headers`. When present its headers are resolved on every request so
+        #   token-based schemes (e.g. OAuth) can refresh an expired token mid-session.
+        def initialize(base_url:, max_retries: 2, timeout: 60.0, headers: {}, auth_provider: nil)
           @base_url = base_url
           @max_retries = max_retries
           @timeout = timeout
+          @auth_provider = auth_provider
           @default_headers = {
             "X-Fern-Language": "Ruby",
             "X-Fern-SDK-Name": "seed",
@@ -36,6 +40,9 @@ module Seed
         # @return [HTTP::Response] The HTTP response.
         def send(request)
           url = build_url(request)
+          # Resolve auth headers once per request (not per retry) so token-based
+          # providers refresh at most once here; static providers are cheap.
+          auth_headers = resolve_auth_headers
           attempt = 0
           response = nil
 
@@ -43,8 +50,9 @@ module Seed
             http_request = build_http_request(
               url:,
               method: request.method,
-              headers: request.encode_headers(protected_keys: @default_headers.keys),
-              body: request.encode_body
+              headers: request.encode_headers(protected_keys: @default_headers.keys + auth_headers.keys),
+              body: request.encode_body,
+              auth_headers: auth_headers
             )
 
             conn = connect(url)
@@ -157,12 +165,27 @@ module Seed
                 "HTTP is only allowed for localhost. Use HTTPS or pass a localhost URL."
         end
 
+        # Resolves the auth headers to send with the next request. Delegates to the
+        # configured auth provider (if any) on every call so that token-based
+        # providers (e.g. OAuth client-credentials) can refresh an expired token
+        # before the request is sent. Returns an empty hash when no provider is set,
+        # which keeps the api-key / basic / bearer / no-auth paths unchanged.
+        # @return [Hash] The auth headers for the current request.
+        def resolve_auth_headers
+          return {} if @auth_provider.nil?
+
+          @auth_provider.auth_headers
+        end
+
         # @param url [URI::Generic] The url to the resource.
         # @param method [String] The HTTP method to use.
         # @param headers [Hash] The headers for the request.
         # @param body [String, nil] The body for the request.
+        # @param auth_headers [Hash] The auth headers resolved for this request. These
+        #   take precedence over the static default headers but not over per-request
+        #   headers, mirroring the previous baked-header precedence.
         # @return [HTTP::Request] The HTTP request.
-        def build_http_request(url:, method:, headers: {}, body: nil)
+        def build_http_request(url:, method:, headers: {}, body: nil, auth_headers: {})
           request = Net::HTTPGenericRequest.new(
             method,
             !body.nil?,
@@ -170,7 +193,7 @@ module Seed
             url
           )
 
-          request_headers = @default_headers.merge(headers)
+          request_headers = @default_headers.merge(auth_headers).merge(headers)
           request_headers.each { |name, value| request[name] = value }
           request.body = body if body
 

--- a/seed/ruby-sdk-v2/alias-extends/test/unit/internal/http/test_raw_client.rb
+++ b/seed/ruby-sdk-v2/alias-extends/test/unit/internal/http/test_raw_client.rb
@@ -54,4 +54,71 @@ describe Seed::Internal::Http::RawClient do
       assert client.should_retry?(make_response(502), 2)
     end
   end
+
+  # A minimal auth provider whose `auth_headers` returns a *different* token on
+  # each call, simulating a token that is refreshed on expiry.
+  class RefreshingAuthProvider
+    def initialize
+      @count = 0
+    end
+
+    def auth_headers
+      @count += 1
+      { "Authorization" => "Bearer TOKEN_#{@count}" }
+    end
+  end
+
+  describe "#resolve_auth_headers" do
+    it "returns an empty hash when no auth provider is configured" do
+      client = Seed::Internal::Http::RawClient.new(base_url: "https://example.com")
+
+      assert_equal({}, client.resolve_auth_headers)
+    end
+
+    it "consults the auth provider on every call so an expired token is refreshed" do
+      client = Seed::Internal::Http::RawClient.new(
+        base_url: "https://example.com",
+        auth_provider: RefreshingAuthProvider.new
+      )
+
+      assert_equal({ "Authorization" => "Bearer TOKEN_1" }, client.resolve_auth_headers)
+      assert_equal({ "Authorization" => "Bearer TOKEN_2" }, client.resolve_auth_headers)
+    end
+  end
+
+  describe "#build_http_request auth header precedence" do
+    let(:client) do
+      Seed::Internal::Http::RawClient.new(
+        base_url: "https://example.com",
+        headers: { "Authorization" => "Bearer STATIC" }
+      )
+    end
+
+    it "lets resolved auth headers override the static default headers" do
+      request = client.build_http_request(
+        url: URI.parse("https://example.com"),
+        method: "GET",
+        auth_headers: { "Authorization" => "Bearer FRESH" }
+      )
+
+      assert_equal("Bearer FRESH", request["Authorization"])
+    end
+
+    it "lets per-request headers take precedence over auth headers" do
+      request = client.build_http_request(
+        url: URI.parse("https://example.com"),
+        method: "GET",
+        headers: { "Authorization" => "Bearer PER_REQUEST" },
+        auth_headers: { "Authorization" => "Bearer FRESH" }
+      )
+
+      assert_equal("Bearer PER_REQUEST", request["Authorization"])
+    end
+
+    it "defaults auth headers to empty, leaving the default headers unchanged" do
+      request = client.build_http_request(url: URI.parse("https://example.com"), method: "GET")
+
+      assert_equal("Bearer STATIC", request["Authorization"])
+    end
+  end
 end

--- a/seed/ruby-sdk-v2/alias/lib/seed/internal/http/raw_client.rb
+++ b/seed/ruby-sdk-v2/alias/lib/seed/internal/http/raw_client.rb
@@ -21,10 +21,14 @@ module Seed
         # @param max_retries [Integer] The number of times to retry a failed request, defaults to 2.
         # @param timeout [Float] The timeout for the request, defaults to 60.0 seconds.
         # @param headers [Hash] The headers for the request.
-        def initialize(base_url:, max_retries: 2, timeout: 60.0, headers: {})
+        # @param auth_provider [Object, nil] An optional auth provider responding to
+        #   `auth_headers`. When present its headers are resolved on every request so
+        #   token-based schemes (e.g. OAuth) can refresh an expired token mid-session.
+        def initialize(base_url:, max_retries: 2, timeout: 60.0, headers: {}, auth_provider: nil)
           @base_url = base_url
           @max_retries = max_retries
           @timeout = timeout
+          @auth_provider = auth_provider
           @default_headers = {
             "X-Fern-Language": "Ruby",
             "X-Fern-SDK-Name": "seed",
@@ -36,6 +40,9 @@ module Seed
         # @return [HTTP::Response] The HTTP response.
         def send(request)
           url = build_url(request)
+          # Resolve auth headers once per request (not per retry) so token-based
+          # providers refresh at most once here; static providers are cheap.
+          auth_headers = resolve_auth_headers
           attempt = 0
           response = nil
 
@@ -43,8 +50,9 @@ module Seed
             http_request = build_http_request(
               url:,
               method: request.method,
-              headers: request.encode_headers(protected_keys: @default_headers.keys),
-              body: request.encode_body
+              headers: request.encode_headers(protected_keys: @default_headers.keys + auth_headers.keys),
+              body: request.encode_body,
+              auth_headers: auth_headers
             )
 
             conn = connect(url)
@@ -157,12 +165,27 @@ module Seed
                 "HTTP is only allowed for localhost. Use HTTPS or pass a localhost URL."
         end
 
+        # Resolves the auth headers to send with the next request. Delegates to the
+        # configured auth provider (if any) on every call so that token-based
+        # providers (e.g. OAuth client-credentials) can refresh an expired token
+        # before the request is sent. Returns an empty hash when no provider is set,
+        # which keeps the api-key / basic / bearer / no-auth paths unchanged.
+        # @return [Hash] The auth headers for the current request.
+        def resolve_auth_headers
+          return {} if @auth_provider.nil?
+
+          @auth_provider.auth_headers
+        end
+
         # @param url [URI::Generic] The url to the resource.
         # @param method [String] The HTTP method to use.
         # @param headers [Hash] The headers for the request.
         # @param body [String, nil] The body for the request.
+        # @param auth_headers [Hash] The auth headers resolved for this request. These
+        #   take precedence over the static default headers but not over per-request
+        #   headers, mirroring the previous baked-header precedence.
         # @return [HTTP::Request] The HTTP request.
-        def build_http_request(url:, method:, headers: {}, body: nil)
+        def build_http_request(url:, method:, headers: {}, body: nil, auth_headers: {})
           request = Net::HTTPGenericRequest.new(
             method,
             !body.nil?,
@@ -170,7 +193,7 @@ module Seed
             url
           )
 
-          request_headers = @default_headers.merge(headers)
+          request_headers = @default_headers.merge(auth_headers).merge(headers)
           request_headers.each { |name, value| request[name] = value }
           request.body = body if body
 

--- a/seed/ruby-sdk-v2/alias/test/unit/internal/http/test_raw_client.rb
+++ b/seed/ruby-sdk-v2/alias/test/unit/internal/http/test_raw_client.rb
@@ -54,4 +54,71 @@ describe Seed::Internal::Http::RawClient do
       assert client.should_retry?(make_response(502), 2)
     end
   end
+
+  # A minimal auth provider whose `auth_headers` returns a *different* token on
+  # each call, simulating a token that is refreshed on expiry.
+  class RefreshingAuthProvider
+    def initialize
+      @count = 0
+    end
+
+    def auth_headers
+      @count += 1
+      { "Authorization" => "Bearer TOKEN_#{@count}" }
+    end
+  end
+
+  describe "#resolve_auth_headers" do
+    it "returns an empty hash when no auth provider is configured" do
+      client = Seed::Internal::Http::RawClient.new(base_url: "https://example.com")
+
+      assert_equal({}, client.resolve_auth_headers)
+    end
+
+    it "consults the auth provider on every call so an expired token is refreshed" do
+      client = Seed::Internal::Http::RawClient.new(
+        base_url: "https://example.com",
+        auth_provider: RefreshingAuthProvider.new
+      )
+
+      assert_equal({ "Authorization" => "Bearer TOKEN_1" }, client.resolve_auth_headers)
+      assert_equal({ "Authorization" => "Bearer TOKEN_2" }, client.resolve_auth_headers)
+    end
+  end
+
+  describe "#build_http_request auth header precedence" do
+    let(:client) do
+      Seed::Internal::Http::RawClient.new(
+        base_url: "https://example.com",
+        headers: { "Authorization" => "Bearer STATIC" }
+      )
+    end
+
+    it "lets resolved auth headers override the static default headers" do
+      request = client.build_http_request(
+        url: URI.parse("https://example.com"),
+        method: "GET",
+        auth_headers: { "Authorization" => "Bearer FRESH" }
+      )
+
+      assert_equal("Bearer FRESH", request["Authorization"])
+    end
+
+    it "lets per-request headers take precedence over auth headers" do
+      request = client.build_http_request(
+        url: URI.parse("https://example.com"),
+        method: "GET",
+        headers: { "Authorization" => "Bearer PER_REQUEST" },
+        auth_headers: { "Authorization" => "Bearer FRESH" }
+      )
+
+      assert_equal("Bearer PER_REQUEST", request["Authorization"])
+    end
+
+    it "defaults auth headers to empty, leaving the default headers unchanged" do
+      request = client.build_http_request(url: URI.parse("https://example.com"), method: "GET")
+
+      assert_equal("Bearer STATIC", request["Authorization"])
+    end
+  end
 end

--- a/seed/ruby-sdk-v2/allof-inline/lib/seed/internal/http/raw_client.rb
+++ b/seed/ruby-sdk-v2/allof-inline/lib/seed/internal/http/raw_client.rb
@@ -21,10 +21,14 @@ module Seed
         # @param max_retries [Integer] The number of times to retry a failed request, defaults to 2.
         # @param timeout [Float] The timeout for the request, defaults to 60.0 seconds.
         # @param headers [Hash] The headers for the request.
-        def initialize(base_url:, max_retries: 2, timeout: 60.0, headers: {})
+        # @param auth_provider [Object, nil] An optional auth provider responding to
+        #   `auth_headers`. When present its headers are resolved on every request so
+        #   token-based schemes (e.g. OAuth) can refresh an expired token mid-session.
+        def initialize(base_url:, max_retries: 2, timeout: 60.0, headers: {}, auth_provider: nil)
           @base_url = base_url
           @max_retries = max_retries
           @timeout = timeout
+          @auth_provider = auth_provider
           @default_headers = {
             "X-Fern-Language": "Ruby",
             "X-Fern-SDK-Name": "seed",
@@ -36,6 +40,9 @@ module Seed
         # @return [HTTP::Response] The HTTP response.
         def send(request)
           url = build_url(request)
+          # Resolve auth headers once per request (not per retry) so token-based
+          # providers refresh at most once here; static providers are cheap.
+          auth_headers = resolve_auth_headers
           attempt = 0
           response = nil
 
@@ -43,8 +50,9 @@ module Seed
             http_request = build_http_request(
               url:,
               method: request.method,
-              headers: request.encode_headers(protected_keys: @default_headers.keys),
-              body: request.encode_body
+              headers: request.encode_headers(protected_keys: @default_headers.keys + auth_headers.keys),
+              body: request.encode_body,
+              auth_headers: auth_headers
             )
 
             conn = connect(url)
@@ -157,12 +165,27 @@ module Seed
                 "HTTP is only allowed for localhost. Use HTTPS or pass a localhost URL."
         end
 
+        # Resolves the auth headers to send with the next request. Delegates to the
+        # configured auth provider (if any) on every call so that token-based
+        # providers (e.g. OAuth client-credentials) can refresh an expired token
+        # before the request is sent. Returns an empty hash when no provider is set,
+        # which keeps the api-key / basic / bearer / no-auth paths unchanged.
+        # @return [Hash] The auth headers for the current request.
+        def resolve_auth_headers
+          return {} if @auth_provider.nil?
+
+          @auth_provider.auth_headers
+        end
+
         # @param url [URI::Generic] The url to the resource.
         # @param method [String] The HTTP method to use.
         # @param headers [Hash] The headers for the request.
         # @param body [String, nil] The body for the request.
+        # @param auth_headers [Hash] The auth headers resolved for this request. These
+        #   take precedence over the static default headers but not over per-request
+        #   headers, mirroring the previous baked-header precedence.
         # @return [HTTP::Request] The HTTP request.
-        def build_http_request(url:, method:, headers: {}, body: nil)
+        def build_http_request(url:, method:, headers: {}, body: nil, auth_headers: {})
           request = Net::HTTPGenericRequest.new(
             method,
             !body.nil?,
@@ -170,7 +193,7 @@ module Seed
             url
           )
 
-          request_headers = @default_headers.merge(headers)
+          request_headers = @default_headers.merge(auth_headers).merge(headers)
           request_headers.each { |name, value| request[name] = value }
           request.body = body if body
 

--- a/seed/ruby-sdk-v2/allof-inline/test/unit/internal/http/test_raw_client.rb
+++ b/seed/ruby-sdk-v2/allof-inline/test/unit/internal/http/test_raw_client.rb
@@ -54,4 +54,71 @@ describe Seed::Internal::Http::RawClient do
       assert client.should_retry?(make_response(502), 2)
     end
   end
+
+  # A minimal auth provider whose `auth_headers` returns a *different* token on
+  # each call, simulating a token that is refreshed on expiry.
+  class RefreshingAuthProvider
+    def initialize
+      @count = 0
+    end
+
+    def auth_headers
+      @count += 1
+      { "Authorization" => "Bearer TOKEN_#{@count}" }
+    end
+  end
+
+  describe "#resolve_auth_headers" do
+    it "returns an empty hash when no auth provider is configured" do
+      client = Seed::Internal::Http::RawClient.new(base_url: "https://example.com")
+
+      assert_equal({}, client.resolve_auth_headers)
+    end
+
+    it "consults the auth provider on every call so an expired token is refreshed" do
+      client = Seed::Internal::Http::RawClient.new(
+        base_url: "https://example.com",
+        auth_provider: RefreshingAuthProvider.new
+      )
+
+      assert_equal({ "Authorization" => "Bearer TOKEN_1" }, client.resolve_auth_headers)
+      assert_equal({ "Authorization" => "Bearer TOKEN_2" }, client.resolve_auth_headers)
+    end
+  end
+
+  describe "#build_http_request auth header precedence" do
+    let(:client) do
+      Seed::Internal::Http::RawClient.new(
+        base_url: "https://example.com",
+        headers: { "Authorization" => "Bearer STATIC" }
+      )
+    end
+
+    it "lets resolved auth headers override the static default headers" do
+      request = client.build_http_request(
+        url: URI.parse("https://example.com"),
+        method: "GET",
+        auth_headers: { "Authorization" => "Bearer FRESH" }
+      )
+
+      assert_equal("Bearer FRESH", request["Authorization"])
+    end
+
+    it "lets per-request headers take precedence over auth headers" do
+      request = client.build_http_request(
+        url: URI.parse("https://example.com"),
+        method: "GET",
+        headers: { "Authorization" => "Bearer PER_REQUEST" },
+        auth_headers: { "Authorization" => "Bearer FRESH" }
+      )
+
+      assert_equal("Bearer PER_REQUEST", request["Authorization"])
+    end
+
+    it "defaults auth headers to empty, leaving the default headers unchanged" do
+      request = client.build_http_request(url: URI.parse("https://example.com"), method: "GET")
+
+      assert_equal("Bearer STATIC", request["Authorization"])
+    end
+  end
 end

--- a/seed/ruby-sdk-v2/allof/lib/seed/internal/http/raw_client.rb
+++ b/seed/ruby-sdk-v2/allof/lib/seed/internal/http/raw_client.rb
@@ -21,10 +21,14 @@ module Seed
         # @param max_retries [Integer] The number of times to retry a failed request, defaults to 2.
         # @param timeout [Float] The timeout for the request, defaults to 60.0 seconds.
         # @param headers [Hash] The headers for the request.
-        def initialize(base_url:, max_retries: 2, timeout: 60.0, headers: {})
+        # @param auth_provider [Object, nil] An optional auth provider responding to
+        #   `auth_headers`. When present its headers are resolved on every request so
+        #   token-based schemes (e.g. OAuth) can refresh an expired token mid-session.
+        def initialize(base_url:, max_retries: 2, timeout: 60.0, headers: {}, auth_provider: nil)
           @base_url = base_url
           @max_retries = max_retries
           @timeout = timeout
+          @auth_provider = auth_provider
           @default_headers = {
             "X-Fern-Language": "Ruby",
             "X-Fern-SDK-Name": "seed",
@@ -36,6 +40,9 @@ module Seed
         # @return [HTTP::Response] The HTTP response.
         def send(request)
           url = build_url(request)
+          # Resolve auth headers once per request (not per retry) so token-based
+          # providers refresh at most once here; static providers are cheap.
+          auth_headers = resolve_auth_headers
           attempt = 0
           response = nil
 
@@ -43,8 +50,9 @@ module Seed
             http_request = build_http_request(
               url:,
               method: request.method,
-              headers: request.encode_headers(protected_keys: @default_headers.keys),
-              body: request.encode_body
+              headers: request.encode_headers(protected_keys: @default_headers.keys + auth_headers.keys),
+              body: request.encode_body,
+              auth_headers: auth_headers
             )
 
             conn = connect(url)
@@ -157,12 +165,27 @@ module Seed
                 "HTTP is only allowed for localhost. Use HTTPS or pass a localhost URL."
         end
 
+        # Resolves the auth headers to send with the next request. Delegates to the
+        # configured auth provider (if any) on every call so that token-based
+        # providers (e.g. OAuth client-credentials) can refresh an expired token
+        # before the request is sent. Returns an empty hash when no provider is set,
+        # which keeps the api-key / basic / bearer / no-auth paths unchanged.
+        # @return [Hash] The auth headers for the current request.
+        def resolve_auth_headers
+          return {} if @auth_provider.nil?
+
+          @auth_provider.auth_headers
+        end
+
         # @param url [URI::Generic] The url to the resource.
         # @param method [String] The HTTP method to use.
         # @param headers [Hash] The headers for the request.
         # @param body [String, nil] The body for the request.
+        # @param auth_headers [Hash] The auth headers resolved for this request. These
+        #   take precedence over the static default headers but not over per-request
+        #   headers, mirroring the previous baked-header precedence.
         # @return [HTTP::Request] The HTTP request.
-        def build_http_request(url:, method:, headers: {}, body: nil)
+        def build_http_request(url:, method:, headers: {}, body: nil, auth_headers: {})
           request = Net::HTTPGenericRequest.new(
             method,
             !body.nil?,
@@ -170,7 +193,7 @@ module Seed
             url
           )
 
-          request_headers = @default_headers.merge(headers)
+          request_headers = @default_headers.merge(auth_headers).merge(headers)
           request_headers.each { |name, value| request[name] = value }
           request.body = body if body
 

--- a/seed/ruby-sdk-v2/allof/test/unit/internal/http/test_raw_client.rb
+++ b/seed/ruby-sdk-v2/allof/test/unit/internal/http/test_raw_client.rb
@@ -54,4 +54,71 @@ describe Seed::Internal::Http::RawClient do
       assert client.should_retry?(make_response(502), 2)
     end
   end
+
+  # A minimal auth provider whose `auth_headers` returns a *different* token on
+  # each call, simulating a token that is refreshed on expiry.
+  class RefreshingAuthProvider
+    def initialize
+      @count = 0
+    end
+
+    def auth_headers
+      @count += 1
+      { "Authorization" => "Bearer TOKEN_#{@count}" }
+    end
+  end
+
+  describe "#resolve_auth_headers" do
+    it "returns an empty hash when no auth provider is configured" do
+      client = Seed::Internal::Http::RawClient.new(base_url: "https://example.com")
+
+      assert_equal({}, client.resolve_auth_headers)
+    end
+
+    it "consults the auth provider on every call so an expired token is refreshed" do
+      client = Seed::Internal::Http::RawClient.new(
+        base_url: "https://example.com",
+        auth_provider: RefreshingAuthProvider.new
+      )
+
+      assert_equal({ "Authorization" => "Bearer TOKEN_1" }, client.resolve_auth_headers)
+      assert_equal({ "Authorization" => "Bearer TOKEN_2" }, client.resolve_auth_headers)
+    end
+  end
+
+  describe "#build_http_request auth header precedence" do
+    let(:client) do
+      Seed::Internal::Http::RawClient.new(
+        base_url: "https://example.com",
+        headers: { "Authorization" => "Bearer STATIC" }
+      )
+    end
+
+    it "lets resolved auth headers override the static default headers" do
+      request = client.build_http_request(
+        url: URI.parse("https://example.com"),
+        method: "GET",
+        auth_headers: { "Authorization" => "Bearer FRESH" }
+      )
+
+      assert_equal("Bearer FRESH", request["Authorization"])
+    end
+
+    it "lets per-request headers take precedence over auth headers" do
+      request = client.build_http_request(
+        url: URI.parse("https://example.com"),
+        method: "GET",
+        headers: { "Authorization" => "Bearer PER_REQUEST" },
+        auth_headers: { "Authorization" => "Bearer FRESH" }
+      )
+
+      assert_equal("Bearer PER_REQUEST", request["Authorization"])
+    end
+
+    it "defaults auth headers to empty, leaving the default headers unchanged" do
+      request = client.build_http_request(url: URI.parse("https://example.com"), method: "GET")
+
+      assert_equal("Bearer STATIC", request["Authorization"])
+    end
+  end
 end

--- a/seed/ruby-sdk-v2/any-auth/lib/seed/client.rb
+++ b/seed/ruby-sdk-v2/any-auth/lib/seed/client.rb
@@ -41,7 +41,8 @@ module Seed
       headers["Authorization"] = "Basic #{Base64.strict_encode64("#{username}:#{password}")}" if !username.nil? && !password.nil?
       @raw_client = Seed::Internal::Http::RawClient.new(
         base_url: base_url,
-        headers: headers.merge(@auth_provider.nil? ? {} : @auth_provider.auth_headers),
+        headers: headers,
+        auth_provider: @auth_provider,
         max_retries: max_retries
       )
     end

--- a/seed/ruby-sdk-v2/any-auth/lib/seed/internal/http/raw_client.rb
+++ b/seed/ruby-sdk-v2/any-auth/lib/seed/internal/http/raw_client.rb
@@ -21,10 +21,14 @@ module Seed
         # @param max_retries [Integer] The number of times to retry a failed request, defaults to 2.
         # @param timeout [Float] The timeout for the request, defaults to 60.0 seconds.
         # @param headers [Hash] The headers for the request.
-        def initialize(base_url:, max_retries: 2, timeout: 60.0, headers: {})
+        # @param auth_provider [Object, nil] An optional auth provider responding to
+        #   `auth_headers`. When present its headers are resolved on every request so
+        #   token-based schemes (e.g. OAuth) can refresh an expired token mid-session.
+        def initialize(base_url:, max_retries: 2, timeout: 60.0, headers: {}, auth_provider: nil)
           @base_url = base_url
           @max_retries = max_retries
           @timeout = timeout
+          @auth_provider = auth_provider
           @default_headers = {
             "X-Fern-Language": "Ruby",
             "X-Fern-SDK-Name": "seed",
@@ -36,6 +40,9 @@ module Seed
         # @return [HTTP::Response] The HTTP response.
         def send(request)
           url = build_url(request)
+          # Resolve auth headers once per request (not per retry) so token-based
+          # providers refresh at most once here; static providers are cheap.
+          auth_headers = resolve_auth_headers
           attempt = 0
           response = nil
 
@@ -43,8 +50,9 @@ module Seed
             http_request = build_http_request(
               url:,
               method: request.method,
-              headers: request.encode_headers(protected_keys: @default_headers.keys),
-              body: request.encode_body
+              headers: request.encode_headers(protected_keys: @default_headers.keys + auth_headers.keys),
+              body: request.encode_body,
+              auth_headers: auth_headers
             )
 
             conn = connect(url)
@@ -157,12 +165,27 @@ module Seed
                 "HTTP is only allowed for localhost. Use HTTPS or pass a localhost URL."
         end
 
+        # Resolves the auth headers to send with the next request. Delegates to the
+        # configured auth provider (if any) on every call so that token-based
+        # providers (e.g. OAuth client-credentials) can refresh an expired token
+        # before the request is sent. Returns an empty hash when no provider is set,
+        # which keeps the api-key / basic / bearer / no-auth paths unchanged.
+        # @return [Hash] The auth headers for the current request.
+        def resolve_auth_headers
+          return {} if @auth_provider.nil?
+
+          @auth_provider.auth_headers
+        end
+
         # @param url [URI::Generic] The url to the resource.
         # @param method [String] The HTTP method to use.
         # @param headers [Hash] The headers for the request.
         # @param body [String, nil] The body for the request.
+        # @param auth_headers [Hash] The auth headers resolved for this request. These
+        #   take precedence over the static default headers but not over per-request
+        #   headers, mirroring the previous baked-header precedence.
         # @return [HTTP::Request] The HTTP request.
-        def build_http_request(url:, method:, headers: {}, body: nil)
+        def build_http_request(url:, method:, headers: {}, body: nil, auth_headers: {})
           request = Net::HTTPGenericRequest.new(
             method,
             !body.nil?,
@@ -170,7 +193,7 @@ module Seed
             url
           )
 
-          request_headers = @default_headers.merge(headers)
+          request_headers = @default_headers.merge(auth_headers).merge(headers)
           request_headers.each { |name, value| request[name] = value }
           request.body = body if body
 

--- a/seed/ruby-sdk-v2/any-auth/test/unit/internal/http/test_raw_client.rb
+++ b/seed/ruby-sdk-v2/any-auth/test/unit/internal/http/test_raw_client.rb
@@ -54,4 +54,71 @@ describe Seed::Internal::Http::RawClient do
       assert client.should_retry?(make_response(502), 2)
     end
   end
+
+  # A minimal auth provider whose `auth_headers` returns a *different* token on
+  # each call, simulating a token that is refreshed on expiry.
+  class RefreshingAuthProvider
+    def initialize
+      @count = 0
+    end
+
+    def auth_headers
+      @count += 1
+      { "Authorization" => "Bearer TOKEN_#{@count}" }
+    end
+  end
+
+  describe "#resolve_auth_headers" do
+    it "returns an empty hash when no auth provider is configured" do
+      client = Seed::Internal::Http::RawClient.new(base_url: "https://example.com")
+
+      assert_equal({}, client.resolve_auth_headers)
+    end
+
+    it "consults the auth provider on every call so an expired token is refreshed" do
+      client = Seed::Internal::Http::RawClient.new(
+        base_url: "https://example.com",
+        auth_provider: RefreshingAuthProvider.new
+      )
+
+      assert_equal({ "Authorization" => "Bearer TOKEN_1" }, client.resolve_auth_headers)
+      assert_equal({ "Authorization" => "Bearer TOKEN_2" }, client.resolve_auth_headers)
+    end
+  end
+
+  describe "#build_http_request auth header precedence" do
+    let(:client) do
+      Seed::Internal::Http::RawClient.new(
+        base_url: "https://example.com",
+        headers: { "Authorization" => "Bearer STATIC" }
+      )
+    end
+
+    it "lets resolved auth headers override the static default headers" do
+      request = client.build_http_request(
+        url: URI.parse("https://example.com"),
+        method: "GET",
+        auth_headers: { "Authorization" => "Bearer FRESH" }
+      )
+
+      assert_equal("Bearer FRESH", request["Authorization"])
+    end
+
+    it "lets per-request headers take precedence over auth headers" do
+      request = client.build_http_request(
+        url: URI.parse("https://example.com"),
+        method: "GET",
+        headers: { "Authorization" => "Bearer PER_REQUEST" },
+        auth_headers: { "Authorization" => "Bearer FRESH" }
+      )
+
+      assert_equal("Bearer PER_REQUEST", request["Authorization"])
+    end
+
+    it "defaults auth headers to empty, leaving the default headers unchanged" do
+      request = client.build_http_request(url: URI.parse("https://example.com"), method: "GET")
+
+      assert_equal("Bearer STATIC", request["Authorization"])
+    end
+  end
 end

--- a/seed/ruby-sdk-v2/api-wide-base-path-with-default/lib/seed/internal/http/raw_client.rb
+++ b/seed/ruby-sdk-v2/api-wide-base-path-with-default/lib/seed/internal/http/raw_client.rb
@@ -21,10 +21,14 @@ module Seed
         # @param max_retries [Integer] The number of times to retry a failed request, defaults to 2.
         # @param timeout [Float] The timeout for the request, defaults to 60.0 seconds.
         # @param headers [Hash] The headers for the request.
-        def initialize(base_url:, max_retries: 2, timeout: 60.0, headers: {})
+        # @param auth_provider [Object, nil] An optional auth provider responding to
+        #   `auth_headers`. When present its headers are resolved on every request so
+        #   token-based schemes (e.g. OAuth) can refresh an expired token mid-session.
+        def initialize(base_url:, max_retries: 2, timeout: 60.0, headers: {}, auth_provider: nil)
           @base_url = base_url
           @max_retries = max_retries
           @timeout = timeout
+          @auth_provider = auth_provider
           @default_headers = {
             "X-Fern-Language": "Ruby",
             "X-Fern-SDK-Name": "seed",
@@ -36,6 +40,9 @@ module Seed
         # @return [HTTP::Response] The HTTP response.
         def send(request)
           url = build_url(request)
+          # Resolve auth headers once per request (not per retry) so token-based
+          # providers refresh at most once here; static providers are cheap.
+          auth_headers = resolve_auth_headers
           attempt = 0
           response = nil
 
@@ -43,8 +50,9 @@ module Seed
             http_request = build_http_request(
               url:,
               method: request.method,
-              headers: request.encode_headers(protected_keys: @default_headers.keys),
-              body: request.encode_body
+              headers: request.encode_headers(protected_keys: @default_headers.keys + auth_headers.keys),
+              body: request.encode_body,
+              auth_headers: auth_headers
             )
 
             conn = connect(url)
@@ -157,12 +165,27 @@ module Seed
                 "HTTP is only allowed for localhost. Use HTTPS or pass a localhost URL."
         end
 
+        # Resolves the auth headers to send with the next request. Delegates to the
+        # configured auth provider (if any) on every call so that token-based
+        # providers (e.g. OAuth client-credentials) can refresh an expired token
+        # before the request is sent. Returns an empty hash when no provider is set,
+        # which keeps the api-key / basic / bearer / no-auth paths unchanged.
+        # @return [Hash] The auth headers for the current request.
+        def resolve_auth_headers
+          return {} if @auth_provider.nil?
+
+          @auth_provider.auth_headers
+        end
+
         # @param url [URI::Generic] The url to the resource.
         # @param method [String] The HTTP method to use.
         # @param headers [Hash] The headers for the request.
         # @param body [String, nil] The body for the request.
+        # @param auth_headers [Hash] The auth headers resolved for this request. These
+        #   take precedence over the static default headers but not over per-request
+        #   headers, mirroring the previous baked-header precedence.
         # @return [HTTP::Request] The HTTP request.
-        def build_http_request(url:, method:, headers: {}, body: nil)
+        def build_http_request(url:, method:, headers: {}, body: nil, auth_headers: {})
           request = Net::HTTPGenericRequest.new(
             method,
             !body.nil?,
@@ -170,7 +193,7 @@ module Seed
             url
           )
 
-          request_headers = @default_headers.merge(headers)
+          request_headers = @default_headers.merge(auth_headers).merge(headers)
           request_headers.each { |name, value| request[name] = value }
           request.body = body if body
 

--- a/seed/ruby-sdk-v2/api-wide-base-path-with-default/test/unit/internal/http/test_raw_client.rb
+++ b/seed/ruby-sdk-v2/api-wide-base-path-with-default/test/unit/internal/http/test_raw_client.rb
@@ -54,4 +54,71 @@ describe Seed::Internal::Http::RawClient do
       assert client.should_retry?(make_response(502), 2)
     end
   end
+
+  # A minimal auth provider whose `auth_headers` returns a *different* token on
+  # each call, simulating a token that is refreshed on expiry.
+  class RefreshingAuthProvider
+    def initialize
+      @count = 0
+    end
+
+    def auth_headers
+      @count += 1
+      { "Authorization" => "Bearer TOKEN_#{@count}" }
+    end
+  end
+
+  describe "#resolve_auth_headers" do
+    it "returns an empty hash when no auth provider is configured" do
+      client = Seed::Internal::Http::RawClient.new(base_url: "https://example.com")
+
+      assert_equal({}, client.resolve_auth_headers)
+    end
+
+    it "consults the auth provider on every call so an expired token is refreshed" do
+      client = Seed::Internal::Http::RawClient.new(
+        base_url: "https://example.com",
+        auth_provider: RefreshingAuthProvider.new
+      )
+
+      assert_equal({ "Authorization" => "Bearer TOKEN_1" }, client.resolve_auth_headers)
+      assert_equal({ "Authorization" => "Bearer TOKEN_2" }, client.resolve_auth_headers)
+    end
+  end
+
+  describe "#build_http_request auth header precedence" do
+    let(:client) do
+      Seed::Internal::Http::RawClient.new(
+        base_url: "https://example.com",
+        headers: { "Authorization" => "Bearer STATIC" }
+      )
+    end
+
+    it "lets resolved auth headers override the static default headers" do
+      request = client.build_http_request(
+        url: URI.parse("https://example.com"),
+        method: "GET",
+        auth_headers: { "Authorization" => "Bearer FRESH" }
+      )
+
+      assert_equal("Bearer FRESH", request["Authorization"])
+    end
+
+    it "lets per-request headers take precedence over auth headers" do
+      request = client.build_http_request(
+        url: URI.parse("https://example.com"),
+        method: "GET",
+        headers: { "Authorization" => "Bearer PER_REQUEST" },
+        auth_headers: { "Authorization" => "Bearer FRESH" }
+      )
+
+      assert_equal("Bearer PER_REQUEST", request["Authorization"])
+    end
+
+    it "defaults auth headers to empty, leaving the default headers unchanged" do
+      request = client.build_http_request(url: URI.parse("https://example.com"), method: "GET")
+
+      assert_equal("Bearer STATIC", request["Authorization"])
+    end
+  end
 end

--- a/seed/ruby-sdk-v2/api-wide-base-path/lib/seed/internal/http/raw_client.rb
+++ b/seed/ruby-sdk-v2/api-wide-base-path/lib/seed/internal/http/raw_client.rb
@@ -21,10 +21,14 @@ module Seed
         # @param max_retries [Integer] The number of times to retry a failed request, defaults to 2.
         # @param timeout [Float] The timeout for the request, defaults to 60.0 seconds.
         # @param headers [Hash] The headers for the request.
-        def initialize(base_url:, max_retries: 2, timeout: 60.0, headers: {})
+        # @param auth_provider [Object, nil] An optional auth provider responding to
+        #   `auth_headers`. When present its headers are resolved on every request so
+        #   token-based schemes (e.g. OAuth) can refresh an expired token mid-session.
+        def initialize(base_url:, max_retries: 2, timeout: 60.0, headers: {}, auth_provider: nil)
           @base_url = base_url
           @max_retries = max_retries
           @timeout = timeout
+          @auth_provider = auth_provider
           @default_headers = {
             "X-Fern-Language": "Ruby",
             "X-Fern-SDK-Name": "seed",
@@ -36,6 +40,9 @@ module Seed
         # @return [HTTP::Response] The HTTP response.
         def send(request)
           url = build_url(request)
+          # Resolve auth headers once per request (not per retry) so token-based
+          # providers refresh at most once here; static providers are cheap.
+          auth_headers = resolve_auth_headers
           attempt = 0
           response = nil
 
@@ -43,8 +50,9 @@ module Seed
             http_request = build_http_request(
               url:,
               method: request.method,
-              headers: request.encode_headers(protected_keys: @default_headers.keys),
-              body: request.encode_body
+              headers: request.encode_headers(protected_keys: @default_headers.keys + auth_headers.keys),
+              body: request.encode_body,
+              auth_headers: auth_headers
             )
 
             conn = connect(url)
@@ -157,12 +165,27 @@ module Seed
                 "HTTP is only allowed for localhost. Use HTTPS or pass a localhost URL."
         end
 
+        # Resolves the auth headers to send with the next request. Delegates to the
+        # configured auth provider (if any) on every call so that token-based
+        # providers (e.g. OAuth client-credentials) can refresh an expired token
+        # before the request is sent. Returns an empty hash when no provider is set,
+        # which keeps the api-key / basic / bearer / no-auth paths unchanged.
+        # @return [Hash] The auth headers for the current request.
+        def resolve_auth_headers
+          return {} if @auth_provider.nil?
+
+          @auth_provider.auth_headers
+        end
+
         # @param url [URI::Generic] The url to the resource.
         # @param method [String] The HTTP method to use.
         # @param headers [Hash] The headers for the request.
         # @param body [String, nil] The body for the request.
+        # @param auth_headers [Hash] The auth headers resolved for this request. These
+        #   take precedence over the static default headers but not over per-request
+        #   headers, mirroring the previous baked-header precedence.
         # @return [HTTP::Request] The HTTP request.
-        def build_http_request(url:, method:, headers: {}, body: nil)
+        def build_http_request(url:, method:, headers: {}, body: nil, auth_headers: {})
           request = Net::HTTPGenericRequest.new(
             method,
             !body.nil?,
@@ -170,7 +193,7 @@ module Seed
             url
           )
 
-          request_headers = @default_headers.merge(headers)
+          request_headers = @default_headers.merge(auth_headers).merge(headers)
           request_headers.each { |name, value| request[name] = value }
           request.body = body if body
 

--- a/seed/ruby-sdk-v2/api-wide-base-path/test/unit/internal/http/test_raw_client.rb
+++ b/seed/ruby-sdk-v2/api-wide-base-path/test/unit/internal/http/test_raw_client.rb
@@ -54,4 +54,71 @@ describe Seed::Internal::Http::RawClient do
       assert client.should_retry?(make_response(502), 2)
     end
   end
+
+  # A minimal auth provider whose `auth_headers` returns a *different* token on
+  # each call, simulating a token that is refreshed on expiry.
+  class RefreshingAuthProvider
+    def initialize
+      @count = 0
+    end
+
+    def auth_headers
+      @count += 1
+      { "Authorization" => "Bearer TOKEN_#{@count}" }
+    end
+  end
+
+  describe "#resolve_auth_headers" do
+    it "returns an empty hash when no auth provider is configured" do
+      client = Seed::Internal::Http::RawClient.new(base_url: "https://example.com")
+
+      assert_equal({}, client.resolve_auth_headers)
+    end
+
+    it "consults the auth provider on every call so an expired token is refreshed" do
+      client = Seed::Internal::Http::RawClient.new(
+        base_url: "https://example.com",
+        auth_provider: RefreshingAuthProvider.new
+      )
+
+      assert_equal({ "Authorization" => "Bearer TOKEN_1" }, client.resolve_auth_headers)
+      assert_equal({ "Authorization" => "Bearer TOKEN_2" }, client.resolve_auth_headers)
+    end
+  end
+
+  describe "#build_http_request auth header precedence" do
+    let(:client) do
+      Seed::Internal::Http::RawClient.new(
+        base_url: "https://example.com",
+        headers: { "Authorization" => "Bearer STATIC" }
+      )
+    end
+
+    it "lets resolved auth headers override the static default headers" do
+      request = client.build_http_request(
+        url: URI.parse("https://example.com"),
+        method: "GET",
+        auth_headers: { "Authorization" => "Bearer FRESH" }
+      )
+
+      assert_equal("Bearer FRESH", request["Authorization"])
+    end
+
+    it "lets per-request headers take precedence over auth headers" do
+      request = client.build_http_request(
+        url: URI.parse("https://example.com"),
+        method: "GET",
+        headers: { "Authorization" => "Bearer PER_REQUEST" },
+        auth_headers: { "Authorization" => "Bearer FRESH" }
+      )
+
+      assert_equal("Bearer PER_REQUEST", request["Authorization"])
+    end
+
+    it "defaults auth headers to empty, leaving the default headers unchanged" do
+      request = client.build_http_request(url: URI.parse("https://example.com"), method: "GET")
+
+      assert_equal("Bearer STATIC", request["Authorization"])
+    end
+  end
 end

--- a/seed/ruby-sdk-v2/audiences/lib/seed/internal/http/raw_client.rb
+++ b/seed/ruby-sdk-v2/audiences/lib/seed/internal/http/raw_client.rb
@@ -21,10 +21,14 @@ module Seed
         # @param max_retries [Integer] The number of times to retry a failed request, defaults to 2.
         # @param timeout [Float] The timeout for the request, defaults to 60.0 seconds.
         # @param headers [Hash] The headers for the request.
-        def initialize(base_url:, max_retries: 2, timeout: 60.0, headers: {})
+        # @param auth_provider [Object, nil] An optional auth provider responding to
+        #   `auth_headers`. When present its headers are resolved on every request so
+        #   token-based schemes (e.g. OAuth) can refresh an expired token mid-session.
+        def initialize(base_url:, max_retries: 2, timeout: 60.0, headers: {}, auth_provider: nil)
           @base_url = base_url
           @max_retries = max_retries
           @timeout = timeout
+          @auth_provider = auth_provider
           @default_headers = {
             "X-Fern-Language": "Ruby",
             "X-Fern-SDK-Name": "seed",
@@ -36,6 +40,9 @@ module Seed
         # @return [HTTP::Response] The HTTP response.
         def send(request)
           url = build_url(request)
+          # Resolve auth headers once per request (not per retry) so token-based
+          # providers refresh at most once here; static providers are cheap.
+          auth_headers = resolve_auth_headers
           attempt = 0
           response = nil
 
@@ -43,8 +50,9 @@ module Seed
             http_request = build_http_request(
               url:,
               method: request.method,
-              headers: request.encode_headers(protected_keys: @default_headers.keys),
-              body: request.encode_body
+              headers: request.encode_headers(protected_keys: @default_headers.keys + auth_headers.keys),
+              body: request.encode_body,
+              auth_headers: auth_headers
             )
 
             conn = connect(url)
@@ -157,12 +165,27 @@ module Seed
                 "HTTP is only allowed for localhost. Use HTTPS or pass a localhost URL."
         end
 
+        # Resolves the auth headers to send with the next request. Delegates to the
+        # configured auth provider (if any) on every call so that token-based
+        # providers (e.g. OAuth client-credentials) can refresh an expired token
+        # before the request is sent. Returns an empty hash when no provider is set,
+        # which keeps the api-key / basic / bearer / no-auth paths unchanged.
+        # @return [Hash] The auth headers for the current request.
+        def resolve_auth_headers
+          return {} if @auth_provider.nil?
+
+          @auth_provider.auth_headers
+        end
+
         # @param url [URI::Generic] The url to the resource.
         # @param method [String] The HTTP method to use.
         # @param headers [Hash] The headers for the request.
         # @param body [String, nil] The body for the request.
+        # @param auth_headers [Hash] The auth headers resolved for this request. These
+        #   take precedence over the static default headers but not over per-request
+        #   headers, mirroring the previous baked-header precedence.
         # @return [HTTP::Request] The HTTP request.
-        def build_http_request(url:, method:, headers: {}, body: nil)
+        def build_http_request(url:, method:, headers: {}, body: nil, auth_headers: {})
           request = Net::HTTPGenericRequest.new(
             method,
             !body.nil?,
@@ -170,7 +193,7 @@ module Seed
             url
           )
 
-          request_headers = @default_headers.merge(headers)
+          request_headers = @default_headers.merge(auth_headers).merge(headers)
           request_headers.each { |name, value| request[name] = value }
           request.body = body if body
 

--- a/seed/ruby-sdk-v2/audiences/test/unit/internal/http/test_raw_client.rb
+++ b/seed/ruby-sdk-v2/audiences/test/unit/internal/http/test_raw_client.rb
@@ -54,4 +54,71 @@ describe Seed::Internal::Http::RawClient do
       assert client.should_retry?(make_response(502), 2)
     end
   end
+
+  # A minimal auth provider whose `auth_headers` returns a *different* token on
+  # each call, simulating a token that is refreshed on expiry.
+  class RefreshingAuthProvider
+    def initialize
+      @count = 0
+    end
+
+    def auth_headers
+      @count += 1
+      { "Authorization" => "Bearer TOKEN_#{@count}" }
+    end
+  end
+
+  describe "#resolve_auth_headers" do
+    it "returns an empty hash when no auth provider is configured" do
+      client = Seed::Internal::Http::RawClient.new(base_url: "https://example.com")
+
+      assert_equal({}, client.resolve_auth_headers)
+    end
+
+    it "consults the auth provider on every call so an expired token is refreshed" do
+      client = Seed::Internal::Http::RawClient.new(
+        base_url: "https://example.com",
+        auth_provider: RefreshingAuthProvider.new
+      )
+
+      assert_equal({ "Authorization" => "Bearer TOKEN_1" }, client.resolve_auth_headers)
+      assert_equal({ "Authorization" => "Bearer TOKEN_2" }, client.resolve_auth_headers)
+    end
+  end
+
+  describe "#build_http_request auth header precedence" do
+    let(:client) do
+      Seed::Internal::Http::RawClient.new(
+        base_url: "https://example.com",
+        headers: { "Authorization" => "Bearer STATIC" }
+      )
+    end
+
+    it "lets resolved auth headers override the static default headers" do
+      request = client.build_http_request(
+        url: URI.parse("https://example.com"),
+        method: "GET",
+        auth_headers: { "Authorization" => "Bearer FRESH" }
+      )
+
+      assert_equal("Bearer FRESH", request["Authorization"])
+    end
+
+    it "lets per-request headers take precedence over auth headers" do
+      request = client.build_http_request(
+        url: URI.parse("https://example.com"),
+        method: "GET",
+        headers: { "Authorization" => "Bearer PER_REQUEST" },
+        auth_headers: { "Authorization" => "Bearer FRESH" }
+      )
+
+      assert_equal("Bearer PER_REQUEST", request["Authorization"])
+    end
+
+    it "defaults auth headers to empty, leaving the default headers unchanged" do
+      request = client.build_http_request(url: URI.parse("https://example.com"), method: "GET")
+
+      assert_equal("Bearer STATIC", request["Authorization"])
+    end
+  end
 end

--- a/seed/ruby-sdk-v2/basic-auth-environment-variables/lib/seed/internal/http/raw_client.rb
+++ b/seed/ruby-sdk-v2/basic-auth-environment-variables/lib/seed/internal/http/raw_client.rb
@@ -21,10 +21,14 @@ module Seed
         # @param max_retries [Integer] The number of times to retry a failed request, defaults to 2.
         # @param timeout [Float] The timeout for the request, defaults to 60.0 seconds.
         # @param headers [Hash] The headers for the request.
-        def initialize(base_url:, max_retries: 2, timeout: 60.0, headers: {})
+        # @param auth_provider [Object, nil] An optional auth provider responding to
+        #   `auth_headers`. When present its headers are resolved on every request so
+        #   token-based schemes (e.g. OAuth) can refresh an expired token mid-session.
+        def initialize(base_url:, max_retries: 2, timeout: 60.0, headers: {}, auth_provider: nil)
           @base_url = base_url
           @max_retries = max_retries
           @timeout = timeout
+          @auth_provider = auth_provider
           @default_headers = {
             "X-Fern-Language": "Ruby",
             "X-Fern-SDK-Name": "seed",
@@ -36,6 +40,9 @@ module Seed
         # @return [HTTP::Response] The HTTP response.
         def send(request)
           url = build_url(request)
+          # Resolve auth headers once per request (not per retry) so token-based
+          # providers refresh at most once here; static providers are cheap.
+          auth_headers = resolve_auth_headers
           attempt = 0
           response = nil
 
@@ -43,8 +50,9 @@ module Seed
             http_request = build_http_request(
               url:,
               method: request.method,
-              headers: request.encode_headers(protected_keys: @default_headers.keys),
-              body: request.encode_body
+              headers: request.encode_headers(protected_keys: @default_headers.keys + auth_headers.keys),
+              body: request.encode_body,
+              auth_headers: auth_headers
             )
 
             conn = connect(url)
@@ -157,12 +165,27 @@ module Seed
                 "HTTP is only allowed for localhost. Use HTTPS or pass a localhost URL."
         end
 
+        # Resolves the auth headers to send with the next request. Delegates to the
+        # configured auth provider (if any) on every call so that token-based
+        # providers (e.g. OAuth client-credentials) can refresh an expired token
+        # before the request is sent. Returns an empty hash when no provider is set,
+        # which keeps the api-key / basic / bearer / no-auth paths unchanged.
+        # @return [Hash] The auth headers for the current request.
+        def resolve_auth_headers
+          return {} if @auth_provider.nil?
+
+          @auth_provider.auth_headers
+        end
+
         # @param url [URI::Generic] The url to the resource.
         # @param method [String] The HTTP method to use.
         # @param headers [Hash] The headers for the request.
         # @param body [String, nil] The body for the request.
+        # @param auth_headers [Hash] The auth headers resolved for this request. These
+        #   take precedence over the static default headers but not over per-request
+        #   headers, mirroring the previous baked-header precedence.
         # @return [HTTP::Request] The HTTP request.
-        def build_http_request(url:, method:, headers: {}, body: nil)
+        def build_http_request(url:, method:, headers: {}, body: nil, auth_headers: {})
           request = Net::HTTPGenericRequest.new(
             method,
             !body.nil?,
@@ -170,7 +193,7 @@ module Seed
             url
           )
 
-          request_headers = @default_headers.merge(headers)
+          request_headers = @default_headers.merge(auth_headers).merge(headers)
           request_headers.each { |name, value| request[name] = value }
           request.body = body if body
 

--- a/seed/ruby-sdk-v2/basic-auth-environment-variables/test/unit/internal/http/test_raw_client.rb
+++ b/seed/ruby-sdk-v2/basic-auth-environment-variables/test/unit/internal/http/test_raw_client.rb
@@ -54,4 +54,71 @@ describe Seed::Internal::Http::RawClient do
       assert client.should_retry?(make_response(502), 2)
     end
   end
+
+  # A minimal auth provider whose `auth_headers` returns a *different* token on
+  # each call, simulating a token that is refreshed on expiry.
+  class RefreshingAuthProvider
+    def initialize
+      @count = 0
+    end
+
+    def auth_headers
+      @count += 1
+      { "Authorization" => "Bearer TOKEN_#{@count}" }
+    end
+  end
+
+  describe "#resolve_auth_headers" do
+    it "returns an empty hash when no auth provider is configured" do
+      client = Seed::Internal::Http::RawClient.new(base_url: "https://example.com")
+
+      assert_equal({}, client.resolve_auth_headers)
+    end
+
+    it "consults the auth provider on every call so an expired token is refreshed" do
+      client = Seed::Internal::Http::RawClient.new(
+        base_url: "https://example.com",
+        auth_provider: RefreshingAuthProvider.new
+      )
+
+      assert_equal({ "Authorization" => "Bearer TOKEN_1" }, client.resolve_auth_headers)
+      assert_equal({ "Authorization" => "Bearer TOKEN_2" }, client.resolve_auth_headers)
+    end
+  end
+
+  describe "#build_http_request auth header precedence" do
+    let(:client) do
+      Seed::Internal::Http::RawClient.new(
+        base_url: "https://example.com",
+        headers: { "Authorization" => "Bearer STATIC" }
+      )
+    end
+
+    it "lets resolved auth headers override the static default headers" do
+      request = client.build_http_request(
+        url: URI.parse("https://example.com"),
+        method: "GET",
+        auth_headers: { "Authorization" => "Bearer FRESH" }
+      )
+
+      assert_equal("Bearer FRESH", request["Authorization"])
+    end
+
+    it "lets per-request headers take precedence over auth headers" do
+      request = client.build_http_request(
+        url: URI.parse("https://example.com"),
+        method: "GET",
+        headers: { "Authorization" => "Bearer PER_REQUEST" },
+        auth_headers: { "Authorization" => "Bearer FRESH" }
+      )
+
+      assert_equal("Bearer PER_REQUEST", request["Authorization"])
+    end
+
+    it "defaults auth headers to empty, leaving the default headers unchanged" do
+      request = client.build_http_request(url: URI.parse("https://example.com"), method: "GET")
+
+      assert_equal("Bearer STATIC", request["Authorization"])
+    end
+  end
 end

--- a/seed/ruby-sdk-v2/basic-auth-pw-omitted/wire-tests/lib/seed/internal/http/raw_client.rb
+++ b/seed/ruby-sdk-v2/basic-auth-pw-omitted/wire-tests/lib/seed/internal/http/raw_client.rb
@@ -21,10 +21,14 @@ module Seed
         # @param max_retries [Integer] The number of times to retry a failed request, defaults to 2.
         # @param timeout [Float] The timeout for the request, defaults to 60.0 seconds.
         # @param headers [Hash] The headers for the request.
-        def initialize(base_url:, max_retries: 2, timeout: 60.0, headers: {})
+        # @param auth_provider [Object, nil] An optional auth provider responding to
+        #   `auth_headers`. When present its headers are resolved on every request so
+        #   token-based schemes (e.g. OAuth) can refresh an expired token mid-session.
+        def initialize(base_url:, max_retries: 2, timeout: 60.0, headers: {}, auth_provider: nil)
           @base_url = base_url
           @max_retries = max_retries
           @timeout = timeout
+          @auth_provider = auth_provider
           @default_headers = {
             "X-Fern-Language": "Ruby",
             "X-Fern-SDK-Name": "seed",
@@ -36,6 +40,9 @@ module Seed
         # @return [HTTP::Response] The HTTP response.
         def send(request)
           url = build_url(request)
+          # Resolve auth headers once per request (not per retry) so token-based
+          # providers refresh at most once here; static providers are cheap.
+          auth_headers = resolve_auth_headers
           attempt = 0
           response = nil
 
@@ -43,8 +50,9 @@ module Seed
             http_request = build_http_request(
               url:,
               method: request.method,
-              headers: request.encode_headers(protected_keys: @default_headers.keys),
-              body: request.encode_body
+              headers: request.encode_headers(protected_keys: @default_headers.keys + auth_headers.keys),
+              body: request.encode_body,
+              auth_headers: auth_headers
             )
 
             conn = connect(url)
@@ -157,12 +165,27 @@ module Seed
                 "HTTP is only allowed for localhost. Use HTTPS or pass a localhost URL."
         end
 
+        # Resolves the auth headers to send with the next request. Delegates to the
+        # configured auth provider (if any) on every call so that token-based
+        # providers (e.g. OAuth client-credentials) can refresh an expired token
+        # before the request is sent. Returns an empty hash when no provider is set,
+        # which keeps the api-key / basic / bearer / no-auth paths unchanged.
+        # @return [Hash] The auth headers for the current request.
+        def resolve_auth_headers
+          return {} if @auth_provider.nil?
+
+          @auth_provider.auth_headers
+        end
+
         # @param url [URI::Generic] The url to the resource.
         # @param method [String] The HTTP method to use.
         # @param headers [Hash] The headers for the request.
         # @param body [String, nil] The body for the request.
+        # @param auth_headers [Hash] The auth headers resolved for this request. These
+        #   take precedence over the static default headers but not over per-request
+        #   headers, mirroring the previous baked-header precedence.
         # @return [HTTP::Request] The HTTP request.
-        def build_http_request(url:, method:, headers: {}, body: nil)
+        def build_http_request(url:, method:, headers: {}, body: nil, auth_headers: {})
           request = Net::HTTPGenericRequest.new(
             method,
             !body.nil?,
@@ -170,7 +193,7 @@ module Seed
             url
           )
 
-          request_headers = @default_headers.merge(headers)
+          request_headers = @default_headers.merge(auth_headers).merge(headers)
           request_headers.each { |name, value| request[name] = value }
           request.body = body if body
 

--- a/seed/ruby-sdk-v2/basic-auth-pw-omitted/wire-tests/test/unit/internal/http/test_raw_client.rb
+++ b/seed/ruby-sdk-v2/basic-auth-pw-omitted/wire-tests/test/unit/internal/http/test_raw_client.rb
@@ -54,4 +54,71 @@ describe Seed::Internal::Http::RawClient do
       assert client.should_retry?(make_response(502), 2)
     end
   end
+
+  # A minimal auth provider whose `auth_headers` returns a *different* token on
+  # each call, simulating a token that is refreshed on expiry.
+  class RefreshingAuthProvider
+    def initialize
+      @count = 0
+    end
+
+    def auth_headers
+      @count += 1
+      { "Authorization" => "Bearer TOKEN_#{@count}" }
+    end
+  end
+
+  describe "#resolve_auth_headers" do
+    it "returns an empty hash when no auth provider is configured" do
+      client = Seed::Internal::Http::RawClient.new(base_url: "https://example.com")
+
+      assert_equal({}, client.resolve_auth_headers)
+    end
+
+    it "consults the auth provider on every call so an expired token is refreshed" do
+      client = Seed::Internal::Http::RawClient.new(
+        base_url: "https://example.com",
+        auth_provider: RefreshingAuthProvider.new
+      )
+
+      assert_equal({ "Authorization" => "Bearer TOKEN_1" }, client.resolve_auth_headers)
+      assert_equal({ "Authorization" => "Bearer TOKEN_2" }, client.resolve_auth_headers)
+    end
+  end
+
+  describe "#build_http_request auth header precedence" do
+    let(:client) do
+      Seed::Internal::Http::RawClient.new(
+        base_url: "https://example.com",
+        headers: { "Authorization" => "Bearer STATIC" }
+      )
+    end
+
+    it "lets resolved auth headers override the static default headers" do
+      request = client.build_http_request(
+        url: URI.parse("https://example.com"),
+        method: "GET",
+        auth_headers: { "Authorization" => "Bearer FRESH" }
+      )
+
+      assert_equal("Bearer FRESH", request["Authorization"])
+    end
+
+    it "lets per-request headers take precedence over auth headers" do
+      request = client.build_http_request(
+        url: URI.parse("https://example.com"),
+        method: "GET",
+        headers: { "Authorization" => "Bearer PER_REQUEST" },
+        auth_headers: { "Authorization" => "Bearer FRESH" }
+      )
+
+      assert_equal("Bearer PER_REQUEST", request["Authorization"])
+    end
+
+    it "defaults auth headers to empty, leaving the default headers unchanged" do
+      request = client.build_http_request(url: URI.parse("https://example.com"), method: "GET")
+
+      assert_equal("Bearer STATIC", request["Authorization"])
+    end
+  end
 end

--- a/seed/ruby-sdk-v2/basic-auth/wire-tests/lib/seed/internal/http/raw_client.rb
+++ b/seed/ruby-sdk-v2/basic-auth/wire-tests/lib/seed/internal/http/raw_client.rb
@@ -21,10 +21,14 @@ module Seed
         # @param max_retries [Integer] The number of times to retry a failed request, defaults to 2.
         # @param timeout [Float] The timeout for the request, defaults to 60.0 seconds.
         # @param headers [Hash] The headers for the request.
-        def initialize(base_url:, max_retries: 2, timeout: 60.0, headers: {})
+        # @param auth_provider [Object, nil] An optional auth provider responding to
+        #   `auth_headers`. When present its headers are resolved on every request so
+        #   token-based schemes (e.g. OAuth) can refresh an expired token mid-session.
+        def initialize(base_url:, max_retries: 2, timeout: 60.0, headers: {}, auth_provider: nil)
           @base_url = base_url
           @max_retries = max_retries
           @timeout = timeout
+          @auth_provider = auth_provider
           @default_headers = {
             "X-Fern-Language": "Ruby",
             "X-Fern-SDK-Name": "seed",
@@ -36,6 +40,9 @@ module Seed
         # @return [HTTP::Response] The HTTP response.
         def send(request)
           url = build_url(request)
+          # Resolve auth headers once per request (not per retry) so token-based
+          # providers refresh at most once here; static providers are cheap.
+          auth_headers = resolve_auth_headers
           attempt = 0
           response = nil
 
@@ -43,8 +50,9 @@ module Seed
             http_request = build_http_request(
               url:,
               method: request.method,
-              headers: request.encode_headers(protected_keys: @default_headers.keys),
-              body: request.encode_body
+              headers: request.encode_headers(protected_keys: @default_headers.keys + auth_headers.keys),
+              body: request.encode_body,
+              auth_headers: auth_headers
             )
 
             conn = connect(url)
@@ -157,12 +165,27 @@ module Seed
                 "HTTP is only allowed for localhost. Use HTTPS or pass a localhost URL."
         end
 
+        # Resolves the auth headers to send with the next request. Delegates to the
+        # configured auth provider (if any) on every call so that token-based
+        # providers (e.g. OAuth client-credentials) can refresh an expired token
+        # before the request is sent. Returns an empty hash when no provider is set,
+        # which keeps the api-key / basic / bearer / no-auth paths unchanged.
+        # @return [Hash] The auth headers for the current request.
+        def resolve_auth_headers
+          return {} if @auth_provider.nil?
+
+          @auth_provider.auth_headers
+        end
+
         # @param url [URI::Generic] The url to the resource.
         # @param method [String] The HTTP method to use.
         # @param headers [Hash] The headers for the request.
         # @param body [String, nil] The body for the request.
+        # @param auth_headers [Hash] The auth headers resolved for this request. These
+        #   take precedence over the static default headers but not over per-request
+        #   headers, mirroring the previous baked-header precedence.
         # @return [HTTP::Request] The HTTP request.
-        def build_http_request(url:, method:, headers: {}, body: nil)
+        def build_http_request(url:, method:, headers: {}, body: nil, auth_headers: {})
           request = Net::HTTPGenericRequest.new(
             method,
             !body.nil?,
@@ -170,7 +193,7 @@ module Seed
             url
           )
 
-          request_headers = @default_headers.merge(headers)
+          request_headers = @default_headers.merge(auth_headers).merge(headers)
           request_headers.each { |name, value| request[name] = value }
           request.body = body if body
 

--- a/seed/ruby-sdk-v2/basic-auth/wire-tests/test/unit/internal/http/test_raw_client.rb
+++ b/seed/ruby-sdk-v2/basic-auth/wire-tests/test/unit/internal/http/test_raw_client.rb
@@ -54,4 +54,71 @@ describe Seed::Internal::Http::RawClient do
       assert client.should_retry?(make_response(502), 2)
     end
   end
+
+  # A minimal auth provider whose `auth_headers` returns a *different* token on
+  # each call, simulating a token that is refreshed on expiry.
+  class RefreshingAuthProvider
+    def initialize
+      @count = 0
+    end
+
+    def auth_headers
+      @count += 1
+      { "Authorization" => "Bearer TOKEN_#{@count}" }
+    end
+  end
+
+  describe "#resolve_auth_headers" do
+    it "returns an empty hash when no auth provider is configured" do
+      client = Seed::Internal::Http::RawClient.new(base_url: "https://example.com")
+
+      assert_equal({}, client.resolve_auth_headers)
+    end
+
+    it "consults the auth provider on every call so an expired token is refreshed" do
+      client = Seed::Internal::Http::RawClient.new(
+        base_url: "https://example.com",
+        auth_provider: RefreshingAuthProvider.new
+      )
+
+      assert_equal({ "Authorization" => "Bearer TOKEN_1" }, client.resolve_auth_headers)
+      assert_equal({ "Authorization" => "Bearer TOKEN_2" }, client.resolve_auth_headers)
+    end
+  end
+
+  describe "#build_http_request auth header precedence" do
+    let(:client) do
+      Seed::Internal::Http::RawClient.new(
+        base_url: "https://example.com",
+        headers: { "Authorization" => "Bearer STATIC" }
+      )
+    end
+
+    it "lets resolved auth headers override the static default headers" do
+      request = client.build_http_request(
+        url: URI.parse("https://example.com"),
+        method: "GET",
+        auth_headers: { "Authorization" => "Bearer FRESH" }
+      )
+
+      assert_equal("Bearer FRESH", request["Authorization"])
+    end
+
+    it "lets per-request headers take precedence over auth headers" do
+      request = client.build_http_request(
+        url: URI.parse("https://example.com"),
+        method: "GET",
+        headers: { "Authorization" => "Bearer PER_REQUEST" },
+        auth_headers: { "Authorization" => "Bearer FRESH" }
+      )
+
+      assert_equal("Bearer PER_REQUEST", request["Authorization"])
+    end
+
+    it "defaults auth headers to empty, leaving the default headers unchanged" do
+      request = client.build_http_request(url: URI.parse("https://example.com"), method: "GET")
+
+      assert_equal("Bearer STATIC", request["Authorization"])
+    end
+  end
 end

--- a/seed/ruby-sdk-v2/bearer-token-environment-variable/lib/seed/internal/http/raw_client.rb
+++ b/seed/ruby-sdk-v2/bearer-token-environment-variable/lib/seed/internal/http/raw_client.rb
@@ -21,10 +21,14 @@ module Seed
         # @param max_retries [Integer] The number of times to retry a failed request, defaults to 2.
         # @param timeout [Float] The timeout for the request, defaults to 60.0 seconds.
         # @param headers [Hash] The headers for the request.
-        def initialize(base_url:, max_retries: 2, timeout: 60.0, headers: {})
+        # @param auth_provider [Object, nil] An optional auth provider responding to
+        #   `auth_headers`. When present its headers are resolved on every request so
+        #   token-based schemes (e.g. OAuth) can refresh an expired token mid-session.
+        def initialize(base_url:, max_retries: 2, timeout: 60.0, headers: {}, auth_provider: nil)
           @base_url = base_url
           @max_retries = max_retries
           @timeout = timeout
+          @auth_provider = auth_provider
           @default_headers = {
             "X-Fern-Language": "Ruby",
             "X-Fern-SDK-Name": "seed",
@@ -36,6 +40,9 @@ module Seed
         # @return [HTTP::Response] The HTTP response.
         def send(request)
           url = build_url(request)
+          # Resolve auth headers once per request (not per retry) so token-based
+          # providers refresh at most once here; static providers are cheap.
+          auth_headers = resolve_auth_headers
           attempt = 0
           response = nil
 
@@ -43,8 +50,9 @@ module Seed
             http_request = build_http_request(
               url:,
               method: request.method,
-              headers: request.encode_headers(protected_keys: @default_headers.keys),
-              body: request.encode_body
+              headers: request.encode_headers(protected_keys: @default_headers.keys + auth_headers.keys),
+              body: request.encode_body,
+              auth_headers: auth_headers
             )
 
             conn = connect(url)
@@ -157,12 +165,27 @@ module Seed
                 "HTTP is only allowed for localhost. Use HTTPS or pass a localhost URL."
         end
 
+        # Resolves the auth headers to send with the next request. Delegates to the
+        # configured auth provider (if any) on every call so that token-based
+        # providers (e.g. OAuth client-credentials) can refresh an expired token
+        # before the request is sent. Returns an empty hash when no provider is set,
+        # which keeps the api-key / basic / bearer / no-auth paths unchanged.
+        # @return [Hash] The auth headers for the current request.
+        def resolve_auth_headers
+          return {} if @auth_provider.nil?
+
+          @auth_provider.auth_headers
+        end
+
         # @param url [URI::Generic] The url to the resource.
         # @param method [String] The HTTP method to use.
         # @param headers [Hash] The headers for the request.
         # @param body [String, nil] The body for the request.
+        # @param auth_headers [Hash] The auth headers resolved for this request. These
+        #   take precedence over the static default headers but not over per-request
+        #   headers, mirroring the previous baked-header precedence.
         # @return [HTTP::Request] The HTTP request.
-        def build_http_request(url:, method:, headers: {}, body: nil)
+        def build_http_request(url:, method:, headers: {}, body: nil, auth_headers: {})
           request = Net::HTTPGenericRequest.new(
             method,
             !body.nil?,
@@ -170,7 +193,7 @@ module Seed
             url
           )
 
-          request_headers = @default_headers.merge(headers)
+          request_headers = @default_headers.merge(auth_headers).merge(headers)
           request_headers.each { |name, value| request[name] = value }
           request.body = body if body
 

--- a/seed/ruby-sdk-v2/bearer-token-environment-variable/test/unit/internal/http/test_raw_client.rb
+++ b/seed/ruby-sdk-v2/bearer-token-environment-variable/test/unit/internal/http/test_raw_client.rb
@@ -54,4 +54,71 @@ describe Seed::Internal::Http::RawClient do
       assert client.should_retry?(make_response(502), 2)
     end
   end
+
+  # A minimal auth provider whose `auth_headers` returns a *different* token on
+  # each call, simulating a token that is refreshed on expiry.
+  class RefreshingAuthProvider
+    def initialize
+      @count = 0
+    end
+
+    def auth_headers
+      @count += 1
+      { "Authorization" => "Bearer TOKEN_#{@count}" }
+    end
+  end
+
+  describe "#resolve_auth_headers" do
+    it "returns an empty hash when no auth provider is configured" do
+      client = Seed::Internal::Http::RawClient.new(base_url: "https://example.com")
+
+      assert_equal({}, client.resolve_auth_headers)
+    end
+
+    it "consults the auth provider on every call so an expired token is refreshed" do
+      client = Seed::Internal::Http::RawClient.new(
+        base_url: "https://example.com",
+        auth_provider: RefreshingAuthProvider.new
+      )
+
+      assert_equal({ "Authorization" => "Bearer TOKEN_1" }, client.resolve_auth_headers)
+      assert_equal({ "Authorization" => "Bearer TOKEN_2" }, client.resolve_auth_headers)
+    end
+  end
+
+  describe "#build_http_request auth header precedence" do
+    let(:client) do
+      Seed::Internal::Http::RawClient.new(
+        base_url: "https://example.com",
+        headers: { "Authorization" => "Bearer STATIC" }
+      )
+    end
+
+    it "lets resolved auth headers override the static default headers" do
+      request = client.build_http_request(
+        url: URI.parse("https://example.com"),
+        method: "GET",
+        auth_headers: { "Authorization" => "Bearer FRESH" }
+      )
+
+      assert_equal("Bearer FRESH", request["Authorization"])
+    end
+
+    it "lets per-request headers take precedence over auth headers" do
+      request = client.build_http_request(
+        url: URI.parse("https://example.com"),
+        method: "GET",
+        headers: { "Authorization" => "Bearer PER_REQUEST" },
+        auth_headers: { "Authorization" => "Bearer FRESH" }
+      )
+
+      assert_equal("Bearer PER_REQUEST", request["Authorization"])
+    end
+
+    it "defaults auth headers to empty, leaving the default headers unchanged" do
+      request = client.build_http_request(url: URI.parse("https://example.com"), method: "GET")
+
+      assert_equal("Bearer STATIC", request["Authorization"])
+    end
+  end
 end

--- a/seed/ruby-sdk-v2/bytes-download/lib/seed/internal/http/raw_client.rb
+++ b/seed/ruby-sdk-v2/bytes-download/lib/seed/internal/http/raw_client.rb
@@ -21,10 +21,14 @@ module Seed
         # @param max_retries [Integer] The number of times to retry a failed request, defaults to 2.
         # @param timeout [Float] The timeout for the request, defaults to 60.0 seconds.
         # @param headers [Hash] The headers for the request.
-        def initialize(base_url:, max_retries: 2, timeout: 60.0, headers: {})
+        # @param auth_provider [Object, nil] An optional auth provider responding to
+        #   `auth_headers`. When present its headers are resolved on every request so
+        #   token-based schemes (e.g. OAuth) can refresh an expired token mid-session.
+        def initialize(base_url:, max_retries: 2, timeout: 60.0, headers: {}, auth_provider: nil)
           @base_url = base_url
           @max_retries = max_retries
           @timeout = timeout
+          @auth_provider = auth_provider
           @default_headers = {
             "X-Fern-Language": "Ruby",
             "X-Fern-SDK-Name": "seed",
@@ -36,6 +40,9 @@ module Seed
         # @return [HTTP::Response] The HTTP response.
         def send(request)
           url = build_url(request)
+          # Resolve auth headers once per request (not per retry) so token-based
+          # providers refresh at most once here; static providers are cheap.
+          auth_headers = resolve_auth_headers
           attempt = 0
           response = nil
 
@@ -43,8 +50,9 @@ module Seed
             http_request = build_http_request(
               url:,
               method: request.method,
-              headers: request.encode_headers(protected_keys: @default_headers.keys),
-              body: request.encode_body
+              headers: request.encode_headers(protected_keys: @default_headers.keys + auth_headers.keys),
+              body: request.encode_body,
+              auth_headers: auth_headers
             )
 
             conn = connect(url)
@@ -157,12 +165,27 @@ module Seed
                 "HTTP is only allowed for localhost. Use HTTPS or pass a localhost URL."
         end
 
+        # Resolves the auth headers to send with the next request. Delegates to the
+        # configured auth provider (if any) on every call so that token-based
+        # providers (e.g. OAuth client-credentials) can refresh an expired token
+        # before the request is sent. Returns an empty hash when no provider is set,
+        # which keeps the api-key / basic / bearer / no-auth paths unchanged.
+        # @return [Hash] The auth headers for the current request.
+        def resolve_auth_headers
+          return {} if @auth_provider.nil?
+
+          @auth_provider.auth_headers
+        end
+
         # @param url [URI::Generic] The url to the resource.
         # @param method [String] The HTTP method to use.
         # @param headers [Hash] The headers for the request.
         # @param body [String, nil] The body for the request.
+        # @param auth_headers [Hash] The auth headers resolved for this request. These
+        #   take precedence over the static default headers but not over per-request
+        #   headers, mirroring the previous baked-header precedence.
         # @return [HTTP::Request] The HTTP request.
-        def build_http_request(url:, method:, headers: {}, body: nil)
+        def build_http_request(url:, method:, headers: {}, body: nil, auth_headers: {})
           request = Net::HTTPGenericRequest.new(
             method,
             !body.nil?,
@@ -170,7 +193,7 @@ module Seed
             url
           )
 
-          request_headers = @default_headers.merge(headers)
+          request_headers = @default_headers.merge(auth_headers).merge(headers)
           request_headers.each { |name, value| request[name] = value }
           request.body = body if body
 

--- a/seed/ruby-sdk-v2/bytes-download/test/unit/internal/http/test_raw_client.rb
+++ b/seed/ruby-sdk-v2/bytes-download/test/unit/internal/http/test_raw_client.rb
@@ -54,4 +54,71 @@ describe Seed::Internal::Http::RawClient do
       assert client.should_retry?(make_response(502), 2)
     end
   end
+
+  # A minimal auth provider whose `auth_headers` returns a *different* token on
+  # each call, simulating a token that is refreshed on expiry.
+  class RefreshingAuthProvider
+    def initialize
+      @count = 0
+    end
+
+    def auth_headers
+      @count += 1
+      { "Authorization" => "Bearer TOKEN_#{@count}" }
+    end
+  end
+
+  describe "#resolve_auth_headers" do
+    it "returns an empty hash when no auth provider is configured" do
+      client = Seed::Internal::Http::RawClient.new(base_url: "https://example.com")
+
+      assert_equal({}, client.resolve_auth_headers)
+    end
+
+    it "consults the auth provider on every call so an expired token is refreshed" do
+      client = Seed::Internal::Http::RawClient.new(
+        base_url: "https://example.com",
+        auth_provider: RefreshingAuthProvider.new
+      )
+
+      assert_equal({ "Authorization" => "Bearer TOKEN_1" }, client.resolve_auth_headers)
+      assert_equal({ "Authorization" => "Bearer TOKEN_2" }, client.resolve_auth_headers)
+    end
+  end
+
+  describe "#build_http_request auth header precedence" do
+    let(:client) do
+      Seed::Internal::Http::RawClient.new(
+        base_url: "https://example.com",
+        headers: { "Authorization" => "Bearer STATIC" }
+      )
+    end
+
+    it "lets resolved auth headers override the static default headers" do
+      request = client.build_http_request(
+        url: URI.parse("https://example.com"),
+        method: "GET",
+        auth_headers: { "Authorization" => "Bearer FRESH" }
+      )
+
+      assert_equal("Bearer FRESH", request["Authorization"])
+    end
+
+    it "lets per-request headers take precedence over auth headers" do
+      request = client.build_http_request(
+        url: URI.parse("https://example.com"),
+        method: "GET",
+        headers: { "Authorization" => "Bearer PER_REQUEST" },
+        auth_headers: { "Authorization" => "Bearer FRESH" }
+      )
+
+      assert_equal("Bearer PER_REQUEST", request["Authorization"])
+    end
+
+    it "defaults auth headers to empty, leaving the default headers unchanged" do
+      request = client.build_http_request(url: URI.parse("https://example.com"), method: "GET")
+
+      assert_equal("Bearer STATIC", request["Authorization"])
+    end
+  end
 end

--- a/seed/ruby-sdk-v2/bytes-upload/lib/seed/internal/http/raw_client.rb
+++ b/seed/ruby-sdk-v2/bytes-upload/lib/seed/internal/http/raw_client.rb
@@ -21,10 +21,14 @@ module Seed
         # @param max_retries [Integer] The number of times to retry a failed request, defaults to 2.
         # @param timeout [Float] The timeout for the request, defaults to 60.0 seconds.
         # @param headers [Hash] The headers for the request.
-        def initialize(base_url:, max_retries: 2, timeout: 60.0, headers: {})
+        # @param auth_provider [Object, nil] An optional auth provider responding to
+        #   `auth_headers`. When present its headers are resolved on every request so
+        #   token-based schemes (e.g. OAuth) can refresh an expired token mid-session.
+        def initialize(base_url:, max_retries: 2, timeout: 60.0, headers: {}, auth_provider: nil)
           @base_url = base_url
           @max_retries = max_retries
           @timeout = timeout
+          @auth_provider = auth_provider
           @default_headers = {
             "X-Fern-Language": "Ruby",
             "X-Fern-SDK-Name": "seed",
@@ -36,6 +40,9 @@ module Seed
         # @return [HTTP::Response] The HTTP response.
         def send(request)
           url = build_url(request)
+          # Resolve auth headers once per request (not per retry) so token-based
+          # providers refresh at most once here; static providers are cheap.
+          auth_headers = resolve_auth_headers
           attempt = 0
           response = nil
 
@@ -43,8 +50,9 @@ module Seed
             http_request = build_http_request(
               url:,
               method: request.method,
-              headers: request.encode_headers(protected_keys: @default_headers.keys),
-              body: request.encode_body
+              headers: request.encode_headers(protected_keys: @default_headers.keys + auth_headers.keys),
+              body: request.encode_body,
+              auth_headers: auth_headers
             )
 
             conn = connect(url)
@@ -157,12 +165,27 @@ module Seed
                 "HTTP is only allowed for localhost. Use HTTPS or pass a localhost URL."
         end
 
+        # Resolves the auth headers to send with the next request. Delegates to the
+        # configured auth provider (if any) on every call so that token-based
+        # providers (e.g. OAuth client-credentials) can refresh an expired token
+        # before the request is sent. Returns an empty hash when no provider is set,
+        # which keeps the api-key / basic / bearer / no-auth paths unchanged.
+        # @return [Hash] The auth headers for the current request.
+        def resolve_auth_headers
+          return {} if @auth_provider.nil?
+
+          @auth_provider.auth_headers
+        end
+
         # @param url [URI::Generic] The url to the resource.
         # @param method [String] The HTTP method to use.
         # @param headers [Hash] The headers for the request.
         # @param body [String, nil] The body for the request.
+        # @param auth_headers [Hash] The auth headers resolved for this request. These
+        #   take precedence over the static default headers but not over per-request
+        #   headers, mirroring the previous baked-header precedence.
         # @return [HTTP::Request] The HTTP request.
-        def build_http_request(url:, method:, headers: {}, body: nil)
+        def build_http_request(url:, method:, headers: {}, body: nil, auth_headers: {})
           request = Net::HTTPGenericRequest.new(
             method,
             !body.nil?,
@@ -170,7 +193,7 @@ module Seed
             url
           )
 
-          request_headers = @default_headers.merge(headers)
+          request_headers = @default_headers.merge(auth_headers).merge(headers)
           request_headers.each { |name, value| request[name] = value }
           request.body = body if body
 

--- a/seed/ruby-sdk-v2/bytes-upload/test/unit/internal/http/test_raw_client.rb
+++ b/seed/ruby-sdk-v2/bytes-upload/test/unit/internal/http/test_raw_client.rb
@@ -54,4 +54,71 @@ describe Seed::Internal::Http::RawClient do
       assert client.should_retry?(make_response(502), 2)
     end
   end
+
+  # A minimal auth provider whose `auth_headers` returns a *different* token on
+  # each call, simulating a token that is refreshed on expiry.
+  class RefreshingAuthProvider
+    def initialize
+      @count = 0
+    end
+
+    def auth_headers
+      @count += 1
+      { "Authorization" => "Bearer TOKEN_#{@count}" }
+    end
+  end
+
+  describe "#resolve_auth_headers" do
+    it "returns an empty hash when no auth provider is configured" do
+      client = Seed::Internal::Http::RawClient.new(base_url: "https://example.com")
+
+      assert_equal({}, client.resolve_auth_headers)
+    end
+
+    it "consults the auth provider on every call so an expired token is refreshed" do
+      client = Seed::Internal::Http::RawClient.new(
+        base_url: "https://example.com",
+        auth_provider: RefreshingAuthProvider.new
+      )
+
+      assert_equal({ "Authorization" => "Bearer TOKEN_1" }, client.resolve_auth_headers)
+      assert_equal({ "Authorization" => "Bearer TOKEN_2" }, client.resolve_auth_headers)
+    end
+  end
+
+  describe "#build_http_request auth header precedence" do
+    let(:client) do
+      Seed::Internal::Http::RawClient.new(
+        base_url: "https://example.com",
+        headers: { "Authorization" => "Bearer STATIC" }
+      )
+    end
+
+    it "lets resolved auth headers override the static default headers" do
+      request = client.build_http_request(
+        url: URI.parse("https://example.com"),
+        method: "GET",
+        auth_headers: { "Authorization" => "Bearer FRESH" }
+      )
+
+      assert_equal("Bearer FRESH", request["Authorization"])
+    end
+
+    it "lets per-request headers take precedence over auth headers" do
+      request = client.build_http_request(
+        url: URI.parse("https://example.com"),
+        method: "GET",
+        headers: { "Authorization" => "Bearer PER_REQUEST" },
+        auth_headers: { "Authorization" => "Bearer FRESH" }
+      )
+
+      assert_equal("Bearer PER_REQUEST", request["Authorization"])
+    end
+
+    it "defaults auth headers to empty, leaving the default headers unchanged" do
+      request = client.build_http_request(url: URI.parse("https://example.com"), method: "GET")
+
+      assert_equal("Bearer STATIC", request["Authorization"])
+    end
+  end
 end

--- a/seed/ruby-sdk-v2/circular-references-advanced/lib/seed/internal/http/raw_client.rb
+++ b/seed/ruby-sdk-v2/circular-references-advanced/lib/seed/internal/http/raw_client.rb
@@ -21,10 +21,14 @@ module Seed
         # @param max_retries [Integer] The number of times to retry a failed request, defaults to 2.
         # @param timeout [Float] The timeout for the request, defaults to 60.0 seconds.
         # @param headers [Hash] The headers for the request.
-        def initialize(base_url:, max_retries: 2, timeout: 60.0, headers: {})
+        # @param auth_provider [Object, nil] An optional auth provider responding to
+        #   `auth_headers`. When present its headers are resolved on every request so
+        #   token-based schemes (e.g. OAuth) can refresh an expired token mid-session.
+        def initialize(base_url:, max_retries: 2, timeout: 60.0, headers: {}, auth_provider: nil)
           @base_url = base_url
           @max_retries = max_retries
           @timeout = timeout
+          @auth_provider = auth_provider
           @default_headers = {
             "X-Fern-Language": "Ruby",
             "X-Fern-SDK-Name": "seed",
@@ -36,6 +40,9 @@ module Seed
         # @return [HTTP::Response] The HTTP response.
         def send(request)
           url = build_url(request)
+          # Resolve auth headers once per request (not per retry) so token-based
+          # providers refresh at most once here; static providers are cheap.
+          auth_headers = resolve_auth_headers
           attempt = 0
           response = nil
 
@@ -43,8 +50,9 @@ module Seed
             http_request = build_http_request(
               url:,
               method: request.method,
-              headers: request.encode_headers(protected_keys: @default_headers.keys),
-              body: request.encode_body
+              headers: request.encode_headers(protected_keys: @default_headers.keys + auth_headers.keys),
+              body: request.encode_body,
+              auth_headers: auth_headers
             )
 
             conn = connect(url)
@@ -157,12 +165,27 @@ module Seed
                 "HTTP is only allowed for localhost. Use HTTPS or pass a localhost URL."
         end
 
+        # Resolves the auth headers to send with the next request. Delegates to the
+        # configured auth provider (if any) on every call so that token-based
+        # providers (e.g. OAuth client-credentials) can refresh an expired token
+        # before the request is sent. Returns an empty hash when no provider is set,
+        # which keeps the api-key / basic / bearer / no-auth paths unchanged.
+        # @return [Hash] The auth headers for the current request.
+        def resolve_auth_headers
+          return {} if @auth_provider.nil?
+
+          @auth_provider.auth_headers
+        end
+
         # @param url [URI::Generic] The url to the resource.
         # @param method [String] The HTTP method to use.
         # @param headers [Hash] The headers for the request.
         # @param body [String, nil] The body for the request.
+        # @param auth_headers [Hash] The auth headers resolved for this request. These
+        #   take precedence over the static default headers but not over per-request
+        #   headers, mirroring the previous baked-header precedence.
         # @return [HTTP::Request] The HTTP request.
-        def build_http_request(url:, method:, headers: {}, body: nil)
+        def build_http_request(url:, method:, headers: {}, body: nil, auth_headers: {})
           request = Net::HTTPGenericRequest.new(
             method,
             !body.nil?,
@@ -170,7 +193,7 @@ module Seed
             url
           )
 
-          request_headers = @default_headers.merge(headers)
+          request_headers = @default_headers.merge(auth_headers).merge(headers)
           request_headers.each { |name, value| request[name] = value }
           request.body = body if body
 

--- a/seed/ruby-sdk-v2/circular-references-advanced/test/unit/internal/http/test_raw_client.rb
+++ b/seed/ruby-sdk-v2/circular-references-advanced/test/unit/internal/http/test_raw_client.rb
@@ -54,4 +54,71 @@ describe Seed::Internal::Http::RawClient do
       assert client.should_retry?(make_response(502), 2)
     end
   end
+
+  # A minimal auth provider whose `auth_headers` returns a *different* token on
+  # each call, simulating a token that is refreshed on expiry.
+  class RefreshingAuthProvider
+    def initialize
+      @count = 0
+    end
+
+    def auth_headers
+      @count += 1
+      { "Authorization" => "Bearer TOKEN_#{@count}" }
+    end
+  end
+
+  describe "#resolve_auth_headers" do
+    it "returns an empty hash when no auth provider is configured" do
+      client = Seed::Internal::Http::RawClient.new(base_url: "https://example.com")
+
+      assert_equal({}, client.resolve_auth_headers)
+    end
+
+    it "consults the auth provider on every call so an expired token is refreshed" do
+      client = Seed::Internal::Http::RawClient.new(
+        base_url: "https://example.com",
+        auth_provider: RefreshingAuthProvider.new
+      )
+
+      assert_equal({ "Authorization" => "Bearer TOKEN_1" }, client.resolve_auth_headers)
+      assert_equal({ "Authorization" => "Bearer TOKEN_2" }, client.resolve_auth_headers)
+    end
+  end
+
+  describe "#build_http_request auth header precedence" do
+    let(:client) do
+      Seed::Internal::Http::RawClient.new(
+        base_url: "https://example.com",
+        headers: { "Authorization" => "Bearer STATIC" }
+      )
+    end
+
+    it "lets resolved auth headers override the static default headers" do
+      request = client.build_http_request(
+        url: URI.parse("https://example.com"),
+        method: "GET",
+        auth_headers: { "Authorization" => "Bearer FRESH" }
+      )
+
+      assert_equal("Bearer FRESH", request["Authorization"])
+    end
+
+    it "lets per-request headers take precedence over auth headers" do
+      request = client.build_http_request(
+        url: URI.parse("https://example.com"),
+        method: "GET",
+        headers: { "Authorization" => "Bearer PER_REQUEST" },
+        auth_headers: { "Authorization" => "Bearer FRESH" }
+      )
+
+      assert_equal("Bearer PER_REQUEST", request["Authorization"])
+    end
+
+    it "defaults auth headers to empty, leaving the default headers unchanged" do
+      request = client.build_http_request(url: URI.parse("https://example.com"), method: "GET")
+
+      assert_equal("Bearer STATIC", request["Authorization"])
+    end
+  end
 end

--- a/seed/ruby-sdk-v2/circular-references-extends/lib/seed/internal/http/raw_client.rb
+++ b/seed/ruby-sdk-v2/circular-references-extends/lib/seed/internal/http/raw_client.rb
@@ -21,10 +21,14 @@ module Seed
         # @param max_retries [Integer] The number of times to retry a failed request, defaults to 2.
         # @param timeout [Float] The timeout for the request, defaults to 60.0 seconds.
         # @param headers [Hash] The headers for the request.
-        def initialize(base_url:, max_retries: 2, timeout: 60.0, headers: {})
+        # @param auth_provider [Object, nil] An optional auth provider responding to
+        #   `auth_headers`. When present its headers are resolved on every request so
+        #   token-based schemes (e.g. OAuth) can refresh an expired token mid-session.
+        def initialize(base_url:, max_retries: 2, timeout: 60.0, headers: {}, auth_provider: nil)
           @base_url = base_url
           @max_retries = max_retries
           @timeout = timeout
+          @auth_provider = auth_provider
           @default_headers = {
             "X-Fern-Language": "Ruby",
             "X-Fern-SDK-Name": "seed",
@@ -36,6 +40,9 @@ module Seed
         # @return [HTTP::Response] The HTTP response.
         def send(request)
           url = build_url(request)
+          # Resolve auth headers once per request (not per retry) so token-based
+          # providers refresh at most once here; static providers are cheap.
+          auth_headers = resolve_auth_headers
           attempt = 0
           response = nil
 
@@ -43,8 +50,9 @@ module Seed
             http_request = build_http_request(
               url:,
               method: request.method,
-              headers: request.encode_headers(protected_keys: @default_headers.keys),
-              body: request.encode_body
+              headers: request.encode_headers(protected_keys: @default_headers.keys + auth_headers.keys),
+              body: request.encode_body,
+              auth_headers: auth_headers
             )
 
             conn = connect(url)
@@ -157,12 +165,27 @@ module Seed
                 "HTTP is only allowed for localhost. Use HTTPS or pass a localhost URL."
         end
 
+        # Resolves the auth headers to send with the next request. Delegates to the
+        # configured auth provider (if any) on every call so that token-based
+        # providers (e.g. OAuth client-credentials) can refresh an expired token
+        # before the request is sent. Returns an empty hash when no provider is set,
+        # which keeps the api-key / basic / bearer / no-auth paths unchanged.
+        # @return [Hash] The auth headers for the current request.
+        def resolve_auth_headers
+          return {} if @auth_provider.nil?
+
+          @auth_provider.auth_headers
+        end
+
         # @param url [URI::Generic] The url to the resource.
         # @param method [String] The HTTP method to use.
         # @param headers [Hash] The headers for the request.
         # @param body [String, nil] The body for the request.
+        # @param auth_headers [Hash] The auth headers resolved for this request. These
+        #   take precedence over the static default headers but not over per-request
+        #   headers, mirroring the previous baked-header precedence.
         # @return [HTTP::Request] The HTTP request.
-        def build_http_request(url:, method:, headers: {}, body: nil)
+        def build_http_request(url:, method:, headers: {}, body: nil, auth_headers: {})
           request = Net::HTTPGenericRequest.new(
             method,
             !body.nil?,
@@ -170,7 +193,7 @@ module Seed
             url
           )
 
-          request_headers = @default_headers.merge(headers)
+          request_headers = @default_headers.merge(auth_headers).merge(headers)
           request_headers.each { |name, value| request[name] = value }
           request.body = body if body
 

--- a/seed/ruby-sdk-v2/circular-references-extends/test/unit/internal/http/test_raw_client.rb
+++ b/seed/ruby-sdk-v2/circular-references-extends/test/unit/internal/http/test_raw_client.rb
@@ -54,4 +54,71 @@ describe Seed::Internal::Http::RawClient do
       assert client.should_retry?(make_response(502), 2)
     end
   end
+
+  # A minimal auth provider whose `auth_headers` returns a *different* token on
+  # each call, simulating a token that is refreshed on expiry.
+  class RefreshingAuthProvider
+    def initialize
+      @count = 0
+    end
+
+    def auth_headers
+      @count += 1
+      { "Authorization" => "Bearer TOKEN_#{@count}" }
+    end
+  end
+
+  describe "#resolve_auth_headers" do
+    it "returns an empty hash when no auth provider is configured" do
+      client = Seed::Internal::Http::RawClient.new(base_url: "https://example.com")
+
+      assert_equal({}, client.resolve_auth_headers)
+    end
+
+    it "consults the auth provider on every call so an expired token is refreshed" do
+      client = Seed::Internal::Http::RawClient.new(
+        base_url: "https://example.com",
+        auth_provider: RefreshingAuthProvider.new
+      )
+
+      assert_equal({ "Authorization" => "Bearer TOKEN_1" }, client.resolve_auth_headers)
+      assert_equal({ "Authorization" => "Bearer TOKEN_2" }, client.resolve_auth_headers)
+    end
+  end
+
+  describe "#build_http_request auth header precedence" do
+    let(:client) do
+      Seed::Internal::Http::RawClient.new(
+        base_url: "https://example.com",
+        headers: { "Authorization" => "Bearer STATIC" }
+      )
+    end
+
+    it "lets resolved auth headers override the static default headers" do
+      request = client.build_http_request(
+        url: URI.parse("https://example.com"),
+        method: "GET",
+        auth_headers: { "Authorization" => "Bearer FRESH" }
+      )
+
+      assert_equal("Bearer FRESH", request["Authorization"])
+    end
+
+    it "lets per-request headers take precedence over auth headers" do
+      request = client.build_http_request(
+        url: URI.parse("https://example.com"),
+        method: "GET",
+        headers: { "Authorization" => "Bearer PER_REQUEST" },
+        auth_headers: { "Authorization" => "Bearer FRESH" }
+      )
+
+      assert_equal("Bearer PER_REQUEST", request["Authorization"])
+    end
+
+    it "defaults auth headers to empty, leaving the default headers unchanged" do
+      request = client.build_http_request(url: URI.parse("https://example.com"), method: "GET")
+
+      assert_equal("Bearer STATIC", request["Authorization"])
+    end
+  end
 end

--- a/seed/ruby-sdk-v2/circular-references/lib/seed/internal/http/raw_client.rb
+++ b/seed/ruby-sdk-v2/circular-references/lib/seed/internal/http/raw_client.rb
@@ -21,10 +21,14 @@ module Seed
         # @param max_retries [Integer] The number of times to retry a failed request, defaults to 2.
         # @param timeout [Float] The timeout for the request, defaults to 60.0 seconds.
         # @param headers [Hash] The headers for the request.
-        def initialize(base_url:, max_retries: 2, timeout: 60.0, headers: {})
+        # @param auth_provider [Object, nil] An optional auth provider responding to
+        #   `auth_headers`. When present its headers are resolved on every request so
+        #   token-based schemes (e.g. OAuth) can refresh an expired token mid-session.
+        def initialize(base_url:, max_retries: 2, timeout: 60.0, headers: {}, auth_provider: nil)
           @base_url = base_url
           @max_retries = max_retries
           @timeout = timeout
+          @auth_provider = auth_provider
           @default_headers = {
             "X-Fern-Language": "Ruby",
             "X-Fern-SDK-Name": "seed",
@@ -36,6 +40,9 @@ module Seed
         # @return [HTTP::Response] The HTTP response.
         def send(request)
           url = build_url(request)
+          # Resolve auth headers once per request (not per retry) so token-based
+          # providers refresh at most once here; static providers are cheap.
+          auth_headers = resolve_auth_headers
           attempt = 0
           response = nil
 
@@ -43,8 +50,9 @@ module Seed
             http_request = build_http_request(
               url:,
               method: request.method,
-              headers: request.encode_headers(protected_keys: @default_headers.keys),
-              body: request.encode_body
+              headers: request.encode_headers(protected_keys: @default_headers.keys + auth_headers.keys),
+              body: request.encode_body,
+              auth_headers: auth_headers
             )
 
             conn = connect(url)
@@ -157,12 +165,27 @@ module Seed
                 "HTTP is only allowed for localhost. Use HTTPS or pass a localhost URL."
         end
 
+        # Resolves the auth headers to send with the next request. Delegates to the
+        # configured auth provider (if any) on every call so that token-based
+        # providers (e.g. OAuth client-credentials) can refresh an expired token
+        # before the request is sent. Returns an empty hash when no provider is set,
+        # which keeps the api-key / basic / bearer / no-auth paths unchanged.
+        # @return [Hash] The auth headers for the current request.
+        def resolve_auth_headers
+          return {} if @auth_provider.nil?
+
+          @auth_provider.auth_headers
+        end
+
         # @param url [URI::Generic] The url to the resource.
         # @param method [String] The HTTP method to use.
         # @param headers [Hash] The headers for the request.
         # @param body [String, nil] The body for the request.
+        # @param auth_headers [Hash] The auth headers resolved for this request. These
+        #   take precedence over the static default headers but not over per-request
+        #   headers, mirroring the previous baked-header precedence.
         # @return [HTTP::Request] The HTTP request.
-        def build_http_request(url:, method:, headers: {}, body: nil)
+        def build_http_request(url:, method:, headers: {}, body: nil, auth_headers: {})
           request = Net::HTTPGenericRequest.new(
             method,
             !body.nil?,
@@ -170,7 +193,7 @@ module Seed
             url
           )
 
-          request_headers = @default_headers.merge(headers)
+          request_headers = @default_headers.merge(auth_headers).merge(headers)
           request_headers.each { |name, value| request[name] = value }
           request.body = body if body
 

--- a/seed/ruby-sdk-v2/circular-references/test/unit/internal/http/test_raw_client.rb
+++ b/seed/ruby-sdk-v2/circular-references/test/unit/internal/http/test_raw_client.rb
@@ -54,4 +54,71 @@ describe Seed::Internal::Http::RawClient do
       assert client.should_retry?(make_response(502), 2)
     end
   end
+
+  # A minimal auth provider whose `auth_headers` returns a *different* token on
+  # each call, simulating a token that is refreshed on expiry.
+  class RefreshingAuthProvider
+    def initialize
+      @count = 0
+    end
+
+    def auth_headers
+      @count += 1
+      { "Authorization" => "Bearer TOKEN_#{@count}" }
+    end
+  end
+
+  describe "#resolve_auth_headers" do
+    it "returns an empty hash when no auth provider is configured" do
+      client = Seed::Internal::Http::RawClient.new(base_url: "https://example.com")
+
+      assert_equal({}, client.resolve_auth_headers)
+    end
+
+    it "consults the auth provider on every call so an expired token is refreshed" do
+      client = Seed::Internal::Http::RawClient.new(
+        base_url: "https://example.com",
+        auth_provider: RefreshingAuthProvider.new
+      )
+
+      assert_equal({ "Authorization" => "Bearer TOKEN_1" }, client.resolve_auth_headers)
+      assert_equal({ "Authorization" => "Bearer TOKEN_2" }, client.resolve_auth_headers)
+    end
+  end
+
+  describe "#build_http_request auth header precedence" do
+    let(:client) do
+      Seed::Internal::Http::RawClient.new(
+        base_url: "https://example.com",
+        headers: { "Authorization" => "Bearer STATIC" }
+      )
+    end
+
+    it "lets resolved auth headers override the static default headers" do
+      request = client.build_http_request(
+        url: URI.parse("https://example.com"),
+        method: "GET",
+        auth_headers: { "Authorization" => "Bearer FRESH" }
+      )
+
+      assert_equal("Bearer FRESH", request["Authorization"])
+    end
+
+    it "lets per-request headers take precedence over auth headers" do
+      request = client.build_http_request(
+        url: URI.parse("https://example.com"),
+        method: "GET",
+        headers: { "Authorization" => "Bearer PER_REQUEST" },
+        auth_headers: { "Authorization" => "Bearer FRESH" }
+      )
+
+      assert_equal("Bearer PER_REQUEST", request["Authorization"])
+    end
+
+    it "defaults auth headers to empty, leaving the default headers unchanged" do
+      request = client.build_http_request(url: URI.parse("https://example.com"), method: "GET")
+
+      assert_equal("Bearer STATIC", request["Authorization"])
+    end
+  end
 end

--- a/seed/ruby-sdk-v2/cli-multi-spec-namespaced/lib/seed/internal/http/raw_client.rb
+++ b/seed/ruby-sdk-v2/cli-multi-spec-namespaced/lib/seed/internal/http/raw_client.rb
@@ -21,10 +21,14 @@ module Seed
         # @param max_retries [Integer] The number of times to retry a failed request, defaults to 2.
         # @param timeout [Float] The timeout for the request, defaults to 60.0 seconds.
         # @param headers [Hash] The headers for the request.
-        def initialize(base_url:, max_retries: 2, timeout: 60.0, headers: {})
+        # @param auth_provider [Object, nil] An optional auth provider responding to
+        #   `auth_headers`. When present its headers are resolved on every request so
+        #   token-based schemes (e.g. OAuth) can refresh an expired token mid-session.
+        def initialize(base_url:, max_retries: 2, timeout: 60.0, headers: {}, auth_provider: nil)
           @base_url = base_url
           @max_retries = max_retries
           @timeout = timeout
+          @auth_provider = auth_provider
           @default_headers = {
             "X-Fern-Language": "Ruby",
             "X-Fern-SDK-Name": "seed",
@@ -36,6 +40,9 @@ module Seed
         # @return [HTTP::Response] The HTTP response.
         def send(request)
           url = build_url(request)
+          # Resolve auth headers once per request (not per retry) so token-based
+          # providers refresh at most once here; static providers are cheap.
+          auth_headers = resolve_auth_headers
           attempt = 0
           response = nil
 
@@ -43,8 +50,9 @@ module Seed
             http_request = build_http_request(
               url:,
               method: request.method,
-              headers: request.encode_headers(protected_keys: @default_headers.keys),
-              body: request.encode_body
+              headers: request.encode_headers(protected_keys: @default_headers.keys + auth_headers.keys),
+              body: request.encode_body,
+              auth_headers: auth_headers
             )
 
             conn = connect(url)
@@ -157,12 +165,27 @@ module Seed
                 "HTTP is only allowed for localhost. Use HTTPS or pass a localhost URL."
         end
 
+        # Resolves the auth headers to send with the next request. Delegates to the
+        # configured auth provider (if any) on every call so that token-based
+        # providers (e.g. OAuth client-credentials) can refresh an expired token
+        # before the request is sent. Returns an empty hash when no provider is set,
+        # which keeps the api-key / basic / bearer / no-auth paths unchanged.
+        # @return [Hash] The auth headers for the current request.
+        def resolve_auth_headers
+          return {} if @auth_provider.nil?
+
+          @auth_provider.auth_headers
+        end
+
         # @param url [URI::Generic] The url to the resource.
         # @param method [String] The HTTP method to use.
         # @param headers [Hash] The headers for the request.
         # @param body [String, nil] The body for the request.
+        # @param auth_headers [Hash] The auth headers resolved for this request. These
+        #   take precedence over the static default headers but not over per-request
+        #   headers, mirroring the previous baked-header precedence.
         # @return [HTTP::Request] The HTTP request.
-        def build_http_request(url:, method:, headers: {}, body: nil)
+        def build_http_request(url:, method:, headers: {}, body: nil, auth_headers: {})
           request = Net::HTTPGenericRequest.new(
             method,
             !body.nil?,
@@ -170,7 +193,7 @@ module Seed
             url
           )
 
-          request_headers = @default_headers.merge(headers)
+          request_headers = @default_headers.merge(auth_headers).merge(headers)
           request_headers.each { |name, value| request[name] = value }
           request.body = body if body
 

--- a/seed/ruby-sdk-v2/cli-multi-spec-namespaced/test/unit/internal/http/test_raw_client.rb
+++ b/seed/ruby-sdk-v2/cli-multi-spec-namespaced/test/unit/internal/http/test_raw_client.rb
@@ -54,4 +54,71 @@ describe Seed::Internal::Http::RawClient do
       assert client.should_retry?(make_response(502), 2)
     end
   end
+
+  # A minimal auth provider whose `auth_headers` returns a *different* token on
+  # each call, simulating a token that is refreshed on expiry.
+  class RefreshingAuthProvider
+    def initialize
+      @count = 0
+    end
+
+    def auth_headers
+      @count += 1
+      { "Authorization" => "Bearer TOKEN_#{@count}" }
+    end
+  end
+
+  describe "#resolve_auth_headers" do
+    it "returns an empty hash when no auth provider is configured" do
+      client = Seed::Internal::Http::RawClient.new(base_url: "https://example.com")
+
+      assert_equal({}, client.resolve_auth_headers)
+    end
+
+    it "consults the auth provider on every call so an expired token is refreshed" do
+      client = Seed::Internal::Http::RawClient.new(
+        base_url: "https://example.com",
+        auth_provider: RefreshingAuthProvider.new
+      )
+
+      assert_equal({ "Authorization" => "Bearer TOKEN_1" }, client.resolve_auth_headers)
+      assert_equal({ "Authorization" => "Bearer TOKEN_2" }, client.resolve_auth_headers)
+    end
+  end
+
+  describe "#build_http_request auth header precedence" do
+    let(:client) do
+      Seed::Internal::Http::RawClient.new(
+        base_url: "https://example.com",
+        headers: { "Authorization" => "Bearer STATIC" }
+      )
+    end
+
+    it "lets resolved auth headers override the static default headers" do
+      request = client.build_http_request(
+        url: URI.parse("https://example.com"),
+        method: "GET",
+        auth_headers: { "Authorization" => "Bearer FRESH" }
+      )
+
+      assert_equal("Bearer FRESH", request["Authorization"])
+    end
+
+    it "lets per-request headers take precedence over auth headers" do
+      request = client.build_http_request(
+        url: URI.parse("https://example.com"),
+        method: "GET",
+        headers: { "Authorization" => "Bearer PER_REQUEST" },
+        auth_headers: { "Authorization" => "Bearer FRESH" }
+      )
+
+      assert_equal("Bearer PER_REQUEST", request["Authorization"])
+    end
+
+    it "defaults auth headers to empty, leaving the default headers unchanged" do
+      request = client.build_http_request(url: URI.parse("https://example.com"), method: "GET")
+
+      assert_equal("Bearer STATIC", request["Authorization"])
+    end
+  end
 end

--- a/seed/ruby-sdk-v2/cli-multi-spec/lib/seed/internal/http/raw_client.rb
+++ b/seed/ruby-sdk-v2/cli-multi-spec/lib/seed/internal/http/raw_client.rb
@@ -21,10 +21,14 @@ module Seed
         # @param max_retries [Integer] The number of times to retry a failed request, defaults to 2.
         # @param timeout [Float] The timeout for the request, defaults to 60.0 seconds.
         # @param headers [Hash] The headers for the request.
-        def initialize(base_url:, max_retries: 2, timeout: 60.0, headers: {})
+        # @param auth_provider [Object, nil] An optional auth provider responding to
+        #   `auth_headers`. When present its headers are resolved on every request so
+        #   token-based schemes (e.g. OAuth) can refresh an expired token mid-session.
+        def initialize(base_url:, max_retries: 2, timeout: 60.0, headers: {}, auth_provider: nil)
           @base_url = base_url
           @max_retries = max_retries
           @timeout = timeout
+          @auth_provider = auth_provider
           @default_headers = {
             "X-Fern-Language": "Ruby",
             "X-Fern-SDK-Name": "seed",
@@ -36,6 +40,9 @@ module Seed
         # @return [HTTP::Response] The HTTP response.
         def send(request)
           url = build_url(request)
+          # Resolve auth headers once per request (not per retry) so token-based
+          # providers refresh at most once here; static providers are cheap.
+          auth_headers = resolve_auth_headers
           attempt = 0
           response = nil
 
@@ -43,8 +50,9 @@ module Seed
             http_request = build_http_request(
               url:,
               method: request.method,
-              headers: request.encode_headers(protected_keys: @default_headers.keys),
-              body: request.encode_body
+              headers: request.encode_headers(protected_keys: @default_headers.keys + auth_headers.keys),
+              body: request.encode_body,
+              auth_headers: auth_headers
             )
 
             conn = connect(url)
@@ -157,12 +165,27 @@ module Seed
                 "HTTP is only allowed for localhost. Use HTTPS or pass a localhost URL."
         end
 
+        # Resolves the auth headers to send with the next request. Delegates to the
+        # configured auth provider (if any) on every call so that token-based
+        # providers (e.g. OAuth client-credentials) can refresh an expired token
+        # before the request is sent. Returns an empty hash when no provider is set,
+        # which keeps the api-key / basic / bearer / no-auth paths unchanged.
+        # @return [Hash] The auth headers for the current request.
+        def resolve_auth_headers
+          return {} if @auth_provider.nil?
+
+          @auth_provider.auth_headers
+        end
+
         # @param url [URI::Generic] The url to the resource.
         # @param method [String] The HTTP method to use.
         # @param headers [Hash] The headers for the request.
         # @param body [String, nil] The body for the request.
+        # @param auth_headers [Hash] The auth headers resolved for this request. These
+        #   take precedence over the static default headers but not over per-request
+        #   headers, mirroring the previous baked-header precedence.
         # @return [HTTP::Request] The HTTP request.
-        def build_http_request(url:, method:, headers: {}, body: nil)
+        def build_http_request(url:, method:, headers: {}, body: nil, auth_headers: {})
           request = Net::HTTPGenericRequest.new(
             method,
             !body.nil?,
@@ -170,7 +193,7 @@ module Seed
             url
           )
 
-          request_headers = @default_headers.merge(headers)
+          request_headers = @default_headers.merge(auth_headers).merge(headers)
           request_headers.each { |name, value| request[name] = value }
           request.body = body if body
 

--- a/seed/ruby-sdk-v2/cli-multi-spec/test/unit/internal/http/test_raw_client.rb
+++ b/seed/ruby-sdk-v2/cli-multi-spec/test/unit/internal/http/test_raw_client.rb
@@ -54,4 +54,71 @@ describe Seed::Internal::Http::RawClient do
       assert client.should_retry?(make_response(502), 2)
     end
   end
+
+  # A minimal auth provider whose `auth_headers` returns a *different* token on
+  # each call, simulating a token that is refreshed on expiry.
+  class RefreshingAuthProvider
+    def initialize
+      @count = 0
+    end
+
+    def auth_headers
+      @count += 1
+      { "Authorization" => "Bearer TOKEN_#{@count}" }
+    end
+  end
+
+  describe "#resolve_auth_headers" do
+    it "returns an empty hash when no auth provider is configured" do
+      client = Seed::Internal::Http::RawClient.new(base_url: "https://example.com")
+
+      assert_equal({}, client.resolve_auth_headers)
+    end
+
+    it "consults the auth provider on every call so an expired token is refreshed" do
+      client = Seed::Internal::Http::RawClient.new(
+        base_url: "https://example.com",
+        auth_provider: RefreshingAuthProvider.new
+      )
+
+      assert_equal({ "Authorization" => "Bearer TOKEN_1" }, client.resolve_auth_headers)
+      assert_equal({ "Authorization" => "Bearer TOKEN_2" }, client.resolve_auth_headers)
+    end
+  end
+
+  describe "#build_http_request auth header precedence" do
+    let(:client) do
+      Seed::Internal::Http::RawClient.new(
+        base_url: "https://example.com",
+        headers: { "Authorization" => "Bearer STATIC" }
+      )
+    end
+
+    it "lets resolved auth headers override the static default headers" do
+      request = client.build_http_request(
+        url: URI.parse("https://example.com"),
+        method: "GET",
+        auth_headers: { "Authorization" => "Bearer FRESH" }
+      )
+
+      assert_equal("Bearer FRESH", request["Authorization"])
+    end
+
+    it "lets per-request headers take precedence over auth headers" do
+      request = client.build_http_request(
+        url: URI.parse("https://example.com"),
+        method: "GET",
+        headers: { "Authorization" => "Bearer PER_REQUEST" },
+        auth_headers: { "Authorization" => "Bearer FRESH" }
+      )
+
+      assert_equal("Bearer PER_REQUEST", request["Authorization"])
+    end
+
+    it "defaults auth headers to empty, leaving the default headers unchanged" do
+      request = client.build_http_request(url: URI.parse("https://example.com"), method: "GET")
+
+      assert_equal("Bearer STATIC", request["Authorization"])
+    end
+  end
 end

--- a/seed/ruby-sdk-v2/client-side-params/lib/seed/internal/http/raw_client.rb
+++ b/seed/ruby-sdk-v2/client-side-params/lib/seed/internal/http/raw_client.rb
@@ -21,10 +21,14 @@ module Seed
         # @param max_retries [Integer] The number of times to retry a failed request, defaults to 2.
         # @param timeout [Float] The timeout for the request, defaults to 60.0 seconds.
         # @param headers [Hash] The headers for the request.
-        def initialize(base_url:, max_retries: 2, timeout: 60.0, headers: {})
+        # @param auth_provider [Object, nil] An optional auth provider responding to
+        #   `auth_headers`. When present its headers are resolved on every request so
+        #   token-based schemes (e.g. OAuth) can refresh an expired token mid-session.
+        def initialize(base_url:, max_retries: 2, timeout: 60.0, headers: {}, auth_provider: nil)
           @base_url = base_url
           @max_retries = max_retries
           @timeout = timeout
+          @auth_provider = auth_provider
           @default_headers = {
             "X-Fern-Language": "Ruby",
             "X-Fern-SDK-Name": "seed",
@@ -36,6 +40,9 @@ module Seed
         # @return [HTTP::Response] The HTTP response.
         def send(request)
           url = build_url(request)
+          # Resolve auth headers once per request (not per retry) so token-based
+          # providers refresh at most once here; static providers are cheap.
+          auth_headers = resolve_auth_headers
           attempt = 0
           response = nil
 
@@ -43,8 +50,9 @@ module Seed
             http_request = build_http_request(
               url:,
               method: request.method,
-              headers: request.encode_headers(protected_keys: @default_headers.keys),
-              body: request.encode_body
+              headers: request.encode_headers(protected_keys: @default_headers.keys + auth_headers.keys),
+              body: request.encode_body,
+              auth_headers: auth_headers
             )
 
             conn = connect(url)
@@ -157,12 +165,27 @@ module Seed
                 "HTTP is only allowed for localhost. Use HTTPS or pass a localhost URL."
         end
 
+        # Resolves the auth headers to send with the next request. Delegates to the
+        # configured auth provider (if any) on every call so that token-based
+        # providers (e.g. OAuth client-credentials) can refresh an expired token
+        # before the request is sent. Returns an empty hash when no provider is set,
+        # which keeps the api-key / basic / bearer / no-auth paths unchanged.
+        # @return [Hash] The auth headers for the current request.
+        def resolve_auth_headers
+          return {} if @auth_provider.nil?
+
+          @auth_provider.auth_headers
+        end
+
         # @param url [URI::Generic] The url to the resource.
         # @param method [String] The HTTP method to use.
         # @param headers [Hash] The headers for the request.
         # @param body [String, nil] The body for the request.
+        # @param auth_headers [Hash] The auth headers resolved for this request. These
+        #   take precedence over the static default headers but not over per-request
+        #   headers, mirroring the previous baked-header precedence.
         # @return [HTTP::Request] The HTTP request.
-        def build_http_request(url:, method:, headers: {}, body: nil)
+        def build_http_request(url:, method:, headers: {}, body: nil, auth_headers: {})
           request = Net::HTTPGenericRequest.new(
             method,
             !body.nil?,
@@ -170,7 +193,7 @@ module Seed
             url
           )
 
-          request_headers = @default_headers.merge(headers)
+          request_headers = @default_headers.merge(auth_headers).merge(headers)
           request_headers.each { |name, value| request[name] = value }
           request.body = body if body
 

--- a/seed/ruby-sdk-v2/client-side-params/test/unit/internal/http/test_raw_client.rb
+++ b/seed/ruby-sdk-v2/client-side-params/test/unit/internal/http/test_raw_client.rb
@@ -54,4 +54,71 @@ describe Seed::Internal::Http::RawClient do
       assert client.should_retry?(make_response(502), 2)
     end
   end
+
+  # A minimal auth provider whose `auth_headers` returns a *different* token on
+  # each call, simulating a token that is refreshed on expiry.
+  class RefreshingAuthProvider
+    def initialize
+      @count = 0
+    end
+
+    def auth_headers
+      @count += 1
+      { "Authorization" => "Bearer TOKEN_#{@count}" }
+    end
+  end
+
+  describe "#resolve_auth_headers" do
+    it "returns an empty hash when no auth provider is configured" do
+      client = Seed::Internal::Http::RawClient.new(base_url: "https://example.com")
+
+      assert_equal({}, client.resolve_auth_headers)
+    end
+
+    it "consults the auth provider on every call so an expired token is refreshed" do
+      client = Seed::Internal::Http::RawClient.new(
+        base_url: "https://example.com",
+        auth_provider: RefreshingAuthProvider.new
+      )
+
+      assert_equal({ "Authorization" => "Bearer TOKEN_1" }, client.resolve_auth_headers)
+      assert_equal({ "Authorization" => "Bearer TOKEN_2" }, client.resolve_auth_headers)
+    end
+  end
+
+  describe "#build_http_request auth header precedence" do
+    let(:client) do
+      Seed::Internal::Http::RawClient.new(
+        base_url: "https://example.com",
+        headers: { "Authorization" => "Bearer STATIC" }
+      )
+    end
+
+    it "lets resolved auth headers override the static default headers" do
+      request = client.build_http_request(
+        url: URI.parse("https://example.com"),
+        method: "GET",
+        auth_headers: { "Authorization" => "Bearer FRESH" }
+      )
+
+      assert_equal("Bearer FRESH", request["Authorization"])
+    end
+
+    it "lets per-request headers take precedence over auth headers" do
+      request = client.build_http_request(
+        url: URI.parse("https://example.com"),
+        method: "GET",
+        headers: { "Authorization" => "Bearer PER_REQUEST" },
+        auth_headers: { "Authorization" => "Bearer FRESH" }
+      )
+
+      assert_equal("Bearer PER_REQUEST", request["Authorization"])
+    end
+
+    it "defaults auth headers to empty, leaving the default headers unchanged" do
+      request = client.build_http_request(url: URI.parse("https://example.com"), method: "GET")
+
+      assert_equal("Bearer STATIC", request["Authorization"])
+    end
+  end
 end

--- a/seed/ruby-sdk-v2/content-type/lib/seed/internal/http/raw_client.rb
+++ b/seed/ruby-sdk-v2/content-type/lib/seed/internal/http/raw_client.rb
@@ -21,10 +21,14 @@ module Seed
         # @param max_retries [Integer] The number of times to retry a failed request, defaults to 2.
         # @param timeout [Float] The timeout for the request, defaults to 60.0 seconds.
         # @param headers [Hash] The headers for the request.
-        def initialize(base_url:, max_retries: 2, timeout: 60.0, headers: {})
+        # @param auth_provider [Object, nil] An optional auth provider responding to
+        #   `auth_headers`. When present its headers are resolved on every request so
+        #   token-based schemes (e.g. OAuth) can refresh an expired token mid-session.
+        def initialize(base_url:, max_retries: 2, timeout: 60.0, headers: {}, auth_provider: nil)
           @base_url = base_url
           @max_retries = max_retries
           @timeout = timeout
+          @auth_provider = auth_provider
           @default_headers = {
             "X-Fern-Language": "Ruby",
             "X-Fern-SDK-Name": "seed",
@@ -36,6 +40,9 @@ module Seed
         # @return [HTTP::Response] The HTTP response.
         def send(request)
           url = build_url(request)
+          # Resolve auth headers once per request (not per retry) so token-based
+          # providers refresh at most once here; static providers are cheap.
+          auth_headers = resolve_auth_headers
           attempt = 0
           response = nil
 
@@ -43,8 +50,9 @@ module Seed
             http_request = build_http_request(
               url:,
               method: request.method,
-              headers: request.encode_headers(protected_keys: @default_headers.keys),
-              body: request.encode_body
+              headers: request.encode_headers(protected_keys: @default_headers.keys + auth_headers.keys),
+              body: request.encode_body,
+              auth_headers: auth_headers
             )
 
             conn = connect(url)
@@ -157,12 +165,27 @@ module Seed
                 "HTTP is only allowed for localhost. Use HTTPS or pass a localhost URL."
         end
 
+        # Resolves the auth headers to send with the next request. Delegates to the
+        # configured auth provider (if any) on every call so that token-based
+        # providers (e.g. OAuth client-credentials) can refresh an expired token
+        # before the request is sent. Returns an empty hash when no provider is set,
+        # which keeps the api-key / basic / bearer / no-auth paths unchanged.
+        # @return [Hash] The auth headers for the current request.
+        def resolve_auth_headers
+          return {} if @auth_provider.nil?
+
+          @auth_provider.auth_headers
+        end
+
         # @param url [URI::Generic] The url to the resource.
         # @param method [String] The HTTP method to use.
         # @param headers [Hash] The headers for the request.
         # @param body [String, nil] The body for the request.
+        # @param auth_headers [Hash] The auth headers resolved for this request. These
+        #   take precedence over the static default headers but not over per-request
+        #   headers, mirroring the previous baked-header precedence.
         # @return [HTTP::Request] The HTTP request.
-        def build_http_request(url:, method:, headers: {}, body: nil)
+        def build_http_request(url:, method:, headers: {}, body: nil, auth_headers: {})
           request = Net::HTTPGenericRequest.new(
             method,
             !body.nil?,
@@ -170,7 +193,7 @@ module Seed
             url
           )
 
-          request_headers = @default_headers.merge(headers)
+          request_headers = @default_headers.merge(auth_headers).merge(headers)
           request_headers.each { |name, value| request[name] = value }
           request.body = body if body
 

--- a/seed/ruby-sdk-v2/content-type/test/unit/internal/http/test_raw_client.rb
+++ b/seed/ruby-sdk-v2/content-type/test/unit/internal/http/test_raw_client.rb
@@ -54,4 +54,71 @@ describe Seed::Internal::Http::RawClient do
       assert client.should_retry?(make_response(502), 2)
     end
   end
+
+  # A minimal auth provider whose `auth_headers` returns a *different* token on
+  # each call, simulating a token that is refreshed on expiry.
+  class RefreshingAuthProvider
+    def initialize
+      @count = 0
+    end
+
+    def auth_headers
+      @count += 1
+      { "Authorization" => "Bearer TOKEN_#{@count}" }
+    end
+  end
+
+  describe "#resolve_auth_headers" do
+    it "returns an empty hash when no auth provider is configured" do
+      client = Seed::Internal::Http::RawClient.new(base_url: "https://example.com")
+
+      assert_equal({}, client.resolve_auth_headers)
+    end
+
+    it "consults the auth provider on every call so an expired token is refreshed" do
+      client = Seed::Internal::Http::RawClient.new(
+        base_url: "https://example.com",
+        auth_provider: RefreshingAuthProvider.new
+      )
+
+      assert_equal({ "Authorization" => "Bearer TOKEN_1" }, client.resolve_auth_headers)
+      assert_equal({ "Authorization" => "Bearer TOKEN_2" }, client.resolve_auth_headers)
+    end
+  end
+
+  describe "#build_http_request auth header precedence" do
+    let(:client) do
+      Seed::Internal::Http::RawClient.new(
+        base_url: "https://example.com",
+        headers: { "Authorization" => "Bearer STATIC" }
+      )
+    end
+
+    it "lets resolved auth headers override the static default headers" do
+      request = client.build_http_request(
+        url: URI.parse("https://example.com"),
+        method: "GET",
+        auth_headers: { "Authorization" => "Bearer FRESH" }
+      )
+
+      assert_equal("Bearer FRESH", request["Authorization"])
+    end
+
+    it "lets per-request headers take precedence over auth headers" do
+      request = client.build_http_request(
+        url: URI.parse("https://example.com"),
+        method: "GET",
+        headers: { "Authorization" => "Bearer PER_REQUEST" },
+        auth_headers: { "Authorization" => "Bearer FRESH" }
+      )
+
+      assert_equal("Bearer PER_REQUEST", request["Authorization"])
+    end
+
+    it "defaults auth headers to empty, leaving the default headers unchanged" do
+      request = client.build_http_request(url: URI.parse("https://example.com"), method: "GET")
+
+      assert_equal("Bearer STATIC", request["Authorization"])
+    end
+  end
 end

--- a/seed/ruby-sdk-v2/cross-package-type-names/lib/seed/internal/http/raw_client.rb
+++ b/seed/ruby-sdk-v2/cross-package-type-names/lib/seed/internal/http/raw_client.rb
@@ -21,10 +21,14 @@ module Seed
         # @param max_retries [Integer] The number of times to retry a failed request, defaults to 2.
         # @param timeout [Float] The timeout for the request, defaults to 60.0 seconds.
         # @param headers [Hash] The headers for the request.
-        def initialize(base_url:, max_retries: 2, timeout: 60.0, headers: {})
+        # @param auth_provider [Object, nil] An optional auth provider responding to
+        #   `auth_headers`. When present its headers are resolved on every request so
+        #   token-based schemes (e.g. OAuth) can refresh an expired token mid-session.
+        def initialize(base_url:, max_retries: 2, timeout: 60.0, headers: {}, auth_provider: nil)
           @base_url = base_url
           @max_retries = max_retries
           @timeout = timeout
+          @auth_provider = auth_provider
           @default_headers = {
             "X-Fern-Language": "Ruby",
             "X-Fern-SDK-Name": "seed",
@@ -36,6 +40,9 @@ module Seed
         # @return [HTTP::Response] The HTTP response.
         def send(request)
           url = build_url(request)
+          # Resolve auth headers once per request (not per retry) so token-based
+          # providers refresh at most once here; static providers are cheap.
+          auth_headers = resolve_auth_headers
           attempt = 0
           response = nil
 
@@ -43,8 +50,9 @@ module Seed
             http_request = build_http_request(
               url:,
               method: request.method,
-              headers: request.encode_headers(protected_keys: @default_headers.keys),
-              body: request.encode_body
+              headers: request.encode_headers(protected_keys: @default_headers.keys + auth_headers.keys),
+              body: request.encode_body,
+              auth_headers: auth_headers
             )
 
             conn = connect(url)
@@ -157,12 +165,27 @@ module Seed
                 "HTTP is only allowed for localhost. Use HTTPS or pass a localhost URL."
         end
 
+        # Resolves the auth headers to send with the next request. Delegates to the
+        # configured auth provider (if any) on every call so that token-based
+        # providers (e.g. OAuth client-credentials) can refresh an expired token
+        # before the request is sent. Returns an empty hash when no provider is set,
+        # which keeps the api-key / basic / bearer / no-auth paths unchanged.
+        # @return [Hash] The auth headers for the current request.
+        def resolve_auth_headers
+          return {} if @auth_provider.nil?
+
+          @auth_provider.auth_headers
+        end
+
         # @param url [URI::Generic] The url to the resource.
         # @param method [String] The HTTP method to use.
         # @param headers [Hash] The headers for the request.
         # @param body [String, nil] The body for the request.
+        # @param auth_headers [Hash] The auth headers resolved for this request. These
+        #   take precedence over the static default headers but not over per-request
+        #   headers, mirroring the previous baked-header precedence.
         # @return [HTTP::Request] The HTTP request.
-        def build_http_request(url:, method:, headers: {}, body: nil)
+        def build_http_request(url:, method:, headers: {}, body: nil, auth_headers: {})
           request = Net::HTTPGenericRequest.new(
             method,
             !body.nil?,
@@ -170,7 +193,7 @@ module Seed
             url
           )
 
-          request_headers = @default_headers.merge(headers)
+          request_headers = @default_headers.merge(auth_headers).merge(headers)
           request_headers.each { |name, value| request[name] = value }
           request.body = body if body
 

--- a/seed/ruby-sdk-v2/cross-package-type-names/test/unit/internal/http/test_raw_client.rb
+++ b/seed/ruby-sdk-v2/cross-package-type-names/test/unit/internal/http/test_raw_client.rb
@@ -54,4 +54,71 @@ describe Seed::Internal::Http::RawClient do
       assert client.should_retry?(make_response(502), 2)
     end
   end
+
+  # A minimal auth provider whose `auth_headers` returns a *different* token on
+  # each call, simulating a token that is refreshed on expiry.
+  class RefreshingAuthProvider
+    def initialize
+      @count = 0
+    end
+
+    def auth_headers
+      @count += 1
+      { "Authorization" => "Bearer TOKEN_#{@count}" }
+    end
+  end
+
+  describe "#resolve_auth_headers" do
+    it "returns an empty hash when no auth provider is configured" do
+      client = Seed::Internal::Http::RawClient.new(base_url: "https://example.com")
+
+      assert_equal({}, client.resolve_auth_headers)
+    end
+
+    it "consults the auth provider on every call so an expired token is refreshed" do
+      client = Seed::Internal::Http::RawClient.new(
+        base_url: "https://example.com",
+        auth_provider: RefreshingAuthProvider.new
+      )
+
+      assert_equal({ "Authorization" => "Bearer TOKEN_1" }, client.resolve_auth_headers)
+      assert_equal({ "Authorization" => "Bearer TOKEN_2" }, client.resolve_auth_headers)
+    end
+  end
+
+  describe "#build_http_request auth header precedence" do
+    let(:client) do
+      Seed::Internal::Http::RawClient.new(
+        base_url: "https://example.com",
+        headers: { "Authorization" => "Bearer STATIC" }
+      )
+    end
+
+    it "lets resolved auth headers override the static default headers" do
+      request = client.build_http_request(
+        url: URI.parse("https://example.com"),
+        method: "GET",
+        auth_headers: { "Authorization" => "Bearer FRESH" }
+      )
+
+      assert_equal("Bearer FRESH", request["Authorization"])
+    end
+
+    it "lets per-request headers take precedence over auth headers" do
+      request = client.build_http_request(
+        url: URI.parse("https://example.com"),
+        method: "GET",
+        headers: { "Authorization" => "Bearer PER_REQUEST" },
+        auth_headers: { "Authorization" => "Bearer FRESH" }
+      )
+
+      assert_equal("Bearer PER_REQUEST", request["Authorization"])
+    end
+
+    it "defaults auth headers to empty, leaving the default headers unchanged" do
+      request = client.build_http_request(url: URI.parse("https://example.com"), method: "GET")
+
+      assert_equal("Bearer STATIC", request["Authorization"])
+    end
+  end
 end

--- a/seed/ruby-sdk-v2/dollar-string-examples/lib/seed/internal/http/raw_client.rb
+++ b/seed/ruby-sdk-v2/dollar-string-examples/lib/seed/internal/http/raw_client.rb
@@ -21,10 +21,14 @@ module Seed
         # @param max_retries [Integer] The number of times to retry a failed request, defaults to 2.
         # @param timeout [Float] The timeout for the request, defaults to 60.0 seconds.
         # @param headers [Hash] The headers for the request.
-        def initialize(base_url:, max_retries: 2, timeout: 60.0, headers: {})
+        # @param auth_provider [Object, nil] An optional auth provider responding to
+        #   `auth_headers`. When present its headers are resolved on every request so
+        #   token-based schemes (e.g. OAuth) can refresh an expired token mid-session.
+        def initialize(base_url:, max_retries: 2, timeout: 60.0, headers: {}, auth_provider: nil)
           @base_url = base_url
           @max_retries = max_retries
           @timeout = timeout
+          @auth_provider = auth_provider
           @default_headers = {
             "X-Fern-Language": "Ruby",
             "X-Fern-SDK-Name": "seed",
@@ -36,6 +40,9 @@ module Seed
         # @return [HTTP::Response] The HTTP response.
         def send(request)
           url = build_url(request)
+          # Resolve auth headers once per request (not per retry) so token-based
+          # providers refresh at most once here; static providers are cheap.
+          auth_headers = resolve_auth_headers
           attempt = 0
           response = nil
 
@@ -43,8 +50,9 @@ module Seed
             http_request = build_http_request(
               url:,
               method: request.method,
-              headers: request.encode_headers(protected_keys: @default_headers.keys),
-              body: request.encode_body
+              headers: request.encode_headers(protected_keys: @default_headers.keys + auth_headers.keys),
+              body: request.encode_body,
+              auth_headers: auth_headers
             )
 
             conn = connect(url)
@@ -157,12 +165,27 @@ module Seed
                 "HTTP is only allowed for localhost. Use HTTPS or pass a localhost URL."
         end
 
+        # Resolves the auth headers to send with the next request. Delegates to the
+        # configured auth provider (if any) on every call so that token-based
+        # providers (e.g. OAuth client-credentials) can refresh an expired token
+        # before the request is sent. Returns an empty hash when no provider is set,
+        # which keeps the api-key / basic / bearer / no-auth paths unchanged.
+        # @return [Hash] The auth headers for the current request.
+        def resolve_auth_headers
+          return {} if @auth_provider.nil?
+
+          @auth_provider.auth_headers
+        end
+
         # @param url [URI::Generic] The url to the resource.
         # @param method [String] The HTTP method to use.
         # @param headers [Hash] The headers for the request.
         # @param body [String, nil] The body for the request.
+        # @param auth_headers [Hash] The auth headers resolved for this request. These
+        #   take precedence over the static default headers but not over per-request
+        #   headers, mirroring the previous baked-header precedence.
         # @return [HTTP::Request] The HTTP request.
-        def build_http_request(url:, method:, headers: {}, body: nil)
+        def build_http_request(url:, method:, headers: {}, body: nil, auth_headers: {})
           request = Net::HTTPGenericRequest.new(
             method,
             !body.nil?,
@@ -170,7 +193,7 @@ module Seed
             url
           )
 
-          request_headers = @default_headers.merge(headers)
+          request_headers = @default_headers.merge(auth_headers).merge(headers)
           request_headers.each { |name, value| request[name] = value }
           request.body = body if body
 

--- a/seed/ruby-sdk-v2/dollar-string-examples/test/unit/internal/http/test_raw_client.rb
+++ b/seed/ruby-sdk-v2/dollar-string-examples/test/unit/internal/http/test_raw_client.rb
@@ -54,4 +54,71 @@ describe Seed::Internal::Http::RawClient do
       assert client.should_retry?(make_response(502), 2)
     end
   end
+
+  # A minimal auth provider whose `auth_headers` returns a *different* token on
+  # each call, simulating a token that is refreshed on expiry.
+  class RefreshingAuthProvider
+    def initialize
+      @count = 0
+    end
+
+    def auth_headers
+      @count += 1
+      { "Authorization" => "Bearer TOKEN_#{@count}" }
+    end
+  end
+
+  describe "#resolve_auth_headers" do
+    it "returns an empty hash when no auth provider is configured" do
+      client = Seed::Internal::Http::RawClient.new(base_url: "https://example.com")
+
+      assert_equal({}, client.resolve_auth_headers)
+    end
+
+    it "consults the auth provider on every call so an expired token is refreshed" do
+      client = Seed::Internal::Http::RawClient.new(
+        base_url: "https://example.com",
+        auth_provider: RefreshingAuthProvider.new
+      )
+
+      assert_equal({ "Authorization" => "Bearer TOKEN_1" }, client.resolve_auth_headers)
+      assert_equal({ "Authorization" => "Bearer TOKEN_2" }, client.resolve_auth_headers)
+    end
+  end
+
+  describe "#build_http_request auth header precedence" do
+    let(:client) do
+      Seed::Internal::Http::RawClient.new(
+        base_url: "https://example.com",
+        headers: { "Authorization" => "Bearer STATIC" }
+      )
+    end
+
+    it "lets resolved auth headers override the static default headers" do
+      request = client.build_http_request(
+        url: URI.parse("https://example.com"),
+        method: "GET",
+        auth_headers: { "Authorization" => "Bearer FRESH" }
+      )
+
+      assert_equal("Bearer FRESH", request["Authorization"])
+    end
+
+    it "lets per-request headers take precedence over auth headers" do
+      request = client.build_http_request(
+        url: URI.parse("https://example.com"),
+        method: "GET",
+        headers: { "Authorization" => "Bearer PER_REQUEST" },
+        auth_headers: { "Authorization" => "Bearer FRESH" }
+      )
+
+      assert_equal("Bearer PER_REQUEST", request["Authorization"])
+    end
+
+    it "defaults auth headers to empty, leaving the default headers unchanged" do
+      request = client.build_http_request(url: URI.parse("https://example.com"), method: "GET")
+
+      assert_equal("Bearer STATIC", request["Authorization"])
+    end
+  end
 end

--- a/seed/ruby-sdk-v2/empty-clients/lib/seed/internal/http/raw_client.rb
+++ b/seed/ruby-sdk-v2/empty-clients/lib/seed/internal/http/raw_client.rb
@@ -21,10 +21,14 @@ module Seed
         # @param max_retries [Integer] The number of times to retry a failed request, defaults to 2.
         # @param timeout [Float] The timeout for the request, defaults to 60.0 seconds.
         # @param headers [Hash] The headers for the request.
-        def initialize(base_url:, max_retries: 2, timeout: 60.0, headers: {})
+        # @param auth_provider [Object, nil] An optional auth provider responding to
+        #   `auth_headers`. When present its headers are resolved on every request so
+        #   token-based schemes (e.g. OAuth) can refresh an expired token mid-session.
+        def initialize(base_url:, max_retries: 2, timeout: 60.0, headers: {}, auth_provider: nil)
           @base_url = base_url
           @max_retries = max_retries
           @timeout = timeout
+          @auth_provider = auth_provider
           @default_headers = {
             "X-Fern-Language": "Ruby",
             "X-Fern-SDK-Name": "seed",
@@ -36,6 +40,9 @@ module Seed
         # @return [HTTP::Response] The HTTP response.
         def send(request)
           url = build_url(request)
+          # Resolve auth headers once per request (not per retry) so token-based
+          # providers refresh at most once here; static providers are cheap.
+          auth_headers = resolve_auth_headers
           attempt = 0
           response = nil
 
@@ -43,8 +50,9 @@ module Seed
             http_request = build_http_request(
               url:,
               method: request.method,
-              headers: request.encode_headers(protected_keys: @default_headers.keys),
-              body: request.encode_body
+              headers: request.encode_headers(protected_keys: @default_headers.keys + auth_headers.keys),
+              body: request.encode_body,
+              auth_headers: auth_headers
             )
 
             conn = connect(url)
@@ -157,12 +165,27 @@ module Seed
                 "HTTP is only allowed for localhost. Use HTTPS or pass a localhost URL."
         end
 
+        # Resolves the auth headers to send with the next request. Delegates to the
+        # configured auth provider (if any) on every call so that token-based
+        # providers (e.g. OAuth client-credentials) can refresh an expired token
+        # before the request is sent. Returns an empty hash when no provider is set,
+        # which keeps the api-key / basic / bearer / no-auth paths unchanged.
+        # @return [Hash] The auth headers for the current request.
+        def resolve_auth_headers
+          return {} if @auth_provider.nil?
+
+          @auth_provider.auth_headers
+        end
+
         # @param url [URI::Generic] The url to the resource.
         # @param method [String] The HTTP method to use.
         # @param headers [Hash] The headers for the request.
         # @param body [String, nil] The body for the request.
+        # @param auth_headers [Hash] The auth headers resolved for this request. These
+        #   take precedence over the static default headers but not over per-request
+        #   headers, mirroring the previous baked-header precedence.
         # @return [HTTP::Request] The HTTP request.
-        def build_http_request(url:, method:, headers: {}, body: nil)
+        def build_http_request(url:, method:, headers: {}, body: nil, auth_headers: {})
           request = Net::HTTPGenericRequest.new(
             method,
             !body.nil?,
@@ -170,7 +193,7 @@ module Seed
             url
           )
 
-          request_headers = @default_headers.merge(headers)
+          request_headers = @default_headers.merge(auth_headers).merge(headers)
           request_headers.each { |name, value| request[name] = value }
           request.body = body if body
 

--- a/seed/ruby-sdk-v2/empty-clients/test/unit/internal/http/test_raw_client.rb
+++ b/seed/ruby-sdk-v2/empty-clients/test/unit/internal/http/test_raw_client.rb
@@ -54,4 +54,71 @@ describe Seed::Internal::Http::RawClient do
       assert client.should_retry?(make_response(502), 2)
     end
   end
+
+  # A minimal auth provider whose `auth_headers` returns a *different* token on
+  # each call, simulating a token that is refreshed on expiry.
+  class RefreshingAuthProvider
+    def initialize
+      @count = 0
+    end
+
+    def auth_headers
+      @count += 1
+      { "Authorization" => "Bearer TOKEN_#{@count}" }
+    end
+  end
+
+  describe "#resolve_auth_headers" do
+    it "returns an empty hash when no auth provider is configured" do
+      client = Seed::Internal::Http::RawClient.new(base_url: "https://example.com")
+
+      assert_equal({}, client.resolve_auth_headers)
+    end
+
+    it "consults the auth provider on every call so an expired token is refreshed" do
+      client = Seed::Internal::Http::RawClient.new(
+        base_url: "https://example.com",
+        auth_provider: RefreshingAuthProvider.new
+      )
+
+      assert_equal({ "Authorization" => "Bearer TOKEN_1" }, client.resolve_auth_headers)
+      assert_equal({ "Authorization" => "Bearer TOKEN_2" }, client.resolve_auth_headers)
+    end
+  end
+
+  describe "#build_http_request auth header precedence" do
+    let(:client) do
+      Seed::Internal::Http::RawClient.new(
+        base_url: "https://example.com",
+        headers: { "Authorization" => "Bearer STATIC" }
+      )
+    end
+
+    it "lets resolved auth headers override the static default headers" do
+      request = client.build_http_request(
+        url: URI.parse("https://example.com"),
+        method: "GET",
+        auth_headers: { "Authorization" => "Bearer FRESH" }
+      )
+
+      assert_equal("Bearer FRESH", request["Authorization"])
+    end
+
+    it "lets per-request headers take precedence over auth headers" do
+      request = client.build_http_request(
+        url: URI.parse("https://example.com"),
+        method: "GET",
+        headers: { "Authorization" => "Bearer PER_REQUEST" },
+        auth_headers: { "Authorization" => "Bearer FRESH" }
+      )
+
+      assert_equal("Bearer PER_REQUEST", request["Authorization"])
+    end
+
+    it "defaults auth headers to empty, leaving the default headers unchanged" do
+      request = client.build_http_request(url: URI.parse("https://example.com"), method: "GET")
+
+      assert_equal("Bearer STATIC", request["Authorization"])
+    end
+  end
 end

--- a/seed/ruby-sdk-v2/endpoint-security-auth/lib/seed/client.rb
+++ b/seed/ruby-sdk-v2/endpoint-security-auth/lib/seed/client.rb
@@ -39,7 +39,8 @@ module Seed
       headers["Authorization"] = "Basic #{Base64.strict_encode64("#{username}:#{password}")}" if !username.nil? && !password.nil?
       @raw_client = Seed::Internal::Http::RawClient.new(
         base_url: base_url,
-        headers: headers.merge(@auth_provider.auth_headers),
+        headers: headers,
+        auth_provider: @auth_provider,
         max_retries: max_retries
       )
     end

--- a/seed/ruby-sdk-v2/endpoint-security-auth/lib/seed/internal/http/raw_client.rb
+++ b/seed/ruby-sdk-v2/endpoint-security-auth/lib/seed/internal/http/raw_client.rb
@@ -21,10 +21,14 @@ module Seed
         # @param max_retries [Integer] The number of times to retry a failed request, defaults to 2.
         # @param timeout [Float] The timeout for the request, defaults to 60.0 seconds.
         # @param headers [Hash] The headers for the request.
-        def initialize(base_url:, max_retries: 2, timeout: 60.0, headers: {})
+        # @param auth_provider [Object, nil] An optional auth provider responding to
+        #   `auth_headers`. When present its headers are resolved on every request so
+        #   token-based schemes (e.g. OAuth) can refresh an expired token mid-session.
+        def initialize(base_url:, max_retries: 2, timeout: 60.0, headers: {}, auth_provider: nil)
           @base_url = base_url
           @max_retries = max_retries
           @timeout = timeout
+          @auth_provider = auth_provider
           @default_headers = {
             "X-Fern-Language": "Ruby",
             "X-Fern-SDK-Name": "seed",
@@ -36,6 +40,9 @@ module Seed
         # @return [HTTP::Response] The HTTP response.
         def send(request)
           url = build_url(request)
+          # Resolve auth headers once per request (not per retry) so token-based
+          # providers refresh at most once here; static providers are cheap.
+          auth_headers = resolve_auth_headers
           attempt = 0
           response = nil
 
@@ -43,8 +50,9 @@ module Seed
             http_request = build_http_request(
               url:,
               method: request.method,
-              headers: request.encode_headers(protected_keys: @default_headers.keys),
-              body: request.encode_body
+              headers: request.encode_headers(protected_keys: @default_headers.keys + auth_headers.keys),
+              body: request.encode_body,
+              auth_headers: auth_headers
             )
 
             conn = connect(url)
@@ -157,12 +165,27 @@ module Seed
                 "HTTP is only allowed for localhost. Use HTTPS or pass a localhost URL."
         end
 
+        # Resolves the auth headers to send with the next request. Delegates to the
+        # configured auth provider (if any) on every call so that token-based
+        # providers (e.g. OAuth client-credentials) can refresh an expired token
+        # before the request is sent. Returns an empty hash when no provider is set,
+        # which keeps the api-key / basic / bearer / no-auth paths unchanged.
+        # @return [Hash] The auth headers for the current request.
+        def resolve_auth_headers
+          return {} if @auth_provider.nil?
+
+          @auth_provider.auth_headers
+        end
+
         # @param url [URI::Generic] The url to the resource.
         # @param method [String] The HTTP method to use.
         # @param headers [Hash] The headers for the request.
         # @param body [String, nil] The body for the request.
+        # @param auth_headers [Hash] The auth headers resolved for this request. These
+        #   take precedence over the static default headers but not over per-request
+        #   headers, mirroring the previous baked-header precedence.
         # @return [HTTP::Request] The HTTP request.
-        def build_http_request(url:, method:, headers: {}, body: nil)
+        def build_http_request(url:, method:, headers: {}, body: nil, auth_headers: {})
           request = Net::HTTPGenericRequest.new(
             method,
             !body.nil?,
@@ -170,7 +193,7 @@ module Seed
             url
           )
 
-          request_headers = @default_headers.merge(headers)
+          request_headers = @default_headers.merge(auth_headers).merge(headers)
           request_headers.each { |name, value| request[name] = value }
           request.body = body if body
 

--- a/seed/ruby-sdk-v2/endpoint-security-auth/test/unit/internal/http/test_raw_client.rb
+++ b/seed/ruby-sdk-v2/endpoint-security-auth/test/unit/internal/http/test_raw_client.rb
@@ -54,4 +54,71 @@ describe Seed::Internal::Http::RawClient do
       assert client.should_retry?(make_response(502), 2)
     end
   end
+
+  # A minimal auth provider whose `auth_headers` returns a *different* token on
+  # each call, simulating a token that is refreshed on expiry.
+  class RefreshingAuthProvider
+    def initialize
+      @count = 0
+    end
+
+    def auth_headers
+      @count += 1
+      { "Authorization" => "Bearer TOKEN_#{@count}" }
+    end
+  end
+
+  describe "#resolve_auth_headers" do
+    it "returns an empty hash when no auth provider is configured" do
+      client = Seed::Internal::Http::RawClient.new(base_url: "https://example.com")
+
+      assert_equal({}, client.resolve_auth_headers)
+    end
+
+    it "consults the auth provider on every call so an expired token is refreshed" do
+      client = Seed::Internal::Http::RawClient.new(
+        base_url: "https://example.com",
+        auth_provider: RefreshingAuthProvider.new
+      )
+
+      assert_equal({ "Authorization" => "Bearer TOKEN_1" }, client.resolve_auth_headers)
+      assert_equal({ "Authorization" => "Bearer TOKEN_2" }, client.resolve_auth_headers)
+    end
+  end
+
+  describe "#build_http_request auth header precedence" do
+    let(:client) do
+      Seed::Internal::Http::RawClient.new(
+        base_url: "https://example.com",
+        headers: { "Authorization" => "Bearer STATIC" }
+      )
+    end
+
+    it "lets resolved auth headers override the static default headers" do
+      request = client.build_http_request(
+        url: URI.parse("https://example.com"),
+        method: "GET",
+        auth_headers: { "Authorization" => "Bearer FRESH" }
+      )
+
+      assert_equal("Bearer FRESH", request["Authorization"])
+    end
+
+    it "lets per-request headers take precedence over auth headers" do
+      request = client.build_http_request(
+        url: URI.parse("https://example.com"),
+        method: "GET",
+        headers: { "Authorization" => "Bearer PER_REQUEST" },
+        auth_headers: { "Authorization" => "Bearer FRESH" }
+      )
+
+      assert_equal("Bearer PER_REQUEST", request["Authorization"])
+    end
+
+    it "defaults auth headers to empty, leaving the default headers unchanged" do
+      request = client.build_http_request(url: URI.parse("https://example.com"), method: "GET")
+
+      assert_equal("Bearer STATIC", request["Authorization"])
+    end
+  end
 end

--- a/seed/ruby-sdk-v2/enum/lib/seed/internal/http/raw_client.rb
+++ b/seed/ruby-sdk-v2/enum/lib/seed/internal/http/raw_client.rb
@@ -21,10 +21,14 @@ module Seed
         # @param max_retries [Integer] The number of times to retry a failed request, defaults to 2.
         # @param timeout [Float] The timeout for the request, defaults to 60.0 seconds.
         # @param headers [Hash] The headers for the request.
-        def initialize(base_url:, max_retries: 2, timeout: 60.0, headers: {})
+        # @param auth_provider [Object, nil] An optional auth provider responding to
+        #   `auth_headers`. When present its headers are resolved on every request so
+        #   token-based schemes (e.g. OAuth) can refresh an expired token mid-session.
+        def initialize(base_url:, max_retries: 2, timeout: 60.0, headers: {}, auth_provider: nil)
           @base_url = base_url
           @max_retries = max_retries
           @timeout = timeout
+          @auth_provider = auth_provider
           @default_headers = {
             "X-Fern-Language": "Ruby",
             "X-Fern-SDK-Name": "seed",
@@ -36,6 +40,9 @@ module Seed
         # @return [HTTP::Response] The HTTP response.
         def send(request)
           url = build_url(request)
+          # Resolve auth headers once per request (not per retry) so token-based
+          # providers refresh at most once here; static providers are cheap.
+          auth_headers = resolve_auth_headers
           attempt = 0
           response = nil
 
@@ -43,8 +50,9 @@ module Seed
             http_request = build_http_request(
               url:,
               method: request.method,
-              headers: request.encode_headers(protected_keys: @default_headers.keys),
-              body: request.encode_body
+              headers: request.encode_headers(protected_keys: @default_headers.keys + auth_headers.keys),
+              body: request.encode_body,
+              auth_headers: auth_headers
             )
 
             conn = connect(url)
@@ -157,12 +165,27 @@ module Seed
                 "HTTP is only allowed for localhost. Use HTTPS or pass a localhost URL."
         end
 
+        # Resolves the auth headers to send with the next request. Delegates to the
+        # configured auth provider (if any) on every call so that token-based
+        # providers (e.g. OAuth client-credentials) can refresh an expired token
+        # before the request is sent. Returns an empty hash when no provider is set,
+        # which keeps the api-key / basic / bearer / no-auth paths unchanged.
+        # @return [Hash] The auth headers for the current request.
+        def resolve_auth_headers
+          return {} if @auth_provider.nil?
+
+          @auth_provider.auth_headers
+        end
+
         # @param url [URI::Generic] The url to the resource.
         # @param method [String] The HTTP method to use.
         # @param headers [Hash] The headers for the request.
         # @param body [String, nil] The body for the request.
+        # @param auth_headers [Hash] The auth headers resolved for this request. These
+        #   take precedence over the static default headers but not over per-request
+        #   headers, mirroring the previous baked-header precedence.
         # @return [HTTP::Request] The HTTP request.
-        def build_http_request(url:, method:, headers: {}, body: nil)
+        def build_http_request(url:, method:, headers: {}, body: nil, auth_headers: {})
           request = Net::HTTPGenericRequest.new(
             method,
             !body.nil?,
@@ -170,7 +193,7 @@ module Seed
             url
           )
 
-          request_headers = @default_headers.merge(headers)
+          request_headers = @default_headers.merge(auth_headers).merge(headers)
           request_headers.each { |name, value| request[name] = value }
           request.body = body if body
 

--- a/seed/ruby-sdk-v2/enum/test/unit/internal/http/test_raw_client.rb
+++ b/seed/ruby-sdk-v2/enum/test/unit/internal/http/test_raw_client.rb
@@ -54,4 +54,71 @@ describe Seed::Internal::Http::RawClient do
       assert client.should_retry?(make_response(502), 2)
     end
   end
+
+  # A minimal auth provider whose `auth_headers` returns a *different* token on
+  # each call, simulating a token that is refreshed on expiry.
+  class RefreshingAuthProvider
+    def initialize
+      @count = 0
+    end
+
+    def auth_headers
+      @count += 1
+      { "Authorization" => "Bearer TOKEN_#{@count}" }
+    end
+  end
+
+  describe "#resolve_auth_headers" do
+    it "returns an empty hash when no auth provider is configured" do
+      client = Seed::Internal::Http::RawClient.new(base_url: "https://example.com")
+
+      assert_equal({}, client.resolve_auth_headers)
+    end
+
+    it "consults the auth provider on every call so an expired token is refreshed" do
+      client = Seed::Internal::Http::RawClient.new(
+        base_url: "https://example.com",
+        auth_provider: RefreshingAuthProvider.new
+      )
+
+      assert_equal({ "Authorization" => "Bearer TOKEN_1" }, client.resolve_auth_headers)
+      assert_equal({ "Authorization" => "Bearer TOKEN_2" }, client.resolve_auth_headers)
+    end
+  end
+
+  describe "#build_http_request auth header precedence" do
+    let(:client) do
+      Seed::Internal::Http::RawClient.new(
+        base_url: "https://example.com",
+        headers: { "Authorization" => "Bearer STATIC" }
+      )
+    end
+
+    it "lets resolved auth headers override the static default headers" do
+      request = client.build_http_request(
+        url: URI.parse("https://example.com"),
+        method: "GET",
+        auth_headers: { "Authorization" => "Bearer FRESH" }
+      )
+
+      assert_equal("Bearer FRESH", request["Authorization"])
+    end
+
+    it "lets per-request headers take precedence over auth headers" do
+      request = client.build_http_request(
+        url: URI.parse("https://example.com"),
+        method: "GET",
+        headers: { "Authorization" => "Bearer PER_REQUEST" },
+        auth_headers: { "Authorization" => "Bearer FRESH" }
+      )
+
+      assert_equal("Bearer PER_REQUEST", request["Authorization"])
+    end
+
+    it "defaults auth headers to empty, leaving the default headers unchanged" do
+      request = client.build_http_request(url: URI.parse("https://example.com"), method: "GET")
+
+      assert_equal("Bearer STATIC", request["Authorization"])
+    end
+  end
 end

--- a/seed/ruby-sdk-v2/error-property/lib/seed/internal/http/raw_client.rb
+++ b/seed/ruby-sdk-v2/error-property/lib/seed/internal/http/raw_client.rb
@@ -21,10 +21,14 @@ module Seed
         # @param max_retries [Integer] The number of times to retry a failed request, defaults to 2.
         # @param timeout [Float] The timeout for the request, defaults to 60.0 seconds.
         # @param headers [Hash] The headers for the request.
-        def initialize(base_url:, max_retries: 2, timeout: 60.0, headers: {})
+        # @param auth_provider [Object, nil] An optional auth provider responding to
+        #   `auth_headers`. When present its headers are resolved on every request so
+        #   token-based schemes (e.g. OAuth) can refresh an expired token mid-session.
+        def initialize(base_url:, max_retries: 2, timeout: 60.0, headers: {}, auth_provider: nil)
           @base_url = base_url
           @max_retries = max_retries
           @timeout = timeout
+          @auth_provider = auth_provider
           @default_headers = {
             "X-Fern-Language": "Ruby",
             "X-Fern-SDK-Name": "seed",
@@ -36,6 +40,9 @@ module Seed
         # @return [HTTP::Response] The HTTP response.
         def send(request)
           url = build_url(request)
+          # Resolve auth headers once per request (not per retry) so token-based
+          # providers refresh at most once here; static providers are cheap.
+          auth_headers = resolve_auth_headers
           attempt = 0
           response = nil
 
@@ -43,8 +50,9 @@ module Seed
             http_request = build_http_request(
               url:,
               method: request.method,
-              headers: request.encode_headers(protected_keys: @default_headers.keys),
-              body: request.encode_body
+              headers: request.encode_headers(protected_keys: @default_headers.keys + auth_headers.keys),
+              body: request.encode_body,
+              auth_headers: auth_headers
             )
 
             conn = connect(url)
@@ -157,12 +165,27 @@ module Seed
                 "HTTP is only allowed for localhost. Use HTTPS or pass a localhost URL."
         end
 
+        # Resolves the auth headers to send with the next request. Delegates to the
+        # configured auth provider (if any) on every call so that token-based
+        # providers (e.g. OAuth client-credentials) can refresh an expired token
+        # before the request is sent. Returns an empty hash when no provider is set,
+        # which keeps the api-key / basic / bearer / no-auth paths unchanged.
+        # @return [Hash] The auth headers for the current request.
+        def resolve_auth_headers
+          return {} if @auth_provider.nil?
+
+          @auth_provider.auth_headers
+        end
+
         # @param url [URI::Generic] The url to the resource.
         # @param method [String] The HTTP method to use.
         # @param headers [Hash] The headers for the request.
         # @param body [String, nil] The body for the request.
+        # @param auth_headers [Hash] The auth headers resolved for this request. These
+        #   take precedence over the static default headers but not over per-request
+        #   headers, mirroring the previous baked-header precedence.
         # @return [HTTP::Request] The HTTP request.
-        def build_http_request(url:, method:, headers: {}, body: nil)
+        def build_http_request(url:, method:, headers: {}, body: nil, auth_headers: {})
           request = Net::HTTPGenericRequest.new(
             method,
             !body.nil?,
@@ -170,7 +193,7 @@ module Seed
             url
           )
 
-          request_headers = @default_headers.merge(headers)
+          request_headers = @default_headers.merge(auth_headers).merge(headers)
           request_headers.each { |name, value| request[name] = value }
           request.body = body if body
 

--- a/seed/ruby-sdk-v2/error-property/test/unit/internal/http/test_raw_client.rb
+++ b/seed/ruby-sdk-v2/error-property/test/unit/internal/http/test_raw_client.rb
@@ -54,4 +54,71 @@ describe Seed::Internal::Http::RawClient do
       assert client.should_retry?(make_response(502), 2)
     end
   end
+
+  # A minimal auth provider whose `auth_headers` returns a *different* token on
+  # each call, simulating a token that is refreshed on expiry.
+  class RefreshingAuthProvider
+    def initialize
+      @count = 0
+    end
+
+    def auth_headers
+      @count += 1
+      { "Authorization" => "Bearer TOKEN_#{@count}" }
+    end
+  end
+
+  describe "#resolve_auth_headers" do
+    it "returns an empty hash when no auth provider is configured" do
+      client = Seed::Internal::Http::RawClient.new(base_url: "https://example.com")
+
+      assert_equal({}, client.resolve_auth_headers)
+    end
+
+    it "consults the auth provider on every call so an expired token is refreshed" do
+      client = Seed::Internal::Http::RawClient.new(
+        base_url: "https://example.com",
+        auth_provider: RefreshingAuthProvider.new
+      )
+
+      assert_equal({ "Authorization" => "Bearer TOKEN_1" }, client.resolve_auth_headers)
+      assert_equal({ "Authorization" => "Bearer TOKEN_2" }, client.resolve_auth_headers)
+    end
+  end
+
+  describe "#build_http_request auth header precedence" do
+    let(:client) do
+      Seed::Internal::Http::RawClient.new(
+        base_url: "https://example.com",
+        headers: { "Authorization" => "Bearer STATIC" }
+      )
+    end
+
+    it "lets resolved auth headers override the static default headers" do
+      request = client.build_http_request(
+        url: URI.parse("https://example.com"),
+        method: "GET",
+        auth_headers: { "Authorization" => "Bearer FRESH" }
+      )
+
+      assert_equal("Bearer FRESH", request["Authorization"])
+    end
+
+    it "lets per-request headers take precedence over auth headers" do
+      request = client.build_http_request(
+        url: URI.parse("https://example.com"),
+        method: "GET",
+        headers: { "Authorization" => "Bearer PER_REQUEST" },
+        auth_headers: { "Authorization" => "Bearer FRESH" }
+      )
+
+      assert_equal("Bearer PER_REQUEST", request["Authorization"])
+    end
+
+    it "defaults auth headers to empty, leaving the default headers unchanged" do
+      request = client.build_http_request(url: URI.parse("https://example.com"), method: "GET")
+
+      assert_equal("Bearer STATIC", request["Authorization"])
+    end
+  end
 end

--- a/seed/ruby-sdk-v2/errors/lib/seed/internal/http/raw_client.rb
+++ b/seed/ruby-sdk-v2/errors/lib/seed/internal/http/raw_client.rb
@@ -21,10 +21,14 @@ module Seed
         # @param max_retries [Integer] The number of times to retry a failed request, defaults to 2.
         # @param timeout [Float] The timeout for the request, defaults to 60.0 seconds.
         # @param headers [Hash] The headers for the request.
-        def initialize(base_url:, max_retries: 2, timeout: 60.0, headers: {})
+        # @param auth_provider [Object, nil] An optional auth provider responding to
+        #   `auth_headers`. When present its headers are resolved on every request so
+        #   token-based schemes (e.g. OAuth) can refresh an expired token mid-session.
+        def initialize(base_url:, max_retries: 2, timeout: 60.0, headers: {}, auth_provider: nil)
           @base_url = base_url
           @max_retries = max_retries
           @timeout = timeout
+          @auth_provider = auth_provider
           @default_headers = {
             "X-Fern-Language": "Ruby",
             "X-Fern-SDK-Name": "seed",
@@ -36,6 +40,9 @@ module Seed
         # @return [HTTP::Response] The HTTP response.
         def send(request)
           url = build_url(request)
+          # Resolve auth headers once per request (not per retry) so token-based
+          # providers refresh at most once here; static providers are cheap.
+          auth_headers = resolve_auth_headers
           attempt = 0
           response = nil
 
@@ -43,8 +50,9 @@ module Seed
             http_request = build_http_request(
               url:,
               method: request.method,
-              headers: request.encode_headers(protected_keys: @default_headers.keys),
-              body: request.encode_body
+              headers: request.encode_headers(protected_keys: @default_headers.keys + auth_headers.keys),
+              body: request.encode_body,
+              auth_headers: auth_headers
             )
 
             conn = connect(url)
@@ -157,12 +165,27 @@ module Seed
                 "HTTP is only allowed for localhost. Use HTTPS or pass a localhost URL."
         end
 
+        # Resolves the auth headers to send with the next request. Delegates to the
+        # configured auth provider (if any) on every call so that token-based
+        # providers (e.g. OAuth client-credentials) can refresh an expired token
+        # before the request is sent. Returns an empty hash when no provider is set,
+        # which keeps the api-key / basic / bearer / no-auth paths unchanged.
+        # @return [Hash] The auth headers for the current request.
+        def resolve_auth_headers
+          return {} if @auth_provider.nil?
+
+          @auth_provider.auth_headers
+        end
+
         # @param url [URI::Generic] The url to the resource.
         # @param method [String] The HTTP method to use.
         # @param headers [Hash] The headers for the request.
         # @param body [String, nil] The body for the request.
+        # @param auth_headers [Hash] The auth headers resolved for this request. These
+        #   take precedence over the static default headers but not over per-request
+        #   headers, mirroring the previous baked-header precedence.
         # @return [HTTP::Request] The HTTP request.
-        def build_http_request(url:, method:, headers: {}, body: nil)
+        def build_http_request(url:, method:, headers: {}, body: nil, auth_headers: {})
           request = Net::HTTPGenericRequest.new(
             method,
             !body.nil?,
@@ -170,7 +193,7 @@ module Seed
             url
           )
 
-          request_headers = @default_headers.merge(headers)
+          request_headers = @default_headers.merge(auth_headers).merge(headers)
           request_headers.each { |name, value| request[name] = value }
           request.body = body if body
 

--- a/seed/ruby-sdk-v2/errors/test/unit/internal/http/test_raw_client.rb
+++ b/seed/ruby-sdk-v2/errors/test/unit/internal/http/test_raw_client.rb
@@ -54,4 +54,71 @@ describe Seed::Internal::Http::RawClient do
       assert client.should_retry?(make_response(502), 2)
     end
   end
+
+  # A minimal auth provider whose `auth_headers` returns a *different* token on
+  # each call, simulating a token that is refreshed on expiry.
+  class RefreshingAuthProvider
+    def initialize
+      @count = 0
+    end
+
+    def auth_headers
+      @count += 1
+      { "Authorization" => "Bearer TOKEN_#{@count}" }
+    end
+  end
+
+  describe "#resolve_auth_headers" do
+    it "returns an empty hash when no auth provider is configured" do
+      client = Seed::Internal::Http::RawClient.new(base_url: "https://example.com")
+
+      assert_equal({}, client.resolve_auth_headers)
+    end
+
+    it "consults the auth provider on every call so an expired token is refreshed" do
+      client = Seed::Internal::Http::RawClient.new(
+        base_url: "https://example.com",
+        auth_provider: RefreshingAuthProvider.new
+      )
+
+      assert_equal({ "Authorization" => "Bearer TOKEN_1" }, client.resolve_auth_headers)
+      assert_equal({ "Authorization" => "Bearer TOKEN_2" }, client.resolve_auth_headers)
+    end
+  end
+
+  describe "#build_http_request auth header precedence" do
+    let(:client) do
+      Seed::Internal::Http::RawClient.new(
+        base_url: "https://example.com",
+        headers: { "Authorization" => "Bearer STATIC" }
+      )
+    end
+
+    it "lets resolved auth headers override the static default headers" do
+      request = client.build_http_request(
+        url: URI.parse("https://example.com"),
+        method: "GET",
+        auth_headers: { "Authorization" => "Bearer FRESH" }
+      )
+
+      assert_equal("Bearer FRESH", request["Authorization"])
+    end
+
+    it "lets per-request headers take precedence over auth headers" do
+      request = client.build_http_request(
+        url: URI.parse("https://example.com"),
+        method: "GET",
+        headers: { "Authorization" => "Bearer PER_REQUEST" },
+        auth_headers: { "Authorization" => "Bearer FRESH" }
+      )
+
+      assert_equal("Bearer PER_REQUEST", request["Authorization"])
+    end
+
+    it "defaults auth headers to empty, leaving the default headers unchanged" do
+      request = client.build_http_request(url: URI.parse("https://example.com"), method: "GET")
+
+      assert_equal("Bearer STATIC", request["Authorization"])
+    end
+  end
 end

--- a/seed/ruby-sdk-v2/examples/include-platform-headers/lib/seed/internal/http/raw_client.rb
+++ b/seed/ruby-sdk-v2/examples/include-platform-headers/lib/seed/internal/http/raw_client.rb
@@ -23,10 +23,14 @@ module Seed
         # @param max_retries [Integer] The number of times to retry a failed request, defaults to 2.
         # @param timeout [Float] The timeout for the request, defaults to 60.0 seconds.
         # @param headers [Hash] The headers for the request.
-        def initialize(base_url:, max_retries: 2, timeout: 60.0, headers: {})
+        # @param auth_provider [Object, nil] An optional auth provider responding to
+        #   `auth_headers`. When present its headers are resolved on every request so
+        #   token-based schemes (e.g. OAuth) can refresh an expired token mid-session.
+        def initialize(base_url:, max_retries: 2, timeout: 60.0, headers: {}, auth_provider: nil)
           @base_url = base_url
           @max_retries = max_retries
           @timeout = timeout
+          @auth_provider = auth_provider
           @default_headers = {
             "X-Fern-Language": "Ruby",
             "X-Fern-SDK-Name": "seed",
@@ -94,6 +98,9 @@ module Seed
         # @return [HTTP::Response] The HTTP response.
         def send(request)
           url = build_url(request)
+          # Resolve auth headers once per request (not per retry) so token-based
+          # providers refresh at most once here; static providers are cheap.
+          auth_headers = resolve_auth_headers
           attempt = 0
           response = nil
 
@@ -101,8 +108,9 @@ module Seed
             http_request = build_http_request(
               url:,
               method: request.method,
-              headers: request.encode_headers(protected_keys: @default_headers.keys),
-              body: request.encode_body
+              headers: request.encode_headers(protected_keys: @default_headers.keys + auth_headers.keys),
+              body: request.encode_body,
+              auth_headers: auth_headers
             )
 
             conn = connect(url)
@@ -215,12 +223,27 @@ module Seed
                 "HTTP is only allowed for localhost. Use HTTPS or pass a localhost URL."
         end
 
+        # Resolves the auth headers to send with the next request. Delegates to the
+        # configured auth provider (if any) on every call so that token-based
+        # providers (e.g. OAuth client-credentials) can refresh an expired token
+        # before the request is sent. Returns an empty hash when no provider is set,
+        # which keeps the api-key / basic / bearer / no-auth paths unchanged.
+        # @return [Hash] The auth headers for the current request.
+        def resolve_auth_headers
+          return {} if @auth_provider.nil?
+
+          @auth_provider.auth_headers
+        end
+
         # @param url [URI::Generic] The url to the resource.
         # @param method [String] The HTTP method to use.
         # @param headers [Hash] The headers for the request.
         # @param body [String, nil] The body for the request.
+        # @param auth_headers [Hash] The auth headers resolved for this request. These
+        #   take precedence over the static default headers but not over per-request
+        #   headers, mirroring the previous baked-header precedence.
         # @return [HTTP::Request] The HTTP request.
-        def build_http_request(url:, method:, headers: {}, body: nil)
+        def build_http_request(url:, method:, headers: {}, body: nil, auth_headers: {})
           request = Net::HTTPGenericRequest.new(
             method,
             !body.nil?,
@@ -228,7 +251,7 @@ module Seed
             url
           )
 
-          request_headers = @default_headers.merge(headers)
+          request_headers = @default_headers.merge(auth_headers).merge(headers)
           request_headers.each { |name, value| request[name] = value }
           request.body = body if body
 

--- a/seed/ruby-sdk-v2/examples/include-platform-headers/test/unit/internal/http/test_raw_client.rb
+++ b/seed/ruby-sdk-v2/examples/include-platform-headers/test/unit/internal/http/test_raw_client.rb
@@ -54,4 +54,71 @@ describe Seed::Internal::Http::RawClient do
       assert client.should_retry?(make_response(502), 2)
     end
   end
+
+  # A minimal auth provider whose `auth_headers` returns a *different* token on
+  # each call, simulating a token that is refreshed on expiry.
+  class RefreshingAuthProvider
+    def initialize
+      @count = 0
+    end
+
+    def auth_headers
+      @count += 1
+      { "Authorization" => "Bearer TOKEN_#{@count}" }
+    end
+  end
+
+  describe "#resolve_auth_headers" do
+    it "returns an empty hash when no auth provider is configured" do
+      client = Seed::Internal::Http::RawClient.new(base_url: "https://example.com")
+
+      assert_equal({}, client.resolve_auth_headers)
+    end
+
+    it "consults the auth provider on every call so an expired token is refreshed" do
+      client = Seed::Internal::Http::RawClient.new(
+        base_url: "https://example.com",
+        auth_provider: RefreshingAuthProvider.new
+      )
+
+      assert_equal({ "Authorization" => "Bearer TOKEN_1" }, client.resolve_auth_headers)
+      assert_equal({ "Authorization" => "Bearer TOKEN_2" }, client.resolve_auth_headers)
+    end
+  end
+
+  describe "#build_http_request auth header precedence" do
+    let(:client) do
+      Seed::Internal::Http::RawClient.new(
+        base_url: "https://example.com",
+        headers: { "Authorization" => "Bearer STATIC" }
+      )
+    end
+
+    it "lets resolved auth headers override the static default headers" do
+      request = client.build_http_request(
+        url: URI.parse("https://example.com"),
+        method: "GET",
+        auth_headers: { "Authorization" => "Bearer FRESH" }
+      )
+
+      assert_equal("Bearer FRESH", request["Authorization"])
+    end
+
+    it "lets per-request headers take precedence over auth headers" do
+      request = client.build_http_request(
+        url: URI.parse("https://example.com"),
+        method: "GET",
+        headers: { "Authorization" => "Bearer PER_REQUEST" },
+        auth_headers: { "Authorization" => "Bearer FRESH" }
+      )
+
+      assert_equal("Bearer PER_REQUEST", request["Authorization"])
+    end
+
+    it "defaults auth headers to empty, leaving the default headers unchanged" do
+      request = client.build_http_request(url: URI.parse("https://example.com"), method: "GET")
+
+      assert_equal("Bearer STATIC", request["Authorization"])
+    end
+  end
 end

--- a/seed/ruby-sdk-v2/examples/no-custom-config/lib/seed/internal/http/raw_client.rb
+++ b/seed/ruby-sdk-v2/examples/no-custom-config/lib/seed/internal/http/raw_client.rb
@@ -21,10 +21,14 @@ module Seed
         # @param max_retries [Integer] The number of times to retry a failed request, defaults to 2.
         # @param timeout [Float] The timeout for the request, defaults to 60.0 seconds.
         # @param headers [Hash] The headers for the request.
-        def initialize(base_url:, max_retries: 2, timeout: 60.0, headers: {})
+        # @param auth_provider [Object, nil] An optional auth provider responding to
+        #   `auth_headers`. When present its headers are resolved on every request so
+        #   token-based schemes (e.g. OAuth) can refresh an expired token mid-session.
+        def initialize(base_url:, max_retries: 2, timeout: 60.0, headers: {}, auth_provider: nil)
           @base_url = base_url
           @max_retries = max_retries
           @timeout = timeout
+          @auth_provider = auth_provider
           @default_headers = {
             "X-Fern-Language": "Ruby",
             "X-Fern-SDK-Name": "seed",
@@ -36,6 +40,9 @@ module Seed
         # @return [HTTP::Response] The HTTP response.
         def send(request)
           url = build_url(request)
+          # Resolve auth headers once per request (not per retry) so token-based
+          # providers refresh at most once here; static providers are cheap.
+          auth_headers = resolve_auth_headers
           attempt = 0
           response = nil
 
@@ -43,8 +50,9 @@ module Seed
             http_request = build_http_request(
               url:,
               method: request.method,
-              headers: request.encode_headers(protected_keys: @default_headers.keys),
-              body: request.encode_body
+              headers: request.encode_headers(protected_keys: @default_headers.keys + auth_headers.keys),
+              body: request.encode_body,
+              auth_headers: auth_headers
             )
 
             conn = connect(url)
@@ -157,12 +165,27 @@ module Seed
                 "HTTP is only allowed for localhost. Use HTTPS or pass a localhost URL."
         end
 
+        # Resolves the auth headers to send with the next request. Delegates to the
+        # configured auth provider (if any) on every call so that token-based
+        # providers (e.g. OAuth client-credentials) can refresh an expired token
+        # before the request is sent. Returns an empty hash when no provider is set,
+        # which keeps the api-key / basic / bearer / no-auth paths unchanged.
+        # @return [Hash] The auth headers for the current request.
+        def resolve_auth_headers
+          return {} if @auth_provider.nil?
+
+          @auth_provider.auth_headers
+        end
+
         # @param url [URI::Generic] The url to the resource.
         # @param method [String] The HTTP method to use.
         # @param headers [Hash] The headers for the request.
         # @param body [String, nil] The body for the request.
+        # @param auth_headers [Hash] The auth headers resolved for this request. These
+        #   take precedence over the static default headers but not over per-request
+        #   headers, mirroring the previous baked-header precedence.
         # @return [HTTP::Request] The HTTP request.
-        def build_http_request(url:, method:, headers: {}, body: nil)
+        def build_http_request(url:, method:, headers: {}, body: nil, auth_headers: {})
           request = Net::HTTPGenericRequest.new(
             method,
             !body.nil?,
@@ -170,7 +193,7 @@ module Seed
             url
           )
 
-          request_headers = @default_headers.merge(headers)
+          request_headers = @default_headers.merge(auth_headers).merge(headers)
           request_headers.each { |name, value| request[name] = value }
           request.body = body if body
 

--- a/seed/ruby-sdk-v2/examples/no-custom-config/test/unit/internal/http/test_raw_client.rb
+++ b/seed/ruby-sdk-v2/examples/no-custom-config/test/unit/internal/http/test_raw_client.rb
@@ -54,4 +54,71 @@ describe Seed::Internal::Http::RawClient do
       assert client.should_retry?(make_response(502), 2)
     end
   end
+
+  # A minimal auth provider whose `auth_headers` returns a *different* token on
+  # each call, simulating a token that is refreshed on expiry.
+  class RefreshingAuthProvider
+    def initialize
+      @count = 0
+    end
+
+    def auth_headers
+      @count += 1
+      { "Authorization" => "Bearer TOKEN_#{@count}" }
+    end
+  end
+
+  describe "#resolve_auth_headers" do
+    it "returns an empty hash when no auth provider is configured" do
+      client = Seed::Internal::Http::RawClient.new(base_url: "https://example.com")
+
+      assert_equal({}, client.resolve_auth_headers)
+    end
+
+    it "consults the auth provider on every call so an expired token is refreshed" do
+      client = Seed::Internal::Http::RawClient.new(
+        base_url: "https://example.com",
+        auth_provider: RefreshingAuthProvider.new
+      )
+
+      assert_equal({ "Authorization" => "Bearer TOKEN_1" }, client.resolve_auth_headers)
+      assert_equal({ "Authorization" => "Bearer TOKEN_2" }, client.resolve_auth_headers)
+    end
+  end
+
+  describe "#build_http_request auth header precedence" do
+    let(:client) do
+      Seed::Internal::Http::RawClient.new(
+        base_url: "https://example.com",
+        headers: { "Authorization" => "Bearer STATIC" }
+      )
+    end
+
+    it "lets resolved auth headers override the static default headers" do
+      request = client.build_http_request(
+        url: URI.parse("https://example.com"),
+        method: "GET",
+        auth_headers: { "Authorization" => "Bearer FRESH" }
+      )
+
+      assert_equal("Bearer FRESH", request["Authorization"])
+    end
+
+    it "lets per-request headers take precedence over auth headers" do
+      request = client.build_http_request(
+        url: URI.parse("https://example.com"),
+        method: "GET",
+        headers: { "Authorization" => "Bearer PER_REQUEST" },
+        auth_headers: { "Authorization" => "Bearer FRESH" }
+      )
+
+      assert_equal("Bearer PER_REQUEST", request["Authorization"])
+    end
+
+    it "defaults auth headers to empty, leaving the default headers unchanged" do
+      request = client.build_http_request(url: URI.parse("https://example.com"), method: "GET")
+
+      assert_equal("Bearer STATIC", request["Authorization"])
+    end
+  end
 end

--- a/seed/ruby-sdk-v2/examples/omit-fern-headers/lib/seed/internal/http/raw_client.rb
+++ b/seed/ruby-sdk-v2/examples/omit-fern-headers/lib/seed/internal/http/raw_client.rb
@@ -21,10 +21,14 @@ module Seed
         # @param max_retries [Integer] The number of times to retry a failed request, defaults to 2.
         # @param timeout [Float] The timeout for the request, defaults to 60.0 seconds.
         # @param headers [Hash] The headers for the request.
-        def initialize(base_url:, max_retries: 2, timeout: 60.0, headers: {})
+        # @param auth_provider [Object, nil] An optional auth provider responding to
+        #   `auth_headers`. When present its headers are resolved on every request so
+        #   token-based schemes (e.g. OAuth) can refresh an expired token mid-session.
+        def initialize(base_url:, max_retries: 2, timeout: 60.0, headers: {}, auth_provider: nil)
           @base_url = base_url
           @max_retries = max_retries
           @timeout = timeout
+          @auth_provider = auth_provider
           @default_headers = headers
         end
 
@@ -32,6 +36,9 @@ module Seed
         # @return [HTTP::Response] The HTTP response.
         def send(request)
           url = build_url(request)
+          # Resolve auth headers once per request (not per retry) so token-based
+          # providers refresh at most once here; static providers are cheap.
+          auth_headers = resolve_auth_headers
           attempt = 0
           response = nil
 
@@ -39,8 +46,9 @@ module Seed
             http_request = build_http_request(
               url:,
               method: request.method,
-              headers: request.encode_headers(protected_keys: @default_headers.keys),
-              body: request.encode_body
+              headers: request.encode_headers(protected_keys: @default_headers.keys + auth_headers.keys),
+              body: request.encode_body,
+              auth_headers: auth_headers
             )
 
             conn = connect(url)
@@ -153,12 +161,27 @@ module Seed
                 "HTTP is only allowed for localhost. Use HTTPS or pass a localhost URL."
         end
 
+        # Resolves the auth headers to send with the next request. Delegates to the
+        # configured auth provider (if any) on every call so that token-based
+        # providers (e.g. OAuth client-credentials) can refresh an expired token
+        # before the request is sent. Returns an empty hash when no provider is set,
+        # which keeps the api-key / basic / bearer / no-auth paths unchanged.
+        # @return [Hash] The auth headers for the current request.
+        def resolve_auth_headers
+          return {} if @auth_provider.nil?
+
+          @auth_provider.auth_headers
+        end
+
         # @param url [URI::Generic] The url to the resource.
         # @param method [String] The HTTP method to use.
         # @param headers [Hash] The headers for the request.
         # @param body [String, nil] The body for the request.
+        # @param auth_headers [Hash] The auth headers resolved for this request. These
+        #   take precedence over the static default headers but not over per-request
+        #   headers, mirroring the previous baked-header precedence.
         # @return [HTTP::Request] The HTTP request.
-        def build_http_request(url:, method:, headers: {}, body: nil)
+        def build_http_request(url:, method:, headers: {}, body: nil, auth_headers: {})
           request = Net::HTTPGenericRequest.new(
             method,
             !body.nil?,
@@ -166,7 +189,7 @@ module Seed
             url
           )
 
-          request_headers = @default_headers.merge(headers)
+          request_headers = @default_headers.merge(auth_headers).merge(headers)
           request_headers.each { |name, value| request[name] = value }
           request.body = body if body
 

--- a/seed/ruby-sdk-v2/examples/omit-fern-headers/test/unit/internal/http/test_raw_client.rb
+++ b/seed/ruby-sdk-v2/examples/omit-fern-headers/test/unit/internal/http/test_raw_client.rb
@@ -54,4 +54,71 @@ describe Seed::Internal::Http::RawClient do
       assert client.should_retry?(make_response(502), 2)
     end
   end
+
+  # A minimal auth provider whose `auth_headers` returns a *different* token on
+  # each call, simulating a token that is refreshed on expiry.
+  class RefreshingAuthProvider
+    def initialize
+      @count = 0
+    end
+
+    def auth_headers
+      @count += 1
+      { "Authorization" => "Bearer TOKEN_#{@count}" }
+    end
+  end
+
+  describe "#resolve_auth_headers" do
+    it "returns an empty hash when no auth provider is configured" do
+      client = Seed::Internal::Http::RawClient.new(base_url: "https://example.com")
+
+      assert_equal({}, client.resolve_auth_headers)
+    end
+
+    it "consults the auth provider on every call so an expired token is refreshed" do
+      client = Seed::Internal::Http::RawClient.new(
+        base_url: "https://example.com",
+        auth_provider: RefreshingAuthProvider.new
+      )
+
+      assert_equal({ "Authorization" => "Bearer TOKEN_1" }, client.resolve_auth_headers)
+      assert_equal({ "Authorization" => "Bearer TOKEN_2" }, client.resolve_auth_headers)
+    end
+  end
+
+  describe "#build_http_request auth header precedence" do
+    let(:client) do
+      Seed::Internal::Http::RawClient.new(
+        base_url: "https://example.com",
+        headers: { "Authorization" => "Bearer STATIC" }
+      )
+    end
+
+    it "lets resolved auth headers override the static default headers" do
+      request = client.build_http_request(
+        url: URI.parse("https://example.com"),
+        method: "GET",
+        auth_headers: { "Authorization" => "Bearer FRESH" }
+      )
+
+      assert_equal("Bearer FRESH", request["Authorization"])
+    end
+
+    it "lets per-request headers take precedence over auth headers" do
+      request = client.build_http_request(
+        url: URI.parse("https://example.com"),
+        method: "GET",
+        headers: { "Authorization" => "Bearer PER_REQUEST" },
+        auth_headers: { "Authorization" => "Bearer FRESH" }
+      )
+
+      assert_equal("Bearer PER_REQUEST", request["Authorization"])
+    end
+
+    it "defaults auth headers to empty, leaving the default headers unchanged" do
+      request = client.build_http_request(url: URI.parse("https://example.com"), method: "GET")
+
+      assert_equal("Bearer STATIC", request["Authorization"])
+    end
+  end
 end

--- a/seed/ruby-sdk-v2/examples/readme-config/lib/seed/internal/http/raw_client.rb
+++ b/seed/ruby-sdk-v2/examples/readme-config/lib/seed/internal/http/raw_client.rb
@@ -21,10 +21,14 @@ module Seed
         # @param max_retries [Integer] The number of times to retry a failed request, defaults to 2.
         # @param timeout [Float] The timeout for the request, defaults to 60.0 seconds.
         # @param headers [Hash] The headers for the request.
-        def initialize(base_url:, max_retries: 2, timeout: 60.0, headers: {})
+        # @param auth_provider [Object, nil] An optional auth provider responding to
+        #   `auth_headers`. When present its headers are resolved on every request so
+        #   token-based schemes (e.g. OAuth) can refresh an expired token mid-session.
+        def initialize(base_url:, max_retries: 2, timeout: 60.0, headers: {}, auth_provider: nil)
           @base_url = base_url
           @max_retries = max_retries
           @timeout = timeout
+          @auth_provider = auth_provider
           @default_headers = {
             "X-Fern-Language": "Ruby",
             "X-Fern-SDK-Name": "seed",
@@ -36,6 +40,9 @@ module Seed
         # @return [HTTP::Response] The HTTP response.
         def send(request)
           url = build_url(request)
+          # Resolve auth headers once per request (not per retry) so token-based
+          # providers refresh at most once here; static providers are cheap.
+          auth_headers = resolve_auth_headers
           attempt = 0
           response = nil
 
@@ -43,8 +50,9 @@ module Seed
             http_request = build_http_request(
               url:,
               method: request.method,
-              headers: request.encode_headers(protected_keys: @default_headers.keys),
-              body: request.encode_body
+              headers: request.encode_headers(protected_keys: @default_headers.keys + auth_headers.keys),
+              body: request.encode_body,
+              auth_headers: auth_headers
             )
 
             conn = connect(url)
@@ -157,12 +165,27 @@ module Seed
                 "HTTP is only allowed for localhost. Use HTTPS or pass a localhost URL."
         end
 
+        # Resolves the auth headers to send with the next request. Delegates to the
+        # configured auth provider (if any) on every call so that token-based
+        # providers (e.g. OAuth client-credentials) can refresh an expired token
+        # before the request is sent. Returns an empty hash when no provider is set,
+        # which keeps the api-key / basic / bearer / no-auth paths unchanged.
+        # @return [Hash] The auth headers for the current request.
+        def resolve_auth_headers
+          return {} if @auth_provider.nil?
+
+          @auth_provider.auth_headers
+        end
+
         # @param url [URI::Generic] The url to the resource.
         # @param method [String] The HTTP method to use.
         # @param headers [Hash] The headers for the request.
         # @param body [String, nil] The body for the request.
+        # @param auth_headers [Hash] The auth headers resolved for this request. These
+        #   take precedence over the static default headers but not over per-request
+        #   headers, mirroring the previous baked-header precedence.
         # @return [HTTP::Request] The HTTP request.
-        def build_http_request(url:, method:, headers: {}, body: nil)
+        def build_http_request(url:, method:, headers: {}, body: nil, auth_headers: {})
           request = Net::HTTPGenericRequest.new(
             method,
             !body.nil?,
@@ -170,7 +193,7 @@ module Seed
             url
           )
 
-          request_headers = @default_headers.merge(headers)
+          request_headers = @default_headers.merge(auth_headers).merge(headers)
           request_headers.each { |name, value| request[name] = value }
           request.body = body if body
 

--- a/seed/ruby-sdk-v2/examples/readme-config/test/unit/internal/http/test_raw_client.rb
+++ b/seed/ruby-sdk-v2/examples/readme-config/test/unit/internal/http/test_raw_client.rb
@@ -54,4 +54,71 @@ describe Seed::Internal::Http::RawClient do
       assert client.should_retry?(make_response(502), 2)
     end
   end
+
+  # A minimal auth provider whose `auth_headers` returns a *different* token on
+  # each call, simulating a token that is refreshed on expiry.
+  class RefreshingAuthProvider
+    def initialize
+      @count = 0
+    end
+
+    def auth_headers
+      @count += 1
+      { "Authorization" => "Bearer TOKEN_#{@count}" }
+    end
+  end
+
+  describe "#resolve_auth_headers" do
+    it "returns an empty hash when no auth provider is configured" do
+      client = Seed::Internal::Http::RawClient.new(base_url: "https://example.com")
+
+      assert_equal({}, client.resolve_auth_headers)
+    end
+
+    it "consults the auth provider on every call so an expired token is refreshed" do
+      client = Seed::Internal::Http::RawClient.new(
+        base_url: "https://example.com",
+        auth_provider: RefreshingAuthProvider.new
+      )
+
+      assert_equal({ "Authorization" => "Bearer TOKEN_1" }, client.resolve_auth_headers)
+      assert_equal({ "Authorization" => "Bearer TOKEN_2" }, client.resolve_auth_headers)
+    end
+  end
+
+  describe "#build_http_request auth header precedence" do
+    let(:client) do
+      Seed::Internal::Http::RawClient.new(
+        base_url: "https://example.com",
+        headers: { "Authorization" => "Bearer STATIC" }
+      )
+    end
+
+    it "lets resolved auth headers override the static default headers" do
+      request = client.build_http_request(
+        url: URI.parse("https://example.com"),
+        method: "GET",
+        auth_headers: { "Authorization" => "Bearer FRESH" }
+      )
+
+      assert_equal("Bearer FRESH", request["Authorization"])
+    end
+
+    it "lets per-request headers take precedence over auth headers" do
+      request = client.build_http_request(
+        url: URI.parse("https://example.com"),
+        method: "GET",
+        headers: { "Authorization" => "Bearer PER_REQUEST" },
+        auth_headers: { "Authorization" => "Bearer FRESH" }
+      )
+
+      assert_equal("Bearer PER_REQUEST", request["Authorization"])
+    end
+
+    it "defaults auth headers to empty, leaving the default headers unchanged" do
+      request = client.build_http_request(url: URI.parse("https://example.com"), method: "GET")
+
+      assert_equal("Bearer STATIC", request["Authorization"])
+    end
+  end
 end

--- a/seed/ruby-sdk-v2/examples/require-paths/lib/seed/internal/http/raw_client.rb
+++ b/seed/ruby-sdk-v2/examples/require-paths/lib/seed/internal/http/raw_client.rb
@@ -21,10 +21,14 @@ module Seed
         # @param max_retries [Integer] The number of times to retry a failed request, defaults to 2.
         # @param timeout [Float] The timeout for the request, defaults to 60.0 seconds.
         # @param headers [Hash] The headers for the request.
-        def initialize(base_url:, max_retries: 2, timeout: 60.0, headers: {})
+        # @param auth_provider [Object, nil] An optional auth provider responding to
+        #   `auth_headers`. When present its headers are resolved on every request so
+        #   token-based schemes (e.g. OAuth) can refresh an expired token mid-session.
+        def initialize(base_url:, max_retries: 2, timeout: 60.0, headers: {}, auth_provider: nil)
           @base_url = base_url
           @max_retries = max_retries
           @timeout = timeout
+          @auth_provider = auth_provider
           @default_headers = {
             "X-Fern-Language": "Ruby",
             "X-Fern-SDK-Name": "seed",
@@ -36,6 +40,9 @@ module Seed
         # @return [HTTP::Response] The HTTP response.
         def send(request)
           url = build_url(request)
+          # Resolve auth headers once per request (not per retry) so token-based
+          # providers refresh at most once here; static providers are cheap.
+          auth_headers = resolve_auth_headers
           attempt = 0
           response = nil
 
@@ -43,8 +50,9 @@ module Seed
             http_request = build_http_request(
               url:,
               method: request.method,
-              headers: request.encode_headers(protected_keys: @default_headers.keys),
-              body: request.encode_body
+              headers: request.encode_headers(protected_keys: @default_headers.keys + auth_headers.keys),
+              body: request.encode_body,
+              auth_headers: auth_headers
             )
 
             conn = connect(url)
@@ -157,12 +165,27 @@ module Seed
                 "HTTP is only allowed for localhost. Use HTTPS or pass a localhost URL."
         end
 
+        # Resolves the auth headers to send with the next request. Delegates to the
+        # configured auth provider (if any) on every call so that token-based
+        # providers (e.g. OAuth client-credentials) can refresh an expired token
+        # before the request is sent. Returns an empty hash when no provider is set,
+        # which keeps the api-key / basic / bearer / no-auth paths unchanged.
+        # @return [Hash] The auth headers for the current request.
+        def resolve_auth_headers
+          return {} if @auth_provider.nil?
+
+          @auth_provider.auth_headers
+        end
+
         # @param url [URI::Generic] The url to the resource.
         # @param method [String] The HTTP method to use.
         # @param headers [Hash] The headers for the request.
         # @param body [String, nil] The body for the request.
+        # @param auth_headers [Hash] The auth headers resolved for this request. These
+        #   take precedence over the static default headers but not over per-request
+        #   headers, mirroring the previous baked-header precedence.
         # @return [HTTP::Request] The HTTP request.
-        def build_http_request(url:, method:, headers: {}, body: nil)
+        def build_http_request(url:, method:, headers: {}, body: nil, auth_headers: {})
           request = Net::HTTPGenericRequest.new(
             method,
             !body.nil?,
@@ -170,7 +193,7 @@ module Seed
             url
           )
 
-          request_headers = @default_headers.merge(headers)
+          request_headers = @default_headers.merge(auth_headers).merge(headers)
           request_headers.each { |name, value| request[name] = value }
           request.body = body if body
 

--- a/seed/ruby-sdk-v2/examples/require-paths/test/unit/internal/http/test_raw_client.rb
+++ b/seed/ruby-sdk-v2/examples/require-paths/test/unit/internal/http/test_raw_client.rb
@@ -54,4 +54,71 @@ describe Seed::Internal::Http::RawClient do
       assert client.should_retry?(make_response(502), 2)
     end
   end
+
+  # A minimal auth provider whose `auth_headers` returns a *different* token on
+  # each call, simulating a token that is refreshed on expiry.
+  class RefreshingAuthProvider
+    def initialize
+      @count = 0
+    end
+
+    def auth_headers
+      @count += 1
+      { "Authorization" => "Bearer TOKEN_#{@count}" }
+    end
+  end
+
+  describe "#resolve_auth_headers" do
+    it "returns an empty hash when no auth provider is configured" do
+      client = Seed::Internal::Http::RawClient.new(base_url: "https://example.com")
+
+      assert_equal({}, client.resolve_auth_headers)
+    end
+
+    it "consults the auth provider on every call so an expired token is refreshed" do
+      client = Seed::Internal::Http::RawClient.new(
+        base_url: "https://example.com",
+        auth_provider: RefreshingAuthProvider.new
+      )
+
+      assert_equal({ "Authorization" => "Bearer TOKEN_1" }, client.resolve_auth_headers)
+      assert_equal({ "Authorization" => "Bearer TOKEN_2" }, client.resolve_auth_headers)
+    end
+  end
+
+  describe "#build_http_request auth header precedence" do
+    let(:client) do
+      Seed::Internal::Http::RawClient.new(
+        base_url: "https://example.com",
+        headers: { "Authorization" => "Bearer STATIC" }
+      )
+    end
+
+    it "lets resolved auth headers override the static default headers" do
+      request = client.build_http_request(
+        url: URI.parse("https://example.com"),
+        method: "GET",
+        auth_headers: { "Authorization" => "Bearer FRESH" }
+      )
+
+      assert_equal("Bearer FRESH", request["Authorization"])
+    end
+
+    it "lets per-request headers take precedence over auth headers" do
+      request = client.build_http_request(
+        url: URI.parse("https://example.com"),
+        method: "GET",
+        headers: { "Authorization" => "Bearer PER_REQUEST" },
+        auth_headers: { "Authorization" => "Bearer FRESH" }
+      )
+
+      assert_equal("Bearer PER_REQUEST", request["Authorization"])
+    end
+
+    it "defaults auth headers to empty, leaving the default headers unchanged" do
+      request = client.build_http_request(url: URI.parse("https://example.com"), method: "GET")
+
+      assert_equal("Bearer STATIC", request["Authorization"])
+    end
+  end
 end

--- a/seed/ruby-sdk-v2/examples/wire-tests/lib/seed/internal/http/raw_client.rb
+++ b/seed/ruby-sdk-v2/examples/wire-tests/lib/seed/internal/http/raw_client.rb
@@ -21,10 +21,14 @@ module Seed
         # @param max_retries [Integer] The number of times to retry a failed request, defaults to 2.
         # @param timeout [Float] The timeout for the request, defaults to 60.0 seconds.
         # @param headers [Hash] The headers for the request.
-        def initialize(base_url:, max_retries: 2, timeout: 60.0, headers: {})
+        # @param auth_provider [Object, nil] An optional auth provider responding to
+        #   `auth_headers`. When present its headers are resolved on every request so
+        #   token-based schemes (e.g. OAuth) can refresh an expired token mid-session.
+        def initialize(base_url:, max_retries: 2, timeout: 60.0, headers: {}, auth_provider: nil)
           @base_url = base_url
           @max_retries = max_retries
           @timeout = timeout
+          @auth_provider = auth_provider
           @default_headers = {
             "X-Fern-Language": "Ruby",
             "X-Fern-SDK-Name": "seed",
@@ -36,6 +40,9 @@ module Seed
         # @return [HTTP::Response] The HTTP response.
         def send(request)
           url = build_url(request)
+          # Resolve auth headers once per request (not per retry) so token-based
+          # providers refresh at most once here; static providers are cheap.
+          auth_headers = resolve_auth_headers
           attempt = 0
           response = nil
 
@@ -43,8 +50,9 @@ module Seed
             http_request = build_http_request(
               url:,
               method: request.method,
-              headers: request.encode_headers(protected_keys: @default_headers.keys),
-              body: request.encode_body
+              headers: request.encode_headers(protected_keys: @default_headers.keys + auth_headers.keys),
+              body: request.encode_body,
+              auth_headers: auth_headers
             )
 
             conn = connect(url)
@@ -157,12 +165,27 @@ module Seed
                 "HTTP is only allowed for localhost. Use HTTPS or pass a localhost URL."
         end
 
+        # Resolves the auth headers to send with the next request. Delegates to the
+        # configured auth provider (if any) on every call so that token-based
+        # providers (e.g. OAuth client-credentials) can refresh an expired token
+        # before the request is sent. Returns an empty hash when no provider is set,
+        # which keeps the api-key / basic / bearer / no-auth paths unchanged.
+        # @return [Hash] The auth headers for the current request.
+        def resolve_auth_headers
+          return {} if @auth_provider.nil?
+
+          @auth_provider.auth_headers
+        end
+
         # @param url [URI::Generic] The url to the resource.
         # @param method [String] The HTTP method to use.
         # @param headers [Hash] The headers for the request.
         # @param body [String, nil] The body for the request.
+        # @param auth_headers [Hash] The auth headers resolved for this request. These
+        #   take precedence over the static default headers but not over per-request
+        #   headers, mirroring the previous baked-header precedence.
         # @return [HTTP::Request] The HTTP request.
-        def build_http_request(url:, method:, headers: {}, body: nil)
+        def build_http_request(url:, method:, headers: {}, body: nil, auth_headers: {})
           request = Net::HTTPGenericRequest.new(
             method,
             !body.nil?,
@@ -170,7 +193,7 @@ module Seed
             url
           )
 
-          request_headers = @default_headers.merge(headers)
+          request_headers = @default_headers.merge(auth_headers).merge(headers)
           request_headers.each { |name, value| request[name] = value }
           request.body = body if body
 

--- a/seed/ruby-sdk-v2/examples/wire-tests/test/unit/internal/http/test_raw_client.rb
+++ b/seed/ruby-sdk-v2/examples/wire-tests/test/unit/internal/http/test_raw_client.rb
@@ -54,4 +54,71 @@ describe Seed::Internal::Http::RawClient do
       assert client.should_retry?(make_response(502), 2)
     end
   end
+
+  # A minimal auth provider whose `auth_headers` returns a *different* token on
+  # each call, simulating a token that is refreshed on expiry.
+  class RefreshingAuthProvider
+    def initialize
+      @count = 0
+    end
+
+    def auth_headers
+      @count += 1
+      { "Authorization" => "Bearer TOKEN_#{@count}" }
+    end
+  end
+
+  describe "#resolve_auth_headers" do
+    it "returns an empty hash when no auth provider is configured" do
+      client = Seed::Internal::Http::RawClient.new(base_url: "https://example.com")
+
+      assert_equal({}, client.resolve_auth_headers)
+    end
+
+    it "consults the auth provider on every call so an expired token is refreshed" do
+      client = Seed::Internal::Http::RawClient.new(
+        base_url: "https://example.com",
+        auth_provider: RefreshingAuthProvider.new
+      )
+
+      assert_equal({ "Authorization" => "Bearer TOKEN_1" }, client.resolve_auth_headers)
+      assert_equal({ "Authorization" => "Bearer TOKEN_2" }, client.resolve_auth_headers)
+    end
+  end
+
+  describe "#build_http_request auth header precedence" do
+    let(:client) do
+      Seed::Internal::Http::RawClient.new(
+        base_url: "https://example.com",
+        headers: { "Authorization" => "Bearer STATIC" }
+      )
+    end
+
+    it "lets resolved auth headers override the static default headers" do
+      request = client.build_http_request(
+        url: URI.parse("https://example.com"),
+        method: "GET",
+        auth_headers: { "Authorization" => "Bearer FRESH" }
+      )
+
+      assert_equal("Bearer FRESH", request["Authorization"])
+    end
+
+    it "lets per-request headers take precedence over auth headers" do
+      request = client.build_http_request(
+        url: URI.parse("https://example.com"),
+        method: "GET",
+        headers: { "Authorization" => "Bearer PER_REQUEST" },
+        auth_headers: { "Authorization" => "Bearer FRESH" }
+      )
+
+      assert_equal("Bearer PER_REQUEST", request["Authorization"])
+    end
+
+    it "defaults auth headers to empty, leaving the default headers unchanged" do
+      request = client.build_http_request(url: URI.parse("https://example.com"), method: "GET")
+
+      assert_equal("Bearer STATIC", request["Authorization"])
+    end
+  end
 end

--- a/seed/ruby-sdk-v2/exhaustive/wire-tests/lib/seed/internal/http/raw_client.rb
+++ b/seed/ruby-sdk-v2/exhaustive/wire-tests/lib/seed/internal/http/raw_client.rb
@@ -21,10 +21,14 @@ module Seed
         # @param max_retries [Integer] The number of times to retry a failed request, defaults to 5.
         # @param timeout [Float] The timeout for the request, defaults to 60.0 seconds.
         # @param headers [Hash] The headers for the request.
-        def initialize(base_url:, max_retries: 5, timeout: 60.0, headers: {})
+        # @param auth_provider [Object, nil] An optional auth provider responding to
+        #   `auth_headers`. When present its headers are resolved on every request so
+        #   token-based schemes (e.g. OAuth) can refresh an expired token mid-session.
+        def initialize(base_url:, max_retries: 5, timeout: 60.0, headers: {}, auth_provider: nil)
           @base_url = base_url
           @max_retries = max_retries
           @timeout = timeout
+          @auth_provider = auth_provider
           @default_headers = {
             "X-Fern-Language": "Ruby",
             "X-Fern-SDK-Name": "seed",
@@ -36,6 +40,9 @@ module Seed
         # @return [HTTP::Response] The HTTP response.
         def send(request)
           url = build_url(request)
+          # Resolve auth headers once per request (not per retry) so token-based
+          # providers refresh at most once here; static providers are cheap.
+          auth_headers = resolve_auth_headers
           attempt = 0
           response = nil
 
@@ -43,8 +50,9 @@ module Seed
             http_request = build_http_request(
               url:,
               method: request.method,
-              headers: request.encode_headers(protected_keys: @default_headers.keys),
-              body: request.encode_body
+              headers: request.encode_headers(protected_keys: @default_headers.keys + auth_headers.keys),
+              body: request.encode_body,
+              auth_headers: auth_headers
             )
 
             conn = connect(url)
@@ -157,12 +165,27 @@ module Seed
                 "HTTP is only allowed for localhost. Use HTTPS or pass a localhost URL."
         end
 
+        # Resolves the auth headers to send with the next request. Delegates to the
+        # configured auth provider (if any) on every call so that token-based
+        # providers (e.g. OAuth client-credentials) can refresh an expired token
+        # before the request is sent. Returns an empty hash when no provider is set,
+        # which keeps the api-key / basic / bearer / no-auth paths unchanged.
+        # @return [Hash] The auth headers for the current request.
+        def resolve_auth_headers
+          return {} if @auth_provider.nil?
+
+          @auth_provider.auth_headers
+        end
+
         # @param url [URI::Generic] The url to the resource.
         # @param method [String] The HTTP method to use.
         # @param headers [Hash] The headers for the request.
         # @param body [String, nil] The body for the request.
+        # @param auth_headers [Hash] The auth headers resolved for this request. These
+        #   take precedence over the static default headers but not over per-request
+        #   headers, mirroring the previous baked-header precedence.
         # @return [HTTP::Request] The HTTP request.
-        def build_http_request(url:, method:, headers: {}, body: nil)
+        def build_http_request(url:, method:, headers: {}, body: nil, auth_headers: {})
           request = Net::HTTPGenericRequest.new(
             method,
             !body.nil?,
@@ -170,7 +193,7 @@ module Seed
             url
           )
 
-          request_headers = @default_headers.merge(headers)
+          request_headers = @default_headers.merge(auth_headers).merge(headers)
           request_headers.each { |name, value| request[name] = value }
           request.body = body if body
 

--- a/seed/ruby-sdk-v2/exhaustive/wire-tests/test/unit/internal/http/test_raw_client.rb
+++ b/seed/ruby-sdk-v2/exhaustive/wire-tests/test/unit/internal/http/test_raw_client.rb
@@ -54,4 +54,71 @@ describe Seed::Internal::Http::RawClient do
       assert client.should_retry?(make_response(502), 2)
     end
   end
+
+  # A minimal auth provider whose `auth_headers` returns a *different* token on
+  # each call, simulating a token that is refreshed on expiry.
+  class RefreshingAuthProvider
+    def initialize
+      @count = 0
+    end
+
+    def auth_headers
+      @count += 1
+      { "Authorization" => "Bearer TOKEN_#{@count}" }
+    end
+  end
+
+  describe "#resolve_auth_headers" do
+    it "returns an empty hash when no auth provider is configured" do
+      client = Seed::Internal::Http::RawClient.new(base_url: "https://example.com")
+
+      assert_equal({}, client.resolve_auth_headers)
+    end
+
+    it "consults the auth provider on every call so an expired token is refreshed" do
+      client = Seed::Internal::Http::RawClient.new(
+        base_url: "https://example.com",
+        auth_provider: RefreshingAuthProvider.new
+      )
+
+      assert_equal({ "Authorization" => "Bearer TOKEN_1" }, client.resolve_auth_headers)
+      assert_equal({ "Authorization" => "Bearer TOKEN_2" }, client.resolve_auth_headers)
+    end
+  end
+
+  describe "#build_http_request auth header precedence" do
+    let(:client) do
+      Seed::Internal::Http::RawClient.new(
+        base_url: "https://example.com",
+        headers: { "Authorization" => "Bearer STATIC" }
+      )
+    end
+
+    it "lets resolved auth headers override the static default headers" do
+      request = client.build_http_request(
+        url: URI.parse("https://example.com"),
+        method: "GET",
+        auth_headers: { "Authorization" => "Bearer FRESH" }
+      )
+
+      assert_equal("Bearer FRESH", request["Authorization"])
+    end
+
+    it "lets per-request headers take precedence over auth headers" do
+      request = client.build_http_request(
+        url: URI.parse("https://example.com"),
+        method: "GET",
+        headers: { "Authorization" => "Bearer PER_REQUEST" },
+        auth_headers: { "Authorization" => "Bearer FRESH" }
+      )
+
+      assert_equal("Bearer PER_REQUEST", request["Authorization"])
+    end
+
+    it "defaults auth headers to empty, leaving the default headers unchanged" do
+      request = client.build_http_request(url: URI.parse("https://example.com"), method: "GET")
+
+      assert_equal("Bearer STATIC", request["Authorization"])
+    end
+  end
 end

--- a/seed/ruby-sdk-v2/extends/lib/seed/internal/http/raw_client.rb
+++ b/seed/ruby-sdk-v2/extends/lib/seed/internal/http/raw_client.rb
@@ -21,10 +21,14 @@ module Seed
         # @param max_retries [Integer] The number of times to retry a failed request, defaults to 2.
         # @param timeout [Float] The timeout for the request, defaults to 60.0 seconds.
         # @param headers [Hash] The headers for the request.
-        def initialize(base_url:, max_retries: 2, timeout: 60.0, headers: {})
+        # @param auth_provider [Object, nil] An optional auth provider responding to
+        #   `auth_headers`. When present its headers are resolved on every request so
+        #   token-based schemes (e.g. OAuth) can refresh an expired token mid-session.
+        def initialize(base_url:, max_retries: 2, timeout: 60.0, headers: {}, auth_provider: nil)
           @base_url = base_url
           @max_retries = max_retries
           @timeout = timeout
+          @auth_provider = auth_provider
           @default_headers = {
             "X-Fern-Language": "Ruby",
             "X-Fern-SDK-Name": "seed",
@@ -36,6 +40,9 @@ module Seed
         # @return [HTTP::Response] The HTTP response.
         def send(request)
           url = build_url(request)
+          # Resolve auth headers once per request (not per retry) so token-based
+          # providers refresh at most once here; static providers are cheap.
+          auth_headers = resolve_auth_headers
           attempt = 0
           response = nil
 
@@ -43,8 +50,9 @@ module Seed
             http_request = build_http_request(
               url:,
               method: request.method,
-              headers: request.encode_headers(protected_keys: @default_headers.keys),
-              body: request.encode_body
+              headers: request.encode_headers(protected_keys: @default_headers.keys + auth_headers.keys),
+              body: request.encode_body,
+              auth_headers: auth_headers
             )
 
             conn = connect(url)
@@ -157,12 +165,27 @@ module Seed
                 "HTTP is only allowed for localhost. Use HTTPS or pass a localhost URL."
         end
 
+        # Resolves the auth headers to send with the next request. Delegates to the
+        # configured auth provider (if any) on every call so that token-based
+        # providers (e.g. OAuth client-credentials) can refresh an expired token
+        # before the request is sent. Returns an empty hash when no provider is set,
+        # which keeps the api-key / basic / bearer / no-auth paths unchanged.
+        # @return [Hash] The auth headers for the current request.
+        def resolve_auth_headers
+          return {} if @auth_provider.nil?
+
+          @auth_provider.auth_headers
+        end
+
         # @param url [URI::Generic] The url to the resource.
         # @param method [String] The HTTP method to use.
         # @param headers [Hash] The headers for the request.
         # @param body [String, nil] The body for the request.
+        # @param auth_headers [Hash] The auth headers resolved for this request. These
+        #   take precedence over the static default headers but not over per-request
+        #   headers, mirroring the previous baked-header precedence.
         # @return [HTTP::Request] The HTTP request.
-        def build_http_request(url:, method:, headers: {}, body: nil)
+        def build_http_request(url:, method:, headers: {}, body: nil, auth_headers: {})
           request = Net::HTTPGenericRequest.new(
             method,
             !body.nil?,
@@ -170,7 +193,7 @@ module Seed
             url
           )
 
-          request_headers = @default_headers.merge(headers)
+          request_headers = @default_headers.merge(auth_headers).merge(headers)
           request_headers.each { |name, value| request[name] = value }
           request.body = body if body
 

--- a/seed/ruby-sdk-v2/extends/test/unit/internal/http/test_raw_client.rb
+++ b/seed/ruby-sdk-v2/extends/test/unit/internal/http/test_raw_client.rb
@@ -54,4 +54,71 @@ describe Seed::Internal::Http::RawClient do
       assert client.should_retry?(make_response(502), 2)
     end
   end
+
+  # A minimal auth provider whose `auth_headers` returns a *different* token on
+  # each call, simulating a token that is refreshed on expiry.
+  class RefreshingAuthProvider
+    def initialize
+      @count = 0
+    end
+
+    def auth_headers
+      @count += 1
+      { "Authorization" => "Bearer TOKEN_#{@count}" }
+    end
+  end
+
+  describe "#resolve_auth_headers" do
+    it "returns an empty hash when no auth provider is configured" do
+      client = Seed::Internal::Http::RawClient.new(base_url: "https://example.com")
+
+      assert_equal({}, client.resolve_auth_headers)
+    end
+
+    it "consults the auth provider on every call so an expired token is refreshed" do
+      client = Seed::Internal::Http::RawClient.new(
+        base_url: "https://example.com",
+        auth_provider: RefreshingAuthProvider.new
+      )
+
+      assert_equal({ "Authorization" => "Bearer TOKEN_1" }, client.resolve_auth_headers)
+      assert_equal({ "Authorization" => "Bearer TOKEN_2" }, client.resolve_auth_headers)
+    end
+  end
+
+  describe "#build_http_request auth header precedence" do
+    let(:client) do
+      Seed::Internal::Http::RawClient.new(
+        base_url: "https://example.com",
+        headers: { "Authorization" => "Bearer STATIC" }
+      )
+    end
+
+    it "lets resolved auth headers override the static default headers" do
+      request = client.build_http_request(
+        url: URI.parse("https://example.com"),
+        method: "GET",
+        auth_headers: { "Authorization" => "Bearer FRESH" }
+      )
+
+      assert_equal("Bearer FRESH", request["Authorization"])
+    end
+
+    it "lets per-request headers take precedence over auth headers" do
+      request = client.build_http_request(
+        url: URI.parse("https://example.com"),
+        method: "GET",
+        headers: { "Authorization" => "Bearer PER_REQUEST" },
+        auth_headers: { "Authorization" => "Bearer FRESH" }
+      )
+
+      assert_equal("Bearer PER_REQUEST", request["Authorization"])
+    end
+
+    it "defaults auth headers to empty, leaving the default headers unchanged" do
+      request = client.build_http_request(url: URI.parse("https://example.com"), method: "GET")
+
+      assert_equal("Bearer STATIC", request["Authorization"])
+    end
+  end
 end

--- a/seed/ruby-sdk-v2/extra-properties/lib/seed/internal/http/raw_client.rb
+++ b/seed/ruby-sdk-v2/extra-properties/lib/seed/internal/http/raw_client.rb
@@ -21,10 +21,14 @@ module Seed
         # @param max_retries [Integer] The number of times to retry a failed request, defaults to 2.
         # @param timeout [Float] The timeout for the request, defaults to 60.0 seconds.
         # @param headers [Hash] The headers for the request.
-        def initialize(base_url:, max_retries: 2, timeout: 60.0, headers: {})
+        # @param auth_provider [Object, nil] An optional auth provider responding to
+        #   `auth_headers`. When present its headers are resolved on every request so
+        #   token-based schemes (e.g. OAuth) can refresh an expired token mid-session.
+        def initialize(base_url:, max_retries: 2, timeout: 60.0, headers: {}, auth_provider: nil)
           @base_url = base_url
           @max_retries = max_retries
           @timeout = timeout
+          @auth_provider = auth_provider
           @default_headers = {
             "X-Fern-Language": "Ruby",
             "X-Fern-SDK-Name": "seed",
@@ -36,6 +40,9 @@ module Seed
         # @return [HTTP::Response] The HTTP response.
         def send(request)
           url = build_url(request)
+          # Resolve auth headers once per request (not per retry) so token-based
+          # providers refresh at most once here; static providers are cheap.
+          auth_headers = resolve_auth_headers
           attempt = 0
           response = nil
 
@@ -43,8 +50,9 @@ module Seed
             http_request = build_http_request(
               url:,
               method: request.method,
-              headers: request.encode_headers(protected_keys: @default_headers.keys),
-              body: request.encode_body
+              headers: request.encode_headers(protected_keys: @default_headers.keys + auth_headers.keys),
+              body: request.encode_body,
+              auth_headers: auth_headers
             )
 
             conn = connect(url)
@@ -157,12 +165,27 @@ module Seed
                 "HTTP is only allowed for localhost. Use HTTPS or pass a localhost URL."
         end
 
+        # Resolves the auth headers to send with the next request. Delegates to the
+        # configured auth provider (if any) on every call so that token-based
+        # providers (e.g. OAuth client-credentials) can refresh an expired token
+        # before the request is sent. Returns an empty hash when no provider is set,
+        # which keeps the api-key / basic / bearer / no-auth paths unchanged.
+        # @return [Hash] The auth headers for the current request.
+        def resolve_auth_headers
+          return {} if @auth_provider.nil?
+
+          @auth_provider.auth_headers
+        end
+
         # @param url [URI::Generic] The url to the resource.
         # @param method [String] The HTTP method to use.
         # @param headers [Hash] The headers for the request.
         # @param body [String, nil] The body for the request.
+        # @param auth_headers [Hash] The auth headers resolved for this request. These
+        #   take precedence over the static default headers but not over per-request
+        #   headers, mirroring the previous baked-header precedence.
         # @return [HTTP::Request] The HTTP request.
-        def build_http_request(url:, method:, headers: {}, body: nil)
+        def build_http_request(url:, method:, headers: {}, body: nil, auth_headers: {})
           request = Net::HTTPGenericRequest.new(
             method,
             !body.nil?,
@@ -170,7 +193,7 @@ module Seed
             url
           )
 
-          request_headers = @default_headers.merge(headers)
+          request_headers = @default_headers.merge(auth_headers).merge(headers)
           request_headers.each { |name, value| request[name] = value }
           request.body = body if body
 

--- a/seed/ruby-sdk-v2/extra-properties/test/unit/internal/http/test_raw_client.rb
+++ b/seed/ruby-sdk-v2/extra-properties/test/unit/internal/http/test_raw_client.rb
@@ -54,4 +54,71 @@ describe Seed::Internal::Http::RawClient do
       assert client.should_retry?(make_response(502), 2)
     end
   end
+
+  # A minimal auth provider whose `auth_headers` returns a *different* token on
+  # each call, simulating a token that is refreshed on expiry.
+  class RefreshingAuthProvider
+    def initialize
+      @count = 0
+    end
+
+    def auth_headers
+      @count += 1
+      { "Authorization" => "Bearer TOKEN_#{@count}" }
+    end
+  end
+
+  describe "#resolve_auth_headers" do
+    it "returns an empty hash when no auth provider is configured" do
+      client = Seed::Internal::Http::RawClient.new(base_url: "https://example.com")
+
+      assert_equal({}, client.resolve_auth_headers)
+    end
+
+    it "consults the auth provider on every call so an expired token is refreshed" do
+      client = Seed::Internal::Http::RawClient.new(
+        base_url: "https://example.com",
+        auth_provider: RefreshingAuthProvider.new
+      )
+
+      assert_equal({ "Authorization" => "Bearer TOKEN_1" }, client.resolve_auth_headers)
+      assert_equal({ "Authorization" => "Bearer TOKEN_2" }, client.resolve_auth_headers)
+    end
+  end
+
+  describe "#build_http_request auth header precedence" do
+    let(:client) do
+      Seed::Internal::Http::RawClient.new(
+        base_url: "https://example.com",
+        headers: { "Authorization" => "Bearer STATIC" }
+      )
+    end
+
+    it "lets resolved auth headers override the static default headers" do
+      request = client.build_http_request(
+        url: URI.parse("https://example.com"),
+        method: "GET",
+        auth_headers: { "Authorization" => "Bearer FRESH" }
+      )
+
+      assert_equal("Bearer FRESH", request["Authorization"])
+    end
+
+    it "lets per-request headers take precedence over auth headers" do
+      request = client.build_http_request(
+        url: URI.parse("https://example.com"),
+        method: "GET",
+        headers: { "Authorization" => "Bearer PER_REQUEST" },
+        auth_headers: { "Authorization" => "Bearer FRESH" }
+      )
+
+      assert_equal("Bearer PER_REQUEST", request["Authorization"])
+    end
+
+    it "defaults auth headers to empty, leaving the default headers unchanged" do
+      request = client.build_http_request(url: URI.parse("https://example.com"), method: "GET")
+
+      assert_equal("Bearer STATIC", request["Authorization"])
+    end
+  end
 end

--- a/seed/ruby-sdk-v2/file-download/lib/seed/internal/http/raw_client.rb
+++ b/seed/ruby-sdk-v2/file-download/lib/seed/internal/http/raw_client.rb
@@ -21,10 +21,14 @@ module Seed
         # @param max_retries [Integer] The number of times to retry a failed request, defaults to 2.
         # @param timeout [Float] The timeout for the request, defaults to 60.0 seconds.
         # @param headers [Hash] The headers for the request.
-        def initialize(base_url:, max_retries: 2, timeout: 60.0, headers: {})
+        # @param auth_provider [Object, nil] An optional auth provider responding to
+        #   `auth_headers`. When present its headers are resolved on every request so
+        #   token-based schemes (e.g. OAuth) can refresh an expired token mid-session.
+        def initialize(base_url:, max_retries: 2, timeout: 60.0, headers: {}, auth_provider: nil)
           @base_url = base_url
           @max_retries = max_retries
           @timeout = timeout
+          @auth_provider = auth_provider
           @default_headers = {
             "X-Fern-Language": "Ruby",
             "X-Fern-SDK-Name": "seed",
@@ -36,6 +40,9 @@ module Seed
         # @return [HTTP::Response] The HTTP response.
         def send(request)
           url = build_url(request)
+          # Resolve auth headers once per request (not per retry) so token-based
+          # providers refresh at most once here; static providers are cheap.
+          auth_headers = resolve_auth_headers
           attempt = 0
           response = nil
 
@@ -43,8 +50,9 @@ module Seed
             http_request = build_http_request(
               url:,
               method: request.method,
-              headers: request.encode_headers(protected_keys: @default_headers.keys),
-              body: request.encode_body
+              headers: request.encode_headers(protected_keys: @default_headers.keys + auth_headers.keys),
+              body: request.encode_body,
+              auth_headers: auth_headers
             )
 
             conn = connect(url)
@@ -157,12 +165,27 @@ module Seed
                 "HTTP is only allowed for localhost. Use HTTPS or pass a localhost URL."
         end
 
+        # Resolves the auth headers to send with the next request. Delegates to the
+        # configured auth provider (if any) on every call so that token-based
+        # providers (e.g. OAuth client-credentials) can refresh an expired token
+        # before the request is sent. Returns an empty hash when no provider is set,
+        # which keeps the api-key / basic / bearer / no-auth paths unchanged.
+        # @return [Hash] The auth headers for the current request.
+        def resolve_auth_headers
+          return {} if @auth_provider.nil?
+
+          @auth_provider.auth_headers
+        end
+
         # @param url [URI::Generic] The url to the resource.
         # @param method [String] The HTTP method to use.
         # @param headers [Hash] The headers for the request.
         # @param body [String, nil] The body for the request.
+        # @param auth_headers [Hash] The auth headers resolved for this request. These
+        #   take precedence over the static default headers but not over per-request
+        #   headers, mirroring the previous baked-header precedence.
         # @return [HTTP::Request] The HTTP request.
-        def build_http_request(url:, method:, headers: {}, body: nil)
+        def build_http_request(url:, method:, headers: {}, body: nil, auth_headers: {})
           request = Net::HTTPGenericRequest.new(
             method,
             !body.nil?,
@@ -170,7 +193,7 @@ module Seed
             url
           )
 
-          request_headers = @default_headers.merge(headers)
+          request_headers = @default_headers.merge(auth_headers).merge(headers)
           request_headers.each { |name, value| request[name] = value }
           request.body = body if body
 

--- a/seed/ruby-sdk-v2/file-download/test/unit/internal/http/test_raw_client.rb
+++ b/seed/ruby-sdk-v2/file-download/test/unit/internal/http/test_raw_client.rb
@@ -54,4 +54,71 @@ describe Seed::Internal::Http::RawClient do
       assert client.should_retry?(make_response(502), 2)
     end
   end
+
+  # A minimal auth provider whose `auth_headers` returns a *different* token on
+  # each call, simulating a token that is refreshed on expiry.
+  class RefreshingAuthProvider
+    def initialize
+      @count = 0
+    end
+
+    def auth_headers
+      @count += 1
+      { "Authorization" => "Bearer TOKEN_#{@count}" }
+    end
+  end
+
+  describe "#resolve_auth_headers" do
+    it "returns an empty hash when no auth provider is configured" do
+      client = Seed::Internal::Http::RawClient.new(base_url: "https://example.com")
+
+      assert_equal({}, client.resolve_auth_headers)
+    end
+
+    it "consults the auth provider on every call so an expired token is refreshed" do
+      client = Seed::Internal::Http::RawClient.new(
+        base_url: "https://example.com",
+        auth_provider: RefreshingAuthProvider.new
+      )
+
+      assert_equal({ "Authorization" => "Bearer TOKEN_1" }, client.resolve_auth_headers)
+      assert_equal({ "Authorization" => "Bearer TOKEN_2" }, client.resolve_auth_headers)
+    end
+  end
+
+  describe "#build_http_request auth header precedence" do
+    let(:client) do
+      Seed::Internal::Http::RawClient.new(
+        base_url: "https://example.com",
+        headers: { "Authorization" => "Bearer STATIC" }
+      )
+    end
+
+    it "lets resolved auth headers override the static default headers" do
+      request = client.build_http_request(
+        url: URI.parse("https://example.com"),
+        method: "GET",
+        auth_headers: { "Authorization" => "Bearer FRESH" }
+      )
+
+      assert_equal("Bearer FRESH", request["Authorization"])
+    end
+
+    it "lets per-request headers take precedence over auth headers" do
+      request = client.build_http_request(
+        url: URI.parse("https://example.com"),
+        method: "GET",
+        headers: { "Authorization" => "Bearer PER_REQUEST" },
+        auth_headers: { "Authorization" => "Bearer FRESH" }
+      )
+
+      assert_equal("Bearer PER_REQUEST", request["Authorization"])
+    end
+
+    it "defaults auth headers to empty, leaving the default headers unchanged" do
+      request = client.build_http_request(url: URI.parse("https://example.com"), method: "GET")
+
+      assert_equal("Bearer STATIC", request["Authorization"])
+    end
+  end
 end

--- a/seed/ruby-sdk-v2/file-upload-openapi/lib/seed/internal/http/raw_client.rb
+++ b/seed/ruby-sdk-v2/file-upload-openapi/lib/seed/internal/http/raw_client.rb
@@ -21,10 +21,14 @@ module Seed
         # @param max_retries [Integer] The number of times to retry a failed request, defaults to 2.
         # @param timeout [Float] The timeout for the request, defaults to 60.0 seconds.
         # @param headers [Hash] The headers for the request.
-        def initialize(base_url:, max_retries: 2, timeout: 60.0, headers: {})
+        # @param auth_provider [Object, nil] An optional auth provider responding to
+        #   `auth_headers`. When present its headers are resolved on every request so
+        #   token-based schemes (e.g. OAuth) can refresh an expired token mid-session.
+        def initialize(base_url:, max_retries: 2, timeout: 60.0, headers: {}, auth_provider: nil)
           @base_url = base_url
           @max_retries = max_retries
           @timeout = timeout
+          @auth_provider = auth_provider
           @default_headers = {
             "X-Fern-Language": "Ruby",
             "X-Fern-SDK-Name": "seed",
@@ -36,6 +40,9 @@ module Seed
         # @return [HTTP::Response] The HTTP response.
         def send(request)
           url = build_url(request)
+          # Resolve auth headers once per request (not per retry) so token-based
+          # providers refresh at most once here; static providers are cheap.
+          auth_headers = resolve_auth_headers
           attempt = 0
           response = nil
 
@@ -43,8 +50,9 @@ module Seed
             http_request = build_http_request(
               url:,
               method: request.method,
-              headers: request.encode_headers(protected_keys: @default_headers.keys),
-              body: request.encode_body
+              headers: request.encode_headers(protected_keys: @default_headers.keys + auth_headers.keys),
+              body: request.encode_body,
+              auth_headers: auth_headers
             )
 
             conn = connect(url)
@@ -157,12 +165,27 @@ module Seed
                 "HTTP is only allowed for localhost. Use HTTPS or pass a localhost URL."
         end
 
+        # Resolves the auth headers to send with the next request. Delegates to the
+        # configured auth provider (if any) on every call so that token-based
+        # providers (e.g. OAuth client-credentials) can refresh an expired token
+        # before the request is sent. Returns an empty hash when no provider is set,
+        # which keeps the api-key / basic / bearer / no-auth paths unchanged.
+        # @return [Hash] The auth headers for the current request.
+        def resolve_auth_headers
+          return {} if @auth_provider.nil?
+
+          @auth_provider.auth_headers
+        end
+
         # @param url [URI::Generic] The url to the resource.
         # @param method [String] The HTTP method to use.
         # @param headers [Hash] The headers for the request.
         # @param body [String, nil] The body for the request.
+        # @param auth_headers [Hash] The auth headers resolved for this request. These
+        #   take precedence over the static default headers but not over per-request
+        #   headers, mirroring the previous baked-header precedence.
         # @return [HTTP::Request] The HTTP request.
-        def build_http_request(url:, method:, headers: {}, body: nil)
+        def build_http_request(url:, method:, headers: {}, body: nil, auth_headers: {})
           request = Net::HTTPGenericRequest.new(
             method,
             !body.nil?,
@@ -170,7 +193,7 @@ module Seed
             url
           )
 
-          request_headers = @default_headers.merge(headers)
+          request_headers = @default_headers.merge(auth_headers).merge(headers)
           request_headers.each { |name, value| request[name] = value }
           request.body = body if body
 

--- a/seed/ruby-sdk-v2/file-upload-openapi/test/unit/internal/http/test_raw_client.rb
+++ b/seed/ruby-sdk-v2/file-upload-openapi/test/unit/internal/http/test_raw_client.rb
@@ -54,4 +54,71 @@ describe Seed::Internal::Http::RawClient do
       assert client.should_retry?(make_response(502), 2)
     end
   end
+
+  # A minimal auth provider whose `auth_headers` returns a *different* token on
+  # each call, simulating a token that is refreshed on expiry.
+  class RefreshingAuthProvider
+    def initialize
+      @count = 0
+    end
+
+    def auth_headers
+      @count += 1
+      { "Authorization" => "Bearer TOKEN_#{@count}" }
+    end
+  end
+
+  describe "#resolve_auth_headers" do
+    it "returns an empty hash when no auth provider is configured" do
+      client = Seed::Internal::Http::RawClient.new(base_url: "https://example.com")
+
+      assert_equal({}, client.resolve_auth_headers)
+    end
+
+    it "consults the auth provider on every call so an expired token is refreshed" do
+      client = Seed::Internal::Http::RawClient.new(
+        base_url: "https://example.com",
+        auth_provider: RefreshingAuthProvider.new
+      )
+
+      assert_equal({ "Authorization" => "Bearer TOKEN_1" }, client.resolve_auth_headers)
+      assert_equal({ "Authorization" => "Bearer TOKEN_2" }, client.resolve_auth_headers)
+    end
+  end
+
+  describe "#build_http_request auth header precedence" do
+    let(:client) do
+      Seed::Internal::Http::RawClient.new(
+        base_url: "https://example.com",
+        headers: { "Authorization" => "Bearer STATIC" }
+      )
+    end
+
+    it "lets resolved auth headers override the static default headers" do
+      request = client.build_http_request(
+        url: URI.parse("https://example.com"),
+        method: "GET",
+        auth_headers: { "Authorization" => "Bearer FRESH" }
+      )
+
+      assert_equal("Bearer FRESH", request["Authorization"])
+    end
+
+    it "lets per-request headers take precedence over auth headers" do
+      request = client.build_http_request(
+        url: URI.parse("https://example.com"),
+        method: "GET",
+        headers: { "Authorization" => "Bearer PER_REQUEST" },
+        auth_headers: { "Authorization" => "Bearer FRESH" }
+      )
+
+      assert_equal("Bearer PER_REQUEST", request["Authorization"])
+    end
+
+    it "defaults auth headers to empty, leaving the default headers unchanged" do
+      request = client.build_http_request(url: URI.parse("https://example.com"), method: "GET")
+
+      assert_equal("Bearer STATIC", request["Authorization"])
+    end
+  end
 end

--- a/seed/ruby-sdk-v2/file-upload/lib/seed/internal/http/raw_client.rb
+++ b/seed/ruby-sdk-v2/file-upload/lib/seed/internal/http/raw_client.rb
@@ -21,10 +21,14 @@ module Seed
         # @param max_retries [Integer] The number of times to retry a failed request, defaults to 2.
         # @param timeout [Float] The timeout for the request, defaults to 60.0 seconds.
         # @param headers [Hash] The headers for the request.
-        def initialize(base_url:, max_retries: 2, timeout: 60.0, headers: {})
+        # @param auth_provider [Object, nil] An optional auth provider responding to
+        #   `auth_headers`. When present its headers are resolved on every request so
+        #   token-based schemes (e.g. OAuth) can refresh an expired token mid-session.
+        def initialize(base_url:, max_retries: 2, timeout: 60.0, headers: {}, auth_provider: nil)
           @base_url = base_url
           @max_retries = max_retries
           @timeout = timeout
+          @auth_provider = auth_provider
           @default_headers = {
             "X-Fern-Language": "Ruby",
             "X-Fern-SDK-Name": "seed",
@@ -36,6 +40,9 @@ module Seed
         # @return [HTTP::Response] The HTTP response.
         def send(request)
           url = build_url(request)
+          # Resolve auth headers once per request (not per retry) so token-based
+          # providers refresh at most once here; static providers are cheap.
+          auth_headers = resolve_auth_headers
           attempt = 0
           response = nil
 
@@ -43,8 +50,9 @@ module Seed
             http_request = build_http_request(
               url:,
               method: request.method,
-              headers: request.encode_headers(protected_keys: @default_headers.keys),
-              body: request.encode_body
+              headers: request.encode_headers(protected_keys: @default_headers.keys + auth_headers.keys),
+              body: request.encode_body,
+              auth_headers: auth_headers
             )
 
             conn = connect(url)
@@ -157,12 +165,27 @@ module Seed
                 "HTTP is only allowed for localhost. Use HTTPS or pass a localhost URL."
         end
 
+        # Resolves the auth headers to send with the next request. Delegates to the
+        # configured auth provider (if any) on every call so that token-based
+        # providers (e.g. OAuth client-credentials) can refresh an expired token
+        # before the request is sent. Returns an empty hash when no provider is set,
+        # which keeps the api-key / basic / bearer / no-auth paths unchanged.
+        # @return [Hash] The auth headers for the current request.
+        def resolve_auth_headers
+          return {} if @auth_provider.nil?
+
+          @auth_provider.auth_headers
+        end
+
         # @param url [URI::Generic] The url to the resource.
         # @param method [String] The HTTP method to use.
         # @param headers [Hash] The headers for the request.
         # @param body [String, nil] The body for the request.
+        # @param auth_headers [Hash] The auth headers resolved for this request. These
+        #   take precedence over the static default headers but not over per-request
+        #   headers, mirroring the previous baked-header precedence.
         # @return [HTTP::Request] The HTTP request.
-        def build_http_request(url:, method:, headers: {}, body: nil)
+        def build_http_request(url:, method:, headers: {}, body: nil, auth_headers: {})
           request = Net::HTTPGenericRequest.new(
             method,
             !body.nil?,
@@ -170,7 +193,7 @@ module Seed
             url
           )
 
-          request_headers = @default_headers.merge(headers)
+          request_headers = @default_headers.merge(auth_headers).merge(headers)
           request_headers.each { |name, value| request[name] = value }
           request.body = body if body
 

--- a/seed/ruby-sdk-v2/file-upload/test/unit/internal/http/test_raw_client.rb
+++ b/seed/ruby-sdk-v2/file-upload/test/unit/internal/http/test_raw_client.rb
@@ -54,4 +54,71 @@ describe Seed::Internal::Http::RawClient do
       assert client.should_retry?(make_response(502), 2)
     end
   end
+
+  # A minimal auth provider whose `auth_headers` returns a *different* token on
+  # each call, simulating a token that is refreshed on expiry.
+  class RefreshingAuthProvider
+    def initialize
+      @count = 0
+    end
+
+    def auth_headers
+      @count += 1
+      { "Authorization" => "Bearer TOKEN_#{@count}" }
+    end
+  end
+
+  describe "#resolve_auth_headers" do
+    it "returns an empty hash when no auth provider is configured" do
+      client = Seed::Internal::Http::RawClient.new(base_url: "https://example.com")
+
+      assert_equal({}, client.resolve_auth_headers)
+    end
+
+    it "consults the auth provider on every call so an expired token is refreshed" do
+      client = Seed::Internal::Http::RawClient.new(
+        base_url: "https://example.com",
+        auth_provider: RefreshingAuthProvider.new
+      )
+
+      assert_equal({ "Authorization" => "Bearer TOKEN_1" }, client.resolve_auth_headers)
+      assert_equal({ "Authorization" => "Bearer TOKEN_2" }, client.resolve_auth_headers)
+    end
+  end
+
+  describe "#build_http_request auth header precedence" do
+    let(:client) do
+      Seed::Internal::Http::RawClient.new(
+        base_url: "https://example.com",
+        headers: { "Authorization" => "Bearer STATIC" }
+      )
+    end
+
+    it "lets resolved auth headers override the static default headers" do
+      request = client.build_http_request(
+        url: URI.parse("https://example.com"),
+        method: "GET",
+        auth_headers: { "Authorization" => "Bearer FRESH" }
+      )
+
+      assert_equal("Bearer FRESH", request["Authorization"])
+    end
+
+    it "lets per-request headers take precedence over auth headers" do
+      request = client.build_http_request(
+        url: URI.parse("https://example.com"),
+        method: "GET",
+        headers: { "Authorization" => "Bearer PER_REQUEST" },
+        auth_headers: { "Authorization" => "Bearer FRESH" }
+      )
+
+      assert_equal("Bearer PER_REQUEST", request["Authorization"])
+    end
+
+    it "defaults auth headers to empty, leaving the default headers unchanged" do
+      request = client.build_http_request(url: URI.parse("https://example.com"), method: "GET")
+
+      assert_equal("Bearer STATIC", request["Authorization"])
+    end
+  end
 end

--- a/seed/ruby-sdk-v2/folders/lib/seed/internal/http/raw_client.rb
+++ b/seed/ruby-sdk-v2/folders/lib/seed/internal/http/raw_client.rb
@@ -21,10 +21,14 @@ module Seed
         # @param max_retries [Integer] The number of times to retry a failed request, defaults to 2.
         # @param timeout [Float] The timeout for the request, defaults to 60.0 seconds.
         # @param headers [Hash] The headers for the request.
-        def initialize(base_url:, max_retries: 2, timeout: 60.0, headers: {})
+        # @param auth_provider [Object, nil] An optional auth provider responding to
+        #   `auth_headers`. When present its headers are resolved on every request so
+        #   token-based schemes (e.g. OAuth) can refresh an expired token mid-session.
+        def initialize(base_url:, max_retries: 2, timeout: 60.0, headers: {}, auth_provider: nil)
           @base_url = base_url
           @max_retries = max_retries
           @timeout = timeout
+          @auth_provider = auth_provider
           @default_headers = {
             "X-Fern-Language": "Ruby",
             "X-Fern-SDK-Name": "seed",
@@ -36,6 +40,9 @@ module Seed
         # @return [HTTP::Response] The HTTP response.
         def send(request)
           url = build_url(request)
+          # Resolve auth headers once per request (not per retry) so token-based
+          # providers refresh at most once here; static providers are cheap.
+          auth_headers = resolve_auth_headers
           attempt = 0
           response = nil
 
@@ -43,8 +50,9 @@ module Seed
             http_request = build_http_request(
               url:,
               method: request.method,
-              headers: request.encode_headers(protected_keys: @default_headers.keys),
-              body: request.encode_body
+              headers: request.encode_headers(protected_keys: @default_headers.keys + auth_headers.keys),
+              body: request.encode_body,
+              auth_headers: auth_headers
             )
 
             conn = connect(url)
@@ -157,12 +165,27 @@ module Seed
                 "HTTP is only allowed for localhost. Use HTTPS or pass a localhost URL."
         end
 
+        # Resolves the auth headers to send with the next request. Delegates to the
+        # configured auth provider (if any) on every call so that token-based
+        # providers (e.g. OAuth client-credentials) can refresh an expired token
+        # before the request is sent. Returns an empty hash when no provider is set,
+        # which keeps the api-key / basic / bearer / no-auth paths unchanged.
+        # @return [Hash] The auth headers for the current request.
+        def resolve_auth_headers
+          return {} if @auth_provider.nil?
+
+          @auth_provider.auth_headers
+        end
+
         # @param url [URI::Generic] The url to the resource.
         # @param method [String] The HTTP method to use.
         # @param headers [Hash] The headers for the request.
         # @param body [String, nil] The body for the request.
+        # @param auth_headers [Hash] The auth headers resolved for this request. These
+        #   take precedence over the static default headers but not over per-request
+        #   headers, mirroring the previous baked-header precedence.
         # @return [HTTP::Request] The HTTP request.
-        def build_http_request(url:, method:, headers: {}, body: nil)
+        def build_http_request(url:, method:, headers: {}, body: nil, auth_headers: {})
           request = Net::HTTPGenericRequest.new(
             method,
             !body.nil?,
@@ -170,7 +193,7 @@ module Seed
             url
           )
 
-          request_headers = @default_headers.merge(headers)
+          request_headers = @default_headers.merge(auth_headers).merge(headers)
           request_headers.each { |name, value| request[name] = value }
           request.body = body if body
 

--- a/seed/ruby-sdk-v2/folders/test/unit/internal/http/test_raw_client.rb
+++ b/seed/ruby-sdk-v2/folders/test/unit/internal/http/test_raw_client.rb
@@ -54,4 +54,71 @@ describe Seed::Internal::Http::RawClient do
       assert client.should_retry?(make_response(502), 2)
     end
   end
+
+  # A minimal auth provider whose `auth_headers` returns a *different* token on
+  # each call, simulating a token that is refreshed on expiry.
+  class RefreshingAuthProvider
+    def initialize
+      @count = 0
+    end
+
+    def auth_headers
+      @count += 1
+      { "Authorization" => "Bearer TOKEN_#{@count}" }
+    end
+  end
+
+  describe "#resolve_auth_headers" do
+    it "returns an empty hash when no auth provider is configured" do
+      client = Seed::Internal::Http::RawClient.new(base_url: "https://example.com")
+
+      assert_equal({}, client.resolve_auth_headers)
+    end
+
+    it "consults the auth provider on every call so an expired token is refreshed" do
+      client = Seed::Internal::Http::RawClient.new(
+        base_url: "https://example.com",
+        auth_provider: RefreshingAuthProvider.new
+      )
+
+      assert_equal({ "Authorization" => "Bearer TOKEN_1" }, client.resolve_auth_headers)
+      assert_equal({ "Authorization" => "Bearer TOKEN_2" }, client.resolve_auth_headers)
+    end
+  end
+
+  describe "#build_http_request auth header precedence" do
+    let(:client) do
+      Seed::Internal::Http::RawClient.new(
+        base_url: "https://example.com",
+        headers: { "Authorization" => "Bearer STATIC" }
+      )
+    end
+
+    it "lets resolved auth headers override the static default headers" do
+      request = client.build_http_request(
+        url: URI.parse("https://example.com"),
+        method: "GET",
+        auth_headers: { "Authorization" => "Bearer FRESH" }
+      )
+
+      assert_equal("Bearer FRESH", request["Authorization"])
+    end
+
+    it "lets per-request headers take precedence over auth headers" do
+      request = client.build_http_request(
+        url: URI.parse("https://example.com"),
+        method: "GET",
+        headers: { "Authorization" => "Bearer PER_REQUEST" },
+        auth_headers: { "Authorization" => "Bearer FRESH" }
+      )
+
+      assert_equal("Bearer PER_REQUEST", request["Authorization"])
+    end
+
+    it "defaults auth headers to empty, leaving the default headers unchanged" do
+      request = client.build_http_request(url: URI.parse("https://example.com"), method: "GET")
+
+      assert_equal("Bearer STATIC", request["Authorization"])
+    end
+  end
 end

--- a/seed/ruby-sdk-v2/header-auth-environment-variable/lib/seed/internal/http/raw_client.rb
+++ b/seed/ruby-sdk-v2/header-auth-environment-variable/lib/seed/internal/http/raw_client.rb
@@ -21,10 +21,14 @@ module Seed
         # @param max_retries [Integer] The number of times to retry a failed request, defaults to 2.
         # @param timeout [Float] The timeout for the request, defaults to 60.0 seconds.
         # @param headers [Hash] The headers for the request.
-        def initialize(base_url:, max_retries: 2, timeout: 60.0, headers: {})
+        # @param auth_provider [Object, nil] An optional auth provider responding to
+        #   `auth_headers`. When present its headers are resolved on every request so
+        #   token-based schemes (e.g. OAuth) can refresh an expired token mid-session.
+        def initialize(base_url:, max_retries: 2, timeout: 60.0, headers: {}, auth_provider: nil)
           @base_url = base_url
           @max_retries = max_retries
           @timeout = timeout
+          @auth_provider = auth_provider
           @default_headers = {
             "X-Fern-Language": "Ruby",
             "X-Fern-SDK-Name": "seed",
@@ -36,6 +40,9 @@ module Seed
         # @return [HTTP::Response] The HTTP response.
         def send(request)
           url = build_url(request)
+          # Resolve auth headers once per request (not per retry) so token-based
+          # providers refresh at most once here; static providers are cheap.
+          auth_headers = resolve_auth_headers
           attempt = 0
           response = nil
 
@@ -43,8 +50,9 @@ module Seed
             http_request = build_http_request(
               url:,
               method: request.method,
-              headers: request.encode_headers(protected_keys: @default_headers.keys),
-              body: request.encode_body
+              headers: request.encode_headers(protected_keys: @default_headers.keys + auth_headers.keys),
+              body: request.encode_body,
+              auth_headers: auth_headers
             )
 
             conn = connect(url)
@@ -157,12 +165,27 @@ module Seed
                 "HTTP is only allowed for localhost. Use HTTPS or pass a localhost URL."
         end
 
+        # Resolves the auth headers to send with the next request. Delegates to the
+        # configured auth provider (if any) on every call so that token-based
+        # providers (e.g. OAuth client-credentials) can refresh an expired token
+        # before the request is sent. Returns an empty hash when no provider is set,
+        # which keeps the api-key / basic / bearer / no-auth paths unchanged.
+        # @return [Hash] The auth headers for the current request.
+        def resolve_auth_headers
+          return {} if @auth_provider.nil?
+
+          @auth_provider.auth_headers
+        end
+
         # @param url [URI::Generic] The url to the resource.
         # @param method [String] The HTTP method to use.
         # @param headers [Hash] The headers for the request.
         # @param body [String, nil] The body for the request.
+        # @param auth_headers [Hash] The auth headers resolved for this request. These
+        #   take precedence over the static default headers but not over per-request
+        #   headers, mirroring the previous baked-header precedence.
         # @return [HTTP::Request] The HTTP request.
-        def build_http_request(url:, method:, headers: {}, body: nil)
+        def build_http_request(url:, method:, headers: {}, body: nil, auth_headers: {})
           request = Net::HTTPGenericRequest.new(
             method,
             !body.nil?,
@@ -170,7 +193,7 @@ module Seed
             url
           )
 
-          request_headers = @default_headers.merge(headers)
+          request_headers = @default_headers.merge(auth_headers).merge(headers)
           request_headers.each { |name, value| request[name] = value }
           request.body = body if body
 

--- a/seed/ruby-sdk-v2/header-auth-environment-variable/test/unit/internal/http/test_raw_client.rb
+++ b/seed/ruby-sdk-v2/header-auth-environment-variable/test/unit/internal/http/test_raw_client.rb
@@ -54,4 +54,71 @@ describe Seed::Internal::Http::RawClient do
       assert client.should_retry?(make_response(502), 2)
     end
   end
+
+  # A minimal auth provider whose `auth_headers` returns a *different* token on
+  # each call, simulating a token that is refreshed on expiry.
+  class RefreshingAuthProvider
+    def initialize
+      @count = 0
+    end
+
+    def auth_headers
+      @count += 1
+      { "Authorization" => "Bearer TOKEN_#{@count}" }
+    end
+  end
+
+  describe "#resolve_auth_headers" do
+    it "returns an empty hash when no auth provider is configured" do
+      client = Seed::Internal::Http::RawClient.new(base_url: "https://example.com")
+
+      assert_equal({}, client.resolve_auth_headers)
+    end
+
+    it "consults the auth provider on every call so an expired token is refreshed" do
+      client = Seed::Internal::Http::RawClient.new(
+        base_url: "https://example.com",
+        auth_provider: RefreshingAuthProvider.new
+      )
+
+      assert_equal({ "Authorization" => "Bearer TOKEN_1" }, client.resolve_auth_headers)
+      assert_equal({ "Authorization" => "Bearer TOKEN_2" }, client.resolve_auth_headers)
+    end
+  end
+
+  describe "#build_http_request auth header precedence" do
+    let(:client) do
+      Seed::Internal::Http::RawClient.new(
+        base_url: "https://example.com",
+        headers: { "Authorization" => "Bearer STATIC" }
+      )
+    end
+
+    it "lets resolved auth headers override the static default headers" do
+      request = client.build_http_request(
+        url: URI.parse("https://example.com"),
+        method: "GET",
+        auth_headers: { "Authorization" => "Bearer FRESH" }
+      )
+
+      assert_equal("Bearer FRESH", request["Authorization"])
+    end
+
+    it "lets per-request headers take precedence over auth headers" do
+      request = client.build_http_request(
+        url: URI.parse("https://example.com"),
+        method: "GET",
+        headers: { "Authorization" => "Bearer PER_REQUEST" },
+        auth_headers: { "Authorization" => "Bearer FRESH" }
+      )
+
+      assert_equal("Bearer PER_REQUEST", request["Authorization"])
+    end
+
+    it "defaults auth headers to empty, leaving the default headers unchanged" do
+      request = client.build_http_request(url: URI.parse("https://example.com"), method: "GET")
+
+      assert_equal("Bearer STATIC", request["Authorization"])
+    end
+  end
 end

--- a/seed/ruby-sdk-v2/header-auth/lib/seed/internal/http/raw_client.rb
+++ b/seed/ruby-sdk-v2/header-auth/lib/seed/internal/http/raw_client.rb
@@ -21,10 +21,14 @@ module Seed
         # @param max_retries [Integer] The number of times to retry a failed request, defaults to 2.
         # @param timeout [Float] The timeout for the request, defaults to 60.0 seconds.
         # @param headers [Hash] The headers for the request.
-        def initialize(base_url:, max_retries: 2, timeout: 60.0, headers: {})
+        # @param auth_provider [Object, nil] An optional auth provider responding to
+        #   `auth_headers`. When present its headers are resolved on every request so
+        #   token-based schemes (e.g. OAuth) can refresh an expired token mid-session.
+        def initialize(base_url:, max_retries: 2, timeout: 60.0, headers: {}, auth_provider: nil)
           @base_url = base_url
           @max_retries = max_retries
           @timeout = timeout
+          @auth_provider = auth_provider
           @default_headers = {
             "X-Fern-Language": "Ruby",
             "X-Fern-SDK-Name": "seed",
@@ -36,6 +40,9 @@ module Seed
         # @return [HTTP::Response] The HTTP response.
         def send(request)
           url = build_url(request)
+          # Resolve auth headers once per request (not per retry) so token-based
+          # providers refresh at most once here; static providers are cheap.
+          auth_headers = resolve_auth_headers
           attempt = 0
           response = nil
 
@@ -43,8 +50,9 @@ module Seed
             http_request = build_http_request(
               url:,
               method: request.method,
-              headers: request.encode_headers(protected_keys: @default_headers.keys),
-              body: request.encode_body
+              headers: request.encode_headers(protected_keys: @default_headers.keys + auth_headers.keys),
+              body: request.encode_body,
+              auth_headers: auth_headers
             )
 
             conn = connect(url)
@@ -157,12 +165,27 @@ module Seed
                 "HTTP is only allowed for localhost. Use HTTPS or pass a localhost URL."
         end
 
+        # Resolves the auth headers to send with the next request. Delegates to the
+        # configured auth provider (if any) on every call so that token-based
+        # providers (e.g. OAuth client-credentials) can refresh an expired token
+        # before the request is sent. Returns an empty hash when no provider is set,
+        # which keeps the api-key / basic / bearer / no-auth paths unchanged.
+        # @return [Hash] The auth headers for the current request.
+        def resolve_auth_headers
+          return {} if @auth_provider.nil?
+
+          @auth_provider.auth_headers
+        end
+
         # @param url [URI::Generic] The url to the resource.
         # @param method [String] The HTTP method to use.
         # @param headers [Hash] The headers for the request.
         # @param body [String, nil] The body for the request.
+        # @param auth_headers [Hash] The auth headers resolved for this request. These
+        #   take precedence over the static default headers but not over per-request
+        #   headers, mirroring the previous baked-header precedence.
         # @return [HTTP::Request] The HTTP request.
-        def build_http_request(url:, method:, headers: {}, body: nil)
+        def build_http_request(url:, method:, headers: {}, body: nil, auth_headers: {})
           request = Net::HTTPGenericRequest.new(
             method,
             !body.nil?,
@@ -170,7 +193,7 @@ module Seed
             url
           )
 
-          request_headers = @default_headers.merge(headers)
+          request_headers = @default_headers.merge(auth_headers).merge(headers)
           request_headers.each { |name, value| request[name] = value }
           request.body = body if body
 

--- a/seed/ruby-sdk-v2/header-auth/test/unit/internal/http/test_raw_client.rb
+++ b/seed/ruby-sdk-v2/header-auth/test/unit/internal/http/test_raw_client.rb
@@ -54,4 +54,71 @@ describe Seed::Internal::Http::RawClient do
       assert client.should_retry?(make_response(502), 2)
     end
   end
+
+  # A minimal auth provider whose `auth_headers` returns a *different* token on
+  # each call, simulating a token that is refreshed on expiry.
+  class RefreshingAuthProvider
+    def initialize
+      @count = 0
+    end
+
+    def auth_headers
+      @count += 1
+      { "Authorization" => "Bearer TOKEN_#{@count}" }
+    end
+  end
+
+  describe "#resolve_auth_headers" do
+    it "returns an empty hash when no auth provider is configured" do
+      client = Seed::Internal::Http::RawClient.new(base_url: "https://example.com")
+
+      assert_equal({}, client.resolve_auth_headers)
+    end
+
+    it "consults the auth provider on every call so an expired token is refreshed" do
+      client = Seed::Internal::Http::RawClient.new(
+        base_url: "https://example.com",
+        auth_provider: RefreshingAuthProvider.new
+      )
+
+      assert_equal({ "Authorization" => "Bearer TOKEN_1" }, client.resolve_auth_headers)
+      assert_equal({ "Authorization" => "Bearer TOKEN_2" }, client.resolve_auth_headers)
+    end
+  end
+
+  describe "#build_http_request auth header precedence" do
+    let(:client) do
+      Seed::Internal::Http::RawClient.new(
+        base_url: "https://example.com",
+        headers: { "Authorization" => "Bearer STATIC" }
+      )
+    end
+
+    it "lets resolved auth headers override the static default headers" do
+      request = client.build_http_request(
+        url: URI.parse("https://example.com"),
+        method: "GET",
+        auth_headers: { "Authorization" => "Bearer FRESH" }
+      )
+
+      assert_equal("Bearer FRESH", request["Authorization"])
+    end
+
+    it "lets per-request headers take precedence over auth headers" do
+      request = client.build_http_request(
+        url: URI.parse("https://example.com"),
+        method: "GET",
+        headers: { "Authorization" => "Bearer PER_REQUEST" },
+        auth_headers: { "Authorization" => "Bearer FRESH" }
+      )
+
+      assert_equal("Bearer PER_REQUEST", request["Authorization"])
+    end
+
+    it "defaults auth headers to empty, leaving the default headers unchanged" do
+      request = client.build_http_request(url: URI.parse("https://example.com"), method: "GET")
+
+      assert_equal("Bearer STATIC", request["Authorization"])
+    end
+  end
 end

--- a/seed/ruby-sdk-v2/http-head/lib/seed/internal/http/raw_client.rb
+++ b/seed/ruby-sdk-v2/http-head/lib/seed/internal/http/raw_client.rb
@@ -21,10 +21,14 @@ module Seed
         # @param max_retries [Integer] The number of times to retry a failed request, defaults to 2.
         # @param timeout [Float] The timeout for the request, defaults to 60.0 seconds.
         # @param headers [Hash] The headers for the request.
-        def initialize(base_url:, max_retries: 2, timeout: 60.0, headers: {})
+        # @param auth_provider [Object, nil] An optional auth provider responding to
+        #   `auth_headers`. When present its headers are resolved on every request so
+        #   token-based schemes (e.g. OAuth) can refresh an expired token mid-session.
+        def initialize(base_url:, max_retries: 2, timeout: 60.0, headers: {}, auth_provider: nil)
           @base_url = base_url
           @max_retries = max_retries
           @timeout = timeout
+          @auth_provider = auth_provider
           @default_headers = {
             "X-Fern-Language": "Ruby",
             "X-Fern-SDK-Name": "seed",
@@ -36,6 +40,9 @@ module Seed
         # @return [HTTP::Response] The HTTP response.
         def send(request)
           url = build_url(request)
+          # Resolve auth headers once per request (not per retry) so token-based
+          # providers refresh at most once here; static providers are cheap.
+          auth_headers = resolve_auth_headers
           attempt = 0
           response = nil
 
@@ -43,8 +50,9 @@ module Seed
             http_request = build_http_request(
               url:,
               method: request.method,
-              headers: request.encode_headers(protected_keys: @default_headers.keys),
-              body: request.encode_body
+              headers: request.encode_headers(protected_keys: @default_headers.keys + auth_headers.keys),
+              body: request.encode_body,
+              auth_headers: auth_headers
             )
 
             conn = connect(url)
@@ -157,12 +165,27 @@ module Seed
                 "HTTP is only allowed for localhost. Use HTTPS or pass a localhost URL."
         end
 
+        # Resolves the auth headers to send with the next request. Delegates to the
+        # configured auth provider (if any) on every call so that token-based
+        # providers (e.g. OAuth client-credentials) can refresh an expired token
+        # before the request is sent. Returns an empty hash when no provider is set,
+        # which keeps the api-key / basic / bearer / no-auth paths unchanged.
+        # @return [Hash] The auth headers for the current request.
+        def resolve_auth_headers
+          return {} if @auth_provider.nil?
+
+          @auth_provider.auth_headers
+        end
+
         # @param url [URI::Generic] The url to the resource.
         # @param method [String] The HTTP method to use.
         # @param headers [Hash] The headers for the request.
         # @param body [String, nil] The body for the request.
+        # @param auth_headers [Hash] The auth headers resolved for this request. These
+        #   take precedence over the static default headers but not over per-request
+        #   headers, mirroring the previous baked-header precedence.
         # @return [HTTP::Request] The HTTP request.
-        def build_http_request(url:, method:, headers: {}, body: nil)
+        def build_http_request(url:, method:, headers: {}, body: nil, auth_headers: {})
           request = Net::HTTPGenericRequest.new(
             method,
             !body.nil?,
@@ -170,7 +193,7 @@ module Seed
             url
           )
 
-          request_headers = @default_headers.merge(headers)
+          request_headers = @default_headers.merge(auth_headers).merge(headers)
           request_headers.each { |name, value| request[name] = value }
           request.body = body if body
 

--- a/seed/ruby-sdk-v2/http-head/test/unit/internal/http/test_raw_client.rb
+++ b/seed/ruby-sdk-v2/http-head/test/unit/internal/http/test_raw_client.rb
@@ -54,4 +54,71 @@ describe Seed::Internal::Http::RawClient do
       assert client.should_retry?(make_response(502), 2)
     end
   end
+
+  # A minimal auth provider whose `auth_headers` returns a *different* token on
+  # each call, simulating a token that is refreshed on expiry.
+  class RefreshingAuthProvider
+    def initialize
+      @count = 0
+    end
+
+    def auth_headers
+      @count += 1
+      { "Authorization" => "Bearer TOKEN_#{@count}" }
+    end
+  end
+
+  describe "#resolve_auth_headers" do
+    it "returns an empty hash when no auth provider is configured" do
+      client = Seed::Internal::Http::RawClient.new(base_url: "https://example.com")
+
+      assert_equal({}, client.resolve_auth_headers)
+    end
+
+    it "consults the auth provider on every call so an expired token is refreshed" do
+      client = Seed::Internal::Http::RawClient.new(
+        base_url: "https://example.com",
+        auth_provider: RefreshingAuthProvider.new
+      )
+
+      assert_equal({ "Authorization" => "Bearer TOKEN_1" }, client.resolve_auth_headers)
+      assert_equal({ "Authorization" => "Bearer TOKEN_2" }, client.resolve_auth_headers)
+    end
+  end
+
+  describe "#build_http_request auth header precedence" do
+    let(:client) do
+      Seed::Internal::Http::RawClient.new(
+        base_url: "https://example.com",
+        headers: { "Authorization" => "Bearer STATIC" }
+      )
+    end
+
+    it "lets resolved auth headers override the static default headers" do
+      request = client.build_http_request(
+        url: URI.parse("https://example.com"),
+        method: "GET",
+        auth_headers: { "Authorization" => "Bearer FRESH" }
+      )
+
+      assert_equal("Bearer FRESH", request["Authorization"])
+    end
+
+    it "lets per-request headers take precedence over auth headers" do
+      request = client.build_http_request(
+        url: URI.parse("https://example.com"),
+        method: "GET",
+        headers: { "Authorization" => "Bearer PER_REQUEST" },
+        auth_headers: { "Authorization" => "Bearer FRESH" }
+      )
+
+      assert_equal("Bearer PER_REQUEST", request["Authorization"])
+    end
+
+    it "defaults auth headers to empty, leaving the default headers unchanged" do
+      request = client.build_http_request(url: URI.parse("https://example.com"), method: "GET")
+
+      assert_equal("Bearer STATIC", request["Authorization"])
+    end
+  end
 end

--- a/seed/ruby-sdk-v2/idempotency-headers/lib/seed/internal/http/raw_client.rb
+++ b/seed/ruby-sdk-v2/idempotency-headers/lib/seed/internal/http/raw_client.rb
@@ -21,10 +21,14 @@ module Seed
         # @param max_retries [Integer] The number of times to retry a failed request, defaults to 2.
         # @param timeout [Float] The timeout for the request, defaults to 60.0 seconds.
         # @param headers [Hash] The headers for the request.
-        def initialize(base_url:, max_retries: 2, timeout: 60.0, headers: {})
+        # @param auth_provider [Object, nil] An optional auth provider responding to
+        #   `auth_headers`. When present its headers are resolved on every request so
+        #   token-based schemes (e.g. OAuth) can refresh an expired token mid-session.
+        def initialize(base_url:, max_retries: 2, timeout: 60.0, headers: {}, auth_provider: nil)
           @base_url = base_url
           @max_retries = max_retries
           @timeout = timeout
+          @auth_provider = auth_provider
           @default_headers = {
             "X-Fern-Language": "Ruby",
             "X-Fern-SDK-Name": "seed",
@@ -36,6 +40,9 @@ module Seed
         # @return [HTTP::Response] The HTTP response.
         def send(request)
           url = build_url(request)
+          # Resolve auth headers once per request (not per retry) so token-based
+          # providers refresh at most once here; static providers are cheap.
+          auth_headers = resolve_auth_headers
           attempt = 0
           response = nil
 
@@ -43,8 +50,9 @@ module Seed
             http_request = build_http_request(
               url:,
               method: request.method,
-              headers: request.encode_headers(protected_keys: @default_headers.keys),
-              body: request.encode_body
+              headers: request.encode_headers(protected_keys: @default_headers.keys + auth_headers.keys),
+              body: request.encode_body,
+              auth_headers: auth_headers
             )
 
             conn = connect(url)
@@ -157,12 +165,27 @@ module Seed
                 "HTTP is only allowed for localhost. Use HTTPS or pass a localhost URL."
         end
 
+        # Resolves the auth headers to send with the next request. Delegates to the
+        # configured auth provider (if any) on every call so that token-based
+        # providers (e.g. OAuth client-credentials) can refresh an expired token
+        # before the request is sent. Returns an empty hash when no provider is set,
+        # which keeps the api-key / basic / bearer / no-auth paths unchanged.
+        # @return [Hash] The auth headers for the current request.
+        def resolve_auth_headers
+          return {} if @auth_provider.nil?
+
+          @auth_provider.auth_headers
+        end
+
         # @param url [URI::Generic] The url to the resource.
         # @param method [String] The HTTP method to use.
         # @param headers [Hash] The headers for the request.
         # @param body [String, nil] The body for the request.
+        # @param auth_headers [Hash] The auth headers resolved for this request. These
+        #   take precedence over the static default headers but not over per-request
+        #   headers, mirroring the previous baked-header precedence.
         # @return [HTTP::Request] The HTTP request.
-        def build_http_request(url:, method:, headers: {}, body: nil)
+        def build_http_request(url:, method:, headers: {}, body: nil, auth_headers: {})
           request = Net::HTTPGenericRequest.new(
             method,
             !body.nil?,
@@ -170,7 +193,7 @@ module Seed
             url
           )
 
-          request_headers = @default_headers.merge(headers)
+          request_headers = @default_headers.merge(auth_headers).merge(headers)
           request_headers.each { |name, value| request[name] = value }
           request.body = body if body
 

--- a/seed/ruby-sdk-v2/idempotency-headers/test/unit/internal/http/test_raw_client.rb
+++ b/seed/ruby-sdk-v2/idempotency-headers/test/unit/internal/http/test_raw_client.rb
@@ -54,4 +54,71 @@ describe Seed::Internal::Http::RawClient do
       assert client.should_retry?(make_response(502), 2)
     end
   end
+
+  # A minimal auth provider whose `auth_headers` returns a *different* token on
+  # each call, simulating a token that is refreshed on expiry.
+  class RefreshingAuthProvider
+    def initialize
+      @count = 0
+    end
+
+    def auth_headers
+      @count += 1
+      { "Authorization" => "Bearer TOKEN_#{@count}" }
+    end
+  end
+
+  describe "#resolve_auth_headers" do
+    it "returns an empty hash when no auth provider is configured" do
+      client = Seed::Internal::Http::RawClient.new(base_url: "https://example.com")
+
+      assert_equal({}, client.resolve_auth_headers)
+    end
+
+    it "consults the auth provider on every call so an expired token is refreshed" do
+      client = Seed::Internal::Http::RawClient.new(
+        base_url: "https://example.com",
+        auth_provider: RefreshingAuthProvider.new
+      )
+
+      assert_equal({ "Authorization" => "Bearer TOKEN_1" }, client.resolve_auth_headers)
+      assert_equal({ "Authorization" => "Bearer TOKEN_2" }, client.resolve_auth_headers)
+    end
+  end
+
+  describe "#build_http_request auth header precedence" do
+    let(:client) do
+      Seed::Internal::Http::RawClient.new(
+        base_url: "https://example.com",
+        headers: { "Authorization" => "Bearer STATIC" }
+      )
+    end
+
+    it "lets resolved auth headers override the static default headers" do
+      request = client.build_http_request(
+        url: URI.parse("https://example.com"),
+        method: "GET",
+        auth_headers: { "Authorization" => "Bearer FRESH" }
+      )
+
+      assert_equal("Bearer FRESH", request["Authorization"])
+    end
+
+    it "lets per-request headers take precedence over auth headers" do
+      request = client.build_http_request(
+        url: URI.parse("https://example.com"),
+        method: "GET",
+        headers: { "Authorization" => "Bearer PER_REQUEST" },
+        auth_headers: { "Authorization" => "Bearer FRESH" }
+      )
+
+      assert_equal("Bearer PER_REQUEST", request["Authorization"])
+    end
+
+    it "defaults auth headers to empty, leaving the default headers unchanged" do
+      request = client.build_http_request(url: URI.parse("https://example.com"), method: "GET")
+
+      assert_equal("Bearer STATIC", request["Authorization"])
+    end
+  end
 end

--- a/seed/ruby-sdk-v2/imdb/lib/seed/internal/http/raw_client.rb
+++ b/seed/ruby-sdk-v2/imdb/lib/seed/internal/http/raw_client.rb
@@ -21,10 +21,14 @@ module Seed
         # @param max_retries [Integer] The number of times to retry a failed request, defaults to 2.
         # @param timeout [Float] The timeout for the request, defaults to 60.0 seconds.
         # @param headers [Hash] The headers for the request.
-        def initialize(base_url:, max_retries: 2, timeout: 60.0, headers: {})
+        # @param auth_provider [Object, nil] An optional auth provider responding to
+        #   `auth_headers`. When present its headers are resolved on every request so
+        #   token-based schemes (e.g. OAuth) can refresh an expired token mid-session.
+        def initialize(base_url:, max_retries: 2, timeout: 60.0, headers: {}, auth_provider: nil)
           @base_url = base_url
           @max_retries = max_retries
           @timeout = timeout
+          @auth_provider = auth_provider
           @default_headers = {
             "X-Fern-Language": "Ruby",
             "X-Fern-SDK-Name": "seed",
@@ -36,6 +40,9 @@ module Seed
         # @return [HTTP::Response] The HTTP response.
         def send(request)
           url = build_url(request)
+          # Resolve auth headers once per request (not per retry) so token-based
+          # providers refresh at most once here; static providers are cheap.
+          auth_headers = resolve_auth_headers
           attempt = 0
           response = nil
 
@@ -43,8 +50,9 @@ module Seed
             http_request = build_http_request(
               url:,
               method: request.method,
-              headers: request.encode_headers(protected_keys: @default_headers.keys),
-              body: request.encode_body
+              headers: request.encode_headers(protected_keys: @default_headers.keys + auth_headers.keys),
+              body: request.encode_body,
+              auth_headers: auth_headers
             )
 
             conn = connect(url)
@@ -157,12 +165,27 @@ module Seed
                 "HTTP is only allowed for localhost. Use HTTPS or pass a localhost URL."
         end
 
+        # Resolves the auth headers to send with the next request. Delegates to the
+        # configured auth provider (if any) on every call so that token-based
+        # providers (e.g. OAuth client-credentials) can refresh an expired token
+        # before the request is sent. Returns an empty hash when no provider is set,
+        # which keeps the api-key / basic / bearer / no-auth paths unchanged.
+        # @return [Hash] The auth headers for the current request.
+        def resolve_auth_headers
+          return {} if @auth_provider.nil?
+
+          @auth_provider.auth_headers
+        end
+
         # @param url [URI::Generic] The url to the resource.
         # @param method [String] The HTTP method to use.
         # @param headers [Hash] The headers for the request.
         # @param body [String, nil] The body for the request.
+        # @param auth_headers [Hash] The auth headers resolved for this request. These
+        #   take precedence over the static default headers but not over per-request
+        #   headers, mirroring the previous baked-header precedence.
         # @return [HTTP::Request] The HTTP request.
-        def build_http_request(url:, method:, headers: {}, body: nil)
+        def build_http_request(url:, method:, headers: {}, body: nil, auth_headers: {})
           request = Net::HTTPGenericRequest.new(
             method,
             !body.nil?,
@@ -170,7 +193,7 @@ module Seed
             url
           )
 
-          request_headers = @default_headers.merge(headers)
+          request_headers = @default_headers.merge(auth_headers).merge(headers)
           request_headers.each { |name, value| request[name] = value }
           request.body = body if body
 

--- a/seed/ruby-sdk-v2/imdb/test/unit/internal/http/test_raw_client.rb
+++ b/seed/ruby-sdk-v2/imdb/test/unit/internal/http/test_raw_client.rb
@@ -54,4 +54,71 @@ describe Seed::Internal::Http::RawClient do
       assert client.should_retry?(make_response(502), 2)
     end
   end
+
+  # A minimal auth provider whose `auth_headers` returns a *different* token on
+  # each call, simulating a token that is refreshed on expiry.
+  class RefreshingAuthProvider
+    def initialize
+      @count = 0
+    end
+
+    def auth_headers
+      @count += 1
+      { "Authorization" => "Bearer TOKEN_#{@count}" }
+    end
+  end
+
+  describe "#resolve_auth_headers" do
+    it "returns an empty hash when no auth provider is configured" do
+      client = Seed::Internal::Http::RawClient.new(base_url: "https://example.com")
+
+      assert_equal({}, client.resolve_auth_headers)
+    end
+
+    it "consults the auth provider on every call so an expired token is refreshed" do
+      client = Seed::Internal::Http::RawClient.new(
+        base_url: "https://example.com",
+        auth_provider: RefreshingAuthProvider.new
+      )
+
+      assert_equal({ "Authorization" => "Bearer TOKEN_1" }, client.resolve_auth_headers)
+      assert_equal({ "Authorization" => "Bearer TOKEN_2" }, client.resolve_auth_headers)
+    end
+  end
+
+  describe "#build_http_request auth header precedence" do
+    let(:client) do
+      Seed::Internal::Http::RawClient.new(
+        base_url: "https://example.com",
+        headers: { "Authorization" => "Bearer STATIC" }
+      )
+    end
+
+    it "lets resolved auth headers override the static default headers" do
+      request = client.build_http_request(
+        url: URI.parse("https://example.com"),
+        method: "GET",
+        auth_headers: { "Authorization" => "Bearer FRESH" }
+      )
+
+      assert_equal("Bearer FRESH", request["Authorization"])
+    end
+
+    it "lets per-request headers take precedence over auth headers" do
+      request = client.build_http_request(
+        url: URI.parse("https://example.com"),
+        method: "GET",
+        headers: { "Authorization" => "Bearer PER_REQUEST" },
+        auth_headers: { "Authorization" => "Bearer FRESH" }
+      )
+
+      assert_equal("Bearer PER_REQUEST", request["Authorization"])
+    end
+
+    it "defaults auth headers to empty, leaving the default headers unchanged" do
+      request = client.build_http_request(url: URI.parse("https://example.com"), method: "GET")
+
+      assert_equal("Bearer STATIC", request["Authorization"])
+    end
+  end
 end

--- a/seed/ruby-sdk-v2/inferred-auth-explicit/lib/seed/client.rb
+++ b/seed/ruby-sdk-v2/inferred-auth-explicit/lib/seed/client.rb
@@ -37,7 +37,8 @@ module Seed
         headers: {
           "User-Agent" => "fern_inferred-auth-explicit/0.0.1",
           "X-Fern-Language" => "Ruby"
-        }.merge(@auth_provider.auth_headers),
+        },
+        auth_provider: @auth_provider,
         max_retries: max_retries
       )
     end

--- a/seed/ruby-sdk-v2/inferred-auth-explicit/lib/seed/internal/http/raw_client.rb
+++ b/seed/ruby-sdk-v2/inferred-auth-explicit/lib/seed/internal/http/raw_client.rb
@@ -21,10 +21,14 @@ module Seed
         # @param max_retries [Integer] The number of times to retry a failed request, defaults to 2.
         # @param timeout [Float] The timeout for the request, defaults to 60.0 seconds.
         # @param headers [Hash] The headers for the request.
-        def initialize(base_url:, max_retries: 2, timeout: 60.0, headers: {})
+        # @param auth_provider [Object, nil] An optional auth provider responding to
+        #   `auth_headers`. When present its headers are resolved on every request so
+        #   token-based schemes (e.g. OAuth) can refresh an expired token mid-session.
+        def initialize(base_url:, max_retries: 2, timeout: 60.0, headers: {}, auth_provider: nil)
           @base_url = base_url
           @max_retries = max_retries
           @timeout = timeout
+          @auth_provider = auth_provider
           @default_headers = {
             "X-Fern-Language": "Ruby",
             "X-Fern-SDK-Name": "seed",
@@ -36,6 +40,9 @@ module Seed
         # @return [HTTP::Response] The HTTP response.
         def send(request)
           url = build_url(request)
+          # Resolve auth headers once per request (not per retry) so token-based
+          # providers refresh at most once here; static providers are cheap.
+          auth_headers = resolve_auth_headers
           attempt = 0
           response = nil
 
@@ -43,8 +50,9 @@ module Seed
             http_request = build_http_request(
               url:,
               method: request.method,
-              headers: request.encode_headers(protected_keys: @default_headers.keys),
-              body: request.encode_body
+              headers: request.encode_headers(protected_keys: @default_headers.keys + auth_headers.keys),
+              body: request.encode_body,
+              auth_headers: auth_headers
             )
 
             conn = connect(url)
@@ -157,12 +165,27 @@ module Seed
                 "HTTP is only allowed for localhost. Use HTTPS or pass a localhost URL."
         end
 
+        # Resolves the auth headers to send with the next request. Delegates to the
+        # configured auth provider (if any) on every call so that token-based
+        # providers (e.g. OAuth client-credentials) can refresh an expired token
+        # before the request is sent. Returns an empty hash when no provider is set,
+        # which keeps the api-key / basic / bearer / no-auth paths unchanged.
+        # @return [Hash] The auth headers for the current request.
+        def resolve_auth_headers
+          return {} if @auth_provider.nil?
+
+          @auth_provider.auth_headers
+        end
+
         # @param url [URI::Generic] The url to the resource.
         # @param method [String] The HTTP method to use.
         # @param headers [Hash] The headers for the request.
         # @param body [String, nil] The body for the request.
+        # @param auth_headers [Hash] The auth headers resolved for this request. These
+        #   take precedence over the static default headers but not over per-request
+        #   headers, mirroring the previous baked-header precedence.
         # @return [HTTP::Request] The HTTP request.
-        def build_http_request(url:, method:, headers: {}, body: nil)
+        def build_http_request(url:, method:, headers: {}, body: nil, auth_headers: {})
           request = Net::HTTPGenericRequest.new(
             method,
             !body.nil?,
@@ -170,7 +193,7 @@ module Seed
             url
           )
 
-          request_headers = @default_headers.merge(headers)
+          request_headers = @default_headers.merge(auth_headers).merge(headers)
           request_headers.each { |name, value| request[name] = value }
           request.body = body if body
 

--- a/seed/ruby-sdk-v2/inferred-auth-explicit/test/unit/internal/http/test_raw_client.rb
+++ b/seed/ruby-sdk-v2/inferred-auth-explicit/test/unit/internal/http/test_raw_client.rb
@@ -54,4 +54,71 @@ describe Seed::Internal::Http::RawClient do
       assert client.should_retry?(make_response(502), 2)
     end
   end
+
+  # A minimal auth provider whose `auth_headers` returns a *different* token on
+  # each call, simulating a token that is refreshed on expiry.
+  class RefreshingAuthProvider
+    def initialize
+      @count = 0
+    end
+
+    def auth_headers
+      @count += 1
+      { "Authorization" => "Bearer TOKEN_#{@count}" }
+    end
+  end
+
+  describe "#resolve_auth_headers" do
+    it "returns an empty hash when no auth provider is configured" do
+      client = Seed::Internal::Http::RawClient.new(base_url: "https://example.com")
+
+      assert_equal({}, client.resolve_auth_headers)
+    end
+
+    it "consults the auth provider on every call so an expired token is refreshed" do
+      client = Seed::Internal::Http::RawClient.new(
+        base_url: "https://example.com",
+        auth_provider: RefreshingAuthProvider.new
+      )
+
+      assert_equal({ "Authorization" => "Bearer TOKEN_1" }, client.resolve_auth_headers)
+      assert_equal({ "Authorization" => "Bearer TOKEN_2" }, client.resolve_auth_headers)
+    end
+  end
+
+  describe "#build_http_request auth header precedence" do
+    let(:client) do
+      Seed::Internal::Http::RawClient.new(
+        base_url: "https://example.com",
+        headers: { "Authorization" => "Bearer STATIC" }
+      )
+    end
+
+    it "lets resolved auth headers override the static default headers" do
+      request = client.build_http_request(
+        url: URI.parse("https://example.com"),
+        method: "GET",
+        auth_headers: { "Authorization" => "Bearer FRESH" }
+      )
+
+      assert_equal("Bearer FRESH", request["Authorization"])
+    end
+
+    it "lets per-request headers take precedence over auth headers" do
+      request = client.build_http_request(
+        url: URI.parse("https://example.com"),
+        method: "GET",
+        headers: { "Authorization" => "Bearer PER_REQUEST" },
+        auth_headers: { "Authorization" => "Bearer FRESH" }
+      )
+
+      assert_equal("Bearer PER_REQUEST", request["Authorization"])
+    end
+
+    it "defaults auth headers to empty, leaving the default headers unchanged" do
+      request = client.build_http_request(url: URI.parse("https://example.com"), method: "GET")
+
+      assert_equal("Bearer STATIC", request["Authorization"])
+    end
+  end
 end

--- a/seed/ruby-sdk-v2/inferred-auth-implicit-api-key/lib/seed/client.rb
+++ b/seed/ruby-sdk-v2/inferred-auth-implicit-api-key/lib/seed/client.rb
@@ -31,7 +31,8 @@ module Seed
         headers: {
           "User-Agent" => "fern_inferred-auth-implicit-api-key/0.0.1",
           "X-Fern-Language" => "Ruby"
-        }.merge(@auth_provider.auth_headers),
+        },
+        auth_provider: @auth_provider,
         max_retries: max_retries
       )
     end

--- a/seed/ruby-sdk-v2/inferred-auth-implicit-api-key/lib/seed/internal/http/raw_client.rb
+++ b/seed/ruby-sdk-v2/inferred-auth-implicit-api-key/lib/seed/internal/http/raw_client.rb
@@ -21,10 +21,14 @@ module Seed
         # @param max_retries [Integer] The number of times to retry a failed request, defaults to 2.
         # @param timeout [Float] The timeout for the request, defaults to 60.0 seconds.
         # @param headers [Hash] The headers for the request.
-        def initialize(base_url:, max_retries: 2, timeout: 60.0, headers: {})
+        # @param auth_provider [Object, nil] An optional auth provider responding to
+        #   `auth_headers`. When present its headers are resolved on every request so
+        #   token-based schemes (e.g. OAuth) can refresh an expired token mid-session.
+        def initialize(base_url:, max_retries: 2, timeout: 60.0, headers: {}, auth_provider: nil)
           @base_url = base_url
           @max_retries = max_retries
           @timeout = timeout
+          @auth_provider = auth_provider
           @default_headers = {
             "X-Fern-Language": "Ruby",
             "X-Fern-SDK-Name": "seed",
@@ -36,6 +40,9 @@ module Seed
         # @return [HTTP::Response] The HTTP response.
         def send(request)
           url = build_url(request)
+          # Resolve auth headers once per request (not per retry) so token-based
+          # providers refresh at most once here; static providers are cheap.
+          auth_headers = resolve_auth_headers
           attempt = 0
           response = nil
 
@@ -43,8 +50,9 @@ module Seed
             http_request = build_http_request(
               url:,
               method: request.method,
-              headers: request.encode_headers(protected_keys: @default_headers.keys),
-              body: request.encode_body
+              headers: request.encode_headers(protected_keys: @default_headers.keys + auth_headers.keys),
+              body: request.encode_body,
+              auth_headers: auth_headers
             )
 
             conn = connect(url)
@@ -157,12 +165,27 @@ module Seed
                 "HTTP is only allowed for localhost. Use HTTPS or pass a localhost URL."
         end
 
+        # Resolves the auth headers to send with the next request. Delegates to the
+        # configured auth provider (if any) on every call so that token-based
+        # providers (e.g. OAuth client-credentials) can refresh an expired token
+        # before the request is sent. Returns an empty hash when no provider is set,
+        # which keeps the api-key / basic / bearer / no-auth paths unchanged.
+        # @return [Hash] The auth headers for the current request.
+        def resolve_auth_headers
+          return {} if @auth_provider.nil?
+
+          @auth_provider.auth_headers
+        end
+
         # @param url [URI::Generic] The url to the resource.
         # @param method [String] The HTTP method to use.
         # @param headers [Hash] The headers for the request.
         # @param body [String, nil] The body for the request.
+        # @param auth_headers [Hash] The auth headers resolved for this request. These
+        #   take precedence over the static default headers but not over per-request
+        #   headers, mirroring the previous baked-header precedence.
         # @return [HTTP::Request] The HTTP request.
-        def build_http_request(url:, method:, headers: {}, body: nil)
+        def build_http_request(url:, method:, headers: {}, body: nil, auth_headers: {})
           request = Net::HTTPGenericRequest.new(
             method,
             !body.nil?,
@@ -170,7 +193,7 @@ module Seed
             url
           )
 
-          request_headers = @default_headers.merge(headers)
+          request_headers = @default_headers.merge(auth_headers).merge(headers)
           request_headers.each { |name, value| request[name] = value }
           request.body = body if body
 

--- a/seed/ruby-sdk-v2/inferred-auth-implicit-api-key/test/unit/internal/http/test_raw_client.rb
+++ b/seed/ruby-sdk-v2/inferred-auth-implicit-api-key/test/unit/internal/http/test_raw_client.rb
@@ -54,4 +54,71 @@ describe Seed::Internal::Http::RawClient do
       assert client.should_retry?(make_response(502), 2)
     end
   end
+
+  # A minimal auth provider whose `auth_headers` returns a *different* token on
+  # each call, simulating a token that is refreshed on expiry.
+  class RefreshingAuthProvider
+    def initialize
+      @count = 0
+    end
+
+    def auth_headers
+      @count += 1
+      { "Authorization" => "Bearer TOKEN_#{@count}" }
+    end
+  end
+
+  describe "#resolve_auth_headers" do
+    it "returns an empty hash when no auth provider is configured" do
+      client = Seed::Internal::Http::RawClient.new(base_url: "https://example.com")
+
+      assert_equal({}, client.resolve_auth_headers)
+    end
+
+    it "consults the auth provider on every call so an expired token is refreshed" do
+      client = Seed::Internal::Http::RawClient.new(
+        base_url: "https://example.com",
+        auth_provider: RefreshingAuthProvider.new
+      )
+
+      assert_equal({ "Authorization" => "Bearer TOKEN_1" }, client.resolve_auth_headers)
+      assert_equal({ "Authorization" => "Bearer TOKEN_2" }, client.resolve_auth_headers)
+    end
+  end
+
+  describe "#build_http_request auth header precedence" do
+    let(:client) do
+      Seed::Internal::Http::RawClient.new(
+        base_url: "https://example.com",
+        headers: { "Authorization" => "Bearer STATIC" }
+      )
+    end
+
+    it "lets resolved auth headers override the static default headers" do
+      request = client.build_http_request(
+        url: URI.parse("https://example.com"),
+        method: "GET",
+        auth_headers: { "Authorization" => "Bearer FRESH" }
+      )
+
+      assert_equal("Bearer FRESH", request["Authorization"])
+    end
+
+    it "lets per-request headers take precedence over auth headers" do
+      request = client.build_http_request(
+        url: URI.parse("https://example.com"),
+        method: "GET",
+        headers: { "Authorization" => "Bearer PER_REQUEST" },
+        auth_headers: { "Authorization" => "Bearer FRESH" }
+      )
+
+      assert_equal("Bearer PER_REQUEST", request["Authorization"])
+    end
+
+    it "defaults auth headers to empty, leaving the default headers unchanged" do
+      request = client.build_http_request(url: URI.parse("https://example.com"), method: "GET")
+
+      assert_equal("Bearer STATIC", request["Authorization"])
+    end
+  end
 end

--- a/seed/ruby-sdk-v2/inferred-auth-implicit-no-expiry/lib/seed/client.rb
+++ b/seed/ruby-sdk-v2/inferred-auth-implicit-no-expiry/lib/seed/client.rb
@@ -37,7 +37,8 @@ module Seed
         headers: {
           "User-Agent" => "fern_inferred-auth-implicit-no-expiry/0.0.1",
           "X-Fern-Language" => "Ruby"
-        }.merge(@auth_provider.auth_headers),
+        },
+        auth_provider: @auth_provider,
         max_retries: max_retries
       )
     end

--- a/seed/ruby-sdk-v2/inferred-auth-implicit-no-expiry/lib/seed/internal/http/raw_client.rb
+++ b/seed/ruby-sdk-v2/inferred-auth-implicit-no-expiry/lib/seed/internal/http/raw_client.rb
@@ -21,10 +21,14 @@ module Seed
         # @param max_retries [Integer] The number of times to retry a failed request, defaults to 2.
         # @param timeout [Float] The timeout for the request, defaults to 60.0 seconds.
         # @param headers [Hash] The headers for the request.
-        def initialize(base_url:, max_retries: 2, timeout: 60.0, headers: {})
+        # @param auth_provider [Object, nil] An optional auth provider responding to
+        #   `auth_headers`. When present its headers are resolved on every request so
+        #   token-based schemes (e.g. OAuth) can refresh an expired token mid-session.
+        def initialize(base_url:, max_retries: 2, timeout: 60.0, headers: {}, auth_provider: nil)
           @base_url = base_url
           @max_retries = max_retries
           @timeout = timeout
+          @auth_provider = auth_provider
           @default_headers = {
             "X-Fern-Language": "Ruby",
             "X-Fern-SDK-Name": "seed",
@@ -36,6 +40,9 @@ module Seed
         # @return [HTTP::Response] The HTTP response.
         def send(request)
           url = build_url(request)
+          # Resolve auth headers once per request (not per retry) so token-based
+          # providers refresh at most once here; static providers are cheap.
+          auth_headers = resolve_auth_headers
           attempt = 0
           response = nil
 
@@ -43,8 +50,9 @@ module Seed
             http_request = build_http_request(
               url:,
               method: request.method,
-              headers: request.encode_headers(protected_keys: @default_headers.keys),
-              body: request.encode_body
+              headers: request.encode_headers(protected_keys: @default_headers.keys + auth_headers.keys),
+              body: request.encode_body,
+              auth_headers: auth_headers
             )
 
             conn = connect(url)
@@ -157,12 +165,27 @@ module Seed
                 "HTTP is only allowed for localhost. Use HTTPS or pass a localhost URL."
         end
 
+        # Resolves the auth headers to send with the next request. Delegates to the
+        # configured auth provider (if any) on every call so that token-based
+        # providers (e.g. OAuth client-credentials) can refresh an expired token
+        # before the request is sent. Returns an empty hash when no provider is set,
+        # which keeps the api-key / basic / bearer / no-auth paths unchanged.
+        # @return [Hash] The auth headers for the current request.
+        def resolve_auth_headers
+          return {} if @auth_provider.nil?
+
+          @auth_provider.auth_headers
+        end
+
         # @param url [URI::Generic] The url to the resource.
         # @param method [String] The HTTP method to use.
         # @param headers [Hash] The headers for the request.
         # @param body [String, nil] The body for the request.
+        # @param auth_headers [Hash] The auth headers resolved for this request. These
+        #   take precedence over the static default headers but not over per-request
+        #   headers, mirroring the previous baked-header precedence.
         # @return [HTTP::Request] The HTTP request.
-        def build_http_request(url:, method:, headers: {}, body: nil)
+        def build_http_request(url:, method:, headers: {}, body: nil, auth_headers: {})
           request = Net::HTTPGenericRequest.new(
             method,
             !body.nil?,
@@ -170,7 +193,7 @@ module Seed
             url
           )
 
-          request_headers = @default_headers.merge(headers)
+          request_headers = @default_headers.merge(auth_headers).merge(headers)
           request_headers.each { |name, value| request[name] = value }
           request.body = body if body
 

--- a/seed/ruby-sdk-v2/inferred-auth-implicit-no-expiry/test/unit/internal/http/test_raw_client.rb
+++ b/seed/ruby-sdk-v2/inferred-auth-implicit-no-expiry/test/unit/internal/http/test_raw_client.rb
@@ -54,4 +54,71 @@ describe Seed::Internal::Http::RawClient do
       assert client.should_retry?(make_response(502), 2)
     end
   end
+
+  # A minimal auth provider whose `auth_headers` returns a *different* token on
+  # each call, simulating a token that is refreshed on expiry.
+  class RefreshingAuthProvider
+    def initialize
+      @count = 0
+    end
+
+    def auth_headers
+      @count += 1
+      { "Authorization" => "Bearer TOKEN_#{@count}" }
+    end
+  end
+
+  describe "#resolve_auth_headers" do
+    it "returns an empty hash when no auth provider is configured" do
+      client = Seed::Internal::Http::RawClient.new(base_url: "https://example.com")
+
+      assert_equal({}, client.resolve_auth_headers)
+    end
+
+    it "consults the auth provider on every call so an expired token is refreshed" do
+      client = Seed::Internal::Http::RawClient.new(
+        base_url: "https://example.com",
+        auth_provider: RefreshingAuthProvider.new
+      )
+
+      assert_equal({ "Authorization" => "Bearer TOKEN_1" }, client.resolve_auth_headers)
+      assert_equal({ "Authorization" => "Bearer TOKEN_2" }, client.resolve_auth_headers)
+    end
+  end
+
+  describe "#build_http_request auth header precedence" do
+    let(:client) do
+      Seed::Internal::Http::RawClient.new(
+        base_url: "https://example.com",
+        headers: { "Authorization" => "Bearer STATIC" }
+      )
+    end
+
+    it "lets resolved auth headers override the static default headers" do
+      request = client.build_http_request(
+        url: URI.parse("https://example.com"),
+        method: "GET",
+        auth_headers: { "Authorization" => "Bearer FRESH" }
+      )
+
+      assert_equal("Bearer FRESH", request["Authorization"])
+    end
+
+    it "lets per-request headers take precedence over auth headers" do
+      request = client.build_http_request(
+        url: URI.parse("https://example.com"),
+        method: "GET",
+        headers: { "Authorization" => "Bearer PER_REQUEST" },
+        auth_headers: { "Authorization" => "Bearer FRESH" }
+      )
+
+      assert_equal("Bearer PER_REQUEST", request["Authorization"])
+    end
+
+    it "defaults auth headers to empty, leaving the default headers unchanged" do
+      request = client.build_http_request(url: URI.parse("https://example.com"), method: "GET")
+
+      assert_equal("Bearer STATIC", request["Authorization"])
+    end
+  end
 end

--- a/seed/ruby-sdk-v2/inferred-auth-implicit-reference/lib/seed/client.rb
+++ b/seed/ruby-sdk-v2/inferred-auth-implicit-reference/lib/seed/client.rb
@@ -29,7 +29,8 @@ module Seed
         headers: {
           "User-Agent" => "fern_inferred-auth-implicit-reference/0.0.1",
           "X-Fern-Language" => "Ruby"
-        }.merge(@auth_provider.auth_headers),
+        },
+        auth_provider: @auth_provider,
         max_retries: max_retries
       )
     end

--- a/seed/ruby-sdk-v2/inferred-auth-implicit-reference/lib/seed/internal/http/raw_client.rb
+++ b/seed/ruby-sdk-v2/inferred-auth-implicit-reference/lib/seed/internal/http/raw_client.rb
@@ -21,10 +21,14 @@ module Seed
         # @param max_retries [Integer] The number of times to retry a failed request, defaults to 2.
         # @param timeout [Float] The timeout for the request, defaults to 60.0 seconds.
         # @param headers [Hash] The headers for the request.
-        def initialize(base_url:, max_retries: 2, timeout: 60.0, headers: {})
+        # @param auth_provider [Object, nil] An optional auth provider responding to
+        #   `auth_headers`. When present its headers are resolved on every request so
+        #   token-based schemes (e.g. OAuth) can refresh an expired token mid-session.
+        def initialize(base_url:, max_retries: 2, timeout: 60.0, headers: {}, auth_provider: nil)
           @base_url = base_url
           @max_retries = max_retries
           @timeout = timeout
+          @auth_provider = auth_provider
           @default_headers = {
             "X-Fern-Language": "Ruby",
             "X-Fern-SDK-Name": "seed",
@@ -36,6 +40,9 @@ module Seed
         # @return [HTTP::Response] The HTTP response.
         def send(request)
           url = build_url(request)
+          # Resolve auth headers once per request (not per retry) so token-based
+          # providers refresh at most once here; static providers are cheap.
+          auth_headers = resolve_auth_headers
           attempt = 0
           response = nil
 
@@ -43,8 +50,9 @@ module Seed
             http_request = build_http_request(
               url:,
               method: request.method,
-              headers: request.encode_headers(protected_keys: @default_headers.keys),
-              body: request.encode_body
+              headers: request.encode_headers(protected_keys: @default_headers.keys + auth_headers.keys),
+              body: request.encode_body,
+              auth_headers: auth_headers
             )
 
             conn = connect(url)
@@ -157,12 +165,27 @@ module Seed
                 "HTTP is only allowed for localhost. Use HTTPS or pass a localhost URL."
         end
 
+        # Resolves the auth headers to send with the next request. Delegates to the
+        # configured auth provider (if any) on every call so that token-based
+        # providers (e.g. OAuth client-credentials) can refresh an expired token
+        # before the request is sent. Returns an empty hash when no provider is set,
+        # which keeps the api-key / basic / bearer / no-auth paths unchanged.
+        # @return [Hash] The auth headers for the current request.
+        def resolve_auth_headers
+          return {} if @auth_provider.nil?
+
+          @auth_provider.auth_headers
+        end
+
         # @param url [URI::Generic] The url to the resource.
         # @param method [String] The HTTP method to use.
         # @param headers [Hash] The headers for the request.
         # @param body [String, nil] The body for the request.
+        # @param auth_headers [Hash] The auth headers resolved for this request. These
+        #   take precedence over the static default headers but not over per-request
+        #   headers, mirroring the previous baked-header precedence.
         # @return [HTTP::Request] The HTTP request.
-        def build_http_request(url:, method:, headers: {}, body: nil)
+        def build_http_request(url:, method:, headers: {}, body: nil, auth_headers: {})
           request = Net::HTTPGenericRequest.new(
             method,
             !body.nil?,
@@ -170,7 +193,7 @@ module Seed
             url
           )
 
-          request_headers = @default_headers.merge(headers)
+          request_headers = @default_headers.merge(auth_headers).merge(headers)
           request_headers.each { |name, value| request[name] = value }
           request.body = body if body
 

--- a/seed/ruby-sdk-v2/inferred-auth-implicit-reference/test/unit/internal/http/test_raw_client.rb
+++ b/seed/ruby-sdk-v2/inferred-auth-implicit-reference/test/unit/internal/http/test_raw_client.rb
@@ -54,4 +54,71 @@ describe Seed::Internal::Http::RawClient do
       assert client.should_retry?(make_response(502), 2)
     end
   end
+
+  # A minimal auth provider whose `auth_headers` returns a *different* token on
+  # each call, simulating a token that is refreshed on expiry.
+  class RefreshingAuthProvider
+    def initialize
+      @count = 0
+    end
+
+    def auth_headers
+      @count += 1
+      { "Authorization" => "Bearer TOKEN_#{@count}" }
+    end
+  end
+
+  describe "#resolve_auth_headers" do
+    it "returns an empty hash when no auth provider is configured" do
+      client = Seed::Internal::Http::RawClient.new(base_url: "https://example.com")
+
+      assert_equal({}, client.resolve_auth_headers)
+    end
+
+    it "consults the auth provider on every call so an expired token is refreshed" do
+      client = Seed::Internal::Http::RawClient.new(
+        base_url: "https://example.com",
+        auth_provider: RefreshingAuthProvider.new
+      )
+
+      assert_equal({ "Authorization" => "Bearer TOKEN_1" }, client.resolve_auth_headers)
+      assert_equal({ "Authorization" => "Bearer TOKEN_2" }, client.resolve_auth_headers)
+    end
+  end
+
+  describe "#build_http_request auth header precedence" do
+    let(:client) do
+      Seed::Internal::Http::RawClient.new(
+        base_url: "https://example.com",
+        headers: { "Authorization" => "Bearer STATIC" }
+      )
+    end
+
+    it "lets resolved auth headers override the static default headers" do
+      request = client.build_http_request(
+        url: URI.parse("https://example.com"),
+        method: "GET",
+        auth_headers: { "Authorization" => "Bearer FRESH" }
+      )
+
+      assert_equal("Bearer FRESH", request["Authorization"])
+    end
+
+    it "lets per-request headers take precedence over auth headers" do
+      request = client.build_http_request(
+        url: URI.parse("https://example.com"),
+        method: "GET",
+        headers: { "Authorization" => "Bearer PER_REQUEST" },
+        auth_headers: { "Authorization" => "Bearer FRESH" }
+      )
+
+      assert_equal("Bearer PER_REQUEST", request["Authorization"])
+    end
+
+    it "defaults auth headers to empty, leaving the default headers unchanged" do
+      request = client.build_http_request(url: URI.parse("https://example.com"), method: "GET")
+
+      assert_equal("Bearer STATIC", request["Authorization"])
+    end
+  end
 end

--- a/seed/ruby-sdk-v2/inferred-auth-implicit/lib/seed/client.rb
+++ b/seed/ruby-sdk-v2/inferred-auth-implicit/lib/seed/client.rb
@@ -37,7 +37,8 @@ module Seed
         headers: {
           "User-Agent" => "fern_inferred-auth-implicit/0.0.1",
           "X-Fern-Language" => "Ruby"
-        }.merge(@auth_provider.auth_headers),
+        },
+        auth_provider: @auth_provider,
         max_retries: max_retries
       )
     end

--- a/seed/ruby-sdk-v2/inferred-auth-implicit/lib/seed/internal/http/raw_client.rb
+++ b/seed/ruby-sdk-v2/inferred-auth-implicit/lib/seed/internal/http/raw_client.rb
@@ -21,10 +21,14 @@ module Seed
         # @param max_retries [Integer] The number of times to retry a failed request, defaults to 2.
         # @param timeout [Float] The timeout for the request, defaults to 60.0 seconds.
         # @param headers [Hash] The headers for the request.
-        def initialize(base_url:, max_retries: 2, timeout: 60.0, headers: {})
+        # @param auth_provider [Object, nil] An optional auth provider responding to
+        #   `auth_headers`. When present its headers are resolved on every request so
+        #   token-based schemes (e.g. OAuth) can refresh an expired token mid-session.
+        def initialize(base_url:, max_retries: 2, timeout: 60.0, headers: {}, auth_provider: nil)
           @base_url = base_url
           @max_retries = max_retries
           @timeout = timeout
+          @auth_provider = auth_provider
           @default_headers = {
             "X-Fern-Language": "Ruby",
             "X-Fern-SDK-Name": "seed",
@@ -36,6 +40,9 @@ module Seed
         # @return [HTTP::Response] The HTTP response.
         def send(request)
           url = build_url(request)
+          # Resolve auth headers once per request (not per retry) so token-based
+          # providers refresh at most once here; static providers are cheap.
+          auth_headers = resolve_auth_headers
           attempt = 0
           response = nil
 
@@ -43,8 +50,9 @@ module Seed
             http_request = build_http_request(
               url:,
               method: request.method,
-              headers: request.encode_headers(protected_keys: @default_headers.keys),
-              body: request.encode_body
+              headers: request.encode_headers(protected_keys: @default_headers.keys + auth_headers.keys),
+              body: request.encode_body,
+              auth_headers: auth_headers
             )
 
             conn = connect(url)
@@ -157,12 +165,27 @@ module Seed
                 "HTTP is only allowed for localhost. Use HTTPS or pass a localhost URL."
         end
 
+        # Resolves the auth headers to send with the next request. Delegates to the
+        # configured auth provider (if any) on every call so that token-based
+        # providers (e.g. OAuth client-credentials) can refresh an expired token
+        # before the request is sent. Returns an empty hash when no provider is set,
+        # which keeps the api-key / basic / bearer / no-auth paths unchanged.
+        # @return [Hash] The auth headers for the current request.
+        def resolve_auth_headers
+          return {} if @auth_provider.nil?
+
+          @auth_provider.auth_headers
+        end
+
         # @param url [URI::Generic] The url to the resource.
         # @param method [String] The HTTP method to use.
         # @param headers [Hash] The headers for the request.
         # @param body [String, nil] The body for the request.
+        # @param auth_headers [Hash] The auth headers resolved for this request. These
+        #   take precedence over the static default headers but not over per-request
+        #   headers, mirroring the previous baked-header precedence.
         # @return [HTTP::Request] The HTTP request.
-        def build_http_request(url:, method:, headers: {}, body: nil)
+        def build_http_request(url:, method:, headers: {}, body: nil, auth_headers: {})
           request = Net::HTTPGenericRequest.new(
             method,
             !body.nil?,
@@ -170,7 +193,7 @@ module Seed
             url
           )
 
-          request_headers = @default_headers.merge(headers)
+          request_headers = @default_headers.merge(auth_headers).merge(headers)
           request_headers.each { |name, value| request[name] = value }
           request.body = body if body
 

--- a/seed/ruby-sdk-v2/inferred-auth-implicit/test/unit/internal/http/test_raw_client.rb
+++ b/seed/ruby-sdk-v2/inferred-auth-implicit/test/unit/internal/http/test_raw_client.rb
@@ -54,4 +54,71 @@ describe Seed::Internal::Http::RawClient do
       assert client.should_retry?(make_response(502), 2)
     end
   end
+
+  # A minimal auth provider whose `auth_headers` returns a *different* token on
+  # each call, simulating a token that is refreshed on expiry.
+  class RefreshingAuthProvider
+    def initialize
+      @count = 0
+    end
+
+    def auth_headers
+      @count += 1
+      { "Authorization" => "Bearer TOKEN_#{@count}" }
+    end
+  end
+
+  describe "#resolve_auth_headers" do
+    it "returns an empty hash when no auth provider is configured" do
+      client = Seed::Internal::Http::RawClient.new(base_url: "https://example.com")
+
+      assert_equal({}, client.resolve_auth_headers)
+    end
+
+    it "consults the auth provider on every call so an expired token is refreshed" do
+      client = Seed::Internal::Http::RawClient.new(
+        base_url: "https://example.com",
+        auth_provider: RefreshingAuthProvider.new
+      )
+
+      assert_equal({ "Authorization" => "Bearer TOKEN_1" }, client.resolve_auth_headers)
+      assert_equal({ "Authorization" => "Bearer TOKEN_2" }, client.resolve_auth_headers)
+    end
+  end
+
+  describe "#build_http_request auth header precedence" do
+    let(:client) do
+      Seed::Internal::Http::RawClient.new(
+        base_url: "https://example.com",
+        headers: { "Authorization" => "Bearer STATIC" }
+      )
+    end
+
+    it "lets resolved auth headers override the static default headers" do
+      request = client.build_http_request(
+        url: URI.parse("https://example.com"),
+        method: "GET",
+        auth_headers: { "Authorization" => "Bearer FRESH" }
+      )
+
+      assert_equal("Bearer FRESH", request["Authorization"])
+    end
+
+    it "lets per-request headers take precedence over auth headers" do
+      request = client.build_http_request(
+        url: URI.parse("https://example.com"),
+        method: "GET",
+        headers: { "Authorization" => "Bearer PER_REQUEST" },
+        auth_headers: { "Authorization" => "Bearer FRESH" }
+      )
+
+      assert_equal("Bearer PER_REQUEST", request["Authorization"])
+    end
+
+    it "defaults auth headers to empty, leaving the default headers unchanged" do
+      request = client.build_http_request(url: URI.parse("https://example.com"), method: "GET")
+
+      assert_equal("Bearer STATIC", request["Authorization"])
+    end
+  end
 end

--- a/seed/ruby-sdk-v2/inline-enum-type-name-override/lib/seed/internal/http/raw_client.rb
+++ b/seed/ruby-sdk-v2/inline-enum-type-name-override/lib/seed/internal/http/raw_client.rb
@@ -21,10 +21,14 @@ module Seed
         # @param max_retries [Integer] The number of times to retry a failed request, defaults to 2.
         # @param timeout [Float] The timeout for the request, defaults to 60.0 seconds.
         # @param headers [Hash] The headers for the request.
-        def initialize(base_url:, max_retries: 2, timeout: 60.0, headers: {})
+        # @param auth_provider [Object, nil] An optional auth provider responding to
+        #   `auth_headers`. When present its headers are resolved on every request so
+        #   token-based schemes (e.g. OAuth) can refresh an expired token mid-session.
+        def initialize(base_url:, max_retries: 2, timeout: 60.0, headers: {}, auth_provider: nil)
           @base_url = base_url
           @max_retries = max_retries
           @timeout = timeout
+          @auth_provider = auth_provider
           @default_headers = {
             "X-Fern-Language": "Ruby",
             "X-Fern-SDK-Name": "seed",
@@ -36,6 +40,9 @@ module Seed
         # @return [HTTP::Response] The HTTP response.
         def send(request)
           url = build_url(request)
+          # Resolve auth headers once per request (not per retry) so token-based
+          # providers refresh at most once here; static providers are cheap.
+          auth_headers = resolve_auth_headers
           attempt = 0
           response = nil
 
@@ -43,8 +50,9 @@ module Seed
             http_request = build_http_request(
               url:,
               method: request.method,
-              headers: request.encode_headers(protected_keys: @default_headers.keys),
-              body: request.encode_body
+              headers: request.encode_headers(protected_keys: @default_headers.keys + auth_headers.keys),
+              body: request.encode_body,
+              auth_headers: auth_headers
             )
 
             conn = connect(url)
@@ -157,12 +165,27 @@ module Seed
                 "HTTP is only allowed for localhost. Use HTTPS or pass a localhost URL."
         end
 
+        # Resolves the auth headers to send with the next request. Delegates to the
+        # configured auth provider (if any) on every call so that token-based
+        # providers (e.g. OAuth client-credentials) can refresh an expired token
+        # before the request is sent. Returns an empty hash when no provider is set,
+        # which keeps the api-key / basic / bearer / no-auth paths unchanged.
+        # @return [Hash] The auth headers for the current request.
+        def resolve_auth_headers
+          return {} if @auth_provider.nil?
+
+          @auth_provider.auth_headers
+        end
+
         # @param url [URI::Generic] The url to the resource.
         # @param method [String] The HTTP method to use.
         # @param headers [Hash] The headers for the request.
         # @param body [String, nil] The body for the request.
+        # @param auth_headers [Hash] The auth headers resolved for this request. These
+        #   take precedence over the static default headers but not over per-request
+        #   headers, mirroring the previous baked-header precedence.
         # @return [HTTP::Request] The HTTP request.
-        def build_http_request(url:, method:, headers: {}, body: nil)
+        def build_http_request(url:, method:, headers: {}, body: nil, auth_headers: {})
           request = Net::HTTPGenericRequest.new(
             method,
             !body.nil?,
@@ -170,7 +193,7 @@ module Seed
             url
           )
 
-          request_headers = @default_headers.merge(headers)
+          request_headers = @default_headers.merge(auth_headers).merge(headers)
           request_headers.each { |name, value| request[name] = value }
           request.body = body if body
 

--- a/seed/ruby-sdk-v2/inline-enum-type-name-override/test/unit/internal/http/test_raw_client.rb
+++ b/seed/ruby-sdk-v2/inline-enum-type-name-override/test/unit/internal/http/test_raw_client.rb
@@ -54,4 +54,71 @@ describe Seed::Internal::Http::RawClient do
       assert client.should_retry?(make_response(502), 2)
     end
   end
+
+  # A minimal auth provider whose `auth_headers` returns a *different* token on
+  # each call, simulating a token that is refreshed on expiry.
+  class RefreshingAuthProvider
+    def initialize
+      @count = 0
+    end
+
+    def auth_headers
+      @count += 1
+      { "Authorization" => "Bearer TOKEN_#{@count}" }
+    end
+  end
+
+  describe "#resolve_auth_headers" do
+    it "returns an empty hash when no auth provider is configured" do
+      client = Seed::Internal::Http::RawClient.new(base_url: "https://example.com")
+
+      assert_equal({}, client.resolve_auth_headers)
+    end
+
+    it "consults the auth provider on every call so an expired token is refreshed" do
+      client = Seed::Internal::Http::RawClient.new(
+        base_url: "https://example.com",
+        auth_provider: RefreshingAuthProvider.new
+      )
+
+      assert_equal({ "Authorization" => "Bearer TOKEN_1" }, client.resolve_auth_headers)
+      assert_equal({ "Authorization" => "Bearer TOKEN_2" }, client.resolve_auth_headers)
+    end
+  end
+
+  describe "#build_http_request auth header precedence" do
+    let(:client) do
+      Seed::Internal::Http::RawClient.new(
+        base_url: "https://example.com",
+        headers: { "Authorization" => "Bearer STATIC" }
+      )
+    end
+
+    it "lets resolved auth headers override the static default headers" do
+      request = client.build_http_request(
+        url: URI.parse("https://example.com"),
+        method: "GET",
+        auth_headers: { "Authorization" => "Bearer FRESH" }
+      )
+
+      assert_equal("Bearer FRESH", request["Authorization"])
+    end
+
+    it "lets per-request headers take precedence over auth headers" do
+      request = client.build_http_request(
+        url: URI.parse("https://example.com"),
+        method: "GET",
+        headers: { "Authorization" => "Bearer PER_REQUEST" },
+        auth_headers: { "Authorization" => "Bearer FRESH" }
+      )
+
+      assert_equal("Bearer PER_REQUEST", request["Authorization"])
+    end
+
+    it "defaults auth headers to empty, leaving the default headers unchanged" do
+      request = client.build_http_request(url: URI.parse("https://example.com"), method: "GET")
+
+      assert_equal("Bearer STATIC", request["Authorization"])
+    end
+  end
 end

--- a/seed/ruby-sdk-v2/license/lib/seed/internal/http/raw_client.rb
+++ b/seed/ruby-sdk-v2/license/lib/seed/internal/http/raw_client.rb
@@ -21,10 +21,14 @@ module Seed
         # @param max_retries [Integer] The number of times to retry a failed request, defaults to 2.
         # @param timeout [Float] The timeout for the request, defaults to 60.0 seconds.
         # @param headers [Hash] The headers for the request.
-        def initialize(base_url:, max_retries: 2, timeout: 60.0, headers: {})
+        # @param auth_provider [Object, nil] An optional auth provider responding to
+        #   `auth_headers`. When present its headers are resolved on every request so
+        #   token-based schemes (e.g. OAuth) can refresh an expired token mid-session.
+        def initialize(base_url:, max_retries: 2, timeout: 60.0, headers: {}, auth_provider: nil)
           @base_url = base_url
           @max_retries = max_retries
           @timeout = timeout
+          @auth_provider = auth_provider
           @default_headers = {
             "X-Fern-Language": "Ruby",
             "X-Fern-SDK-Name": "seed",
@@ -36,6 +40,9 @@ module Seed
         # @return [HTTP::Response] The HTTP response.
         def send(request)
           url = build_url(request)
+          # Resolve auth headers once per request (not per retry) so token-based
+          # providers refresh at most once here; static providers are cheap.
+          auth_headers = resolve_auth_headers
           attempt = 0
           response = nil
 
@@ -43,8 +50,9 @@ module Seed
             http_request = build_http_request(
               url:,
               method: request.method,
-              headers: request.encode_headers(protected_keys: @default_headers.keys),
-              body: request.encode_body
+              headers: request.encode_headers(protected_keys: @default_headers.keys + auth_headers.keys),
+              body: request.encode_body,
+              auth_headers: auth_headers
             )
 
             conn = connect(url)
@@ -157,12 +165,27 @@ module Seed
                 "HTTP is only allowed for localhost. Use HTTPS or pass a localhost URL."
         end
 
+        # Resolves the auth headers to send with the next request. Delegates to the
+        # configured auth provider (if any) on every call so that token-based
+        # providers (e.g. OAuth client-credentials) can refresh an expired token
+        # before the request is sent. Returns an empty hash when no provider is set,
+        # which keeps the api-key / basic / bearer / no-auth paths unchanged.
+        # @return [Hash] The auth headers for the current request.
+        def resolve_auth_headers
+          return {} if @auth_provider.nil?
+
+          @auth_provider.auth_headers
+        end
+
         # @param url [URI::Generic] The url to the resource.
         # @param method [String] The HTTP method to use.
         # @param headers [Hash] The headers for the request.
         # @param body [String, nil] The body for the request.
+        # @param auth_headers [Hash] The auth headers resolved for this request. These
+        #   take precedence over the static default headers but not over per-request
+        #   headers, mirroring the previous baked-header precedence.
         # @return [HTTP::Request] The HTTP request.
-        def build_http_request(url:, method:, headers: {}, body: nil)
+        def build_http_request(url:, method:, headers: {}, body: nil, auth_headers: {})
           request = Net::HTTPGenericRequest.new(
             method,
             !body.nil?,
@@ -170,7 +193,7 @@ module Seed
             url
           )
 
-          request_headers = @default_headers.merge(headers)
+          request_headers = @default_headers.merge(auth_headers).merge(headers)
           request_headers.each { |name, value| request[name] = value }
           request.body = body if body
 

--- a/seed/ruby-sdk-v2/license/test/unit/internal/http/test_raw_client.rb
+++ b/seed/ruby-sdk-v2/license/test/unit/internal/http/test_raw_client.rb
@@ -54,4 +54,71 @@ describe Seed::Internal::Http::RawClient do
       assert client.should_retry?(make_response(502), 2)
     end
   end
+
+  # A minimal auth provider whose `auth_headers` returns a *different* token on
+  # each call, simulating a token that is refreshed on expiry.
+  class RefreshingAuthProvider
+    def initialize
+      @count = 0
+    end
+
+    def auth_headers
+      @count += 1
+      { "Authorization" => "Bearer TOKEN_#{@count}" }
+    end
+  end
+
+  describe "#resolve_auth_headers" do
+    it "returns an empty hash when no auth provider is configured" do
+      client = Seed::Internal::Http::RawClient.new(base_url: "https://example.com")
+
+      assert_equal({}, client.resolve_auth_headers)
+    end
+
+    it "consults the auth provider on every call so an expired token is refreshed" do
+      client = Seed::Internal::Http::RawClient.new(
+        base_url: "https://example.com",
+        auth_provider: RefreshingAuthProvider.new
+      )
+
+      assert_equal({ "Authorization" => "Bearer TOKEN_1" }, client.resolve_auth_headers)
+      assert_equal({ "Authorization" => "Bearer TOKEN_2" }, client.resolve_auth_headers)
+    end
+  end
+
+  describe "#build_http_request auth header precedence" do
+    let(:client) do
+      Seed::Internal::Http::RawClient.new(
+        base_url: "https://example.com",
+        headers: { "Authorization" => "Bearer STATIC" }
+      )
+    end
+
+    it "lets resolved auth headers override the static default headers" do
+      request = client.build_http_request(
+        url: URI.parse("https://example.com"),
+        method: "GET",
+        auth_headers: { "Authorization" => "Bearer FRESH" }
+      )
+
+      assert_equal("Bearer FRESH", request["Authorization"])
+    end
+
+    it "lets per-request headers take precedence over auth headers" do
+      request = client.build_http_request(
+        url: URI.parse("https://example.com"),
+        method: "GET",
+        headers: { "Authorization" => "Bearer PER_REQUEST" },
+        auth_headers: { "Authorization" => "Bearer FRESH" }
+      )
+
+      assert_equal("Bearer PER_REQUEST", request["Authorization"])
+    end
+
+    it "defaults auth headers to empty, leaving the default headers unchanged" do
+      request = client.build_http_request(url: URI.parse("https://example.com"), method: "GET")
+
+      assert_equal("Bearer STATIC", request["Authorization"])
+    end
+  end
 end

--- a/seed/ruby-sdk-v2/literal-user-agent/lib/seed/internal/http/raw_client.rb
+++ b/seed/ruby-sdk-v2/literal-user-agent/lib/seed/internal/http/raw_client.rb
@@ -21,10 +21,14 @@ module Seed
         # @param max_retries [Integer] The number of times to retry a failed request, defaults to 2.
         # @param timeout [Float] The timeout for the request, defaults to 60.0 seconds.
         # @param headers [Hash] The headers for the request.
-        def initialize(base_url:, max_retries: 2, timeout: 60.0, headers: {})
+        # @param auth_provider [Object, nil] An optional auth provider responding to
+        #   `auth_headers`. When present its headers are resolved on every request so
+        #   token-based schemes (e.g. OAuth) can refresh an expired token mid-session.
+        def initialize(base_url:, max_retries: 2, timeout: 60.0, headers: {}, auth_provider: nil)
           @base_url = base_url
           @max_retries = max_retries
           @timeout = timeout
+          @auth_provider = auth_provider
           @default_headers = {
             "X-Fern-Language": "Ruby",
             "X-Fern-SDK-Name": "seed",
@@ -36,6 +40,9 @@ module Seed
         # @return [HTTP::Response] The HTTP response.
         def send(request)
           url = build_url(request)
+          # Resolve auth headers once per request (not per retry) so token-based
+          # providers refresh at most once here; static providers are cheap.
+          auth_headers = resolve_auth_headers
           attempt = 0
           response = nil
 
@@ -43,8 +50,9 @@ module Seed
             http_request = build_http_request(
               url:,
               method: request.method,
-              headers: request.encode_headers(protected_keys: @default_headers.keys),
-              body: request.encode_body
+              headers: request.encode_headers(protected_keys: @default_headers.keys + auth_headers.keys),
+              body: request.encode_body,
+              auth_headers: auth_headers
             )
 
             conn = connect(url)
@@ -157,12 +165,27 @@ module Seed
                 "HTTP is only allowed for localhost. Use HTTPS or pass a localhost URL."
         end
 
+        # Resolves the auth headers to send with the next request. Delegates to the
+        # configured auth provider (if any) on every call so that token-based
+        # providers (e.g. OAuth client-credentials) can refresh an expired token
+        # before the request is sent. Returns an empty hash when no provider is set,
+        # which keeps the api-key / basic / bearer / no-auth paths unchanged.
+        # @return [Hash] The auth headers for the current request.
+        def resolve_auth_headers
+          return {} if @auth_provider.nil?
+
+          @auth_provider.auth_headers
+        end
+
         # @param url [URI::Generic] The url to the resource.
         # @param method [String] The HTTP method to use.
         # @param headers [Hash] The headers for the request.
         # @param body [String, nil] The body for the request.
+        # @param auth_headers [Hash] The auth headers resolved for this request. These
+        #   take precedence over the static default headers but not over per-request
+        #   headers, mirroring the previous baked-header precedence.
         # @return [HTTP::Request] The HTTP request.
-        def build_http_request(url:, method:, headers: {}, body: nil)
+        def build_http_request(url:, method:, headers: {}, body: nil, auth_headers: {})
           request = Net::HTTPGenericRequest.new(
             method,
             !body.nil?,
@@ -170,7 +193,7 @@ module Seed
             url
           )
 
-          request_headers = @default_headers.merge(headers)
+          request_headers = @default_headers.merge(auth_headers).merge(headers)
           request_headers.each { |name, value| request[name] = value }
           request.body = body if body
 

--- a/seed/ruby-sdk-v2/literal-user-agent/test/unit/internal/http/test_raw_client.rb
+++ b/seed/ruby-sdk-v2/literal-user-agent/test/unit/internal/http/test_raw_client.rb
@@ -54,4 +54,71 @@ describe Seed::Internal::Http::RawClient do
       assert client.should_retry?(make_response(502), 2)
     end
   end
+
+  # A minimal auth provider whose `auth_headers` returns a *different* token on
+  # each call, simulating a token that is refreshed on expiry.
+  class RefreshingAuthProvider
+    def initialize
+      @count = 0
+    end
+
+    def auth_headers
+      @count += 1
+      { "Authorization" => "Bearer TOKEN_#{@count}" }
+    end
+  end
+
+  describe "#resolve_auth_headers" do
+    it "returns an empty hash when no auth provider is configured" do
+      client = Seed::Internal::Http::RawClient.new(base_url: "https://example.com")
+
+      assert_equal({}, client.resolve_auth_headers)
+    end
+
+    it "consults the auth provider on every call so an expired token is refreshed" do
+      client = Seed::Internal::Http::RawClient.new(
+        base_url: "https://example.com",
+        auth_provider: RefreshingAuthProvider.new
+      )
+
+      assert_equal({ "Authorization" => "Bearer TOKEN_1" }, client.resolve_auth_headers)
+      assert_equal({ "Authorization" => "Bearer TOKEN_2" }, client.resolve_auth_headers)
+    end
+  end
+
+  describe "#build_http_request auth header precedence" do
+    let(:client) do
+      Seed::Internal::Http::RawClient.new(
+        base_url: "https://example.com",
+        headers: { "Authorization" => "Bearer STATIC" }
+      )
+    end
+
+    it "lets resolved auth headers override the static default headers" do
+      request = client.build_http_request(
+        url: URI.parse("https://example.com"),
+        method: "GET",
+        auth_headers: { "Authorization" => "Bearer FRESH" }
+      )
+
+      assert_equal("Bearer FRESH", request["Authorization"])
+    end
+
+    it "lets per-request headers take precedence over auth headers" do
+      request = client.build_http_request(
+        url: URI.parse("https://example.com"),
+        method: "GET",
+        headers: { "Authorization" => "Bearer PER_REQUEST" },
+        auth_headers: { "Authorization" => "Bearer FRESH" }
+      )
+
+      assert_equal("Bearer PER_REQUEST", request["Authorization"])
+    end
+
+    it "defaults auth headers to empty, leaving the default headers unchanged" do
+      request = client.build_http_request(url: URI.parse("https://example.com"), method: "GET")
+
+      assert_equal("Bearer STATIC", request["Authorization"])
+    end
+  end
 end

--- a/seed/ruby-sdk-v2/literal/lib/seed/internal/http/raw_client.rb
+++ b/seed/ruby-sdk-v2/literal/lib/seed/internal/http/raw_client.rb
@@ -21,10 +21,14 @@ module Seed
         # @param max_retries [Integer] The number of times to retry a failed request, defaults to 2.
         # @param timeout [Float] The timeout for the request, defaults to 60.0 seconds.
         # @param headers [Hash] The headers for the request.
-        def initialize(base_url:, max_retries: 2, timeout: 60.0, headers: {})
+        # @param auth_provider [Object, nil] An optional auth provider responding to
+        #   `auth_headers`. When present its headers are resolved on every request so
+        #   token-based schemes (e.g. OAuth) can refresh an expired token mid-session.
+        def initialize(base_url:, max_retries: 2, timeout: 60.0, headers: {}, auth_provider: nil)
           @base_url = base_url
           @max_retries = max_retries
           @timeout = timeout
+          @auth_provider = auth_provider
           @default_headers = {
             "X-Fern-Language": "Ruby",
             "X-Fern-SDK-Name": "seed",
@@ -36,6 +40,9 @@ module Seed
         # @return [HTTP::Response] The HTTP response.
         def send(request)
           url = build_url(request)
+          # Resolve auth headers once per request (not per retry) so token-based
+          # providers refresh at most once here; static providers are cheap.
+          auth_headers = resolve_auth_headers
           attempt = 0
           response = nil
 
@@ -43,8 +50,9 @@ module Seed
             http_request = build_http_request(
               url:,
               method: request.method,
-              headers: request.encode_headers(protected_keys: @default_headers.keys),
-              body: request.encode_body
+              headers: request.encode_headers(protected_keys: @default_headers.keys + auth_headers.keys),
+              body: request.encode_body,
+              auth_headers: auth_headers
             )
 
             conn = connect(url)
@@ -157,12 +165,27 @@ module Seed
                 "HTTP is only allowed for localhost. Use HTTPS or pass a localhost URL."
         end
 
+        # Resolves the auth headers to send with the next request. Delegates to the
+        # configured auth provider (if any) on every call so that token-based
+        # providers (e.g. OAuth client-credentials) can refresh an expired token
+        # before the request is sent. Returns an empty hash when no provider is set,
+        # which keeps the api-key / basic / bearer / no-auth paths unchanged.
+        # @return [Hash] The auth headers for the current request.
+        def resolve_auth_headers
+          return {} if @auth_provider.nil?
+
+          @auth_provider.auth_headers
+        end
+
         # @param url [URI::Generic] The url to the resource.
         # @param method [String] The HTTP method to use.
         # @param headers [Hash] The headers for the request.
         # @param body [String, nil] The body for the request.
+        # @param auth_headers [Hash] The auth headers resolved for this request. These
+        #   take precedence over the static default headers but not over per-request
+        #   headers, mirroring the previous baked-header precedence.
         # @return [HTTP::Request] The HTTP request.
-        def build_http_request(url:, method:, headers: {}, body: nil)
+        def build_http_request(url:, method:, headers: {}, body: nil, auth_headers: {})
           request = Net::HTTPGenericRequest.new(
             method,
             !body.nil?,
@@ -170,7 +193,7 @@ module Seed
             url
           )
 
-          request_headers = @default_headers.merge(headers)
+          request_headers = @default_headers.merge(auth_headers).merge(headers)
           request_headers.each { |name, value| request[name] = value }
           request.body = body if body
 

--- a/seed/ruby-sdk-v2/literal/test/unit/internal/http/test_raw_client.rb
+++ b/seed/ruby-sdk-v2/literal/test/unit/internal/http/test_raw_client.rb
@@ -54,4 +54,71 @@ describe Seed::Internal::Http::RawClient do
       assert client.should_retry?(make_response(502), 2)
     end
   end
+
+  # A minimal auth provider whose `auth_headers` returns a *different* token on
+  # each call, simulating a token that is refreshed on expiry.
+  class RefreshingAuthProvider
+    def initialize
+      @count = 0
+    end
+
+    def auth_headers
+      @count += 1
+      { "Authorization" => "Bearer TOKEN_#{@count}" }
+    end
+  end
+
+  describe "#resolve_auth_headers" do
+    it "returns an empty hash when no auth provider is configured" do
+      client = Seed::Internal::Http::RawClient.new(base_url: "https://example.com")
+
+      assert_equal({}, client.resolve_auth_headers)
+    end
+
+    it "consults the auth provider on every call so an expired token is refreshed" do
+      client = Seed::Internal::Http::RawClient.new(
+        base_url: "https://example.com",
+        auth_provider: RefreshingAuthProvider.new
+      )
+
+      assert_equal({ "Authorization" => "Bearer TOKEN_1" }, client.resolve_auth_headers)
+      assert_equal({ "Authorization" => "Bearer TOKEN_2" }, client.resolve_auth_headers)
+    end
+  end
+
+  describe "#build_http_request auth header precedence" do
+    let(:client) do
+      Seed::Internal::Http::RawClient.new(
+        base_url: "https://example.com",
+        headers: { "Authorization" => "Bearer STATIC" }
+      )
+    end
+
+    it "lets resolved auth headers override the static default headers" do
+      request = client.build_http_request(
+        url: URI.parse("https://example.com"),
+        method: "GET",
+        auth_headers: { "Authorization" => "Bearer FRESH" }
+      )
+
+      assert_equal("Bearer FRESH", request["Authorization"])
+    end
+
+    it "lets per-request headers take precedence over auth headers" do
+      request = client.build_http_request(
+        url: URI.parse("https://example.com"),
+        method: "GET",
+        headers: { "Authorization" => "Bearer PER_REQUEST" },
+        auth_headers: { "Authorization" => "Bearer FRESH" }
+      )
+
+      assert_equal("Bearer PER_REQUEST", request["Authorization"])
+    end
+
+    it "defaults auth headers to empty, leaving the default headers unchanged" do
+      request = client.build_http_request(url: URI.parse("https://example.com"), method: "GET")
+
+      assert_equal("Bearer STATIC", request["Authorization"])
+    end
+  end
 end

--- a/seed/ruby-sdk-v2/literals-unions/lib/seed/internal/http/raw_client.rb
+++ b/seed/ruby-sdk-v2/literals-unions/lib/seed/internal/http/raw_client.rb
@@ -21,10 +21,14 @@ module Seed
         # @param max_retries [Integer] The number of times to retry a failed request, defaults to 2.
         # @param timeout [Float] The timeout for the request, defaults to 60.0 seconds.
         # @param headers [Hash] The headers for the request.
-        def initialize(base_url:, max_retries: 2, timeout: 60.0, headers: {})
+        # @param auth_provider [Object, nil] An optional auth provider responding to
+        #   `auth_headers`. When present its headers are resolved on every request so
+        #   token-based schemes (e.g. OAuth) can refresh an expired token mid-session.
+        def initialize(base_url:, max_retries: 2, timeout: 60.0, headers: {}, auth_provider: nil)
           @base_url = base_url
           @max_retries = max_retries
           @timeout = timeout
+          @auth_provider = auth_provider
           @default_headers = {
             "X-Fern-Language": "Ruby",
             "X-Fern-SDK-Name": "seed",
@@ -36,6 +40,9 @@ module Seed
         # @return [HTTP::Response] The HTTP response.
         def send(request)
           url = build_url(request)
+          # Resolve auth headers once per request (not per retry) so token-based
+          # providers refresh at most once here; static providers are cheap.
+          auth_headers = resolve_auth_headers
           attempt = 0
           response = nil
 
@@ -43,8 +50,9 @@ module Seed
             http_request = build_http_request(
               url:,
               method: request.method,
-              headers: request.encode_headers(protected_keys: @default_headers.keys),
-              body: request.encode_body
+              headers: request.encode_headers(protected_keys: @default_headers.keys + auth_headers.keys),
+              body: request.encode_body,
+              auth_headers: auth_headers
             )
 
             conn = connect(url)
@@ -157,12 +165,27 @@ module Seed
                 "HTTP is only allowed for localhost. Use HTTPS or pass a localhost URL."
         end
 
+        # Resolves the auth headers to send with the next request. Delegates to the
+        # configured auth provider (if any) on every call so that token-based
+        # providers (e.g. OAuth client-credentials) can refresh an expired token
+        # before the request is sent. Returns an empty hash when no provider is set,
+        # which keeps the api-key / basic / bearer / no-auth paths unchanged.
+        # @return [Hash] The auth headers for the current request.
+        def resolve_auth_headers
+          return {} if @auth_provider.nil?
+
+          @auth_provider.auth_headers
+        end
+
         # @param url [URI::Generic] The url to the resource.
         # @param method [String] The HTTP method to use.
         # @param headers [Hash] The headers for the request.
         # @param body [String, nil] The body for the request.
+        # @param auth_headers [Hash] The auth headers resolved for this request. These
+        #   take precedence over the static default headers but not over per-request
+        #   headers, mirroring the previous baked-header precedence.
         # @return [HTTP::Request] The HTTP request.
-        def build_http_request(url:, method:, headers: {}, body: nil)
+        def build_http_request(url:, method:, headers: {}, body: nil, auth_headers: {})
           request = Net::HTTPGenericRequest.new(
             method,
             !body.nil?,
@@ -170,7 +193,7 @@ module Seed
             url
           )
 
-          request_headers = @default_headers.merge(headers)
+          request_headers = @default_headers.merge(auth_headers).merge(headers)
           request_headers.each { |name, value| request[name] = value }
           request.body = body if body
 

--- a/seed/ruby-sdk-v2/literals-unions/test/unit/internal/http/test_raw_client.rb
+++ b/seed/ruby-sdk-v2/literals-unions/test/unit/internal/http/test_raw_client.rb
@@ -54,4 +54,71 @@ describe Seed::Internal::Http::RawClient do
       assert client.should_retry?(make_response(502), 2)
     end
   end
+
+  # A minimal auth provider whose `auth_headers` returns a *different* token on
+  # each call, simulating a token that is refreshed on expiry.
+  class RefreshingAuthProvider
+    def initialize
+      @count = 0
+    end
+
+    def auth_headers
+      @count += 1
+      { "Authorization" => "Bearer TOKEN_#{@count}" }
+    end
+  end
+
+  describe "#resolve_auth_headers" do
+    it "returns an empty hash when no auth provider is configured" do
+      client = Seed::Internal::Http::RawClient.new(base_url: "https://example.com")
+
+      assert_equal({}, client.resolve_auth_headers)
+    end
+
+    it "consults the auth provider on every call so an expired token is refreshed" do
+      client = Seed::Internal::Http::RawClient.new(
+        base_url: "https://example.com",
+        auth_provider: RefreshingAuthProvider.new
+      )
+
+      assert_equal({ "Authorization" => "Bearer TOKEN_1" }, client.resolve_auth_headers)
+      assert_equal({ "Authorization" => "Bearer TOKEN_2" }, client.resolve_auth_headers)
+    end
+  end
+
+  describe "#build_http_request auth header precedence" do
+    let(:client) do
+      Seed::Internal::Http::RawClient.new(
+        base_url: "https://example.com",
+        headers: { "Authorization" => "Bearer STATIC" }
+      )
+    end
+
+    it "lets resolved auth headers override the static default headers" do
+      request = client.build_http_request(
+        url: URI.parse("https://example.com"),
+        method: "GET",
+        auth_headers: { "Authorization" => "Bearer FRESH" }
+      )
+
+      assert_equal("Bearer FRESH", request["Authorization"])
+    end
+
+    it "lets per-request headers take precedence over auth headers" do
+      request = client.build_http_request(
+        url: URI.parse("https://example.com"),
+        method: "GET",
+        headers: { "Authorization" => "Bearer PER_REQUEST" },
+        auth_headers: { "Authorization" => "Bearer FRESH" }
+      )
+
+      assert_equal("Bearer PER_REQUEST", request["Authorization"])
+    end
+
+    it "defaults auth headers to empty, leaving the default headers unchanged" do
+      request = client.build_http_request(url: URI.parse("https://example.com"), method: "GET")
+
+      assert_equal("Bearer STATIC", request["Authorization"])
+    end
+  end
 end

--- a/seed/ruby-sdk-v2/mixed-case/lib/seed/internal/http/raw_client.rb
+++ b/seed/ruby-sdk-v2/mixed-case/lib/seed/internal/http/raw_client.rb
@@ -21,10 +21,14 @@ module Seed
         # @param max_retries [Integer] The number of times to retry a failed request, defaults to 2.
         # @param timeout [Float] The timeout for the request, defaults to 60.0 seconds.
         # @param headers [Hash] The headers for the request.
-        def initialize(base_url:, max_retries: 2, timeout: 60.0, headers: {})
+        # @param auth_provider [Object, nil] An optional auth provider responding to
+        #   `auth_headers`. When present its headers are resolved on every request so
+        #   token-based schemes (e.g. OAuth) can refresh an expired token mid-session.
+        def initialize(base_url:, max_retries: 2, timeout: 60.0, headers: {}, auth_provider: nil)
           @base_url = base_url
           @max_retries = max_retries
           @timeout = timeout
+          @auth_provider = auth_provider
           @default_headers = {
             "X-Fern-Language": "Ruby",
             "X-Fern-SDK-Name": "seed",
@@ -36,6 +40,9 @@ module Seed
         # @return [HTTP::Response] The HTTP response.
         def send(request)
           url = build_url(request)
+          # Resolve auth headers once per request (not per retry) so token-based
+          # providers refresh at most once here; static providers are cheap.
+          auth_headers = resolve_auth_headers
           attempt = 0
           response = nil
 
@@ -43,8 +50,9 @@ module Seed
             http_request = build_http_request(
               url:,
               method: request.method,
-              headers: request.encode_headers(protected_keys: @default_headers.keys),
-              body: request.encode_body
+              headers: request.encode_headers(protected_keys: @default_headers.keys + auth_headers.keys),
+              body: request.encode_body,
+              auth_headers: auth_headers
             )
 
             conn = connect(url)
@@ -157,12 +165,27 @@ module Seed
                 "HTTP is only allowed for localhost. Use HTTPS or pass a localhost URL."
         end
 
+        # Resolves the auth headers to send with the next request. Delegates to the
+        # configured auth provider (if any) on every call so that token-based
+        # providers (e.g. OAuth client-credentials) can refresh an expired token
+        # before the request is sent. Returns an empty hash when no provider is set,
+        # which keeps the api-key / basic / bearer / no-auth paths unchanged.
+        # @return [Hash] The auth headers for the current request.
+        def resolve_auth_headers
+          return {} if @auth_provider.nil?
+
+          @auth_provider.auth_headers
+        end
+
         # @param url [URI::Generic] The url to the resource.
         # @param method [String] The HTTP method to use.
         # @param headers [Hash] The headers for the request.
         # @param body [String, nil] The body for the request.
+        # @param auth_headers [Hash] The auth headers resolved for this request. These
+        #   take precedence over the static default headers but not over per-request
+        #   headers, mirroring the previous baked-header precedence.
         # @return [HTTP::Request] The HTTP request.
-        def build_http_request(url:, method:, headers: {}, body: nil)
+        def build_http_request(url:, method:, headers: {}, body: nil, auth_headers: {})
           request = Net::HTTPGenericRequest.new(
             method,
             !body.nil?,
@@ -170,7 +193,7 @@ module Seed
             url
           )
 
-          request_headers = @default_headers.merge(headers)
+          request_headers = @default_headers.merge(auth_headers).merge(headers)
           request_headers.each { |name, value| request[name] = value }
           request.body = body if body
 

--- a/seed/ruby-sdk-v2/mixed-case/test/unit/internal/http/test_raw_client.rb
+++ b/seed/ruby-sdk-v2/mixed-case/test/unit/internal/http/test_raw_client.rb
@@ -54,4 +54,71 @@ describe Seed::Internal::Http::RawClient do
       assert client.should_retry?(make_response(502), 2)
     end
   end
+
+  # A minimal auth provider whose `auth_headers` returns a *different* token on
+  # each call, simulating a token that is refreshed on expiry.
+  class RefreshingAuthProvider
+    def initialize
+      @count = 0
+    end
+
+    def auth_headers
+      @count += 1
+      { "Authorization" => "Bearer TOKEN_#{@count}" }
+    end
+  end
+
+  describe "#resolve_auth_headers" do
+    it "returns an empty hash when no auth provider is configured" do
+      client = Seed::Internal::Http::RawClient.new(base_url: "https://example.com")
+
+      assert_equal({}, client.resolve_auth_headers)
+    end
+
+    it "consults the auth provider on every call so an expired token is refreshed" do
+      client = Seed::Internal::Http::RawClient.new(
+        base_url: "https://example.com",
+        auth_provider: RefreshingAuthProvider.new
+      )
+
+      assert_equal({ "Authorization" => "Bearer TOKEN_1" }, client.resolve_auth_headers)
+      assert_equal({ "Authorization" => "Bearer TOKEN_2" }, client.resolve_auth_headers)
+    end
+  end
+
+  describe "#build_http_request auth header precedence" do
+    let(:client) do
+      Seed::Internal::Http::RawClient.new(
+        base_url: "https://example.com",
+        headers: { "Authorization" => "Bearer STATIC" }
+      )
+    end
+
+    it "lets resolved auth headers override the static default headers" do
+      request = client.build_http_request(
+        url: URI.parse("https://example.com"),
+        method: "GET",
+        auth_headers: { "Authorization" => "Bearer FRESH" }
+      )
+
+      assert_equal("Bearer FRESH", request["Authorization"])
+    end
+
+    it "lets per-request headers take precedence over auth headers" do
+      request = client.build_http_request(
+        url: URI.parse("https://example.com"),
+        method: "GET",
+        headers: { "Authorization" => "Bearer PER_REQUEST" },
+        auth_headers: { "Authorization" => "Bearer FRESH" }
+      )
+
+      assert_equal("Bearer PER_REQUEST", request["Authorization"])
+    end
+
+    it "defaults auth headers to empty, leaving the default headers unchanged" do
+      request = client.build_http_request(url: URI.parse("https://example.com"), method: "GET")
+
+      assert_equal("Bearer STATIC", request["Authorization"])
+    end
+  end
 end

--- a/seed/ruby-sdk-v2/mixed-file-directory/lib/seed/internal/http/raw_client.rb
+++ b/seed/ruby-sdk-v2/mixed-file-directory/lib/seed/internal/http/raw_client.rb
@@ -21,10 +21,14 @@ module Seed
         # @param max_retries [Integer] The number of times to retry a failed request, defaults to 2.
         # @param timeout [Float] The timeout for the request, defaults to 60.0 seconds.
         # @param headers [Hash] The headers for the request.
-        def initialize(base_url:, max_retries: 2, timeout: 60.0, headers: {})
+        # @param auth_provider [Object, nil] An optional auth provider responding to
+        #   `auth_headers`. When present its headers are resolved on every request so
+        #   token-based schemes (e.g. OAuth) can refresh an expired token mid-session.
+        def initialize(base_url:, max_retries: 2, timeout: 60.0, headers: {}, auth_provider: nil)
           @base_url = base_url
           @max_retries = max_retries
           @timeout = timeout
+          @auth_provider = auth_provider
           @default_headers = {
             "X-Fern-Language": "Ruby",
             "X-Fern-SDK-Name": "seed",
@@ -36,6 +40,9 @@ module Seed
         # @return [HTTP::Response] The HTTP response.
         def send(request)
           url = build_url(request)
+          # Resolve auth headers once per request (not per retry) so token-based
+          # providers refresh at most once here; static providers are cheap.
+          auth_headers = resolve_auth_headers
           attempt = 0
           response = nil
 
@@ -43,8 +50,9 @@ module Seed
             http_request = build_http_request(
               url:,
               method: request.method,
-              headers: request.encode_headers(protected_keys: @default_headers.keys),
-              body: request.encode_body
+              headers: request.encode_headers(protected_keys: @default_headers.keys + auth_headers.keys),
+              body: request.encode_body,
+              auth_headers: auth_headers
             )
 
             conn = connect(url)
@@ -157,12 +165,27 @@ module Seed
                 "HTTP is only allowed for localhost. Use HTTPS or pass a localhost URL."
         end
 
+        # Resolves the auth headers to send with the next request. Delegates to the
+        # configured auth provider (if any) on every call so that token-based
+        # providers (e.g. OAuth client-credentials) can refresh an expired token
+        # before the request is sent. Returns an empty hash when no provider is set,
+        # which keeps the api-key / basic / bearer / no-auth paths unchanged.
+        # @return [Hash] The auth headers for the current request.
+        def resolve_auth_headers
+          return {} if @auth_provider.nil?
+
+          @auth_provider.auth_headers
+        end
+
         # @param url [URI::Generic] The url to the resource.
         # @param method [String] The HTTP method to use.
         # @param headers [Hash] The headers for the request.
         # @param body [String, nil] The body for the request.
+        # @param auth_headers [Hash] The auth headers resolved for this request. These
+        #   take precedence over the static default headers but not over per-request
+        #   headers, mirroring the previous baked-header precedence.
         # @return [HTTP::Request] The HTTP request.
-        def build_http_request(url:, method:, headers: {}, body: nil)
+        def build_http_request(url:, method:, headers: {}, body: nil, auth_headers: {})
           request = Net::HTTPGenericRequest.new(
             method,
             !body.nil?,
@@ -170,7 +193,7 @@ module Seed
             url
           )
 
-          request_headers = @default_headers.merge(headers)
+          request_headers = @default_headers.merge(auth_headers).merge(headers)
           request_headers.each { |name, value| request[name] = value }
           request.body = body if body
 

--- a/seed/ruby-sdk-v2/mixed-file-directory/test/unit/internal/http/test_raw_client.rb
+++ b/seed/ruby-sdk-v2/mixed-file-directory/test/unit/internal/http/test_raw_client.rb
@@ -54,4 +54,71 @@ describe Seed::Internal::Http::RawClient do
       assert client.should_retry?(make_response(502), 2)
     end
   end
+
+  # A minimal auth provider whose `auth_headers` returns a *different* token on
+  # each call, simulating a token that is refreshed on expiry.
+  class RefreshingAuthProvider
+    def initialize
+      @count = 0
+    end
+
+    def auth_headers
+      @count += 1
+      { "Authorization" => "Bearer TOKEN_#{@count}" }
+    end
+  end
+
+  describe "#resolve_auth_headers" do
+    it "returns an empty hash when no auth provider is configured" do
+      client = Seed::Internal::Http::RawClient.new(base_url: "https://example.com")
+
+      assert_equal({}, client.resolve_auth_headers)
+    end
+
+    it "consults the auth provider on every call so an expired token is refreshed" do
+      client = Seed::Internal::Http::RawClient.new(
+        base_url: "https://example.com",
+        auth_provider: RefreshingAuthProvider.new
+      )
+
+      assert_equal({ "Authorization" => "Bearer TOKEN_1" }, client.resolve_auth_headers)
+      assert_equal({ "Authorization" => "Bearer TOKEN_2" }, client.resolve_auth_headers)
+    end
+  end
+
+  describe "#build_http_request auth header precedence" do
+    let(:client) do
+      Seed::Internal::Http::RawClient.new(
+        base_url: "https://example.com",
+        headers: { "Authorization" => "Bearer STATIC" }
+      )
+    end
+
+    it "lets resolved auth headers override the static default headers" do
+      request = client.build_http_request(
+        url: URI.parse("https://example.com"),
+        method: "GET",
+        auth_headers: { "Authorization" => "Bearer FRESH" }
+      )
+
+      assert_equal("Bearer FRESH", request["Authorization"])
+    end
+
+    it "lets per-request headers take precedence over auth headers" do
+      request = client.build_http_request(
+        url: URI.parse("https://example.com"),
+        method: "GET",
+        headers: { "Authorization" => "Bearer PER_REQUEST" },
+        auth_headers: { "Authorization" => "Bearer FRESH" }
+      )
+
+      assert_equal("Bearer PER_REQUEST", request["Authorization"])
+    end
+
+    it "defaults auth headers to empty, leaving the default headers unchanged" do
+      request = client.build_http_request(url: URI.parse("https://example.com"), method: "GET")
+
+      assert_equal("Bearer STATIC", request["Authorization"])
+    end
+  end
 end

--- a/seed/ruby-sdk-v2/multi-content-type-examples/lib/seed/internal/http/raw_client.rb
+++ b/seed/ruby-sdk-v2/multi-content-type-examples/lib/seed/internal/http/raw_client.rb
@@ -21,10 +21,14 @@ module Seed
         # @param max_retries [Integer] The number of times to retry a failed request, defaults to 2.
         # @param timeout [Float] The timeout for the request, defaults to 60.0 seconds.
         # @param headers [Hash] The headers for the request.
-        def initialize(base_url:, max_retries: 2, timeout: 60.0, headers: {})
+        # @param auth_provider [Object, nil] An optional auth provider responding to
+        #   `auth_headers`. When present its headers are resolved on every request so
+        #   token-based schemes (e.g. OAuth) can refresh an expired token mid-session.
+        def initialize(base_url:, max_retries: 2, timeout: 60.0, headers: {}, auth_provider: nil)
           @base_url = base_url
           @max_retries = max_retries
           @timeout = timeout
+          @auth_provider = auth_provider
           @default_headers = {
             "X-Fern-Language": "Ruby",
             "X-Fern-SDK-Name": "seed",
@@ -36,6 +40,9 @@ module Seed
         # @return [HTTP::Response] The HTTP response.
         def send(request)
           url = build_url(request)
+          # Resolve auth headers once per request (not per retry) so token-based
+          # providers refresh at most once here; static providers are cheap.
+          auth_headers = resolve_auth_headers
           attempt = 0
           response = nil
 
@@ -43,8 +50,9 @@ module Seed
             http_request = build_http_request(
               url:,
               method: request.method,
-              headers: request.encode_headers(protected_keys: @default_headers.keys),
-              body: request.encode_body
+              headers: request.encode_headers(protected_keys: @default_headers.keys + auth_headers.keys),
+              body: request.encode_body,
+              auth_headers: auth_headers
             )
 
             conn = connect(url)
@@ -157,12 +165,27 @@ module Seed
                 "HTTP is only allowed for localhost. Use HTTPS or pass a localhost URL."
         end
 
+        # Resolves the auth headers to send with the next request. Delegates to the
+        # configured auth provider (if any) on every call so that token-based
+        # providers (e.g. OAuth client-credentials) can refresh an expired token
+        # before the request is sent. Returns an empty hash when no provider is set,
+        # which keeps the api-key / basic / bearer / no-auth paths unchanged.
+        # @return [Hash] The auth headers for the current request.
+        def resolve_auth_headers
+          return {} if @auth_provider.nil?
+
+          @auth_provider.auth_headers
+        end
+
         # @param url [URI::Generic] The url to the resource.
         # @param method [String] The HTTP method to use.
         # @param headers [Hash] The headers for the request.
         # @param body [String, nil] The body for the request.
+        # @param auth_headers [Hash] The auth headers resolved for this request. These
+        #   take precedence over the static default headers but not over per-request
+        #   headers, mirroring the previous baked-header precedence.
         # @return [HTTP::Request] The HTTP request.
-        def build_http_request(url:, method:, headers: {}, body: nil)
+        def build_http_request(url:, method:, headers: {}, body: nil, auth_headers: {})
           request = Net::HTTPGenericRequest.new(
             method,
             !body.nil?,
@@ -170,7 +193,7 @@ module Seed
             url
           )
 
-          request_headers = @default_headers.merge(headers)
+          request_headers = @default_headers.merge(auth_headers).merge(headers)
           request_headers.each { |name, value| request[name] = value }
           request.body = body if body
 

--- a/seed/ruby-sdk-v2/multi-content-type-examples/test/unit/internal/http/test_raw_client.rb
+++ b/seed/ruby-sdk-v2/multi-content-type-examples/test/unit/internal/http/test_raw_client.rb
@@ -54,4 +54,71 @@ describe Seed::Internal::Http::RawClient do
       assert client.should_retry?(make_response(502), 2)
     end
   end
+
+  # A minimal auth provider whose `auth_headers` returns a *different* token on
+  # each call, simulating a token that is refreshed on expiry.
+  class RefreshingAuthProvider
+    def initialize
+      @count = 0
+    end
+
+    def auth_headers
+      @count += 1
+      { "Authorization" => "Bearer TOKEN_#{@count}" }
+    end
+  end
+
+  describe "#resolve_auth_headers" do
+    it "returns an empty hash when no auth provider is configured" do
+      client = Seed::Internal::Http::RawClient.new(base_url: "https://example.com")
+
+      assert_equal({}, client.resolve_auth_headers)
+    end
+
+    it "consults the auth provider on every call so an expired token is refreshed" do
+      client = Seed::Internal::Http::RawClient.new(
+        base_url: "https://example.com",
+        auth_provider: RefreshingAuthProvider.new
+      )
+
+      assert_equal({ "Authorization" => "Bearer TOKEN_1" }, client.resolve_auth_headers)
+      assert_equal({ "Authorization" => "Bearer TOKEN_2" }, client.resolve_auth_headers)
+    end
+  end
+
+  describe "#build_http_request auth header precedence" do
+    let(:client) do
+      Seed::Internal::Http::RawClient.new(
+        base_url: "https://example.com",
+        headers: { "Authorization" => "Bearer STATIC" }
+      )
+    end
+
+    it "lets resolved auth headers override the static default headers" do
+      request = client.build_http_request(
+        url: URI.parse("https://example.com"),
+        method: "GET",
+        auth_headers: { "Authorization" => "Bearer FRESH" }
+      )
+
+      assert_equal("Bearer FRESH", request["Authorization"])
+    end
+
+    it "lets per-request headers take precedence over auth headers" do
+      request = client.build_http_request(
+        url: URI.parse("https://example.com"),
+        method: "GET",
+        headers: { "Authorization" => "Bearer PER_REQUEST" },
+        auth_headers: { "Authorization" => "Bearer FRESH" }
+      )
+
+      assert_equal("Bearer PER_REQUEST", request["Authorization"])
+    end
+
+    it "defaults auth headers to empty, leaving the default headers unchanged" do
+      request = client.build_http_request(url: URI.parse("https://example.com"), method: "GET")
+
+      assert_equal("Bearer STATIC", request["Authorization"])
+    end
+  end
 end

--- a/seed/ruby-sdk-v2/multi-line-docs/lib/seed/internal/http/raw_client.rb
+++ b/seed/ruby-sdk-v2/multi-line-docs/lib/seed/internal/http/raw_client.rb
@@ -21,10 +21,14 @@ module Seed
         # @param max_retries [Integer] The number of times to retry a failed request, defaults to 2.
         # @param timeout [Float] The timeout for the request, defaults to 60.0 seconds.
         # @param headers [Hash] The headers for the request.
-        def initialize(base_url:, max_retries: 2, timeout: 60.0, headers: {})
+        # @param auth_provider [Object, nil] An optional auth provider responding to
+        #   `auth_headers`. When present its headers are resolved on every request so
+        #   token-based schemes (e.g. OAuth) can refresh an expired token mid-session.
+        def initialize(base_url:, max_retries: 2, timeout: 60.0, headers: {}, auth_provider: nil)
           @base_url = base_url
           @max_retries = max_retries
           @timeout = timeout
+          @auth_provider = auth_provider
           @default_headers = {
             "X-Fern-Language": "Ruby",
             "X-Fern-SDK-Name": "seed",
@@ -36,6 +40,9 @@ module Seed
         # @return [HTTP::Response] The HTTP response.
         def send(request)
           url = build_url(request)
+          # Resolve auth headers once per request (not per retry) so token-based
+          # providers refresh at most once here; static providers are cheap.
+          auth_headers = resolve_auth_headers
           attempt = 0
           response = nil
 
@@ -43,8 +50,9 @@ module Seed
             http_request = build_http_request(
               url:,
               method: request.method,
-              headers: request.encode_headers(protected_keys: @default_headers.keys),
-              body: request.encode_body
+              headers: request.encode_headers(protected_keys: @default_headers.keys + auth_headers.keys),
+              body: request.encode_body,
+              auth_headers: auth_headers
             )
 
             conn = connect(url)
@@ -157,12 +165,27 @@ module Seed
                 "HTTP is only allowed for localhost. Use HTTPS or pass a localhost URL."
         end
 
+        # Resolves the auth headers to send with the next request. Delegates to the
+        # configured auth provider (if any) on every call so that token-based
+        # providers (e.g. OAuth client-credentials) can refresh an expired token
+        # before the request is sent. Returns an empty hash when no provider is set,
+        # which keeps the api-key / basic / bearer / no-auth paths unchanged.
+        # @return [Hash] The auth headers for the current request.
+        def resolve_auth_headers
+          return {} if @auth_provider.nil?
+
+          @auth_provider.auth_headers
+        end
+
         # @param url [URI::Generic] The url to the resource.
         # @param method [String] The HTTP method to use.
         # @param headers [Hash] The headers for the request.
         # @param body [String, nil] The body for the request.
+        # @param auth_headers [Hash] The auth headers resolved for this request. These
+        #   take precedence over the static default headers but not over per-request
+        #   headers, mirroring the previous baked-header precedence.
         # @return [HTTP::Request] The HTTP request.
-        def build_http_request(url:, method:, headers: {}, body: nil)
+        def build_http_request(url:, method:, headers: {}, body: nil, auth_headers: {})
           request = Net::HTTPGenericRequest.new(
             method,
             !body.nil?,
@@ -170,7 +193,7 @@ module Seed
             url
           )
 
-          request_headers = @default_headers.merge(headers)
+          request_headers = @default_headers.merge(auth_headers).merge(headers)
           request_headers.each { |name, value| request[name] = value }
           request.body = body if body
 

--- a/seed/ruby-sdk-v2/multi-line-docs/test/unit/internal/http/test_raw_client.rb
+++ b/seed/ruby-sdk-v2/multi-line-docs/test/unit/internal/http/test_raw_client.rb
@@ -54,4 +54,71 @@ describe Seed::Internal::Http::RawClient do
       assert client.should_retry?(make_response(502), 2)
     end
   end
+
+  # A minimal auth provider whose `auth_headers` returns a *different* token on
+  # each call, simulating a token that is refreshed on expiry.
+  class RefreshingAuthProvider
+    def initialize
+      @count = 0
+    end
+
+    def auth_headers
+      @count += 1
+      { "Authorization" => "Bearer TOKEN_#{@count}" }
+    end
+  end
+
+  describe "#resolve_auth_headers" do
+    it "returns an empty hash when no auth provider is configured" do
+      client = Seed::Internal::Http::RawClient.new(base_url: "https://example.com")
+
+      assert_equal({}, client.resolve_auth_headers)
+    end
+
+    it "consults the auth provider on every call so an expired token is refreshed" do
+      client = Seed::Internal::Http::RawClient.new(
+        base_url: "https://example.com",
+        auth_provider: RefreshingAuthProvider.new
+      )
+
+      assert_equal({ "Authorization" => "Bearer TOKEN_1" }, client.resolve_auth_headers)
+      assert_equal({ "Authorization" => "Bearer TOKEN_2" }, client.resolve_auth_headers)
+    end
+  end
+
+  describe "#build_http_request auth header precedence" do
+    let(:client) do
+      Seed::Internal::Http::RawClient.new(
+        base_url: "https://example.com",
+        headers: { "Authorization" => "Bearer STATIC" }
+      )
+    end
+
+    it "lets resolved auth headers override the static default headers" do
+      request = client.build_http_request(
+        url: URI.parse("https://example.com"),
+        method: "GET",
+        auth_headers: { "Authorization" => "Bearer FRESH" }
+      )
+
+      assert_equal("Bearer FRESH", request["Authorization"])
+    end
+
+    it "lets per-request headers take precedence over auth headers" do
+      request = client.build_http_request(
+        url: URI.parse("https://example.com"),
+        method: "GET",
+        headers: { "Authorization" => "Bearer PER_REQUEST" },
+        auth_headers: { "Authorization" => "Bearer FRESH" }
+      )
+
+      assert_equal("Bearer PER_REQUEST", request["Authorization"])
+    end
+
+    it "defaults auth headers to empty, leaving the default headers unchanged" do
+      request = client.build_http_request(url: URI.parse("https://example.com"), method: "GET")
+
+      assert_equal("Bearer STATIC", request["Authorization"])
+    end
+  end
 end

--- a/seed/ruby-sdk-v2/multi-url-environment-no-default/lib/seed/internal/http/raw_client.rb
+++ b/seed/ruby-sdk-v2/multi-url-environment-no-default/lib/seed/internal/http/raw_client.rb
@@ -21,10 +21,14 @@ module Seed
         # @param max_retries [Integer] The number of times to retry a failed request, defaults to 2.
         # @param timeout [Float] The timeout for the request, defaults to 60.0 seconds.
         # @param headers [Hash] The headers for the request.
-        def initialize(base_url:, max_retries: 2, timeout: 60.0, headers: {})
+        # @param auth_provider [Object, nil] An optional auth provider responding to
+        #   `auth_headers`. When present its headers are resolved on every request so
+        #   token-based schemes (e.g. OAuth) can refresh an expired token mid-session.
+        def initialize(base_url:, max_retries: 2, timeout: 60.0, headers: {}, auth_provider: nil)
           @base_url = base_url
           @max_retries = max_retries
           @timeout = timeout
+          @auth_provider = auth_provider
           @default_headers = {
             "X-Fern-Language": "Ruby",
             "X-Fern-SDK-Name": "seed",
@@ -36,6 +40,9 @@ module Seed
         # @return [HTTP::Response] The HTTP response.
         def send(request)
           url = build_url(request)
+          # Resolve auth headers once per request (not per retry) so token-based
+          # providers refresh at most once here; static providers are cheap.
+          auth_headers = resolve_auth_headers
           attempt = 0
           response = nil
 
@@ -43,8 +50,9 @@ module Seed
             http_request = build_http_request(
               url:,
               method: request.method,
-              headers: request.encode_headers(protected_keys: @default_headers.keys),
-              body: request.encode_body
+              headers: request.encode_headers(protected_keys: @default_headers.keys + auth_headers.keys),
+              body: request.encode_body,
+              auth_headers: auth_headers
             )
 
             conn = connect(url)
@@ -157,12 +165,27 @@ module Seed
                 "HTTP is only allowed for localhost. Use HTTPS or pass a localhost URL."
         end
 
+        # Resolves the auth headers to send with the next request. Delegates to the
+        # configured auth provider (if any) on every call so that token-based
+        # providers (e.g. OAuth client-credentials) can refresh an expired token
+        # before the request is sent. Returns an empty hash when no provider is set,
+        # which keeps the api-key / basic / bearer / no-auth paths unchanged.
+        # @return [Hash] The auth headers for the current request.
+        def resolve_auth_headers
+          return {} if @auth_provider.nil?
+
+          @auth_provider.auth_headers
+        end
+
         # @param url [URI::Generic] The url to the resource.
         # @param method [String] The HTTP method to use.
         # @param headers [Hash] The headers for the request.
         # @param body [String, nil] The body for the request.
+        # @param auth_headers [Hash] The auth headers resolved for this request. These
+        #   take precedence over the static default headers but not over per-request
+        #   headers, mirroring the previous baked-header precedence.
         # @return [HTTP::Request] The HTTP request.
-        def build_http_request(url:, method:, headers: {}, body: nil)
+        def build_http_request(url:, method:, headers: {}, body: nil, auth_headers: {})
           request = Net::HTTPGenericRequest.new(
             method,
             !body.nil?,
@@ -170,7 +193,7 @@ module Seed
             url
           )
 
-          request_headers = @default_headers.merge(headers)
+          request_headers = @default_headers.merge(auth_headers).merge(headers)
           request_headers.each { |name, value| request[name] = value }
           request.body = body if body
 

--- a/seed/ruby-sdk-v2/multi-url-environment-no-default/test/unit/internal/http/test_raw_client.rb
+++ b/seed/ruby-sdk-v2/multi-url-environment-no-default/test/unit/internal/http/test_raw_client.rb
@@ -54,4 +54,71 @@ describe Seed::Internal::Http::RawClient do
       assert client.should_retry?(make_response(502), 2)
     end
   end
+
+  # A minimal auth provider whose `auth_headers` returns a *different* token on
+  # each call, simulating a token that is refreshed on expiry.
+  class RefreshingAuthProvider
+    def initialize
+      @count = 0
+    end
+
+    def auth_headers
+      @count += 1
+      { "Authorization" => "Bearer TOKEN_#{@count}" }
+    end
+  end
+
+  describe "#resolve_auth_headers" do
+    it "returns an empty hash when no auth provider is configured" do
+      client = Seed::Internal::Http::RawClient.new(base_url: "https://example.com")
+
+      assert_equal({}, client.resolve_auth_headers)
+    end
+
+    it "consults the auth provider on every call so an expired token is refreshed" do
+      client = Seed::Internal::Http::RawClient.new(
+        base_url: "https://example.com",
+        auth_provider: RefreshingAuthProvider.new
+      )
+
+      assert_equal({ "Authorization" => "Bearer TOKEN_1" }, client.resolve_auth_headers)
+      assert_equal({ "Authorization" => "Bearer TOKEN_2" }, client.resolve_auth_headers)
+    end
+  end
+
+  describe "#build_http_request auth header precedence" do
+    let(:client) do
+      Seed::Internal::Http::RawClient.new(
+        base_url: "https://example.com",
+        headers: { "Authorization" => "Bearer STATIC" }
+      )
+    end
+
+    it "lets resolved auth headers override the static default headers" do
+      request = client.build_http_request(
+        url: URI.parse("https://example.com"),
+        method: "GET",
+        auth_headers: { "Authorization" => "Bearer FRESH" }
+      )
+
+      assert_equal("Bearer FRESH", request["Authorization"])
+    end
+
+    it "lets per-request headers take precedence over auth headers" do
+      request = client.build_http_request(
+        url: URI.parse("https://example.com"),
+        method: "GET",
+        headers: { "Authorization" => "Bearer PER_REQUEST" },
+        auth_headers: { "Authorization" => "Bearer FRESH" }
+      )
+
+      assert_equal("Bearer PER_REQUEST", request["Authorization"])
+    end
+
+    it "defaults auth headers to empty, leaving the default headers unchanged" do
+      request = client.build_http_request(url: URI.parse("https://example.com"), method: "GET")
+
+      assert_equal("Bearer STATIC", request["Authorization"])
+    end
+  end
 end

--- a/seed/ruby-sdk-v2/multi-url-environment-reference/lib/seed/internal/http/raw_client.rb
+++ b/seed/ruby-sdk-v2/multi-url-environment-reference/lib/seed/internal/http/raw_client.rb
@@ -21,10 +21,14 @@ module Seed
         # @param max_retries [Integer] The number of times to retry a failed request, defaults to 2.
         # @param timeout [Float] The timeout for the request, defaults to 60.0 seconds.
         # @param headers [Hash] The headers for the request.
-        def initialize(base_url:, max_retries: 2, timeout: 60.0, headers: {})
+        # @param auth_provider [Object, nil] An optional auth provider responding to
+        #   `auth_headers`. When present its headers are resolved on every request so
+        #   token-based schemes (e.g. OAuth) can refresh an expired token mid-session.
+        def initialize(base_url:, max_retries: 2, timeout: 60.0, headers: {}, auth_provider: nil)
           @base_url = base_url
           @max_retries = max_retries
           @timeout = timeout
+          @auth_provider = auth_provider
           @default_headers = {
             "X-Fern-Language": "Ruby",
             "X-Fern-SDK-Name": "seed",
@@ -36,6 +40,9 @@ module Seed
         # @return [HTTP::Response] The HTTP response.
         def send(request)
           url = build_url(request)
+          # Resolve auth headers once per request (not per retry) so token-based
+          # providers refresh at most once here; static providers are cheap.
+          auth_headers = resolve_auth_headers
           attempt = 0
           response = nil
 
@@ -43,8 +50,9 @@ module Seed
             http_request = build_http_request(
               url:,
               method: request.method,
-              headers: request.encode_headers(protected_keys: @default_headers.keys),
-              body: request.encode_body
+              headers: request.encode_headers(protected_keys: @default_headers.keys + auth_headers.keys),
+              body: request.encode_body,
+              auth_headers: auth_headers
             )
 
             conn = connect(url)
@@ -157,12 +165,27 @@ module Seed
                 "HTTP is only allowed for localhost. Use HTTPS or pass a localhost URL."
         end
 
+        # Resolves the auth headers to send with the next request. Delegates to the
+        # configured auth provider (if any) on every call so that token-based
+        # providers (e.g. OAuth client-credentials) can refresh an expired token
+        # before the request is sent. Returns an empty hash when no provider is set,
+        # which keeps the api-key / basic / bearer / no-auth paths unchanged.
+        # @return [Hash] The auth headers for the current request.
+        def resolve_auth_headers
+          return {} if @auth_provider.nil?
+
+          @auth_provider.auth_headers
+        end
+
         # @param url [URI::Generic] The url to the resource.
         # @param method [String] The HTTP method to use.
         # @param headers [Hash] The headers for the request.
         # @param body [String, nil] The body for the request.
+        # @param auth_headers [Hash] The auth headers resolved for this request. These
+        #   take precedence over the static default headers but not over per-request
+        #   headers, mirroring the previous baked-header precedence.
         # @return [HTTP::Request] The HTTP request.
-        def build_http_request(url:, method:, headers: {}, body: nil)
+        def build_http_request(url:, method:, headers: {}, body: nil, auth_headers: {})
           request = Net::HTTPGenericRequest.new(
             method,
             !body.nil?,
@@ -170,7 +193,7 @@ module Seed
             url
           )
 
-          request_headers = @default_headers.merge(headers)
+          request_headers = @default_headers.merge(auth_headers).merge(headers)
           request_headers.each { |name, value| request[name] = value }
           request.body = body if body
 

--- a/seed/ruby-sdk-v2/multi-url-environment-reference/test/unit/internal/http/test_raw_client.rb
+++ b/seed/ruby-sdk-v2/multi-url-environment-reference/test/unit/internal/http/test_raw_client.rb
@@ -54,4 +54,71 @@ describe Seed::Internal::Http::RawClient do
       assert client.should_retry?(make_response(502), 2)
     end
   end
+
+  # A minimal auth provider whose `auth_headers` returns a *different* token on
+  # each call, simulating a token that is refreshed on expiry.
+  class RefreshingAuthProvider
+    def initialize
+      @count = 0
+    end
+
+    def auth_headers
+      @count += 1
+      { "Authorization" => "Bearer TOKEN_#{@count}" }
+    end
+  end
+
+  describe "#resolve_auth_headers" do
+    it "returns an empty hash when no auth provider is configured" do
+      client = Seed::Internal::Http::RawClient.new(base_url: "https://example.com")
+
+      assert_equal({}, client.resolve_auth_headers)
+    end
+
+    it "consults the auth provider on every call so an expired token is refreshed" do
+      client = Seed::Internal::Http::RawClient.new(
+        base_url: "https://example.com",
+        auth_provider: RefreshingAuthProvider.new
+      )
+
+      assert_equal({ "Authorization" => "Bearer TOKEN_1" }, client.resolve_auth_headers)
+      assert_equal({ "Authorization" => "Bearer TOKEN_2" }, client.resolve_auth_headers)
+    end
+  end
+
+  describe "#build_http_request auth header precedence" do
+    let(:client) do
+      Seed::Internal::Http::RawClient.new(
+        base_url: "https://example.com",
+        headers: { "Authorization" => "Bearer STATIC" }
+      )
+    end
+
+    it "lets resolved auth headers override the static default headers" do
+      request = client.build_http_request(
+        url: URI.parse("https://example.com"),
+        method: "GET",
+        auth_headers: { "Authorization" => "Bearer FRESH" }
+      )
+
+      assert_equal("Bearer FRESH", request["Authorization"])
+    end
+
+    it "lets per-request headers take precedence over auth headers" do
+      request = client.build_http_request(
+        url: URI.parse("https://example.com"),
+        method: "GET",
+        headers: { "Authorization" => "Bearer PER_REQUEST" },
+        auth_headers: { "Authorization" => "Bearer FRESH" }
+      )
+
+      assert_equal("Bearer PER_REQUEST", request["Authorization"])
+    end
+
+    it "defaults auth headers to empty, leaving the default headers unchanged" do
+      request = client.build_http_request(url: URI.parse("https://example.com"), method: "GET")
+
+      assert_equal("Bearer STATIC", request["Authorization"])
+    end
+  end
 end

--- a/seed/ruby-sdk-v2/multi-url-environment/lib/seed/internal/http/raw_client.rb
+++ b/seed/ruby-sdk-v2/multi-url-environment/lib/seed/internal/http/raw_client.rb
@@ -21,10 +21,14 @@ module Seed
         # @param max_retries [Integer] The number of times to retry a failed request, defaults to 2.
         # @param timeout [Float] The timeout for the request, defaults to 60.0 seconds.
         # @param headers [Hash] The headers for the request.
-        def initialize(base_url:, max_retries: 2, timeout: 60.0, headers: {})
+        # @param auth_provider [Object, nil] An optional auth provider responding to
+        #   `auth_headers`. When present its headers are resolved on every request so
+        #   token-based schemes (e.g. OAuth) can refresh an expired token mid-session.
+        def initialize(base_url:, max_retries: 2, timeout: 60.0, headers: {}, auth_provider: nil)
           @base_url = base_url
           @max_retries = max_retries
           @timeout = timeout
+          @auth_provider = auth_provider
           @default_headers = {
             "X-Fern-Language": "Ruby",
             "X-Fern-SDK-Name": "seed",
@@ -36,6 +40,9 @@ module Seed
         # @return [HTTP::Response] The HTTP response.
         def send(request)
           url = build_url(request)
+          # Resolve auth headers once per request (not per retry) so token-based
+          # providers refresh at most once here; static providers are cheap.
+          auth_headers = resolve_auth_headers
           attempt = 0
           response = nil
 
@@ -43,8 +50,9 @@ module Seed
             http_request = build_http_request(
               url:,
               method: request.method,
-              headers: request.encode_headers(protected_keys: @default_headers.keys),
-              body: request.encode_body
+              headers: request.encode_headers(protected_keys: @default_headers.keys + auth_headers.keys),
+              body: request.encode_body,
+              auth_headers: auth_headers
             )
 
             conn = connect(url)
@@ -157,12 +165,27 @@ module Seed
                 "HTTP is only allowed for localhost. Use HTTPS or pass a localhost URL."
         end
 
+        # Resolves the auth headers to send with the next request. Delegates to the
+        # configured auth provider (if any) on every call so that token-based
+        # providers (e.g. OAuth client-credentials) can refresh an expired token
+        # before the request is sent. Returns an empty hash when no provider is set,
+        # which keeps the api-key / basic / bearer / no-auth paths unchanged.
+        # @return [Hash] The auth headers for the current request.
+        def resolve_auth_headers
+          return {} if @auth_provider.nil?
+
+          @auth_provider.auth_headers
+        end
+
         # @param url [URI::Generic] The url to the resource.
         # @param method [String] The HTTP method to use.
         # @param headers [Hash] The headers for the request.
         # @param body [String, nil] The body for the request.
+        # @param auth_headers [Hash] The auth headers resolved for this request. These
+        #   take precedence over the static default headers but not over per-request
+        #   headers, mirroring the previous baked-header precedence.
         # @return [HTTP::Request] The HTTP request.
-        def build_http_request(url:, method:, headers: {}, body: nil)
+        def build_http_request(url:, method:, headers: {}, body: nil, auth_headers: {})
           request = Net::HTTPGenericRequest.new(
             method,
             !body.nil?,
@@ -170,7 +193,7 @@ module Seed
             url
           )
 
-          request_headers = @default_headers.merge(headers)
+          request_headers = @default_headers.merge(auth_headers).merge(headers)
           request_headers.each { |name, value| request[name] = value }
           request.body = body if body
 

--- a/seed/ruby-sdk-v2/multi-url-environment/test/unit/internal/http/test_raw_client.rb
+++ b/seed/ruby-sdk-v2/multi-url-environment/test/unit/internal/http/test_raw_client.rb
@@ -54,4 +54,71 @@ describe Seed::Internal::Http::RawClient do
       assert client.should_retry?(make_response(502), 2)
     end
   end
+
+  # A minimal auth provider whose `auth_headers` returns a *different* token on
+  # each call, simulating a token that is refreshed on expiry.
+  class RefreshingAuthProvider
+    def initialize
+      @count = 0
+    end
+
+    def auth_headers
+      @count += 1
+      { "Authorization" => "Bearer TOKEN_#{@count}" }
+    end
+  end
+
+  describe "#resolve_auth_headers" do
+    it "returns an empty hash when no auth provider is configured" do
+      client = Seed::Internal::Http::RawClient.new(base_url: "https://example.com")
+
+      assert_equal({}, client.resolve_auth_headers)
+    end
+
+    it "consults the auth provider on every call so an expired token is refreshed" do
+      client = Seed::Internal::Http::RawClient.new(
+        base_url: "https://example.com",
+        auth_provider: RefreshingAuthProvider.new
+      )
+
+      assert_equal({ "Authorization" => "Bearer TOKEN_1" }, client.resolve_auth_headers)
+      assert_equal({ "Authorization" => "Bearer TOKEN_2" }, client.resolve_auth_headers)
+    end
+  end
+
+  describe "#build_http_request auth header precedence" do
+    let(:client) do
+      Seed::Internal::Http::RawClient.new(
+        base_url: "https://example.com",
+        headers: { "Authorization" => "Bearer STATIC" }
+      )
+    end
+
+    it "lets resolved auth headers override the static default headers" do
+      request = client.build_http_request(
+        url: URI.parse("https://example.com"),
+        method: "GET",
+        auth_headers: { "Authorization" => "Bearer FRESH" }
+      )
+
+      assert_equal("Bearer FRESH", request["Authorization"])
+    end
+
+    it "lets per-request headers take precedence over auth headers" do
+      request = client.build_http_request(
+        url: URI.parse("https://example.com"),
+        method: "GET",
+        headers: { "Authorization" => "Bearer PER_REQUEST" },
+        auth_headers: { "Authorization" => "Bearer FRESH" }
+      )
+
+      assert_equal("Bearer PER_REQUEST", request["Authorization"])
+    end
+
+    it "defaults auth headers to empty, leaving the default headers unchanged" do
+      request = client.build_http_request(url: URI.parse("https://example.com"), method: "GET")
+
+      assert_equal("Bearer STATIC", request["Authorization"])
+    end
+  end
 end

--- a/seed/ruby-sdk-v2/multiple-request-bodies/lib/seed/internal/http/raw_client.rb
+++ b/seed/ruby-sdk-v2/multiple-request-bodies/lib/seed/internal/http/raw_client.rb
@@ -21,10 +21,14 @@ module Seed
         # @param max_retries [Integer] The number of times to retry a failed request, defaults to 2.
         # @param timeout [Float] The timeout for the request, defaults to 60.0 seconds.
         # @param headers [Hash] The headers for the request.
-        def initialize(base_url:, max_retries: 2, timeout: 60.0, headers: {})
+        # @param auth_provider [Object, nil] An optional auth provider responding to
+        #   `auth_headers`. When present its headers are resolved on every request so
+        #   token-based schemes (e.g. OAuth) can refresh an expired token mid-session.
+        def initialize(base_url:, max_retries: 2, timeout: 60.0, headers: {}, auth_provider: nil)
           @base_url = base_url
           @max_retries = max_retries
           @timeout = timeout
+          @auth_provider = auth_provider
           @default_headers = {
             "X-Fern-Language": "Ruby",
             "X-Fern-SDK-Name": "seed",
@@ -36,6 +40,9 @@ module Seed
         # @return [HTTP::Response] The HTTP response.
         def send(request)
           url = build_url(request)
+          # Resolve auth headers once per request (not per retry) so token-based
+          # providers refresh at most once here; static providers are cheap.
+          auth_headers = resolve_auth_headers
           attempt = 0
           response = nil
 
@@ -43,8 +50,9 @@ module Seed
             http_request = build_http_request(
               url:,
               method: request.method,
-              headers: request.encode_headers(protected_keys: @default_headers.keys),
-              body: request.encode_body
+              headers: request.encode_headers(protected_keys: @default_headers.keys + auth_headers.keys),
+              body: request.encode_body,
+              auth_headers: auth_headers
             )
 
             conn = connect(url)
@@ -157,12 +165,27 @@ module Seed
                 "HTTP is only allowed for localhost. Use HTTPS or pass a localhost URL."
         end
 
+        # Resolves the auth headers to send with the next request. Delegates to the
+        # configured auth provider (if any) on every call so that token-based
+        # providers (e.g. OAuth client-credentials) can refresh an expired token
+        # before the request is sent. Returns an empty hash when no provider is set,
+        # which keeps the api-key / basic / bearer / no-auth paths unchanged.
+        # @return [Hash] The auth headers for the current request.
+        def resolve_auth_headers
+          return {} if @auth_provider.nil?
+
+          @auth_provider.auth_headers
+        end
+
         # @param url [URI::Generic] The url to the resource.
         # @param method [String] The HTTP method to use.
         # @param headers [Hash] The headers for the request.
         # @param body [String, nil] The body for the request.
+        # @param auth_headers [Hash] The auth headers resolved for this request. These
+        #   take precedence over the static default headers but not over per-request
+        #   headers, mirroring the previous baked-header precedence.
         # @return [HTTP::Request] The HTTP request.
-        def build_http_request(url:, method:, headers: {}, body: nil)
+        def build_http_request(url:, method:, headers: {}, body: nil, auth_headers: {})
           request = Net::HTTPGenericRequest.new(
             method,
             !body.nil?,
@@ -170,7 +193,7 @@ module Seed
             url
           )
 
-          request_headers = @default_headers.merge(headers)
+          request_headers = @default_headers.merge(auth_headers).merge(headers)
           request_headers.each { |name, value| request[name] = value }
           request.body = body if body
 

--- a/seed/ruby-sdk-v2/multiple-request-bodies/test/unit/internal/http/test_raw_client.rb
+++ b/seed/ruby-sdk-v2/multiple-request-bodies/test/unit/internal/http/test_raw_client.rb
@@ -54,4 +54,71 @@ describe Seed::Internal::Http::RawClient do
       assert client.should_retry?(make_response(502), 2)
     end
   end
+
+  # A minimal auth provider whose `auth_headers` returns a *different* token on
+  # each call, simulating a token that is refreshed on expiry.
+  class RefreshingAuthProvider
+    def initialize
+      @count = 0
+    end
+
+    def auth_headers
+      @count += 1
+      { "Authorization" => "Bearer TOKEN_#{@count}" }
+    end
+  end
+
+  describe "#resolve_auth_headers" do
+    it "returns an empty hash when no auth provider is configured" do
+      client = Seed::Internal::Http::RawClient.new(base_url: "https://example.com")
+
+      assert_equal({}, client.resolve_auth_headers)
+    end
+
+    it "consults the auth provider on every call so an expired token is refreshed" do
+      client = Seed::Internal::Http::RawClient.new(
+        base_url: "https://example.com",
+        auth_provider: RefreshingAuthProvider.new
+      )
+
+      assert_equal({ "Authorization" => "Bearer TOKEN_1" }, client.resolve_auth_headers)
+      assert_equal({ "Authorization" => "Bearer TOKEN_2" }, client.resolve_auth_headers)
+    end
+  end
+
+  describe "#build_http_request auth header precedence" do
+    let(:client) do
+      Seed::Internal::Http::RawClient.new(
+        base_url: "https://example.com",
+        headers: { "Authorization" => "Bearer STATIC" }
+      )
+    end
+
+    it "lets resolved auth headers override the static default headers" do
+      request = client.build_http_request(
+        url: URI.parse("https://example.com"),
+        method: "GET",
+        auth_headers: { "Authorization" => "Bearer FRESH" }
+      )
+
+      assert_equal("Bearer FRESH", request["Authorization"])
+    end
+
+    it "lets per-request headers take precedence over auth headers" do
+      request = client.build_http_request(
+        url: URI.parse("https://example.com"),
+        method: "GET",
+        headers: { "Authorization" => "Bearer PER_REQUEST" },
+        auth_headers: { "Authorization" => "Bearer FRESH" }
+      )
+
+      assert_equal("Bearer PER_REQUEST", request["Authorization"])
+    end
+
+    it "defaults auth headers to empty, leaving the default headers unchanged" do
+      request = client.build_http_request(url: URI.parse("https://example.com"), method: "GET")
+
+      assert_equal("Bearer STATIC", request["Authorization"])
+    end
+  end
 end

--- a/seed/ruby-sdk-v2/no-content-response/lib/seed/internal/http/raw_client.rb
+++ b/seed/ruby-sdk-v2/no-content-response/lib/seed/internal/http/raw_client.rb
@@ -21,10 +21,14 @@ module Seed
         # @param max_retries [Integer] The number of times to retry a failed request, defaults to 2.
         # @param timeout [Float] The timeout for the request, defaults to 60.0 seconds.
         # @param headers [Hash] The headers for the request.
-        def initialize(base_url:, max_retries: 2, timeout: 60.0, headers: {})
+        # @param auth_provider [Object, nil] An optional auth provider responding to
+        #   `auth_headers`. When present its headers are resolved on every request so
+        #   token-based schemes (e.g. OAuth) can refresh an expired token mid-session.
+        def initialize(base_url:, max_retries: 2, timeout: 60.0, headers: {}, auth_provider: nil)
           @base_url = base_url
           @max_retries = max_retries
           @timeout = timeout
+          @auth_provider = auth_provider
           @default_headers = {
             "X-Fern-Language": "Ruby",
             "X-Fern-SDK-Name": "seed",
@@ -36,6 +40,9 @@ module Seed
         # @return [HTTP::Response] The HTTP response.
         def send(request)
           url = build_url(request)
+          # Resolve auth headers once per request (not per retry) so token-based
+          # providers refresh at most once here; static providers are cheap.
+          auth_headers = resolve_auth_headers
           attempt = 0
           response = nil
 
@@ -43,8 +50,9 @@ module Seed
             http_request = build_http_request(
               url:,
               method: request.method,
-              headers: request.encode_headers(protected_keys: @default_headers.keys),
-              body: request.encode_body
+              headers: request.encode_headers(protected_keys: @default_headers.keys + auth_headers.keys),
+              body: request.encode_body,
+              auth_headers: auth_headers
             )
 
             conn = connect(url)
@@ -157,12 +165,27 @@ module Seed
                 "HTTP is only allowed for localhost. Use HTTPS or pass a localhost URL."
         end
 
+        # Resolves the auth headers to send with the next request. Delegates to the
+        # configured auth provider (if any) on every call so that token-based
+        # providers (e.g. OAuth client-credentials) can refresh an expired token
+        # before the request is sent. Returns an empty hash when no provider is set,
+        # which keeps the api-key / basic / bearer / no-auth paths unchanged.
+        # @return [Hash] The auth headers for the current request.
+        def resolve_auth_headers
+          return {} if @auth_provider.nil?
+
+          @auth_provider.auth_headers
+        end
+
         # @param url [URI::Generic] The url to the resource.
         # @param method [String] The HTTP method to use.
         # @param headers [Hash] The headers for the request.
         # @param body [String, nil] The body for the request.
+        # @param auth_headers [Hash] The auth headers resolved for this request. These
+        #   take precedence over the static default headers but not over per-request
+        #   headers, mirroring the previous baked-header precedence.
         # @return [HTTP::Request] The HTTP request.
-        def build_http_request(url:, method:, headers: {}, body: nil)
+        def build_http_request(url:, method:, headers: {}, body: nil, auth_headers: {})
           request = Net::HTTPGenericRequest.new(
             method,
             !body.nil?,
@@ -170,7 +193,7 @@ module Seed
             url
           )
 
-          request_headers = @default_headers.merge(headers)
+          request_headers = @default_headers.merge(auth_headers).merge(headers)
           request_headers.each { |name, value| request[name] = value }
           request.body = body if body
 

--- a/seed/ruby-sdk-v2/no-content-response/test/unit/internal/http/test_raw_client.rb
+++ b/seed/ruby-sdk-v2/no-content-response/test/unit/internal/http/test_raw_client.rb
@@ -54,4 +54,71 @@ describe Seed::Internal::Http::RawClient do
       assert client.should_retry?(make_response(502), 2)
     end
   end
+
+  # A minimal auth provider whose `auth_headers` returns a *different* token on
+  # each call, simulating a token that is refreshed on expiry.
+  class RefreshingAuthProvider
+    def initialize
+      @count = 0
+    end
+
+    def auth_headers
+      @count += 1
+      { "Authorization" => "Bearer TOKEN_#{@count}" }
+    end
+  end
+
+  describe "#resolve_auth_headers" do
+    it "returns an empty hash when no auth provider is configured" do
+      client = Seed::Internal::Http::RawClient.new(base_url: "https://example.com")
+
+      assert_equal({}, client.resolve_auth_headers)
+    end
+
+    it "consults the auth provider on every call so an expired token is refreshed" do
+      client = Seed::Internal::Http::RawClient.new(
+        base_url: "https://example.com",
+        auth_provider: RefreshingAuthProvider.new
+      )
+
+      assert_equal({ "Authorization" => "Bearer TOKEN_1" }, client.resolve_auth_headers)
+      assert_equal({ "Authorization" => "Bearer TOKEN_2" }, client.resolve_auth_headers)
+    end
+  end
+
+  describe "#build_http_request auth header precedence" do
+    let(:client) do
+      Seed::Internal::Http::RawClient.new(
+        base_url: "https://example.com",
+        headers: { "Authorization" => "Bearer STATIC" }
+      )
+    end
+
+    it "lets resolved auth headers override the static default headers" do
+      request = client.build_http_request(
+        url: URI.parse("https://example.com"),
+        method: "GET",
+        auth_headers: { "Authorization" => "Bearer FRESH" }
+      )
+
+      assert_equal("Bearer FRESH", request["Authorization"])
+    end
+
+    it "lets per-request headers take precedence over auth headers" do
+      request = client.build_http_request(
+        url: URI.parse("https://example.com"),
+        method: "GET",
+        headers: { "Authorization" => "Bearer PER_REQUEST" },
+        auth_headers: { "Authorization" => "Bearer FRESH" }
+      )
+
+      assert_equal("Bearer PER_REQUEST", request["Authorization"])
+    end
+
+    it "defaults auth headers to empty, leaving the default headers unchanged" do
+      request = client.build_http_request(url: URI.parse("https://example.com"), method: "GET")
+
+      assert_equal("Bearer STATIC", request["Authorization"])
+    end
+  end
 end

--- a/seed/ruby-sdk-v2/no-environment/lib/seed/internal/http/raw_client.rb
+++ b/seed/ruby-sdk-v2/no-environment/lib/seed/internal/http/raw_client.rb
@@ -21,10 +21,14 @@ module Seed
         # @param max_retries [Integer] The number of times to retry a failed request, defaults to 2.
         # @param timeout [Float] The timeout for the request, defaults to 60.0 seconds.
         # @param headers [Hash] The headers for the request.
-        def initialize(base_url:, max_retries: 2, timeout: 60.0, headers: {})
+        # @param auth_provider [Object, nil] An optional auth provider responding to
+        #   `auth_headers`. When present its headers are resolved on every request so
+        #   token-based schemes (e.g. OAuth) can refresh an expired token mid-session.
+        def initialize(base_url:, max_retries: 2, timeout: 60.0, headers: {}, auth_provider: nil)
           @base_url = base_url
           @max_retries = max_retries
           @timeout = timeout
+          @auth_provider = auth_provider
           @default_headers = {
             "X-Fern-Language": "Ruby",
             "X-Fern-SDK-Name": "seed",
@@ -36,6 +40,9 @@ module Seed
         # @return [HTTP::Response] The HTTP response.
         def send(request)
           url = build_url(request)
+          # Resolve auth headers once per request (not per retry) so token-based
+          # providers refresh at most once here; static providers are cheap.
+          auth_headers = resolve_auth_headers
           attempt = 0
           response = nil
 
@@ -43,8 +50,9 @@ module Seed
             http_request = build_http_request(
               url:,
               method: request.method,
-              headers: request.encode_headers(protected_keys: @default_headers.keys),
-              body: request.encode_body
+              headers: request.encode_headers(protected_keys: @default_headers.keys + auth_headers.keys),
+              body: request.encode_body,
+              auth_headers: auth_headers
             )
 
             conn = connect(url)
@@ -157,12 +165,27 @@ module Seed
                 "HTTP is only allowed for localhost. Use HTTPS or pass a localhost URL."
         end
 
+        # Resolves the auth headers to send with the next request. Delegates to the
+        # configured auth provider (if any) on every call so that token-based
+        # providers (e.g. OAuth client-credentials) can refresh an expired token
+        # before the request is sent. Returns an empty hash when no provider is set,
+        # which keeps the api-key / basic / bearer / no-auth paths unchanged.
+        # @return [Hash] The auth headers for the current request.
+        def resolve_auth_headers
+          return {} if @auth_provider.nil?
+
+          @auth_provider.auth_headers
+        end
+
         # @param url [URI::Generic] The url to the resource.
         # @param method [String] The HTTP method to use.
         # @param headers [Hash] The headers for the request.
         # @param body [String, nil] The body for the request.
+        # @param auth_headers [Hash] The auth headers resolved for this request. These
+        #   take precedence over the static default headers but not over per-request
+        #   headers, mirroring the previous baked-header precedence.
         # @return [HTTP::Request] The HTTP request.
-        def build_http_request(url:, method:, headers: {}, body: nil)
+        def build_http_request(url:, method:, headers: {}, body: nil, auth_headers: {})
           request = Net::HTTPGenericRequest.new(
             method,
             !body.nil?,
@@ -170,7 +193,7 @@ module Seed
             url
           )
 
-          request_headers = @default_headers.merge(headers)
+          request_headers = @default_headers.merge(auth_headers).merge(headers)
           request_headers.each { |name, value| request[name] = value }
           request.body = body if body
 

--- a/seed/ruby-sdk-v2/no-environment/test/unit/internal/http/test_raw_client.rb
+++ b/seed/ruby-sdk-v2/no-environment/test/unit/internal/http/test_raw_client.rb
@@ -54,4 +54,71 @@ describe Seed::Internal::Http::RawClient do
       assert client.should_retry?(make_response(502), 2)
     end
   end
+
+  # A minimal auth provider whose `auth_headers` returns a *different* token on
+  # each call, simulating a token that is refreshed on expiry.
+  class RefreshingAuthProvider
+    def initialize
+      @count = 0
+    end
+
+    def auth_headers
+      @count += 1
+      { "Authorization" => "Bearer TOKEN_#{@count}" }
+    end
+  end
+
+  describe "#resolve_auth_headers" do
+    it "returns an empty hash when no auth provider is configured" do
+      client = Seed::Internal::Http::RawClient.new(base_url: "https://example.com")
+
+      assert_equal({}, client.resolve_auth_headers)
+    end
+
+    it "consults the auth provider on every call so an expired token is refreshed" do
+      client = Seed::Internal::Http::RawClient.new(
+        base_url: "https://example.com",
+        auth_provider: RefreshingAuthProvider.new
+      )
+
+      assert_equal({ "Authorization" => "Bearer TOKEN_1" }, client.resolve_auth_headers)
+      assert_equal({ "Authorization" => "Bearer TOKEN_2" }, client.resolve_auth_headers)
+    end
+  end
+
+  describe "#build_http_request auth header precedence" do
+    let(:client) do
+      Seed::Internal::Http::RawClient.new(
+        base_url: "https://example.com",
+        headers: { "Authorization" => "Bearer STATIC" }
+      )
+    end
+
+    it "lets resolved auth headers override the static default headers" do
+      request = client.build_http_request(
+        url: URI.parse("https://example.com"),
+        method: "GET",
+        auth_headers: { "Authorization" => "Bearer FRESH" }
+      )
+
+      assert_equal("Bearer FRESH", request["Authorization"])
+    end
+
+    it "lets per-request headers take precedence over auth headers" do
+      request = client.build_http_request(
+        url: URI.parse("https://example.com"),
+        method: "GET",
+        headers: { "Authorization" => "Bearer PER_REQUEST" },
+        auth_headers: { "Authorization" => "Bearer FRESH" }
+      )
+
+      assert_equal("Bearer PER_REQUEST", request["Authorization"])
+    end
+
+    it "defaults auth headers to empty, leaving the default headers unchanged" do
+      request = client.build_http_request(url: URI.parse("https://example.com"), method: "GET")
+
+      assert_equal("Bearer STATIC", request["Authorization"])
+    end
+  end
 end

--- a/seed/ruby-sdk-v2/no-retries/lib/seed/internal/http/raw_client.rb
+++ b/seed/ruby-sdk-v2/no-retries/lib/seed/internal/http/raw_client.rb
@@ -21,10 +21,14 @@ module Seed
         # @param max_retries [Integer] The number of times to retry a failed request, defaults to 2.
         # @param timeout [Float] The timeout for the request, defaults to 60.0 seconds.
         # @param headers [Hash] The headers for the request.
-        def initialize(base_url:, max_retries: 2, timeout: 60.0, headers: {})
+        # @param auth_provider [Object, nil] An optional auth provider responding to
+        #   `auth_headers`. When present its headers are resolved on every request so
+        #   token-based schemes (e.g. OAuth) can refresh an expired token mid-session.
+        def initialize(base_url:, max_retries: 2, timeout: 60.0, headers: {}, auth_provider: nil)
           @base_url = base_url
           @max_retries = max_retries
           @timeout = timeout
+          @auth_provider = auth_provider
           @default_headers = {
             "X-Fern-Language": "Ruby",
             "X-Fern-SDK-Name": "seed",
@@ -36,6 +40,9 @@ module Seed
         # @return [HTTP::Response] The HTTP response.
         def send(request)
           url = build_url(request)
+          # Resolve auth headers once per request (not per retry) so token-based
+          # providers refresh at most once here; static providers are cheap.
+          auth_headers = resolve_auth_headers
           attempt = 0
           response = nil
 
@@ -43,8 +50,9 @@ module Seed
             http_request = build_http_request(
               url:,
               method: request.method,
-              headers: request.encode_headers(protected_keys: @default_headers.keys),
-              body: request.encode_body
+              headers: request.encode_headers(protected_keys: @default_headers.keys + auth_headers.keys),
+              body: request.encode_body,
+              auth_headers: auth_headers
             )
 
             conn = connect(url)
@@ -157,12 +165,27 @@ module Seed
                 "HTTP is only allowed for localhost. Use HTTPS or pass a localhost URL."
         end
 
+        # Resolves the auth headers to send with the next request. Delegates to the
+        # configured auth provider (if any) on every call so that token-based
+        # providers (e.g. OAuth client-credentials) can refresh an expired token
+        # before the request is sent. Returns an empty hash when no provider is set,
+        # which keeps the api-key / basic / bearer / no-auth paths unchanged.
+        # @return [Hash] The auth headers for the current request.
+        def resolve_auth_headers
+          return {} if @auth_provider.nil?
+
+          @auth_provider.auth_headers
+        end
+
         # @param url [URI::Generic] The url to the resource.
         # @param method [String] The HTTP method to use.
         # @param headers [Hash] The headers for the request.
         # @param body [String, nil] The body for the request.
+        # @param auth_headers [Hash] The auth headers resolved for this request. These
+        #   take precedence over the static default headers but not over per-request
+        #   headers, mirroring the previous baked-header precedence.
         # @return [HTTP::Request] The HTTP request.
-        def build_http_request(url:, method:, headers: {}, body: nil)
+        def build_http_request(url:, method:, headers: {}, body: nil, auth_headers: {})
           request = Net::HTTPGenericRequest.new(
             method,
             !body.nil?,
@@ -170,7 +193,7 @@ module Seed
             url
           )
 
-          request_headers = @default_headers.merge(headers)
+          request_headers = @default_headers.merge(auth_headers).merge(headers)
           request_headers.each { |name, value| request[name] = value }
           request.body = body if body
 

--- a/seed/ruby-sdk-v2/no-retries/test/unit/internal/http/test_raw_client.rb
+++ b/seed/ruby-sdk-v2/no-retries/test/unit/internal/http/test_raw_client.rb
@@ -54,4 +54,71 @@ describe Seed::Internal::Http::RawClient do
       assert client.should_retry?(make_response(502), 2)
     end
   end
+
+  # A minimal auth provider whose `auth_headers` returns a *different* token on
+  # each call, simulating a token that is refreshed on expiry.
+  class RefreshingAuthProvider
+    def initialize
+      @count = 0
+    end
+
+    def auth_headers
+      @count += 1
+      { "Authorization" => "Bearer TOKEN_#{@count}" }
+    end
+  end
+
+  describe "#resolve_auth_headers" do
+    it "returns an empty hash when no auth provider is configured" do
+      client = Seed::Internal::Http::RawClient.new(base_url: "https://example.com")
+
+      assert_equal({}, client.resolve_auth_headers)
+    end
+
+    it "consults the auth provider on every call so an expired token is refreshed" do
+      client = Seed::Internal::Http::RawClient.new(
+        base_url: "https://example.com",
+        auth_provider: RefreshingAuthProvider.new
+      )
+
+      assert_equal({ "Authorization" => "Bearer TOKEN_1" }, client.resolve_auth_headers)
+      assert_equal({ "Authorization" => "Bearer TOKEN_2" }, client.resolve_auth_headers)
+    end
+  end
+
+  describe "#build_http_request auth header precedence" do
+    let(:client) do
+      Seed::Internal::Http::RawClient.new(
+        base_url: "https://example.com",
+        headers: { "Authorization" => "Bearer STATIC" }
+      )
+    end
+
+    it "lets resolved auth headers override the static default headers" do
+      request = client.build_http_request(
+        url: URI.parse("https://example.com"),
+        method: "GET",
+        auth_headers: { "Authorization" => "Bearer FRESH" }
+      )
+
+      assert_equal("Bearer FRESH", request["Authorization"])
+    end
+
+    it "lets per-request headers take precedence over auth headers" do
+      request = client.build_http_request(
+        url: URI.parse("https://example.com"),
+        method: "GET",
+        headers: { "Authorization" => "Bearer PER_REQUEST" },
+        auth_headers: { "Authorization" => "Bearer FRESH" }
+      )
+
+      assert_equal("Bearer PER_REQUEST", request["Authorization"])
+    end
+
+    it "defaults auth headers to empty, leaving the default headers unchanged" do
+      request = client.build_http_request(url: URI.parse("https://example.com"), method: "GET")
+
+      assert_equal("Bearer STATIC", request["Authorization"])
+    end
+  end
 end

--- a/seed/ruby-sdk-v2/null-type/lib/seed/internal/http/raw_client.rb
+++ b/seed/ruby-sdk-v2/null-type/lib/seed/internal/http/raw_client.rb
@@ -21,10 +21,14 @@ module Seed
         # @param max_retries [Integer] The number of times to retry a failed request, defaults to 2.
         # @param timeout [Float] The timeout for the request, defaults to 60.0 seconds.
         # @param headers [Hash] The headers for the request.
-        def initialize(base_url:, max_retries: 2, timeout: 60.0, headers: {})
+        # @param auth_provider [Object, nil] An optional auth provider responding to
+        #   `auth_headers`. When present its headers are resolved on every request so
+        #   token-based schemes (e.g. OAuth) can refresh an expired token mid-session.
+        def initialize(base_url:, max_retries: 2, timeout: 60.0, headers: {}, auth_provider: nil)
           @base_url = base_url
           @max_retries = max_retries
           @timeout = timeout
+          @auth_provider = auth_provider
           @default_headers = {
             "X-Fern-Language": "Ruby",
             "X-Fern-SDK-Name": "seed",
@@ -36,6 +40,9 @@ module Seed
         # @return [HTTP::Response] The HTTP response.
         def send(request)
           url = build_url(request)
+          # Resolve auth headers once per request (not per retry) so token-based
+          # providers refresh at most once here; static providers are cheap.
+          auth_headers = resolve_auth_headers
           attempt = 0
           response = nil
 
@@ -43,8 +50,9 @@ module Seed
             http_request = build_http_request(
               url:,
               method: request.method,
-              headers: request.encode_headers(protected_keys: @default_headers.keys),
-              body: request.encode_body
+              headers: request.encode_headers(protected_keys: @default_headers.keys + auth_headers.keys),
+              body: request.encode_body,
+              auth_headers: auth_headers
             )
 
             conn = connect(url)
@@ -157,12 +165,27 @@ module Seed
                 "HTTP is only allowed for localhost. Use HTTPS or pass a localhost URL."
         end
 
+        # Resolves the auth headers to send with the next request. Delegates to the
+        # configured auth provider (if any) on every call so that token-based
+        # providers (e.g. OAuth client-credentials) can refresh an expired token
+        # before the request is sent. Returns an empty hash when no provider is set,
+        # which keeps the api-key / basic / bearer / no-auth paths unchanged.
+        # @return [Hash] The auth headers for the current request.
+        def resolve_auth_headers
+          return {} if @auth_provider.nil?
+
+          @auth_provider.auth_headers
+        end
+
         # @param url [URI::Generic] The url to the resource.
         # @param method [String] The HTTP method to use.
         # @param headers [Hash] The headers for the request.
         # @param body [String, nil] The body for the request.
+        # @param auth_headers [Hash] The auth headers resolved for this request. These
+        #   take precedence over the static default headers but not over per-request
+        #   headers, mirroring the previous baked-header precedence.
         # @return [HTTP::Request] The HTTP request.
-        def build_http_request(url:, method:, headers: {}, body: nil)
+        def build_http_request(url:, method:, headers: {}, body: nil, auth_headers: {})
           request = Net::HTTPGenericRequest.new(
             method,
             !body.nil?,
@@ -170,7 +193,7 @@ module Seed
             url
           )
 
-          request_headers = @default_headers.merge(headers)
+          request_headers = @default_headers.merge(auth_headers).merge(headers)
           request_headers.each { |name, value| request[name] = value }
           request.body = body if body
 

--- a/seed/ruby-sdk-v2/null-type/test/unit/internal/http/test_raw_client.rb
+++ b/seed/ruby-sdk-v2/null-type/test/unit/internal/http/test_raw_client.rb
@@ -54,4 +54,71 @@ describe Seed::Internal::Http::RawClient do
       assert client.should_retry?(make_response(502), 2)
     end
   end
+
+  # A minimal auth provider whose `auth_headers` returns a *different* token on
+  # each call, simulating a token that is refreshed on expiry.
+  class RefreshingAuthProvider
+    def initialize
+      @count = 0
+    end
+
+    def auth_headers
+      @count += 1
+      { "Authorization" => "Bearer TOKEN_#{@count}" }
+    end
+  end
+
+  describe "#resolve_auth_headers" do
+    it "returns an empty hash when no auth provider is configured" do
+      client = Seed::Internal::Http::RawClient.new(base_url: "https://example.com")
+
+      assert_equal({}, client.resolve_auth_headers)
+    end
+
+    it "consults the auth provider on every call so an expired token is refreshed" do
+      client = Seed::Internal::Http::RawClient.new(
+        base_url: "https://example.com",
+        auth_provider: RefreshingAuthProvider.new
+      )
+
+      assert_equal({ "Authorization" => "Bearer TOKEN_1" }, client.resolve_auth_headers)
+      assert_equal({ "Authorization" => "Bearer TOKEN_2" }, client.resolve_auth_headers)
+    end
+  end
+
+  describe "#build_http_request auth header precedence" do
+    let(:client) do
+      Seed::Internal::Http::RawClient.new(
+        base_url: "https://example.com",
+        headers: { "Authorization" => "Bearer STATIC" }
+      )
+    end
+
+    it "lets resolved auth headers override the static default headers" do
+      request = client.build_http_request(
+        url: URI.parse("https://example.com"),
+        method: "GET",
+        auth_headers: { "Authorization" => "Bearer FRESH" }
+      )
+
+      assert_equal("Bearer FRESH", request["Authorization"])
+    end
+
+    it "lets per-request headers take precedence over auth headers" do
+      request = client.build_http_request(
+        url: URI.parse("https://example.com"),
+        method: "GET",
+        headers: { "Authorization" => "Bearer PER_REQUEST" },
+        auth_headers: { "Authorization" => "Bearer FRESH" }
+      )
+
+      assert_equal("Bearer PER_REQUEST", request["Authorization"])
+    end
+
+    it "defaults auth headers to empty, leaving the default headers unchanged" do
+      request = client.build_http_request(url: URI.parse("https://example.com"), method: "GET")
+
+      assert_equal("Bearer STATIC", request["Authorization"])
+    end
+  end
 end

--- a/seed/ruby-sdk-v2/nullable-allof-extends/lib/seed/internal/http/raw_client.rb
+++ b/seed/ruby-sdk-v2/nullable-allof-extends/lib/seed/internal/http/raw_client.rb
@@ -21,10 +21,14 @@ module Seed
         # @param max_retries [Integer] The number of times to retry a failed request, defaults to 2.
         # @param timeout [Float] The timeout for the request, defaults to 60.0 seconds.
         # @param headers [Hash] The headers for the request.
-        def initialize(base_url:, max_retries: 2, timeout: 60.0, headers: {})
+        # @param auth_provider [Object, nil] An optional auth provider responding to
+        #   `auth_headers`. When present its headers are resolved on every request so
+        #   token-based schemes (e.g. OAuth) can refresh an expired token mid-session.
+        def initialize(base_url:, max_retries: 2, timeout: 60.0, headers: {}, auth_provider: nil)
           @base_url = base_url
           @max_retries = max_retries
           @timeout = timeout
+          @auth_provider = auth_provider
           @default_headers = {
             "X-Fern-Language": "Ruby",
             "X-Fern-SDK-Name": "seed",
@@ -36,6 +40,9 @@ module Seed
         # @return [HTTP::Response] The HTTP response.
         def send(request)
           url = build_url(request)
+          # Resolve auth headers once per request (not per retry) so token-based
+          # providers refresh at most once here; static providers are cheap.
+          auth_headers = resolve_auth_headers
           attempt = 0
           response = nil
 
@@ -43,8 +50,9 @@ module Seed
             http_request = build_http_request(
               url:,
               method: request.method,
-              headers: request.encode_headers(protected_keys: @default_headers.keys),
-              body: request.encode_body
+              headers: request.encode_headers(protected_keys: @default_headers.keys + auth_headers.keys),
+              body: request.encode_body,
+              auth_headers: auth_headers
             )
 
             conn = connect(url)
@@ -157,12 +165,27 @@ module Seed
                 "HTTP is only allowed for localhost. Use HTTPS or pass a localhost URL."
         end
 
+        # Resolves the auth headers to send with the next request. Delegates to the
+        # configured auth provider (if any) on every call so that token-based
+        # providers (e.g. OAuth client-credentials) can refresh an expired token
+        # before the request is sent. Returns an empty hash when no provider is set,
+        # which keeps the api-key / basic / bearer / no-auth paths unchanged.
+        # @return [Hash] The auth headers for the current request.
+        def resolve_auth_headers
+          return {} if @auth_provider.nil?
+
+          @auth_provider.auth_headers
+        end
+
         # @param url [URI::Generic] The url to the resource.
         # @param method [String] The HTTP method to use.
         # @param headers [Hash] The headers for the request.
         # @param body [String, nil] The body for the request.
+        # @param auth_headers [Hash] The auth headers resolved for this request. These
+        #   take precedence over the static default headers but not over per-request
+        #   headers, mirroring the previous baked-header precedence.
         # @return [HTTP::Request] The HTTP request.
-        def build_http_request(url:, method:, headers: {}, body: nil)
+        def build_http_request(url:, method:, headers: {}, body: nil, auth_headers: {})
           request = Net::HTTPGenericRequest.new(
             method,
             !body.nil?,
@@ -170,7 +193,7 @@ module Seed
             url
           )
 
-          request_headers = @default_headers.merge(headers)
+          request_headers = @default_headers.merge(auth_headers).merge(headers)
           request_headers.each { |name, value| request[name] = value }
           request.body = body if body
 

--- a/seed/ruby-sdk-v2/nullable-allof-extends/test/unit/internal/http/test_raw_client.rb
+++ b/seed/ruby-sdk-v2/nullable-allof-extends/test/unit/internal/http/test_raw_client.rb
@@ -54,4 +54,71 @@ describe Seed::Internal::Http::RawClient do
       assert client.should_retry?(make_response(502), 2)
     end
   end
+
+  # A minimal auth provider whose `auth_headers` returns a *different* token on
+  # each call, simulating a token that is refreshed on expiry.
+  class RefreshingAuthProvider
+    def initialize
+      @count = 0
+    end
+
+    def auth_headers
+      @count += 1
+      { "Authorization" => "Bearer TOKEN_#{@count}" }
+    end
+  end
+
+  describe "#resolve_auth_headers" do
+    it "returns an empty hash when no auth provider is configured" do
+      client = Seed::Internal::Http::RawClient.new(base_url: "https://example.com")
+
+      assert_equal({}, client.resolve_auth_headers)
+    end
+
+    it "consults the auth provider on every call so an expired token is refreshed" do
+      client = Seed::Internal::Http::RawClient.new(
+        base_url: "https://example.com",
+        auth_provider: RefreshingAuthProvider.new
+      )
+
+      assert_equal({ "Authorization" => "Bearer TOKEN_1" }, client.resolve_auth_headers)
+      assert_equal({ "Authorization" => "Bearer TOKEN_2" }, client.resolve_auth_headers)
+    end
+  end
+
+  describe "#build_http_request auth header precedence" do
+    let(:client) do
+      Seed::Internal::Http::RawClient.new(
+        base_url: "https://example.com",
+        headers: { "Authorization" => "Bearer STATIC" }
+      )
+    end
+
+    it "lets resolved auth headers override the static default headers" do
+      request = client.build_http_request(
+        url: URI.parse("https://example.com"),
+        method: "GET",
+        auth_headers: { "Authorization" => "Bearer FRESH" }
+      )
+
+      assert_equal("Bearer FRESH", request["Authorization"])
+    end
+
+    it "lets per-request headers take precedence over auth headers" do
+      request = client.build_http_request(
+        url: URI.parse("https://example.com"),
+        method: "GET",
+        headers: { "Authorization" => "Bearer PER_REQUEST" },
+        auth_headers: { "Authorization" => "Bearer FRESH" }
+      )
+
+      assert_equal("Bearer PER_REQUEST", request["Authorization"])
+    end
+
+    it "defaults auth headers to empty, leaving the default headers unchanged" do
+      request = client.build_http_request(url: URI.parse("https://example.com"), method: "GET")
+
+      assert_equal("Bearer STATIC", request["Authorization"])
+    end
+  end
 end

--- a/seed/ruby-sdk-v2/nullable-optional/lib/seed/internal/http/raw_client.rb
+++ b/seed/ruby-sdk-v2/nullable-optional/lib/seed/internal/http/raw_client.rb
@@ -21,10 +21,14 @@ module Seed
         # @param max_retries [Integer] The number of times to retry a failed request, defaults to 2.
         # @param timeout [Float] The timeout for the request, defaults to 60.0 seconds.
         # @param headers [Hash] The headers for the request.
-        def initialize(base_url:, max_retries: 2, timeout: 60.0, headers: {})
+        # @param auth_provider [Object, nil] An optional auth provider responding to
+        #   `auth_headers`. When present its headers are resolved on every request so
+        #   token-based schemes (e.g. OAuth) can refresh an expired token mid-session.
+        def initialize(base_url:, max_retries: 2, timeout: 60.0, headers: {}, auth_provider: nil)
           @base_url = base_url
           @max_retries = max_retries
           @timeout = timeout
+          @auth_provider = auth_provider
           @default_headers = {
             "X-Fern-Language": "Ruby",
             "X-Fern-SDK-Name": "seed",
@@ -36,6 +40,9 @@ module Seed
         # @return [HTTP::Response] The HTTP response.
         def send(request)
           url = build_url(request)
+          # Resolve auth headers once per request (not per retry) so token-based
+          # providers refresh at most once here; static providers are cheap.
+          auth_headers = resolve_auth_headers
           attempt = 0
           response = nil
 
@@ -43,8 +50,9 @@ module Seed
             http_request = build_http_request(
               url:,
               method: request.method,
-              headers: request.encode_headers(protected_keys: @default_headers.keys),
-              body: request.encode_body
+              headers: request.encode_headers(protected_keys: @default_headers.keys + auth_headers.keys),
+              body: request.encode_body,
+              auth_headers: auth_headers
             )
 
             conn = connect(url)
@@ -157,12 +165,27 @@ module Seed
                 "HTTP is only allowed for localhost. Use HTTPS or pass a localhost URL."
         end
 
+        # Resolves the auth headers to send with the next request. Delegates to the
+        # configured auth provider (if any) on every call so that token-based
+        # providers (e.g. OAuth client-credentials) can refresh an expired token
+        # before the request is sent. Returns an empty hash when no provider is set,
+        # which keeps the api-key / basic / bearer / no-auth paths unchanged.
+        # @return [Hash] The auth headers for the current request.
+        def resolve_auth_headers
+          return {} if @auth_provider.nil?
+
+          @auth_provider.auth_headers
+        end
+
         # @param url [URI::Generic] The url to the resource.
         # @param method [String] The HTTP method to use.
         # @param headers [Hash] The headers for the request.
         # @param body [String, nil] The body for the request.
+        # @param auth_headers [Hash] The auth headers resolved for this request. These
+        #   take precedence over the static default headers but not over per-request
+        #   headers, mirroring the previous baked-header precedence.
         # @return [HTTP::Request] The HTTP request.
-        def build_http_request(url:, method:, headers: {}, body: nil)
+        def build_http_request(url:, method:, headers: {}, body: nil, auth_headers: {})
           request = Net::HTTPGenericRequest.new(
             method,
             !body.nil?,
@@ -170,7 +193,7 @@ module Seed
             url
           )
 
-          request_headers = @default_headers.merge(headers)
+          request_headers = @default_headers.merge(auth_headers).merge(headers)
           request_headers.each { |name, value| request[name] = value }
           request.body = body if body
 

--- a/seed/ruby-sdk-v2/nullable-optional/test/unit/internal/http/test_raw_client.rb
+++ b/seed/ruby-sdk-v2/nullable-optional/test/unit/internal/http/test_raw_client.rb
@@ -54,4 +54,71 @@ describe Seed::Internal::Http::RawClient do
       assert client.should_retry?(make_response(502), 2)
     end
   end
+
+  # A minimal auth provider whose `auth_headers` returns a *different* token on
+  # each call, simulating a token that is refreshed on expiry.
+  class RefreshingAuthProvider
+    def initialize
+      @count = 0
+    end
+
+    def auth_headers
+      @count += 1
+      { "Authorization" => "Bearer TOKEN_#{@count}" }
+    end
+  end
+
+  describe "#resolve_auth_headers" do
+    it "returns an empty hash when no auth provider is configured" do
+      client = Seed::Internal::Http::RawClient.new(base_url: "https://example.com")
+
+      assert_equal({}, client.resolve_auth_headers)
+    end
+
+    it "consults the auth provider on every call so an expired token is refreshed" do
+      client = Seed::Internal::Http::RawClient.new(
+        base_url: "https://example.com",
+        auth_provider: RefreshingAuthProvider.new
+      )
+
+      assert_equal({ "Authorization" => "Bearer TOKEN_1" }, client.resolve_auth_headers)
+      assert_equal({ "Authorization" => "Bearer TOKEN_2" }, client.resolve_auth_headers)
+    end
+  end
+
+  describe "#build_http_request auth header precedence" do
+    let(:client) do
+      Seed::Internal::Http::RawClient.new(
+        base_url: "https://example.com",
+        headers: { "Authorization" => "Bearer STATIC" }
+      )
+    end
+
+    it "lets resolved auth headers override the static default headers" do
+      request = client.build_http_request(
+        url: URI.parse("https://example.com"),
+        method: "GET",
+        auth_headers: { "Authorization" => "Bearer FRESH" }
+      )
+
+      assert_equal("Bearer FRESH", request["Authorization"])
+    end
+
+    it "lets per-request headers take precedence over auth headers" do
+      request = client.build_http_request(
+        url: URI.parse("https://example.com"),
+        method: "GET",
+        headers: { "Authorization" => "Bearer PER_REQUEST" },
+        auth_headers: { "Authorization" => "Bearer FRESH" }
+      )
+
+      assert_equal("Bearer PER_REQUEST", request["Authorization"])
+    end
+
+    it "defaults auth headers to empty, leaving the default headers unchanged" do
+      request = client.build_http_request(url: URI.parse("https://example.com"), method: "GET")
+
+      assert_equal("Bearer STATIC", request["Authorization"])
+    end
+  end
 end

--- a/seed/ruby-sdk-v2/nullable-request-body/lib/seed/internal/http/raw_client.rb
+++ b/seed/ruby-sdk-v2/nullable-request-body/lib/seed/internal/http/raw_client.rb
@@ -21,10 +21,14 @@ module Seed
         # @param max_retries [Integer] The number of times to retry a failed request, defaults to 2.
         # @param timeout [Float] The timeout for the request, defaults to 60.0 seconds.
         # @param headers [Hash] The headers for the request.
-        def initialize(base_url:, max_retries: 2, timeout: 60.0, headers: {})
+        # @param auth_provider [Object, nil] An optional auth provider responding to
+        #   `auth_headers`. When present its headers are resolved on every request so
+        #   token-based schemes (e.g. OAuth) can refresh an expired token mid-session.
+        def initialize(base_url:, max_retries: 2, timeout: 60.0, headers: {}, auth_provider: nil)
           @base_url = base_url
           @max_retries = max_retries
           @timeout = timeout
+          @auth_provider = auth_provider
           @default_headers = {
             "X-Fern-Language": "Ruby",
             "X-Fern-SDK-Name": "seed",
@@ -36,6 +40,9 @@ module Seed
         # @return [HTTP::Response] The HTTP response.
         def send(request)
           url = build_url(request)
+          # Resolve auth headers once per request (not per retry) so token-based
+          # providers refresh at most once here; static providers are cheap.
+          auth_headers = resolve_auth_headers
           attempt = 0
           response = nil
 
@@ -43,8 +50,9 @@ module Seed
             http_request = build_http_request(
               url:,
               method: request.method,
-              headers: request.encode_headers(protected_keys: @default_headers.keys),
-              body: request.encode_body
+              headers: request.encode_headers(protected_keys: @default_headers.keys + auth_headers.keys),
+              body: request.encode_body,
+              auth_headers: auth_headers
             )
 
             conn = connect(url)
@@ -157,12 +165,27 @@ module Seed
                 "HTTP is only allowed for localhost. Use HTTPS or pass a localhost URL."
         end
 
+        # Resolves the auth headers to send with the next request. Delegates to the
+        # configured auth provider (if any) on every call so that token-based
+        # providers (e.g. OAuth client-credentials) can refresh an expired token
+        # before the request is sent. Returns an empty hash when no provider is set,
+        # which keeps the api-key / basic / bearer / no-auth paths unchanged.
+        # @return [Hash] The auth headers for the current request.
+        def resolve_auth_headers
+          return {} if @auth_provider.nil?
+
+          @auth_provider.auth_headers
+        end
+
         # @param url [URI::Generic] The url to the resource.
         # @param method [String] The HTTP method to use.
         # @param headers [Hash] The headers for the request.
         # @param body [String, nil] The body for the request.
+        # @param auth_headers [Hash] The auth headers resolved for this request. These
+        #   take precedence over the static default headers but not over per-request
+        #   headers, mirroring the previous baked-header precedence.
         # @return [HTTP::Request] The HTTP request.
-        def build_http_request(url:, method:, headers: {}, body: nil)
+        def build_http_request(url:, method:, headers: {}, body: nil, auth_headers: {})
           request = Net::HTTPGenericRequest.new(
             method,
             !body.nil?,
@@ -170,7 +193,7 @@ module Seed
             url
           )
 
-          request_headers = @default_headers.merge(headers)
+          request_headers = @default_headers.merge(auth_headers).merge(headers)
           request_headers.each { |name, value| request[name] = value }
           request.body = body if body
 

--- a/seed/ruby-sdk-v2/nullable-request-body/test/unit/internal/http/test_raw_client.rb
+++ b/seed/ruby-sdk-v2/nullable-request-body/test/unit/internal/http/test_raw_client.rb
@@ -54,4 +54,71 @@ describe Seed::Internal::Http::RawClient do
       assert client.should_retry?(make_response(502), 2)
     end
   end
+
+  # A minimal auth provider whose `auth_headers` returns a *different* token on
+  # each call, simulating a token that is refreshed on expiry.
+  class RefreshingAuthProvider
+    def initialize
+      @count = 0
+    end
+
+    def auth_headers
+      @count += 1
+      { "Authorization" => "Bearer TOKEN_#{@count}" }
+    end
+  end
+
+  describe "#resolve_auth_headers" do
+    it "returns an empty hash when no auth provider is configured" do
+      client = Seed::Internal::Http::RawClient.new(base_url: "https://example.com")
+
+      assert_equal({}, client.resolve_auth_headers)
+    end
+
+    it "consults the auth provider on every call so an expired token is refreshed" do
+      client = Seed::Internal::Http::RawClient.new(
+        base_url: "https://example.com",
+        auth_provider: RefreshingAuthProvider.new
+      )
+
+      assert_equal({ "Authorization" => "Bearer TOKEN_1" }, client.resolve_auth_headers)
+      assert_equal({ "Authorization" => "Bearer TOKEN_2" }, client.resolve_auth_headers)
+    end
+  end
+
+  describe "#build_http_request auth header precedence" do
+    let(:client) do
+      Seed::Internal::Http::RawClient.new(
+        base_url: "https://example.com",
+        headers: { "Authorization" => "Bearer STATIC" }
+      )
+    end
+
+    it "lets resolved auth headers override the static default headers" do
+      request = client.build_http_request(
+        url: URI.parse("https://example.com"),
+        method: "GET",
+        auth_headers: { "Authorization" => "Bearer FRESH" }
+      )
+
+      assert_equal("Bearer FRESH", request["Authorization"])
+    end
+
+    it "lets per-request headers take precedence over auth headers" do
+      request = client.build_http_request(
+        url: URI.parse("https://example.com"),
+        method: "GET",
+        headers: { "Authorization" => "Bearer PER_REQUEST" },
+        auth_headers: { "Authorization" => "Bearer FRESH" }
+      )
+
+      assert_equal("Bearer PER_REQUEST", request["Authorization"])
+    end
+
+    it "defaults auth headers to empty, leaving the default headers unchanged" do
+      request = client.build_http_request(url: URI.parse("https://example.com"), method: "GET")
+
+      assert_equal("Bearer STATIC", request["Authorization"])
+    end
+  end
 end

--- a/seed/ruby-sdk-v2/nullable/lib/seed/internal/http/raw_client.rb
+++ b/seed/ruby-sdk-v2/nullable/lib/seed/internal/http/raw_client.rb
@@ -21,10 +21,14 @@ module Seed
         # @param max_retries [Integer] The number of times to retry a failed request, defaults to 2.
         # @param timeout [Float] The timeout for the request, defaults to 60.0 seconds.
         # @param headers [Hash] The headers for the request.
-        def initialize(base_url:, max_retries: 2, timeout: 60.0, headers: {})
+        # @param auth_provider [Object, nil] An optional auth provider responding to
+        #   `auth_headers`. When present its headers are resolved on every request so
+        #   token-based schemes (e.g. OAuth) can refresh an expired token mid-session.
+        def initialize(base_url:, max_retries: 2, timeout: 60.0, headers: {}, auth_provider: nil)
           @base_url = base_url
           @max_retries = max_retries
           @timeout = timeout
+          @auth_provider = auth_provider
           @default_headers = {
             "X-Fern-Language": "Ruby",
             "X-Fern-SDK-Name": "seed",
@@ -36,6 +40,9 @@ module Seed
         # @return [HTTP::Response] The HTTP response.
         def send(request)
           url = build_url(request)
+          # Resolve auth headers once per request (not per retry) so token-based
+          # providers refresh at most once here; static providers are cheap.
+          auth_headers = resolve_auth_headers
           attempt = 0
           response = nil
 
@@ -43,8 +50,9 @@ module Seed
             http_request = build_http_request(
               url:,
               method: request.method,
-              headers: request.encode_headers(protected_keys: @default_headers.keys),
-              body: request.encode_body
+              headers: request.encode_headers(protected_keys: @default_headers.keys + auth_headers.keys),
+              body: request.encode_body,
+              auth_headers: auth_headers
             )
 
             conn = connect(url)
@@ -157,12 +165,27 @@ module Seed
                 "HTTP is only allowed for localhost. Use HTTPS or pass a localhost URL."
         end
 
+        # Resolves the auth headers to send with the next request. Delegates to the
+        # configured auth provider (if any) on every call so that token-based
+        # providers (e.g. OAuth client-credentials) can refresh an expired token
+        # before the request is sent. Returns an empty hash when no provider is set,
+        # which keeps the api-key / basic / bearer / no-auth paths unchanged.
+        # @return [Hash] The auth headers for the current request.
+        def resolve_auth_headers
+          return {} if @auth_provider.nil?
+
+          @auth_provider.auth_headers
+        end
+
         # @param url [URI::Generic] The url to the resource.
         # @param method [String] The HTTP method to use.
         # @param headers [Hash] The headers for the request.
         # @param body [String, nil] The body for the request.
+        # @param auth_headers [Hash] The auth headers resolved for this request. These
+        #   take precedence over the static default headers but not over per-request
+        #   headers, mirroring the previous baked-header precedence.
         # @return [HTTP::Request] The HTTP request.
-        def build_http_request(url:, method:, headers: {}, body: nil)
+        def build_http_request(url:, method:, headers: {}, body: nil, auth_headers: {})
           request = Net::HTTPGenericRequest.new(
             method,
             !body.nil?,
@@ -170,7 +193,7 @@ module Seed
             url
           )
 
-          request_headers = @default_headers.merge(headers)
+          request_headers = @default_headers.merge(auth_headers).merge(headers)
           request_headers.each { |name, value| request[name] = value }
           request.body = body if body
 

--- a/seed/ruby-sdk-v2/nullable/test/unit/internal/http/test_raw_client.rb
+++ b/seed/ruby-sdk-v2/nullable/test/unit/internal/http/test_raw_client.rb
@@ -54,4 +54,71 @@ describe Seed::Internal::Http::RawClient do
       assert client.should_retry?(make_response(502), 2)
     end
   end
+
+  # A minimal auth provider whose `auth_headers` returns a *different* token on
+  # each call, simulating a token that is refreshed on expiry.
+  class RefreshingAuthProvider
+    def initialize
+      @count = 0
+    end
+
+    def auth_headers
+      @count += 1
+      { "Authorization" => "Bearer TOKEN_#{@count}" }
+    end
+  end
+
+  describe "#resolve_auth_headers" do
+    it "returns an empty hash when no auth provider is configured" do
+      client = Seed::Internal::Http::RawClient.new(base_url: "https://example.com")
+
+      assert_equal({}, client.resolve_auth_headers)
+    end
+
+    it "consults the auth provider on every call so an expired token is refreshed" do
+      client = Seed::Internal::Http::RawClient.new(
+        base_url: "https://example.com",
+        auth_provider: RefreshingAuthProvider.new
+      )
+
+      assert_equal({ "Authorization" => "Bearer TOKEN_1" }, client.resolve_auth_headers)
+      assert_equal({ "Authorization" => "Bearer TOKEN_2" }, client.resolve_auth_headers)
+    end
+  end
+
+  describe "#build_http_request auth header precedence" do
+    let(:client) do
+      Seed::Internal::Http::RawClient.new(
+        base_url: "https://example.com",
+        headers: { "Authorization" => "Bearer STATIC" }
+      )
+    end
+
+    it "lets resolved auth headers override the static default headers" do
+      request = client.build_http_request(
+        url: URI.parse("https://example.com"),
+        method: "GET",
+        auth_headers: { "Authorization" => "Bearer FRESH" }
+      )
+
+      assert_equal("Bearer FRESH", request["Authorization"])
+    end
+
+    it "lets per-request headers take precedence over auth headers" do
+      request = client.build_http_request(
+        url: URI.parse("https://example.com"),
+        method: "GET",
+        headers: { "Authorization" => "Bearer PER_REQUEST" },
+        auth_headers: { "Authorization" => "Bearer FRESH" }
+      )
+
+      assert_equal("Bearer PER_REQUEST", request["Authorization"])
+    end
+
+    it "defaults auth headers to empty, leaving the default headers unchanged" do
+      request = client.build_http_request(url: URI.parse("https://example.com"), method: "GET")
+
+      assert_equal("Bearer STATIC", request["Authorization"])
+    end
+  end
 end

--- a/seed/ruby-sdk-v2/oauth-client-credentials-custom/lib/seed/client.rb
+++ b/seed/ruby-sdk-v2/oauth-client-credentials-custom/lib/seed/client.rb
@@ -33,7 +33,8 @@ module Seed
         headers: {
           "User-Agent" => "fern_oauth-client-credentials-custom/0.0.1",
           "X-Fern-Language" => "Ruby"
-        }.merge(@auth_provider.auth_headers),
+        },
+        auth_provider: @auth_provider,
         max_retries: max_retries
       )
     end

--- a/seed/ruby-sdk-v2/oauth-client-credentials-custom/lib/seed/internal/http/raw_client.rb
+++ b/seed/ruby-sdk-v2/oauth-client-credentials-custom/lib/seed/internal/http/raw_client.rb
@@ -21,10 +21,14 @@ module Seed
         # @param max_retries [Integer] The number of times to retry a failed request, defaults to 2.
         # @param timeout [Float] The timeout for the request, defaults to 60.0 seconds.
         # @param headers [Hash] The headers for the request.
-        def initialize(base_url:, max_retries: 2, timeout: 60.0, headers: {})
+        # @param auth_provider [Object, nil] An optional auth provider responding to
+        #   `auth_headers`. When present its headers are resolved on every request so
+        #   token-based schemes (e.g. OAuth) can refresh an expired token mid-session.
+        def initialize(base_url:, max_retries: 2, timeout: 60.0, headers: {}, auth_provider: nil)
           @base_url = base_url
           @max_retries = max_retries
           @timeout = timeout
+          @auth_provider = auth_provider
           @default_headers = {
             "X-Fern-Language": "Ruby",
             "X-Fern-SDK-Name": "seed",
@@ -36,6 +40,9 @@ module Seed
         # @return [HTTP::Response] The HTTP response.
         def send(request)
           url = build_url(request)
+          # Resolve auth headers once per request (not per retry) so token-based
+          # providers refresh at most once here; static providers are cheap.
+          auth_headers = resolve_auth_headers
           attempt = 0
           response = nil
 
@@ -43,8 +50,9 @@ module Seed
             http_request = build_http_request(
               url:,
               method: request.method,
-              headers: request.encode_headers(protected_keys: @default_headers.keys),
-              body: request.encode_body
+              headers: request.encode_headers(protected_keys: @default_headers.keys + auth_headers.keys),
+              body: request.encode_body,
+              auth_headers: auth_headers
             )
 
             conn = connect(url)
@@ -157,12 +165,27 @@ module Seed
                 "HTTP is only allowed for localhost. Use HTTPS or pass a localhost URL."
         end
 
+        # Resolves the auth headers to send with the next request. Delegates to the
+        # configured auth provider (if any) on every call so that token-based
+        # providers (e.g. OAuth client-credentials) can refresh an expired token
+        # before the request is sent. Returns an empty hash when no provider is set,
+        # which keeps the api-key / basic / bearer / no-auth paths unchanged.
+        # @return [Hash] The auth headers for the current request.
+        def resolve_auth_headers
+          return {} if @auth_provider.nil?
+
+          @auth_provider.auth_headers
+        end
+
         # @param url [URI::Generic] The url to the resource.
         # @param method [String] The HTTP method to use.
         # @param headers [Hash] The headers for the request.
         # @param body [String, nil] The body for the request.
+        # @param auth_headers [Hash] The auth headers resolved for this request. These
+        #   take precedence over the static default headers but not over per-request
+        #   headers, mirroring the previous baked-header precedence.
         # @return [HTTP::Request] The HTTP request.
-        def build_http_request(url:, method:, headers: {}, body: nil)
+        def build_http_request(url:, method:, headers: {}, body: nil, auth_headers: {})
           request = Net::HTTPGenericRequest.new(
             method,
             !body.nil?,
@@ -170,7 +193,7 @@ module Seed
             url
           )
 
-          request_headers = @default_headers.merge(headers)
+          request_headers = @default_headers.merge(auth_headers).merge(headers)
           request_headers.each { |name, value| request[name] = value }
           request.body = body if body
 

--- a/seed/ruby-sdk-v2/oauth-client-credentials-custom/test/unit/internal/http/test_raw_client.rb
+++ b/seed/ruby-sdk-v2/oauth-client-credentials-custom/test/unit/internal/http/test_raw_client.rb
@@ -54,4 +54,71 @@ describe Seed::Internal::Http::RawClient do
       assert client.should_retry?(make_response(502), 2)
     end
   end
+
+  # A minimal auth provider whose `auth_headers` returns a *different* token on
+  # each call, simulating a token that is refreshed on expiry.
+  class RefreshingAuthProvider
+    def initialize
+      @count = 0
+    end
+
+    def auth_headers
+      @count += 1
+      { "Authorization" => "Bearer TOKEN_#{@count}" }
+    end
+  end
+
+  describe "#resolve_auth_headers" do
+    it "returns an empty hash when no auth provider is configured" do
+      client = Seed::Internal::Http::RawClient.new(base_url: "https://example.com")
+
+      assert_equal({}, client.resolve_auth_headers)
+    end
+
+    it "consults the auth provider on every call so an expired token is refreshed" do
+      client = Seed::Internal::Http::RawClient.new(
+        base_url: "https://example.com",
+        auth_provider: RefreshingAuthProvider.new
+      )
+
+      assert_equal({ "Authorization" => "Bearer TOKEN_1" }, client.resolve_auth_headers)
+      assert_equal({ "Authorization" => "Bearer TOKEN_2" }, client.resolve_auth_headers)
+    end
+  end
+
+  describe "#build_http_request auth header precedence" do
+    let(:client) do
+      Seed::Internal::Http::RawClient.new(
+        base_url: "https://example.com",
+        headers: { "Authorization" => "Bearer STATIC" }
+      )
+    end
+
+    it "lets resolved auth headers override the static default headers" do
+      request = client.build_http_request(
+        url: URI.parse("https://example.com"),
+        method: "GET",
+        auth_headers: { "Authorization" => "Bearer FRESH" }
+      )
+
+      assert_equal("Bearer FRESH", request["Authorization"])
+    end
+
+    it "lets per-request headers take precedence over auth headers" do
+      request = client.build_http_request(
+        url: URI.parse("https://example.com"),
+        method: "GET",
+        headers: { "Authorization" => "Bearer PER_REQUEST" },
+        auth_headers: { "Authorization" => "Bearer FRESH" }
+      )
+
+      assert_equal("Bearer PER_REQUEST", request["Authorization"])
+    end
+
+    it "defaults auth headers to empty, leaving the default headers unchanged" do
+      request = client.build_http_request(url: URI.parse("https://example.com"), method: "GET")
+
+      assert_equal("Bearer STATIC", request["Authorization"])
+    end
+  end
 end

--- a/seed/ruby-sdk-v2/oauth-client-credentials-default/lib/seed/client.rb
+++ b/seed/ruby-sdk-v2/oauth-client-credentials-default/lib/seed/client.rb
@@ -31,7 +31,8 @@ module Seed
         headers: {
           "User-Agent" => "fern_oauth-client-credentials-default/0.0.1",
           "X-Fern-Language" => "Ruby"
-        }.merge(@auth_provider.auth_headers),
+        },
+        auth_provider: @auth_provider,
         max_retries: max_retries
       )
     end

--- a/seed/ruby-sdk-v2/oauth-client-credentials-default/lib/seed/internal/http/raw_client.rb
+++ b/seed/ruby-sdk-v2/oauth-client-credentials-default/lib/seed/internal/http/raw_client.rb
@@ -21,10 +21,14 @@ module Seed
         # @param max_retries [Integer] The number of times to retry a failed request, defaults to 2.
         # @param timeout [Float] The timeout for the request, defaults to 60.0 seconds.
         # @param headers [Hash] The headers for the request.
-        def initialize(base_url:, max_retries: 2, timeout: 60.0, headers: {})
+        # @param auth_provider [Object, nil] An optional auth provider responding to
+        #   `auth_headers`. When present its headers are resolved on every request so
+        #   token-based schemes (e.g. OAuth) can refresh an expired token mid-session.
+        def initialize(base_url:, max_retries: 2, timeout: 60.0, headers: {}, auth_provider: nil)
           @base_url = base_url
           @max_retries = max_retries
           @timeout = timeout
+          @auth_provider = auth_provider
           @default_headers = {
             "X-Fern-Language": "Ruby",
             "X-Fern-SDK-Name": "seed",
@@ -36,6 +40,9 @@ module Seed
         # @return [HTTP::Response] The HTTP response.
         def send(request)
           url = build_url(request)
+          # Resolve auth headers once per request (not per retry) so token-based
+          # providers refresh at most once here; static providers are cheap.
+          auth_headers = resolve_auth_headers
           attempt = 0
           response = nil
 
@@ -43,8 +50,9 @@ module Seed
             http_request = build_http_request(
               url:,
               method: request.method,
-              headers: request.encode_headers(protected_keys: @default_headers.keys),
-              body: request.encode_body
+              headers: request.encode_headers(protected_keys: @default_headers.keys + auth_headers.keys),
+              body: request.encode_body,
+              auth_headers: auth_headers
             )
 
             conn = connect(url)
@@ -157,12 +165,27 @@ module Seed
                 "HTTP is only allowed for localhost. Use HTTPS or pass a localhost URL."
         end
 
+        # Resolves the auth headers to send with the next request. Delegates to the
+        # configured auth provider (if any) on every call so that token-based
+        # providers (e.g. OAuth client-credentials) can refresh an expired token
+        # before the request is sent. Returns an empty hash when no provider is set,
+        # which keeps the api-key / basic / bearer / no-auth paths unchanged.
+        # @return [Hash] The auth headers for the current request.
+        def resolve_auth_headers
+          return {} if @auth_provider.nil?
+
+          @auth_provider.auth_headers
+        end
+
         # @param url [URI::Generic] The url to the resource.
         # @param method [String] The HTTP method to use.
         # @param headers [Hash] The headers for the request.
         # @param body [String, nil] The body for the request.
+        # @param auth_headers [Hash] The auth headers resolved for this request. These
+        #   take precedence over the static default headers but not over per-request
+        #   headers, mirroring the previous baked-header precedence.
         # @return [HTTP::Request] The HTTP request.
-        def build_http_request(url:, method:, headers: {}, body: nil)
+        def build_http_request(url:, method:, headers: {}, body: nil, auth_headers: {})
           request = Net::HTTPGenericRequest.new(
             method,
             !body.nil?,
@@ -170,7 +193,7 @@ module Seed
             url
           )
 
-          request_headers = @default_headers.merge(headers)
+          request_headers = @default_headers.merge(auth_headers).merge(headers)
           request_headers.each { |name, value| request[name] = value }
           request.body = body if body
 

--- a/seed/ruby-sdk-v2/oauth-client-credentials-default/test/unit/internal/http/test_raw_client.rb
+++ b/seed/ruby-sdk-v2/oauth-client-credentials-default/test/unit/internal/http/test_raw_client.rb
@@ -54,4 +54,71 @@ describe Seed::Internal::Http::RawClient do
       assert client.should_retry?(make_response(502), 2)
     end
   end
+
+  # A minimal auth provider whose `auth_headers` returns a *different* token on
+  # each call, simulating a token that is refreshed on expiry.
+  class RefreshingAuthProvider
+    def initialize
+      @count = 0
+    end
+
+    def auth_headers
+      @count += 1
+      { "Authorization" => "Bearer TOKEN_#{@count}" }
+    end
+  end
+
+  describe "#resolve_auth_headers" do
+    it "returns an empty hash when no auth provider is configured" do
+      client = Seed::Internal::Http::RawClient.new(base_url: "https://example.com")
+
+      assert_equal({}, client.resolve_auth_headers)
+    end
+
+    it "consults the auth provider on every call so an expired token is refreshed" do
+      client = Seed::Internal::Http::RawClient.new(
+        base_url: "https://example.com",
+        auth_provider: RefreshingAuthProvider.new
+      )
+
+      assert_equal({ "Authorization" => "Bearer TOKEN_1" }, client.resolve_auth_headers)
+      assert_equal({ "Authorization" => "Bearer TOKEN_2" }, client.resolve_auth_headers)
+    end
+  end
+
+  describe "#build_http_request auth header precedence" do
+    let(:client) do
+      Seed::Internal::Http::RawClient.new(
+        base_url: "https://example.com",
+        headers: { "Authorization" => "Bearer STATIC" }
+      )
+    end
+
+    it "lets resolved auth headers override the static default headers" do
+      request = client.build_http_request(
+        url: URI.parse("https://example.com"),
+        method: "GET",
+        auth_headers: { "Authorization" => "Bearer FRESH" }
+      )
+
+      assert_equal("Bearer FRESH", request["Authorization"])
+    end
+
+    it "lets per-request headers take precedence over auth headers" do
+      request = client.build_http_request(
+        url: URI.parse("https://example.com"),
+        method: "GET",
+        headers: { "Authorization" => "Bearer PER_REQUEST" },
+        auth_headers: { "Authorization" => "Bearer FRESH" }
+      )
+
+      assert_equal("Bearer PER_REQUEST", request["Authorization"])
+    end
+
+    it "defaults auth headers to empty, leaving the default headers unchanged" do
+      request = client.build_http_request(url: URI.parse("https://example.com"), method: "GET")
+
+      assert_equal("Bearer STATIC", request["Authorization"])
+    end
+  end
 end

--- a/seed/ruby-sdk-v2/oauth-client-credentials-environment-variables/lib/seed/client.rb
+++ b/seed/ruby-sdk-v2/oauth-client-credentials-environment-variables/lib/seed/client.rb
@@ -31,7 +31,8 @@ module Seed
         headers: {
           "User-Agent" => "fern_oauth-client-credentials-environment-variables/0.0.1",
           "X-Fern-Language" => "Ruby"
-        }.merge(@auth_provider.auth_headers),
+        },
+        auth_provider: @auth_provider,
         max_retries: max_retries
       )
     end

--- a/seed/ruby-sdk-v2/oauth-client-credentials-environment-variables/lib/seed/internal/http/raw_client.rb
+++ b/seed/ruby-sdk-v2/oauth-client-credentials-environment-variables/lib/seed/internal/http/raw_client.rb
@@ -21,10 +21,14 @@ module Seed
         # @param max_retries [Integer] The number of times to retry a failed request, defaults to 2.
         # @param timeout [Float] The timeout for the request, defaults to 60.0 seconds.
         # @param headers [Hash] The headers for the request.
-        def initialize(base_url:, max_retries: 2, timeout: 60.0, headers: {})
+        # @param auth_provider [Object, nil] An optional auth provider responding to
+        #   `auth_headers`. When present its headers are resolved on every request so
+        #   token-based schemes (e.g. OAuth) can refresh an expired token mid-session.
+        def initialize(base_url:, max_retries: 2, timeout: 60.0, headers: {}, auth_provider: nil)
           @base_url = base_url
           @max_retries = max_retries
           @timeout = timeout
+          @auth_provider = auth_provider
           @default_headers = {
             "X-Fern-Language": "Ruby",
             "X-Fern-SDK-Name": "seed",
@@ -36,6 +40,9 @@ module Seed
         # @return [HTTP::Response] The HTTP response.
         def send(request)
           url = build_url(request)
+          # Resolve auth headers once per request (not per retry) so token-based
+          # providers refresh at most once here; static providers are cheap.
+          auth_headers = resolve_auth_headers
           attempt = 0
           response = nil
 
@@ -43,8 +50,9 @@ module Seed
             http_request = build_http_request(
               url:,
               method: request.method,
-              headers: request.encode_headers(protected_keys: @default_headers.keys),
-              body: request.encode_body
+              headers: request.encode_headers(protected_keys: @default_headers.keys + auth_headers.keys),
+              body: request.encode_body,
+              auth_headers: auth_headers
             )
 
             conn = connect(url)
@@ -157,12 +165,27 @@ module Seed
                 "HTTP is only allowed for localhost. Use HTTPS or pass a localhost URL."
         end
 
+        # Resolves the auth headers to send with the next request. Delegates to the
+        # configured auth provider (if any) on every call so that token-based
+        # providers (e.g. OAuth client-credentials) can refresh an expired token
+        # before the request is sent. Returns an empty hash when no provider is set,
+        # which keeps the api-key / basic / bearer / no-auth paths unchanged.
+        # @return [Hash] The auth headers for the current request.
+        def resolve_auth_headers
+          return {} if @auth_provider.nil?
+
+          @auth_provider.auth_headers
+        end
+
         # @param url [URI::Generic] The url to the resource.
         # @param method [String] The HTTP method to use.
         # @param headers [Hash] The headers for the request.
         # @param body [String, nil] The body for the request.
+        # @param auth_headers [Hash] The auth headers resolved for this request. These
+        #   take precedence over the static default headers but not over per-request
+        #   headers, mirroring the previous baked-header precedence.
         # @return [HTTP::Request] The HTTP request.
-        def build_http_request(url:, method:, headers: {}, body: nil)
+        def build_http_request(url:, method:, headers: {}, body: nil, auth_headers: {})
           request = Net::HTTPGenericRequest.new(
             method,
             !body.nil?,
@@ -170,7 +193,7 @@ module Seed
             url
           )
 
-          request_headers = @default_headers.merge(headers)
+          request_headers = @default_headers.merge(auth_headers).merge(headers)
           request_headers.each { |name, value| request[name] = value }
           request.body = body if body
 

--- a/seed/ruby-sdk-v2/oauth-client-credentials-environment-variables/test/unit/internal/http/test_raw_client.rb
+++ b/seed/ruby-sdk-v2/oauth-client-credentials-environment-variables/test/unit/internal/http/test_raw_client.rb
@@ -54,4 +54,71 @@ describe Seed::Internal::Http::RawClient do
       assert client.should_retry?(make_response(502), 2)
     end
   end
+
+  # A minimal auth provider whose `auth_headers` returns a *different* token on
+  # each call, simulating a token that is refreshed on expiry.
+  class RefreshingAuthProvider
+    def initialize
+      @count = 0
+    end
+
+    def auth_headers
+      @count += 1
+      { "Authorization" => "Bearer TOKEN_#{@count}" }
+    end
+  end
+
+  describe "#resolve_auth_headers" do
+    it "returns an empty hash when no auth provider is configured" do
+      client = Seed::Internal::Http::RawClient.new(base_url: "https://example.com")
+
+      assert_equal({}, client.resolve_auth_headers)
+    end
+
+    it "consults the auth provider on every call so an expired token is refreshed" do
+      client = Seed::Internal::Http::RawClient.new(
+        base_url: "https://example.com",
+        auth_provider: RefreshingAuthProvider.new
+      )
+
+      assert_equal({ "Authorization" => "Bearer TOKEN_1" }, client.resolve_auth_headers)
+      assert_equal({ "Authorization" => "Bearer TOKEN_2" }, client.resolve_auth_headers)
+    end
+  end
+
+  describe "#build_http_request auth header precedence" do
+    let(:client) do
+      Seed::Internal::Http::RawClient.new(
+        base_url: "https://example.com",
+        headers: { "Authorization" => "Bearer STATIC" }
+      )
+    end
+
+    it "lets resolved auth headers override the static default headers" do
+      request = client.build_http_request(
+        url: URI.parse("https://example.com"),
+        method: "GET",
+        auth_headers: { "Authorization" => "Bearer FRESH" }
+      )
+
+      assert_equal("Bearer FRESH", request["Authorization"])
+    end
+
+    it "lets per-request headers take precedence over auth headers" do
+      request = client.build_http_request(
+        url: URI.parse("https://example.com"),
+        method: "GET",
+        headers: { "Authorization" => "Bearer PER_REQUEST" },
+        auth_headers: { "Authorization" => "Bearer FRESH" }
+      )
+
+      assert_equal("Bearer PER_REQUEST", request["Authorization"])
+    end
+
+    it "defaults auth headers to empty, leaving the default headers unchanged" do
+      request = client.build_http_request(url: URI.parse("https://example.com"), method: "GET")
+
+      assert_equal("Bearer STATIC", request["Authorization"])
+    end
+  end
 end

--- a/seed/ruby-sdk-v2/oauth-client-credentials-mandatory-auth/lib/seed/client.rb
+++ b/seed/ruby-sdk-v2/oauth-client-credentials-mandatory-auth/lib/seed/client.rb
@@ -31,7 +31,8 @@ module Seed
         headers: {
           "User-Agent" => "fern_oauth-client-credentials-mandatory-auth/0.0.1",
           "X-Fern-Language" => "Ruby"
-        }.merge(@auth_provider.auth_headers),
+        },
+        auth_provider: @auth_provider,
         max_retries: max_retries
       )
     end

--- a/seed/ruby-sdk-v2/oauth-client-credentials-mandatory-auth/lib/seed/internal/http/raw_client.rb
+++ b/seed/ruby-sdk-v2/oauth-client-credentials-mandatory-auth/lib/seed/internal/http/raw_client.rb
@@ -21,10 +21,14 @@ module Seed
         # @param max_retries [Integer] The number of times to retry a failed request, defaults to 2.
         # @param timeout [Float] The timeout for the request, defaults to 60.0 seconds.
         # @param headers [Hash] The headers for the request.
-        def initialize(base_url:, max_retries: 2, timeout: 60.0, headers: {})
+        # @param auth_provider [Object, nil] An optional auth provider responding to
+        #   `auth_headers`. When present its headers are resolved on every request so
+        #   token-based schemes (e.g. OAuth) can refresh an expired token mid-session.
+        def initialize(base_url:, max_retries: 2, timeout: 60.0, headers: {}, auth_provider: nil)
           @base_url = base_url
           @max_retries = max_retries
           @timeout = timeout
+          @auth_provider = auth_provider
           @default_headers = {
             "X-Fern-Language": "Ruby",
             "X-Fern-SDK-Name": "seed",
@@ -36,6 +40,9 @@ module Seed
         # @return [HTTP::Response] The HTTP response.
         def send(request)
           url = build_url(request)
+          # Resolve auth headers once per request (not per retry) so token-based
+          # providers refresh at most once here; static providers are cheap.
+          auth_headers = resolve_auth_headers
           attempt = 0
           response = nil
 
@@ -43,8 +50,9 @@ module Seed
             http_request = build_http_request(
               url:,
               method: request.method,
-              headers: request.encode_headers(protected_keys: @default_headers.keys),
-              body: request.encode_body
+              headers: request.encode_headers(protected_keys: @default_headers.keys + auth_headers.keys),
+              body: request.encode_body,
+              auth_headers: auth_headers
             )
 
             conn = connect(url)
@@ -157,12 +165,27 @@ module Seed
                 "HTTP is only allowed for localhost. Use HTTPS or pass a localhost URL."
         end
 
+        # Resolves the auth headers to send with the next request. Delegates to the
+        # configured auth provider (if any) on every call so that token-based
+        # providers (e.g. OAuth client-credentials) can refresh an expired token
+        # before the request is sent. Returns an empty hash when no provider is set,
+        # which keeps the api-key / basic / bearer / no-auth paths unchanged.
+        # @return [Hash] The auth headers for the current request.
+        def resolve_auth_headers
+          return {} if @auth_provider.nil?
+
+          @auth_provider.auth_headers
+        end
+
         # @param url [URI::Generic] The url to the resource.
         # @param method [String] The HTTP method to use.
         # @param headers [Hash] The headers for the request.
         # @param body [String, nil] The body for the request.
+        # @param auth_headers [Hash] The auth headers resolved for this request. These
+        #   take precedence over the static default headers but not over per-request
+        #   headers, mirroring the previous baked-header precedence.
         # @return [HTTP::Request] The HTTP request.
-        def build_http_request(url:, method:, headers: {}, body: nil)
+        def build_http_request(url:, method:, headers: {}, body: nil, auth_headers: {})
           request = Net::HTTPGenericRequest.new(
             method,
             !body.nil?,
@@ -170,7 +193,7 @@ module Seed
             url
           )
 
-          request_headers = @default_headers.merge(headers)
+          request_headers = @default_headers.merge(auth_headers).merge(headers)
           request_headers.each { |name, value| request[name] = value }
           request.body = body if body
 

--- a/seed/ruby-sdk-v2/oauth-client-credentials-mandatory-auth/test/unit/internal/http/test_raw_client.rb
+++ b/seed/ruby-sdk-v2/oauth-client-credentials-mandatory-auth/test/unit/internal/http/test_raw_client.rb
@@ -54,4 +54,71 @@ describe Seed::Internal::Http::RawClient do
       assert client.should_retry?(make_response(502), 2)
     end
   end
+
+  # A minimal auth provider whose `auth_headers` returns a *different* token on
+  # each call, simulating a token that is refreshed on expiry.
+  class RefreshingAuthProvider
+    def initialize
+      @count = 0
+    end
+
+    def auth_headers
+      @count += 1
+      { "Authorization" => "Bearer TOKEN_#{@count}" }
+    end
+  end
+
+  describe "#resolve_auth_headers" do
+    it "returns an empty hash when no auth provider is configured" do
+      client = Seed::Internal::Http::RawClient.new(base_url: "https://example.com")
+
+      assert_equal({}, client.resolve_auth_headers)
+    end
+
+    it "consults the auth provider on every call so an expired token is refreshed" do
+      client = Seed::Internal::Http::RawClient.new(
+        base_url: "https://example.com",
+        auth_provider: RefreshingAuthProvider.new
+      )
+
+      assert_equal({ "Authorization" => "Bearer TOKEN_1" }, client.resolve_auth_headers)
+      assert_equal({ "Authorization" => "Bearer TOKEN_2" }, client.resolve_auth_headers)
+    end
+  end
+
+  describe "#build_http_request auth header precedence" do
+    let(:client) do
+      Seed::Internal::Http::RawClient.new(
+        base_url: "https://example.com",
+        headers: { "Authorization" => "Bearer STATIC" }
+      )
+    end
+
+    it "lets resolved auth headers override the static default headers" do
+      request = client.build_http_request(
+        url: URI.parse("https://example.com"),
+        method: "GET",
+        auth_headers: { "Authorization" => "Bearer FRESH" }
+      )
+
+      assert_equal("Bearer FRESH", request["Authorization"])
+    end
+
+    it "lets per-request headers take precedence over auth headers" do
+      request = client.build_http_request(
+        url: URI.parse("https://example.com"),
+        method: "GET",
+        headers: { "Authorization" => "Bearer PER_REQUEST" },
+        auth_headers: { "Authorization" => "Bearer FRESH" }
+      )
+
+      assert_equal("Bearer PER_REQUEST", request["Authorization"])
+    end
+
+    it "defaults auth headers to empty, leaving the default headers unchanged" do
+      request = client.build_http_request(url: URI.parse("https://example.com"), method: "GET")
+
+      assert_equal("Bearer STATIC", request["Authorization"])
+    end
+  end
 end

--- a/seed/ruby-sdk-v2/oauth-client-credentials-nested-root/lib/seed/client.rb
+++ b/seed/ruby-sdk-v2/oauth-client-credentials-nested-root/lib/seed/client.rb
@@ -31,7 +31,8 @@ module Seed
         headers: {
           "User-Agent" => "fern_oauth-client-credentials-nested-root/0.0.1",
           "X-Fern-Language" => "Ruby"
-        }.merge(@auth_provider.auth_headers),
+        },
+        auth_provider: @auth_provider,
         max_retries: max_retries
       )
     end

--- a/seed/ruby-sdk-v2/oauth-client-credentials-nested-root/lib/seed/internal/http/raw_client.rb
+++ b/seed/ruby-sdk-v2/oauth-client-credentials-nested-root/lib/seed/internal/http/raw_client.rb
@@ -21,10 +21,14 @@ module Seed
         # @param max_retries [Integer] The number of times to retry a failed request, defaults to 2.
         # @param timeout [Float] The timeout for the request, defaults to 60.0 seconds.
         # @param headers [Hash] The headers for the request.
-        def initialize(base_url:, max_retries: 2, timeout: 60.0, headers: {})
+        # @param auth_provider [Object, nil] An optional auth provider responding to
+        #   `auth_headers`. When present its headers are resolved on every request so
+        #   token-based schemes (e.g. OAuth) can refresh an expired token mid-session.
+        def initialize(base_url:, max_retries: 2, timeout: 60.0, headers: {}, auth_provider: nil)
           @base_url = base_url
           @max_retries = max_retries
           @timeout = timeout
+          @auth_provider = auth_provider
           @default_headers = {
             "X-Fern-Language": "Ruby",
             "X-Fern-SDK-Name": "seed",
@@ -36,6 +40,9 @@ module Seed
         # @return [HTTP::Response] The HTTP response.
         def send(request)
           url = build_url(request)
+          # Resolve auth headers once per request (not per retry) so token-based
+          # providers refresh at most once here; static providers are cheap.
+          auth_headers = resolve_auth_headers
           attempt = 0
           response = nil
 
@@ -43,8 +50,9 @@ module Seed
             http_request = build_http_request(
               url:,
               method: request.method,
-              headers: request.encode_headers(protected_keys: @default_headers.keys),
-              body: request.encode_body
+              headers: request.encode_headers(protected_keys: @default_headers.keys + auth_headers.keys),
+              body: request.encode_body,
+              auth_headers: auth_headers
             )
 
             conn = connect(url)
@@ -157,12 +165,27 @@ module Seed
                 "HTTP is only allowed for localhost. Use HTTPS or pass a localhost URL."
         end
 
+        # Resolves the auth headers to send with the next request. Delegates to the
+        # configured auth provider (if any) on every call so that token-based
+        # providers (e.g. OAuth client-credentials) can refresh an expired token
+        # before the request is sent. Returns an empty hash when no provider is set,
+        # which keeps the api-key / basic / bearer / no-auth paths unchanged.
+        # @return [Hash] The auth headers for the current request.
+        def resolve_auth_headers
+          return {} if @auth_provider.nil?
+
+          @auth_provider.auth_headers
+        end
+
         # @param url [URI::Generic] The url to the resource.
         # @param method [String] The HTTP method to use.
         # @param headers [Hash] The headers for the request.
         # @param body [String, nil] The body for the request.
+        # @param auth_headers [Hash] The auth headers resolved for this request. These
+        #   take precedence over the static default headers but not over per-request
+        #   headers, mirroring the previous baked-header precedence.
         # @return [HTTP::Request] The HTTP request.
-        def build_http_request(url:, method:, headers: {}, body: nil)
+        def build_http_request(url:, method:, headers: {}, body: nil, auth_headers: {})
           request = Net::HTTPGenericRequest.new(
             method,
             !body.nil?,
@@ -170,7 +193,7 @@ module Seed
             url
           )
 
-          request_headers = @default_headers.merge(headers)
+          request_headers = @default_headers.merge(auth_headers).merge(headers)
           request_headers.each { |name, value| request[name] = value }
           request.body = body if body
 

--- a/seed/ruby-sdk-v2/oauth-client-credentials-nested-root/test/unit/internal/http/test_raw_client.rb
+++ b/seed/ruby-sdk-v2/oauth-client-credentials-nested-root/test/unit/internal/http/test_raw_client.rb
@@ -54,4 +54,71 @@ describe Seed::Internal::Http::RawClient do
       assert client.should_retry?(make_response(502), 2)
     end
   end
+
+  # A minimal auth provider whose `auth_headers` returns a *different* token on
+  # each call, simulating a token that is refreshed on expiry.
+  class RefreshingAuthProvider
+    def initialize
+      @count = 0
+    end
+
+    def auth_headers
+      @count += 1
+      { "Authorization" => "Bearer TOKEN_#{@count}" }
+    end
+  end
+
+  describe "#resolve_auth_headers" do
+    it "returns an empty hash when no auth provider is configured" do
+      client = Seed::Internal::Http::RawClient.new(base_url: "https://example.com")
+
+      assert_equal({}, client.resolve_auth_headers)
+    end
+
+    it "consults the auth provider on every call so an expired token is refreshed" do
+      client = Seed::Internal::Http::RawClient.new(
+        base_url: "https://example.com",
+        auth_provider: RefreshingAuthProvider.new
+      )
+
+      assert_equal({ "Authorization" => "Bearer TOKEN_1" }, client.resolve_auth_headers)
+      assert_equal({ "Authorization" => "Bearer TOKEN_2" }, client.resolve_auth_headers)
+    end
+  end
+
+  describe "#build_http_request auth header precedence" do
+    let(:client) do
+      Seed::Internal::Http::RawClient.new(
+        base_url: "https://example.com",
+        headers: { "Authorization" => "Bearer STATIC" }
+      )
+    end
+
+    it "lets resolved auth headers override the static default headers" do
+      request = client.build_http_request(
+        url: URI.parse("https://example.com"),
+        method: "GET",
+        auth_headers: { "Authorization" => "Bearer FRESH" }
+      )
+
+      assert_equal("Bearer FRESH", request["Authorization"])
+    end
+
+    it "lets per-request headers take precedence over auth headers" do
+      request = client.build_http_request(
+        url: URI.parse("https://example.com"),
+        method: "GET",
+        headers: { "Authorization" => "Bearer PER_REQUEST" },
+        auth_headers: { "Authorization" => "Bearer FRESH" }
+      )
+
+      assert_equal("Bearer PER_REQUEST", request["Authorization"])
+    end
+
+    it "defaults auth headers to empty, leaving the default headers unchanged" do
+      request = client.build_http_request(url: URI.parse("https://example.com"), method: "GET")
+
+      assert_equal("Bearer STATIC", request["Authorization"])
+    end
+  end
 end

--- a/seed/ruby-sdk-v2/oauth-client-credentials-openapi/lib/seed/client.rb
+++ b/seed/ruby-sdk-v2/oauth-client-credentials-openapi/lib/seed/client.rb
@@ -31,7 +31,8 @@ module Seed
         headers: {
           "User-Agent" => "fern_oauth-client-credentials-openapi/0.0.1",
           "X-Fern-Language" => "Ruby"
-        }.merge(@auth_provider.auth_headers),
+        },
+        auth_provider: @auth_provider,
         max_retries: max_retries
       )
     end

--- a/seed/ruby-sdk-v2/oauth-client-credentials-openapi/lib/seed/internal/http/raw_client.rb
+++ b/seed/ruby-sdk-v2/oauth-client-credentials-openapi/lib/seed/internal/http/raw_client.rb
@@ -21,10 +21,14 @@ module Seed
         # @param max_retries [Integer] The number of times to retry a failed request, defaults to 2.
         # @param timeout [Float] The timeout for the request, defaults to 60.0 seconds.
         # @param headers [Hash] The headers for the request.
-        def initialize(base_url:, max_retries: 2, timeout: 60.0, headers: {})
+        # @param auth_provider [Object, nil] An optional auth provider responding to
+        #   `auth_headers`. When present its headers are resolved on every request so
+        #   token-based schemes (e.g. OAuth) can refresh an expired token mid-session.
+        def initialize(base_url:, max_retries: 2, timeout: 60.0, headers: {}, auth_provider: nil)
           @base_url = base_url
           @max_retries = max_retries
           @timeout = timeout
+          @auth_provider = auth_provider
           @default_headers = {
             "X-Fern-Language": "Ruby",
             "X-Fern-SDK-Name": "seed",
@@ -36,6 +40,9 @@ module Seed
         # @return [HTTP::Response] The HTTP response.
         def send(request)
           url = build_url(request)
+          # Resolve auth headers once per request (not per retry) so token-based
+          # providers refresh at most once here; static providers are cheap.
+          auth_headers = resolve_auth_headers
           attempt = 0
           response = nil
 
@@ -43,8 +50,9 @@ module Seed
             http_request = build_http_request(
               url:,
               method: request.method,
-              headers: request.encode_headers(protected_keys: @default_headers.keys),
-              body: request.encode_body
+              headers: request.encode_headers(protected_keys: @default_headers.keys + auth_headers.keys),
+              body: request.encode_body,
+              auth_headers: auth_headers
             )
 
             conn = connect(url)
@@ -157,12 +165,27 @@ module Seed
                 "HTTP is only allowed for localhost. Use HTTPS or pass a localhost URL."
         end
 
+        # Resolves the auth headers to send with the next request. Delegates to the
+        # configured auth provider (if any) on every call so that token-based
+        # providers (e.g. OAuth client-credentials) can refresh an expired token
+        # before the request is sent. Returns an empty hash when no provider is set,
+        # which keeps the api-key / basic / bearer / no-auth paths unchanged.
+        # @return [Hash] The auth headers for the current request.
+        def resolve_auth_headers
+          return {} if @auth_provider.nil?
+
+          @auth_provider.auth_headers
+        end
+
         # @param url [URI::Generic] The url to the resource.
         # @param method [String] The HTTP method to use.
         # @param headers [Hash] The headers for the request.
         # @param body [String, nil] The body for the request.
+        # @param auth_headers [Hash] The auth headers resolved for this request. These
+        #   take precedence over the static default headers but not over per-request
+        #   headers, mirroring the previous baked-header precedence.
         # @return [HTTP::Request] The HTTP request.
-        def build_http_request(url:, method:, headers: {}, body: nil)
+        def build_http_request(url:, method:, headers: {}, body: nil, auth_headers: {})
           request = Net::HTTPGenericRequest.new(
             method,
             !body.nil?,
@@ -170,7 +193,7 @@ module Seed
             url
           )
 
-          request_headers = @default_headers.merge(headers)
+          request_headers = @default_headers.merge(auth_headers).merge(headers)
           request_headers.each { |name, value| request[name] = value }
           request.body = body if body
 

--- a/seed/ruby-sdk-v2/oauth-client-credentials-openapi/test/unit/internal/http/test_raw_client.rb
+++ b/seed/ruby-sdk-v2/oauth-client-credentials-openapi/test/unit/internal/http/test_raw_client.rb
@@ -54,4 +54,71 @@ describe Seed::Internal::Http::RawClient do
       assert client.should_retry?(make_response(502), 2)
     end
   end
+
+  # A minimal auth provider whose `auth_headers` returns a *different* token on
+  # each call, simulating a token that is refreshed on expiry.
+  class RefreshingAuthProvider
+    def initialize
+      @count = 0
+    end
+
+    def auth_headers
+      @count += 1
+      { "Authorization" => "Bearer TOKEN_#{@count}" }
+    end
+  end
+
+  describe "#resolve_auth_headers" do
+    it "returns an empty hash when no auth provider is configured" do
+      client = Seed::Internal::Http::RawClient.new(base_url: "https://example.com")
+
+      assert_equal({}, client.resolve_auth_headers)
+    end
+
+    it "consults the auth provider on every call so an expired token is refreshed" do
+      client = Seed::Internal::Http::RawClient.new(
+        base_url: "https://example.com",
+        auth_provider: RefreshingAuthProvider.new
+      )
+
+      assert_equal({ "Authorization" => "Bearer TOKEN_1" }, client.resolve_auth_headers)
+      assert_equal({ "Authorization" => "Bearer TOKEN_2" }, client.resolve_auth_headers)
+    end
+  end
+
+  describe "#build_http_request auth header precedence" do
+    let(:client) do
+      Seed::Internal::Http::RawClient.new(
+        base_url: "https://example.com",
+        headers: { "Authorization" => "Bearer STATIC" }
+      )
+    end
+
+    it "lets resolved auth headers override the static default headers" do
+      request = client.build_http_request(
+        url: URI.parse("https://example.com"),
+        method: "GET",
+        auth_headers: { "Authorization" => "Bearer FRESH" }
+      )
+
+      assert_equal("Bearer FRESH", request["Authorization"])
+    end
+
+    it "lets per-request headers take precedence over auth headers" do
+      request = client.build_http_request(
+        url: URI.parse("https://example.com"),
+        method: "GET",
+        headers: { "Authorization" => "Bearer PER_REQUEST" },
+        auth_headers: { "Authorization" => "Bearer FRESH" }
+      )
+
+      assert_equal("Bearer PER_REQUEST", request["Authorization"])
+    end
+
+    it "defaults auth headers to empty, leaving the default headers unchanged" do
+      request = client.build_http_request(url: URI.parse("https://example.com"), method: "GET")
+
+      assert_equal("Bearer STATIC", request["Authorization"])
+    end
+  end
 end

--- a/seed/ruby-sdk-v2/oauth-client-credentials-reference/lib/seed/client.rb
+++ b/seed/ruby-sdk-v2/oauth-client-credentials-reference/lib/seed/client.rb
@@ -31,7 +31,8 @@ module Seed
         headers: {
           "User-Agent" => "fern_oauth-client-credentials-reference/0.0.1",
           "X-Fern-Language" => "Ruby"
-        }.merge(@auth_provider.auth_headers),
+        },
+        auth_provider: @auth_provider,
         max_retries: max_retries
       )
     end

--- a/seed/ruby-sdk-v2/oauth-client-credentials-reference/lib/seed/internal/http/raw_client.rb
+++ b/seed/ruby-sdk-v2/oauth-client-credentials-reference/lib/seed/internal/http/raw_client.rb
@@ -21,10 +21,14 @@ module Seed
         # @param max_retries [Integer] The number of times to retry a failed request, defaults to 2.
         # @param timeout [Float] The timeout for the request, defaults to 60.0 seconds.
         # @param headers [Hash] The headers for the request.
-        def initialize(base_url:, max_retries: 2, timeout: 60.0, headers: {})
+        # @param auth_provider [Object, nil] An optional auth provider responding to
+        #   `auth_headers`. When present its headers are resolved on every request so
+        #   token-based schemes (e.g. OAuth) can refresh an expired token mid-session.
+        def initialize(base_url:, max_retries: 2, timeout: 60.0, headers: {}, auth_provider: nil)
           @base_url = base_url
           @max_retries = max_retries
           @timeout = timeout
+          @auth_provider = auth_provider
           @default_headers = {
             "X-Fern-Language": "Ruby",
             "X-Fern-SDK-Name": "seed",
@@ -36,6 +40,9 @@ module Seed
         # @return [HTTP::Response] The HTTP response.
         def send(request)
           url = build_url(request)
+          # Resolve auth headers once per request (not per retry) so token-based
+          # providers refresh at most once here; static providers are cheap.
+          auth_headers = resolve_auth_headers
           attempt = 0
           response = nil
 
@@ -43,8 +50,9 @@ module Seed
             http_request = build_http_request(
               url:,
               method: request.method,
-              headers: request.encode_headers(protected_keys: @default_headers.keys),
-              body: request.encode_body
+              headers: request.encode_headers(protected_keys: @default_headers.keys + auth_headers.keys),
+              body: request.encode_body,
+              auth_headers: auth_headers
             )
 
             conn = connect(url)
@@ -157,12 +165,27 @@ module Seed
                 "HTTP is only allowed for localhost. Use HTTPS or pass a localhost URL."
         end
 
+        # Resolves the auth headers to send with the next request. Delegates to the
+        # configured auth provider (if any) on every call so that token-based
+        # providers (e.g. OAuth client-credentials) can refresh an expired token
+        # before the request is sent. Returns an empty hash when no provider is set,
+        # which keeps the api-key / basic / bearer / no-auth paths unchanged.
+        # @return [Hash] The auth headers for the current request.
+        def resolve_auth_headers
+          return {} if @auth_provider.nil?
+
+          @auth_provider.auth_headers
+        end
+
         # @param url [URI::Generic] The url to the resource.
         # @param method [String] The HTTP method to use.
         # @param headers [Hash] The headers for the request.
         # @param body [String, nil] The body for the request.
+        # @param auth_headers [Hash] The auth headers resolved for this request. These
+        #   take precedence over the static default headers but not over per-request
+        #   headers, mirroring the previous baked-header precedence.
         # @return [HTTP::Request] The HTTP request.
-        def build_http_request(url:, method:, headers: {}, body: nil)
+        def build_http_request(url:, method:, headers: {}, body: nil, auth_headers: {})
           request = Net::HTTPGenericRequest.new(
             method,
             !body.nil?,
@@ -170,7 +193,7 @@ module Seed
             url
           )
 
-          request_headers = @default_headers.merge(headers)
+          request_headers = @default_headers.merge(auth_headers).merge(headers)
           request_headers.each { |name, value| request[name] = value }
           request.body = body if body
 

--- a/seed/ruby-sdk-v2/oauth-client-credentials-reference/test/unit/internal/http/test_raw_client.rb
+++ b/seed/ruby-sdk-v2/oauth-client-credentials-reference/test/unit/internal/http/test_raw_client.rb
@@ -54,4 +54,71 @@ describe Seed::Internal::Http::RawClient do
       assert client.should_retry?(make_response(502), 2)
     end
   end
+
+  # A minimal auth provider whose `auth_headers` returns a *different* token on
+  # each call, simulating a token that is refreshed on expiry.
+  class RefreshingAuthProvider
+    def initialize
+      @count = 0
+    end
+
+    def auth_headers
+      @count += 1
+      { "Authorization" => "Bearer TOKEN_#{@count}" }
+    end
+  end
+
+  describe "#resolve_auth_headers" do
+    it "returns an empty hash when no auth provider is configured" do
+      client = Seed::Internal::Http::RawClient.new(base_url: "https://example.com")
+
+      assert_equal({}, client.resolve_auth_headers)
+    end
+
+    it "consults the auth provider on every call so an expired token is refreshed" do
+      client = Seed::Internal::Http::RawClient.new(
+        base_url: "https://example.com",
+        auth_provider: RefreshingAuthProvider.new
+      )
+
+      assert_equal({ "Authorization" => "Bearer TOKEN_1" }, client.resolve_auth_headers)
+      assert_equal({ "Authorization" => "Bearer TOKEN_2" }, client.resolve_auth_headers)
+    end
+  end
+
+  describe "#build_http_request auth header precedence" do
+    let(:client) do
+      Seed::Internal::Http::RawClient.new(
+        base_url: "https://example.com",
+        headers: { "Authorization" => "Bearer STATIC" }
+      )
+    end
+
+    it "lets resolved auth headers override the static default headers" do
+      request = client.build_http_request(
+        url: URI.parse("https://example.com"),
+        method: "GET",
+        auth_headers: { "Authorization" => "Bearer FRESH" }
+      )
+
+      assert_equal("Bearer FRESH", request["Authorization"])
+    end
+
+    it "lets per-request headers take precedence over auth headers" do
+      request = client.build_http_request(
+        url: URI.parse("https://example.com"),
+        method: "GET",
+        headers: { "Authorization" => "Bearer PER_REQUEST" },
+        auth_headers: { "Authorization" => "Bearer FRESH" }
+      )
+
+      assert_equal("Bearer PER_REQUEST", request["Authorization"])
+    end
+
+    it "defaults auth headers to empty, leaving the default headers unchanged" do
+      request = client.build_http_request(url: URI.parse("https://example.com"), method: "GET")
+
+      assert_equal("Bearer STATIC", request["Authorization"])
+    end
+  end
 end

--- a/seed/ruby-sdk-v2/oauth-client-credentials-with-variables/lib/seed/client.rb
+++ b/seed/ruby-sdk-v2/oauth-client-credentials-with-variables/lib/seed/client.rb
@@ -31,7 +31,8 @@ module Seed
         headers: {
           "User-Agent" => "fern_oauth-client-credentials-with-variables/0.0.1",
           "X-Fern-Language" => "Ruby"
-        }.merge(@auth_provider.auth_headers),
+        },
+        auth_provider: @auth_provider,
         max_retries: max_retries
       )
     end

--- a/seed/ruby-sdk-v2/oauth-client-credentials-with-variables/lib/seed/internal/http/raw_client.rb
+++ b/seed/ruby-sdk-v2/oauth-client-credentials-with-variables/lib/seed/internal/http/raw_client.rb
@@ -21,10 +21,14 @@ module Seed
         # @param max_retries [Integer] The number of times to retry a failed request, defaults to 2.
         # @param timeout [Float] The timeout for the request, defaults to 60.0 seconds.
         # @param headers [Hash] The headers for the request.
-        def initialize(base_url:, max_retries: 2, timeout: 60.0, headers: {})
+        # @param auth_provider [Object, nil] An optional auth provider responding to
+        #   `auth_headers`. When present its headers are resolved on every request so
+        #   token-based schemes (e.g. OAuth) can refresh an expired token mid-session.
+        def initialize(base_url:, max_retries: 2, timeout: 60.0, headers: {}, auth_provider: nil)
           @base_url = base_url
           @max_retries = max_retries
           @timeout = timeout
+          @auth_provider = auth_provider
           @default_headers = {
             "X-Fern-Language": "Ruby",
             "X-Fern-SDK-Name": "seed",
@@ -36,6 +40,9 @@ module Seed
         # @return [HTTP::Response] The HTTP response.
         def send(request)
           url = build_url(request)
+          # Resolve auth headers once per request (not per retry) so token-based
+          # providers refresh at most once here; static providers are cheap.
+          auth_headers = resolve_auth_headers
           attempt = 0
           response = nil
 
@@ -43,8 +50,9 @@ module Seed
             http_request = build_http_request(
               url:,
               method: request.method,
-              headers: request.encode_headers(protected_keys: @default_headers.keys),
-              body: request.encode_body
+              headers: request.encode_headers(protected_keys: @default_headers.keys + auth_headers.keys),
+              body: request.encode_body,
+              auth_headers: auth_headers
             )
 
             conn = connect(url)
@@ -157,12 +165,27 @@ module Seed
                 "HTTP is only allowed for localhost. Use HTTPS or pass a localhost URL."
         end
 
+        # Resolves the auth headers to send with the next request. Delegates to the
+        # configured auth provider (if any) on every call so that token-based
+        # providers (e.g. OAuth client-credentials) can refresh an expired token
+        # before the request is sent. Returns an empty hash when no provider is set,
+        # which keeps the api-key / basic / bearer / no-auth paths unchanged.
+        # @return [Hash] The auth headers for the current request.
+        def resolve_auth_headers
+          return {} if @auth_provider.nil?
+
+          @auth_provider.auth_headers
+        end
+
         # @param url [URI::Generic] The url to the resource.
         # @param method [String] The HTTP method to use.
         # @param headers [Hash] The headers for the request.
         # @param body [String, nil] The body for the request.
+        # @param auth_headers [Hash] The auth headers resolved for this request. These
+        #   take precedence over the static default headers but not over per-request
+        #   headers, mirroring the previous baked-header precedence.
         # @return [HTTP::Request] The HTTP request.
-        def build_http_request(url:, method:, headers: {}, body: nil)
+        def build_http_request(url:, method:, headers: {}, body: nil, auth_headers: {})
           request = Net::HTTPGenericRequest.new(
             method,
             !body.nil?,
@@ -170,7 +193,7 @@ module Seed
             url
           )
 
-          request_headers = @default_headers.merge(headers)
+          request_headers = @default_headers.merge(auth_headers).merge(headers)
           request_headers.each { |name, value| request[name] = value }
           request.body = body if body
 

--- a/seed/ruby-sdk-v2/oauth-client-credentials-with-variables/test/unit/internal/http/test_raw_client.rb
+++ b/seed/ruby-sdk-v2/oauth-client-credentials-with-variables/test/unit/internal/http/test_raw_client.rb
@@ -54,4 +54,71 @@ describe Seed::Internal::Http::RawClient do
       assert client.should_retry?(make_response(502), 2)
     end
   end
+
+  # A minimal auth provider whose `auth_headers` returns a *different* token on
+  # each call, simulating a token that is refreshed on expiry.
+  class RefreshingAuthProvider
+    def initialize
+      @count = 0
+    end
+
+    def auth_headers
+      @count += 1
+      { "Authorization" => "Bearer TOKEN_#{@count}" }
+    end
+  end
+
+  describe "#resolve_auth_headers" do
+    it "returns an empty hash when no auth provider is configured" do
+      client = Seed::Internal::Http::RawClient.new(base_url: "https://example.com")
+
+      assert_equal({}, client.resolve_auth_headers)
+    end
+
+    it "consults the auth provider on every call so an expired token is refreshed" do
+      client = Seed::Internal::Http::RawClient.new(
+        base_url: "https://example.com",
+        auth_provider: RefreshingAuthProvider.new
+      )
+
+      assert_equal({ "Authorization" => "Bearer TOKEN_1" }, client.resolve_auth_headers)
+      assert_equal({ "Authorization" => "Bearer TOKEN_2" }, client.resolve_auth_headers)
+    end
+  end
+
+  describe "#build_http_request auth header precedence" do
+    let(:client) do
+      Seed::Internal::Http::RawClient.new(
+        base_url: "https://example.com",
+        headers: { "Authorization" => "Bearer STATIC" }
+      )
+    end
+
+    it "lets resolved auth headers override the static default headers" do
+      request = client.build_http_request(
+        url: URI.parse("https://example.com"),
+        method: "GET",
+        auth_headers: { "Authorization" => "Bearer FRESH" }
+      )
+
+      assert_equal("Bearer FRESH", request["Authorization"])
+    end
+
+    it "lets per-request headers take precedence over auth headers" do
+      request = client.build_http_request(
+        url: URI.parse("https://example.com"),
+        method: "GET",
+        headers: { "Authorization" => "Bearer PER_REQUEST" },
+        auth_headers: { "Authorization" => "Bearer FRESH" }
+      )
+
+      assert_equal("Bearer PER_REQUEST", request["Authorization"])
+    end
+
+    it "defaults auth headers to empty, leaving the default headers unchanged" do
+      request = client.build_http_request(url: URI.parse("https://example.com"), method: "GET")
+
+      assert_equal("Bearer STATIC", request["Authorization"])
+    end
+  end
 end

--- a/seed/ruby-sdk-v2/oauth-client-credentials/lib/seed/client.rb
+++ b/seed/ruby-sdk-v2/oauth-client-credentials/lib/seed/client.rb
@@ -31,7 +31,8 @@ module Seed
         headers: {
           "User-Agent" => "fern_oauth-client-credentials/0.0.1",
           "X-Fern-Language" => "Ruby"
-        }.merge(@auth_provider.auth_headers),
+        },
+        auth_provider: @auth_provider,
         max_retries: max_retries
       )
     end

--- a/seed/ruby-sdk-v2/oauth-client-credentials/lib/seed/internal/http/raw_client.rb
+++ b/seed/ruby-sdk-v2/oauth-client-credentials/lib/seed/internal/http/raw_client.rb
@@ -21,10 +21,14 @@ module Seed
         # @param max_retries [Integer] The number of times to retry a failed request, defaults to 2.
         # @param timeout [Float] The timeout for the request, defaults to 60.0 seconds.
         # @param headers [Hash] The headers for the request.
-        def initialize(base_url:, max_retries: 2, timeout: 60.0, headers: {})
+        # @param auth_provider [Object, nil] An optional auth provider responding to
+        #   `auth_headers`. When present its headers are resolved on every request so
+        #   token-based schemes (e.g. OAuth) can refresh an expired token mid-session.
+        def initialize(base_url:, max_retries: 2, timeout: 60.0, headers: {}, auth_provider: nil)
           @base_url = base_url
           @max_retries = max_retries
           @timeout = timeout
+          @auth_provider = auth_provider
           @default_headers = {
             "X-Fern-Language": "Ruby",
             "X-Fern-SDK-Name": "seed",
@@ -36,6 +40,9 @@ module Seed
         # @return [HTTP::Response] The HTTP response.
         def send(request)
           url = build_url(request)
+          # Resolve auth headers once per request (not per retry) so token-based
+          # providers refresh at most once here; static providers are cheap.
+          auth_headers = resolve_auth_headers
           attempt = 0
           response = nil
 
@@ -43,8 +50,9 @@ module Seed
             http_request = build_http_request(
               url:,
               method: request.method,
-              headers: request.encode_headers(protected_keys: @default_headers.keys),
-              body: request.encode_body
+              headers: request.encode_headers(protected_keys: @default_headers.keys + auth_headers.keys),
+              body: request.encode_body,
+              auth_headers: auth_headers
             )
 
             conn = connect(url)
@@ -157,12 +165,27 @@ module Seed
                 "HTTP is only allowed for localhost. Use HTTPS or pass a localhost URL."
         end
 
+        # Resolves the auth headers to send with the next request. Delegates to the
+        # configured auth provider (if any) on every call so that token-based
+        # providers (e.g. OAuth client-credentials) can refresh an expired token
+        # before the request is sent. Returns an empty hash when no provider is set,
+        # which keeps the api-key / basic / bearer / no-auth paths unchanged.
+        # @return [Hash] The auth headers for the current request.
+        def resolve_auth_headers
+          return {} if @auth_provider.nil?
+
+          @auth_provider.auth_headers
+        end
+
         # @param url [URI::Generic] The url to the resource.
         # @param method [String] The HTTP method to use.
         # @param headers [Hash] The headers for the request.
         # @param body [String, nil] The body for the request.
+        # @param auth_headers [Hash] The auth headers resolved for this request. These
+        #   take precedence over the static default headers but not over per-request
+        #   headers, mirroring the previous baked-header precedence.
         # @return [HTTP::Request] The HTTP request.
-        def build_http_request(url:, method:, headers: {}, body: nil)
+        def build_http_request(url:, method:, headers: {}, body: nil, auth_headers: {})
           request = Net::HTTPGenericRequest.new(
             method,
             !body.nil?,
@@ -170,7 +193,7 @@ module Seed
             url
           )
 
-          request_headers = @default_headers.merge(headers)
+          request_headers = @default_headers.merge(auth_headers).merge(headers)
           request_headers.each { |name, value| request[name] = value }
           request.body = body if body
 

--- a/seed/ruby-sdk-v2/oauth-client-credentials/test/unit/internal/http/test_raw_client.rb
+++ b/seed/ruby-sdk-v2/oauth-client-credentials/test/unit/internal/http/test_raw_client.rb
@@ -54,4 +54,71 @@ describe Seed::Internal::Http::RawClient do
       assert client.should_retry?(make_response(502), 2)
     end
   end
+
+  # A minimal auth provider whose `auth_headers` returns a *different* token on
+  # each call, simulating a token that is refreshed on expiry.
+  class RefreshingAuthProvider
+    def initialize
+      @count = 0
+    end
+
+    def auth_headers
+      @count += 1
+      { "Authorization" => "Bearer TOKEN_#{@count}" }
+    end
+  end
+
+  describe "#resolve_auth_headers" do
+    it "returns an empty hash when no auth provider is configured" do
+      client = Seed::Internal::Http::RawClient.new(base_url: "https://example.com")
+
+      assert_equal({}, client.resolve_auth_headers)
+    end
+
+    it "consults the auth provider on every call so an expired token is refreshed" do
+      client = Seed::Internal::Http::RawClient.new(
+        base_url: "https://example.com",
+        auth_provider: RefreshingAuthProvider.new
+      )
+
+      assert_equal({ "Authorization" => "Bearer TOKEN_1" }, client.resolve_auth_headers)
+      assert_equal({ "Authorization" => "Bearer TOKEN_2" }, client.resolve_auth_headers)
+    end
+  end
+
+  describe "#build_http_request auth header precedence" do
+    let(:client) do
+      Seed::Internal::Http::RawClient.new(
+        base_url: "https://example.com",
+        headers: { "Authorization" => "Bearer STATIC" }
+      )
+    end
+
+    it "lets resolved auth headers override the static default headers" do
+      request = client.build_http_request(
+        url: URI.parse("https://example.com"),
+        method: "GET",
+        auth_headers: { "Authorization" => "Bearer FRESH" }
+      )
+
+      assert_equal("Bearer FRESH", request["Authorization"])
+    end
+
+    it "lets per-request headers take precedence over auth headers" do
+      request = client.build_http_request(
+        url: URI.parse("https://example.com"),
+        method: "GET",
+        headers: { "Authorization" => "Bearer PER_REQUEST" },
+        auth_headers: { "Authorization" => "Bearer FRESH" }
+      )
+
+      assert_equal("Bearer PER_REQUEST", request["Authorization"])
+    end
+
+    it "defaults auth headers to empty, leaving the default headers unchanged" do
+      request = client.build_http_request(url: URI.parse("https://example.com"), method: "GET")
+
+      assert_equal("Bearer STATIC", request["Authorization"])
+    end
+  end
 end

--- a/seed/ruby-sdk-v2/object/lib/seed/internal/http/raw_client.rb
+++ b/seed/ruby-sdk-v2/object/lib/seed/internal/http/raw_client.rb
@@ -21,10 +21,14 @@ module Seed
         # @param max_retries [Integer] The number of times to retry a failed request, defaults to 2.
         # @param timeout [Float] The timeout for the request, defaults to 60.0 seconds.
         # @param headers [Hash] The headers for the request.
-        def initialize(base_url:, max_retries: 2, timeout: 60.0, headers: {})
+        # @param auth_provider [Object, nil] An optional auth provider responding to
+        #   `auth_headers`. When present its headers are resolved on every request so
+        #   token-based schemes (e.g. OAuth) can refresh an expired token mid-session.
+        def initialize(base_url:, max_retries: 2, timeout: 60.0, headers: {}, auth_provider: nil)
           @base_url = base_url
           @max_retries = max_retries
           @timeout = timeout
+          @auth_provider = auth_provider
           @default_headers = {
             "X-Fern-Language": "Ruby",
             "X-Fern-SDK-Name": "seed",
@@ -36,6 +40,9 @@ module Seed
         # @return [HTTP::Response] The HTTP response.
         def send(request)
           url = build_url(request)
+          # Resolve auth headers once per request (not per retry) so token-based
+          # providers refresh at most once here; static providers are cheap.
+          auth_headers = resolve_auth_headers
           attempt = 0
           response = nil
 
@@ -43,8 +50,9 @@ module Seed
             http_request = build_http_request(
               url:,
               method: request.method,
-              headers: request.encode_headers(protected_keys: @default_headers.keys),
-              body: request.encode_body
+              headers: request.encode_headers(protected_keys: @default_headers.keys + auth_headers.keys),
+              body: request.encode_body,
+              auth_headers: auth_headers
             )
 
             conn = connect(url)
@@ -157,12 +165,27 @@ module Seed
                 "HTTP is only allowed for localhost. Use HTTPS or pass a localhost URL."
         end
 
+        # Resolves the auth headers to send with the next request. Delegates to the
+        # configured auth provider (if any) on every call so that token-based
+        # providers (e.g. OAuth client-credentials) can refresh an expired token
+        # before the request is sent. Returns an empty hash when no provider is set,
+        # which keeps the api-key / basic / bearer / no-auth paths unchanged.
+        # @return [Hash] The auth headers for the current request.
+        def resolve_auth_headers
+          return {} if @auth_provider.nil?
+
+          @auth_provider.auth_headers
+        end
+
         # @param url [URI::Generic] The url to the resource.
         # @param method [String] The HTTP method to use.
         # @param headers [Hash] The headers for the request.
         # @param body [String, nil] The body for the request.
+        # @param auth_headers [Hash] The auth headers resolved for this request. These
+        #   take precedence over the static default headers but not over per-request
+        #   headers, mirroring the previous baked-header precedence.
         # @return [HTTP::Request] The HTTP request.
-        def build_http_request(url:, method:, headers: {}, body: nil)
+        def build_http_request(url:, method:, headers: {}, body: nil, auth_headers: {})
           request = Net::HTTPGenericRequest.new(
             method,
             !body.nil?,
@@ -170,7 +193,7 @@ module Seed
             url
           )
 
-          request_headers = @default_headers.merge(headers)
+          request_headers = @default_headers.merge(auth_headers).merge(headers)
           request_headers.each { |name, value| request[name] = value }
           request.body = body if body
 

--- a/seed/ruby-sdk-v2/object/test/unit/internal/http/test_raw_client.rb
+++ b/seed/ruby-sdk-v2/object/test/unit/internal/http/test_raw_client.rb
@@ -54,4 +54,71 @@ describe Seed::Internal::Http::RawClient do
       assert client.should_retry?(make_response(502), 2)
     end
   end
+
+  # A minimal auth provider whose `auth_headers` returns a *different* token on
+  # each call, simulating a token that is refreshed on expiry.
+  class RefreshingAuthProvider
+    def initialize
+      @count = 0
+    end
+
+    def auth_headers
+      @count += 1
+      { "Authorization" => "Bearer TOKEN_#{@count}" }
+    end
+  end
+
+  describe "#resolve_auth_headers" do
+    it "returns an empty hash when no auth provider is configured" do
+      client = Seed::Internal::Http::RawClient.new(base_url: "https://example.com")
+
+      assert_equal({}, client.resolve_auth_headers)
+    end
+
+    it "consults the auth provider on every call so an expired token is refreshed" do
+      client = Seed::Internal::Http::RawClient.new(
+        base_url: "https://example.com",
+        auth_provider: RefreshingAuthProvider.new
+      )
+
+      assert_equal({ "Authorization" => "Bearer TOKEN_1" }, client.resolve_auth_headers)
+      assert_equal({ "Authorization" => "Bearer TOKEN_2" }, client.resolve_auth_headers)
+    end
+  end
+
+  describe "#build_http_request auth header precedence" do
+    let(:client) do
+      Seed::Internal::Http::RawClient.new(
+        base_url: "https://example.com",
+        headers: { "Authorization" => "Bearer STATIC" }
+      )
+    end
+
+    it "lets resolved auth headers override the static default headers" do
+      request = client.build_http_request(
+        url: URI.parse("https://example.com"),
+        method: "GET",
+        auth_headers: { "Authorization" => "Bearer FRESH" }
+      )
+
+      assert_equal("Bearer FRESH", request["Authorization"])
+    end
+
+    it "lets per-request headers take precedence over auth headers" do
+      request = client.build_http_request(
+        url: URI.parse("https://example.com"),
+        method: "GET",
+        headers: { "Authorization" => "Bearer PER_REQUEST" },
+        auth_headers: { "Authorization" => "Bearer FRESH" }
+      )
+
+      assert_equal("Bearer PER_REQUEST", request["Authorization"])
+    end
+
+    it "defaults auth headers to empty, leaving the default headers unchanged" do
+      request = client.build_http_request(url: URI.parse("https://example.com"), method: "GET")
+
+      assert_equal("Bearer STATIC", request["Authorization"])
+    end
+  end
 end

--- a/seed/ruby-sdk-v2/objects-with-imports/lib/seed/internal/http/raw_client.rb
+++ b/seed/ruby-sdk-v2/objects-with-imports/lib/seed/internal/http/raw_client.rb
@@ -21,10 +21,14 @@ module Seed
         # @param max_retries [Integer] The number of times to retry a failed request, defaults to 2.
         # @param timeout [Float] The timeout for the request, defaults to 60.0 seconds.
         # @param headers [Hash] The headers for the request.
-        def initialize(base_url:, max_retries: 2, timeout: 60.0, headers: {})
+        # @param auth_provider [Object, nil] An optional auth provider responding to
+        #   `auth_headers`. When present its headers are resolved on every request so
+        #   token-based schemes (e.g. OAuth) can refresh an expired token mid-session.
+        def initialize(base_url:, max_retries: 2, timeout: 60.0, headers: {}, auth_provider: nil)
           @base_url = base_url
           @max_retries = max_retries
           @timeout = timeout
+          @auth_provider = auth_provider
           @default_headers = {
             "X-Fern-Language": "Ruby",
             "X-Fern-SDK-Name": "seed",
@@ -36,6 +40,9 @@ module Seed
         # @return [HTTP::Response] The HTTP response.
         def send(request)
           url = build_url(request)
+          # Resolve auth headers once per request (not per retry) so token-based
+          # providers refresh at most once here; static providers are cheap.
+          auth_headers = resolve_auth_headers
           attempt = 0
           response = nil
 
@@ -43,8 +50,9 @@ module Seed
             http_request = build_http_request(
               url:,
               method: request.method,
-              headers: request.encode_headers(protected_keys: @default_headers.keys),
-              body: request.encode_body
+              headers: request.encode_headers(protected_keys: @default_headers.keys + auth_headers.keys),
+              body: request.encode_body,
+              auth_headers: auth_headers
             )
 
             conn = connect(url)
@@ -157,12 +165,27 @@ module Seed
                 "HTTP is only allowed for localhost. Use HTTPS or pass a localhost URL."
         end
 
+        # Resolves the auth headers to send with the next request. Delegates to the
+        # configured auth provider (if any) on every call so that token-based
+        # providers (e.g. OAuth client-credentials) can refresh an expired token
+        # before the request is sent. Returns an empty hash when no provider is set,
+        # which keeps the api-key / basic / bearer / no-auth paths unchanged.
+        # @return [Hash] The auth headers for the current request.
+        def resolve_auth_headers
+          return {} if @auth_provider.nil?
+
+          @auth_provider.auth_headers
+        end
+
         # @param url [URI::Generic] The url to the resource.
         # @param method [String] The HTTP method to use.
         # @param headers [Hash] The headers for the request.
         # @param body [String, nil] The body for the request.
+        # @param auth_headers [Hash] The auth headers resolved for this request. These
+        #   take precedence over the static default headers but not over per-request
+        #   headers, mirroring the previous baked-header precedence.
         # @return [HTTP::Request] The HTTP request.
-        def build_http_request(url:, method:, headers: {}, body: nil)
+        def build_http_request(url:, method:, headers: {}, body: nil, auth_headers: {})
           request = Net::HTTPGenericRequest.new(
             method,
             !body.nil?,
@@ -170,7 +193,7 @@ module Seed
             url
           )
 
-          request_headers = @default_headers.merge(headers)
+          request_headers = @default_headers.merge(auth_headers).merge(headers)
           request_headers.each { |name, value| request[name] = value }
           request.body = body if body
 

--- a/seed/ruby-sdk-v2/objects-with-imports/test/unit/internal/http/test_raw_client.rb
+++ b/seed/ruby-sdk-v2/objects-with-imports/test/unit/internal/http/test_raw_client.rb
@@ -54,4 +54,71 @@ describe Seed::Internal::Http::RawClient do
       assert client.should_retry?(make_response(502), 2)
     end
   end
+
+  # A minimal auth provider whose `auth_headers` returns a *different* token on
+  # each call, simulating a token that is refreshed on expiry.
+  class RefreshingAuthProvider
+    def initialize
+      @count = 0
+    end
+
+    def auth_headers
+      @count += 1
+      { "Authorization" => "Bearer TOKEN_#{@count}" }
+    end
+  end
+
+  describe "#resolve_auth_headers" do
+    it "returns an empty hash when no auth provider is configured" do
+      client = Seed::Internal::Http::RawClient.new(base_url: "https://example.com")
+
+      assert_equal({}, client.resolve_auth_headers)
+    end
+
+    it "consults the auth provider on every call so an expired token is refreshed" do
+      client = Seed::Internal::Http::RawClient.new(
+        base_url: "https://example.com",
+        auth_provider: RefreshingAuthProvider.new
+      )
+
+      assert_equal({ "Authorization" => "Bearer TOKEN_1" }, client.resolve_auth_headers)
+      assert_equal({ "Authorization" => "Bearer TOKEN_2" }, client.resolve_auth_headers)
+    end
+  end
+
+  describe "#build_http_request auth header precedence" do
+    let(:client) do
+      Seed::Internal::Http::RawClient.new(
+        base_url: "https://example.com",
+        headers: { "Authorization" => "Bearer STATIC" }
+      )
+    end
+
+    it "lets resolved auth headers override the static default headers" do
+      request = client.build_http_request(
+        url: URI.parse("https://example.com"),
+        method: "GET",
+        auth_headers: { "Authorization" => "Bearer FRESH" }
+      )
+
+      assert_equal("Bearer FRESH", request["Authorization"])
+    end
+
+    it "lets per-request headers take precedence over auth headers" do
+      request = client.build_http_request(
+        url: URI.parse("https://example.com"),
+        method: "GET",
+        headers: { "Authorization" => "Bearer PER_REQUEST" },
+        auth_headers: { "Authorization" => "Bearer FRESH" }
+      )
+
+      assert_equal("Bearer PER_REQUEST", request["Authorization"])
+    end
+
+    it "defaults auth headers to empty, leaving the default headers unchanged" do
+      request = client.build_http_request(url: URI.parse("https://example.com"), method: "GET")
+
+      assert_equal("Bearer STATIC", request["Authorization"])
+    end
+  end
 end

--- a/seed/ruby-sdk-v2/openapi-request-body-ref/lib/seed/internal/http/raw_client.rb
+++ b/seed/ruby-sdk-v2/openapi-request-body-ref/lib/seed/internal/http/raw_client.rb
@@ -21,10 +21,14 @@ module Seed
         # @param max_retries [Integer] The number of times to retry a failed request, defaults to 2.
         # @param timeout [Float] The timeout for the request, defaults to 60.0 seconds.
         # @param headers [Hash] The headers for the request.
-        def initialize(base_url:, max_retries: 2, timeout: 60.0, headers: {})
+        # @param auth_provider [Object, nil] An optional auth provider responding to
+        #   `auth_headers`. When present its headers are resolved on every request so
+        #   token-based schemes (e.g. OAuth) can refresh an expired token mid-session.
+        def initialize(base_url:, max_retries: 2, timeout: 60.0, headers: {}, auth_provider: nil)
           @base_url = base_url
           @max_retries = max_retries
           @timeout = timeout
+          @auth_provider = auth_provider
           @default_headers = {
             "X-Fern-Language": "Ruby",
             "X-Fern-SDK-Name": "seed",
@@ -36,6 +40,9 @@ module Seed
         # @return [HTTP::Response] The HTTP response.
         def send(request)
           url = build_url(request)
+          # Resolve auth headers once per request (not per retry) so token-based
+          # providers refresh at most once here; static providers are cheap.
+          auth_headers = resolve_auth_headers
           attempt = 0
           response = nil
 
@@ -43,8 +50,9 @@ module Seed
             http_request = build_http_request(
               url:,
               method: request.method,
-              headers: request.encode_headers(protected_keys: @default_headers.keys),
-              body: request.encode_body
+              headers: request.encode_headers(protected_keys: @default_headers.keys + auth_headers.keys),
+              body: request.encode_body,
+              auth_headers: auth_headers
             )
 
             conn = connect(url)
@@ -157,12 +165,27 @@ module Seed
                 "HTTP is only allowed for localhost. Use HTTPS or pass a localhost URL."
         end
 
+        # Resolves the auth headers to send with the next request. Delegates to the
+        # configured auth provider (if any) on every call so that token-based
+        # providers (e.g. OAuth client-credentials) can refresh an expired token
+        # before the request is sent. Returns an empty hash when no provider is set,
+        # which keeps the api-key / basic / bearer / no-auth paths unchanged.
+        # @return [Hash] The auth headers for the current request.
+        def resolve_auth_headers
+          return {} if @auth_provider.nil?
+
+          @auth_provider.auth_headers
+        end
+
         # @param url [URI::Generic] The url to the resource.
         # @param method [String] The HTTP method to use.
         # @param headers [Hash] The headers for the request.
         # @param body [String, nil] The body for the request.
+        # @param auth_headers [Hash] The auth headers resolved for this request. These
+        #   take precedence over the static default headers but not over per-request
+        #   headers, mirroring the previous baked-header precedence.
         # @return [HTTP::Request] The HTTP request.
-        def build_http_request(url:, method:, headers: {}, body: nil)
+        def build_http_request(url:, method:, headers: {}, body: nil, auth_headers: {})
           request = Net::HTTPGenericRequest.new(
             method,
             !body.nil?,
@@ -170,7 +193,7 @@ module Seed
             url
           )
 
-          request_headers = @default_headers.merge(headers)
+          request_headers = @default_headers.merge(auth_headers).merge(headers)
           request_headers.each { |name, value| request[name] = value }
           request.body = body if body
 

--- a/seed/ruby-sdk-v2/openapi-request-body-ref/test/unit/internal/http/test_raw_client.rb
+++ b/seed/ruby-sdk-v2/openapi-request-body-ref/test/unit/internal/http/test_raw_client.rb
@@ -54,4 +54,71 @@ describe Seed::Internal::Http::RawClient do
       assert client.should_retry?(make_response(502), 2)
     end
   end
+
+  # A minimal auth provider whose `auth_headers` returns a *different* token on
+  # each call, simulating a token that is refreshed on expiry.
+  class RefreshingAuthProvider
+    def initialize
+      @count = 0
+    end
+
+    def auth_headers
+      @count += 1
+      { "Authorization" => "Bearer TOKEN_#{@count}" }
+    end
+  end
+
+  describe "#resolve_auth_headers" do
+    it "returns an empty hash when no auth provider is configured" do
+      client = Seed::Internal::Http::RawClient.new(base_url: "https://example.com")
+
+      assert_equal({}, client.resolve_auth_headers)
+    end
+
+    it "consults the auth provider on every call so an expired token is refreshed" do
+      client = Seed::Internal::Http::RawClient.new(
+        base_url: "https://example.com",
+        auth_provider: RefreshingAuthProvider.new
+      )
+
+      assert_equal({ "Authorization" => "Bearer TOKEN_1" }, client.resolve_auth_headers)
+      assert_equal({ "Authorization" => "Bearer TOKEN_2" }, client.resolve_auth_headers)
+    end
+  end
+
+  describe "#build_http_request auth header precedence" do
+    let(:client) do
+      Seed::Internal::Http::RawClient.new(
+        base_url: "https://example.com",
+        headers: { "Authorization" => "Bearer STATIC" }
+      )
+    end
+
+    it "lets resolved auth headers override the static default headers" do
+      request = client.build_http_request(
+        url: URI.parse("https://example.com"),
+        method: "GET",
+        auth_headers: { "Authorization" => "Bearer FRESH" }
+      )
+
+      assert_equal("Bearer FRESH", request["Authorization"])
+    end
+
+    it "lets per-request headers take precedence over auth headers" do
+      request = client.build_http_request(
+        url: URI.parse("https://example.com"),
+        method: "GET",
+        headers: { "Authorization" => "Bearer PER_REQUEST" },
+        auth_headers: { "Authorization" => "Bearer FRESH" }
+      )
+
+      assert_equal("Bearer PER_REQUEST", request["Authorization"])
+    end
+
+    it "defaults auth headers to empty, leaving the default headers unchanged" do
+      request = client.build_http_request(url: URI.parse("https://example.com"), method: "GET")
+
+      assert_equal("Bearer STATIC", request["Authorization"])
+    end
+  end
 end

--- a/seed/ruby-sdk-v2/openapi-subtitle/lib/seed/internal/http/raw_client.rb
+++ b/seed/ruby-sdk-v2/openapi-subtitle/lib/seed/internal/http/raw_client.rb
@@ -21,10 +21,14 @@ module Seed
         # @param max_retries [Integer] The number of times to retry a failed request, defaults to 2.
         # @param timeout [Float] The timeout for the request, defaults to 60.0 seconds.
         # @param headers [Hash] The headers for the request.
-        def initialize(base_url:, max_retries: 2, timeout: 60.0, headers: {})
+        # @param auth_provider [Object, nil] An optional auth provider responding to
+        #   `auth_headers`. When present its headers are resolved on every request so
+        #   token-based schemes (e.g. OAuth) can refresh an expired token mid-session.
+        def initialize(base_url:, max_retries: 2, timeout: 60.0, headers: {}, auth_provider: nil)
           @base_url = base_url
           @max_retries = max_retries
           @timeout = timeout
+          @auth_provider = auth_provider
           @default_headers = {
             "X-Fern-Language": "Ruby",
             "X-Fern-SDK-Name": "seed",
@@ -36,6 +40,9 @@ module Seed
         # @return [HTTP::Response] The HTTP response.
         def send(request)
           url = build_url(request)
+          # Resolve auth headers once per request (not per retry) so token-based
+          # providers refresh at most once here; static providers are cheap.
+          auth_headers = resolve_auth_headers
           attempt = 0
           response = nil
 
@@ -43,8 +50,9 @@ module Seed
             http_request = build_http_request(
               url:,
               method: request.method,
-              headers: request.encode_headers(protected_keys: @default_headers.keys),
-              body: request.encode_body
+              headers: request.encode_headers(protected_keys: @default_headers.keys + auth_headers.keys),
+              body: request.encode_body,
+              auth_headers: auth_headers
             )
 
             conn = connect(url)
@@ -157,12 +165,27 @@ module Seed
                 "HTTP is only allowed for localhost. Use HTTPS or pass a localhost URL."
         end
 
+        # Resolves the auth headers to send with the next request. Delegates to the
+        # configured auth provider (if any) on every call so that token-based
+        # providers (e.g. OAuth client-credentials) can refresh an expired token
+        # before the request is sent. Returns an empty hash when no provider is set,
+        # which keeps the api-key / basic / bearer / no-auth paths unchanged.
+        # @return [Hash] The auth headers for the current request.
+        def resolve_auth_headers
+          return {} if @auth_provider.nil?
+
+          @auth_provider.auth_headers
+        end
+
         # @param url [URI::Generic] The url to the resource.
         # @param method [String] The HTTP method to use.
         # @param headers [Hash] The headers for the request.
         # @param body [String, nil] The body for the request.
+        # @param auth_headers [Hash] The auth headers resolved for this request. These
+        #   take precedence over the static default headers but not over per-request
+        #   headers, mirroring the previous baked-header precedence.
         # @return [HTTP::Request] The HTTP request.
-        def build_http_request(url:, method:, headers: {}, body: nil)
+        def build_http_request(url:, method:, headers: {}, body: nil, auth_headers: {})
           request = Net::HTTPGenericRequest.new(
             method,
             !body.nil?,
@@ -170,7 +193,7 @@ module Seed
             url
           )
 
-          request_headers = @default_headers.merge(headers)
+          request_headers = @default_headers.merge(auth_headers).merge(headers)
           request_headers.each { |name, value| request[name] = value }
           request.body = body if body
 

--- a/seed/ruby-sdk-v2/openapi-subtitle/test/unit/internal/http/test_raw_client.rb
+++ b/seed/ruby-sdk-v2/openapi-subtitle/test/unit/internal/http/test_raw_client.rb
@@ -54,4 +54,71 @@ describe Seed::Internal::Http::RawClient do
       assert client.should_retry?(make_response(502), 2)
     end
   end
+
+  # A minimal auth provider whose `auth_headers` returns a *different* token on
+  # each call, simulating a token that is refreshed on expiry.
+  class RefreshingAuthProvider
+    def initialize
+      @count = 0
+    end
+
+    def auth_headers
+      @count += 1
+      { "Authorization" => "Bearer TOKEN_#{@count}" }
+    end
+  end
+
+  describe "#resolve_auth_headers" do
+    it "returns an empty hash when no auth provider is configured" do
+      client = Seed::Internal::Http::RawClient.new(base_url: "https://example.com")
+
+      assert_equal({}, client.resolve_auth_headers)
+    end
+
+    it "consults the auth provider on every call so an expired token is refreshed" do
+      client = Seed::Internal::Http::RawClient.new(
+        base_url: "https://example.com",
+        auth_provider: RefreshingAuthProvider.new
+      )
+
+      assert_equal({ "Authorization" => "Bearer TOKEN_1" }, client.resolve_auth_headers)
+      assert_equal({ "Authorization" => "Bearer TOKEN_2" }, client.resolve_auth_headers)
+    end
+  end
+
+  describe "#build_http_request auth header precedence" do
+    let(:client) do
+      Seed::Internal::Http::RawClient.new(
+        base_url: "https://example.com",
+        headers: { "Authorization" => "Bearer STATIC" }
+      )
+    end
+
+    it "lets resolved auth headers override the static default headers" do
+      request = client.build_http_request(
+        url: URI.parse("https://example.com"),
+        method: "GET",
+        auth_headers: { "Authorization" => "Bearer FRESH" }
+      )
+
+      assert_equal("Bearer FRESH", request["Authorization"])
+    end
+
+    it "lets per-request headers take precedence over auth headers" do
+      request = client.build_http_request(
+        url: URI.parse("https://example.com"),
+        method: "GET",
+        headers: { "Authorization" => "Bearer PER_REQUEST" },
+        auth_headers: { "Authorization" => "Bearer FRESH" }
+      )
+
+      assert_equal("Bearer PER_REQUEST", request["Authorization"])
+    end
+
+    it "defaults auth headers to empty, leaving the default headers unchanged" do
+      request = client.build_http_request(url: URI.parse("https://example.com"), method: "GET")
+
+      assert_equal("Bearer STATIC", request["Authorization"])
+    end
+  end
 end

--- a/seed/ruby-sdk-v2/optional/lib/seed/internal/http/raw_client.rb
+++ b/seed/ruby-sdk-v2/optional/lib/seed/internal/http/raw_client.rb
@@ -21,10 +21,14 @@ module Seed
         # @param max_retries [Integer] The number of times to retry a failed request, defaults to 2.
         # @param timeout [Float] The timeout for the request, defaults to 60.0 seconds.
         # @param headers [Hash] The headers for the request.
-        def initialize(base_url:, max_retries: 2, timeout: 60.0, headers: {})
+        # @param auth_provider [Object, nil] An optional auth provider responding to
+        #   `auth_headers`. When present its headers are resolved on every request so
+        #   token-based schemes (e.g. OAuth) can refresh an expired token mid-session.
+        def initialize(base_url:, max_retries: 2, timeout: 60.0, headers: {}, auth_provider: nil)
           @base_url = base_url
           @max_retries = max_retries
           @timeout = timeout
+          @auth_provider = auth_provider
           @default_headers = {
             "X-Fern-Language": "Ruby",
             "X-Fern-SDK-Name": "seed",
@@ -36,6 +40,9 @@ module Seed
         # @return [HTTP::Response] The HTTP response.
         def send(request)
           url = build_url(request)
+          # Resolve auth headers once per request (not per retry) so token-based
+          # providers refresh at most once here; static providers are cheap.
+          auth_headers = resolve_auth_headers
           attempt = 0
           response = nil
 
@@ -43,8 +50,9 @@ module Seed
             http_request = build_http_request(
               url:,
               method: request.method,
-              headers: request.encode_headers(protected_keys: @default_headers.keys),
-              body: request.encode_body
+              headers: request.encode_headers(protected_keys: @default_headers.keys + auth_headers.keys),
+              body: request.encode_body,
+              auth_headers: auth_headers
             )
 
             conn = connect(url)
@@ -157,12 +165,27 @@ module Seed
                 "HTTP is only allowed for localhost. Use HTTPS or pass a localhost URL."
         end
 
+        # Resolves the auth headers to send with the next request. Delegates to the
+        # configured auth provider (if any) on every call so that token-based
+        # providers (e.g. OAuth client-credentials) can refresh an expired token
+        # before the request is sent. Returns an empty hash when no provider is set,
+        # which keeps the api-key / basic / bearer / no-auth paths unchanged.
+        # @return [Hash] The auth headers for the current request.
+        def resolve_auth_headers
+          return {} if @auth_provider.nil?
+
+          @auth_provider.auth_headers
+        end
+
         # @param url [URI::Generic] The url to the resource.
         # @param method [String] The HTTP method to use.
         # @param headers [Hash] The headers for the request.
         # @param body [String, nil] The body for the request.
+        # @param auth_headers [Hash] The auth headers resolved for this request. These
+        #   take precedence over the static default headers but not over per-request
+        #   headers, mirroring the previous baked-header precedence.
         # @return [HTTP::Request] The HTTP request.
-        def build_http_request(url:, method:, headers: {}, body: nil)
+        def build_http_request(url:, method:, headers: {}, body: nil, auth_headers: {})
           request = Net::HTTPGenericRequest.new(
             method,
             !body.nil?,
@@ -170,7 +193,7 @@ module Seed
             url
           )
 
-          request_headers = @default_headers.merge(headers)
+          request_headers = @default_headers.merge(auth_headers).merge(headers)
           request_headers.each { |name, value| request[name] = value }
           request.body = body if body
 

--- a/seed/ruby-sdk-v2/optional/test/unit/internal/http/test_raw_client.rb
+++ b/seed/ruby-sdk-v2/optional/test/unit/internal/http/test_raw_client.rb
@@ -54,4 +54,71 @@ describe Seed::Internal::Http::RawClient do
       assert client.should_retry?(make_response(502), 2)
     end
   end
+
+  # A minimal auth provider whose `auth_headers` returns a *different* token on
+  # each call, simulating a token that is refreshed on expiry.
+  class RefreshingAuthProvider
+    def initialize
+      @count = 0
+    end
+
+    def auth_headers
+      @count += 1
+      { "Authorization" => "Bearer TOKEN_#{@count}" }
+    end
+  end
+
+  describe "#resolve_auth_headers" do
+    it "returns an empty hash when no auth provider is configured" do
+      client = Seed::Internal::Http::RawClient.new(base_url: "https://example.com")
+
+      assert_equal({}, client.resolve_auth_headers)
+    end
+
+    it "consults the auth provider on every call so an expired token is refreshed" do
+      client = Seed::Internal::Http::RawClient.new(
+        base_url: "https://example.com",
+        auth_provider: RefreshingAuthProvider.new
+      )
+
+      assert_equal({ "Authorization" => "Bearer TOKEN_1" }, client.resolve_auth_headers)
+      assert_equal({ "Authorization" => "Bearer TOKEN_2" }, client.resolve_auth_headers)
+    end
+  end
+
+  describe "#build_http_request auth header precedence" do
+    let(:client) do
+      Seed::Internal::Http::RawClient.new(
+        base_url: "https://example.com",
+        headers: { "Authorization" => "Bearer STATIC" }
+      )
+    end
+
+    it "lets resolved auth headers override the static default headers" do
+      request = client.build_http_request(
+        url: URI.parse("https://example.com"),
+        method: "GET",
+        auth_headers: { "Authorization" => "Bearer FRESH" }
+      )
+
+      assert_equal("Bearer FRESH", request["Authorization"])
+    end
+
+    it "lets per-request headers take precedence over auth headers" do
+      request = client.build_http_request(
+        url: URI.parse("https://example.com"),
+        method: "GET",
+        headers: { "Authorization" => "Bearer PER_REQUEST" },
+        auth_headers: { "Authorization" => "Bearer FRESH" }
+      )
+
+      assert_equal("Bearer PER_REQUEST", request["Authorization"])
+    end
+
+    it "defaults auth headers to empty, leaving the default headers unchanged" do
+      request = client.build_http_request(url: URI.parse("https://example.com"), method: "GET")
+
+      assert_equal("Bearer STATIC", request["Authorization"])
+    end
+  end
 end

--- a/seed/ruby-sdk-v2/package-yml/lib/seed/internal/http/raw_client.rb
+++ b/seed/ruby-sdk-v2/package-yml/lib/seed/internal/http/raw_client.rb
@@ -21,10 +21,14 @@ module Seed
         # @param max_retries [Integer] The number of times to retry a failed request, defaults to 2.
         # @param timeout [Float] The timeout for the request, defaults to 60.0 seconds.
         # @param headers [Hash] The headers for the request.
-        def initialize(base_url:, max_retries: 2, timeout: 60.0, headers: {})
+        # @param auth_provider [Object, nil] An optional auth provider responding to
+        #   `auth_headers`. When present its headers are resolved on every request so
+        #   token-based schemes (e.g. OAuth) can refresh an expired token mid-session.
+        def initialize(base_url:, max_retries: 2, timeout: 60.0, headers: {}, auth_provider: nil)
           @base_url = base_url
           @max_retries = max_retries
           @timeout = timeout
+          @auth_provider = auth_provider
           @default_headers = {
             "X-Fern-Language": "Ruby",
             "X-Fern-SDK-Name": "seed",
@@ -36,6 +40,9 @@ module Seed
         # @return [HTTP::Response] The HTTP response.
         def send(request)
           url = build_url(request)
+          # Resolve auth headers once per request (not per retry) so token-based
+          # providers refresh at most once here; static providers are cheap.
+          auth_headers = resolve_auth_headers
           attempt = 0
           response = nil
 
@@ -43,8 +50,9 @@ module Seed
             http_request = build_http_request(
               url:,
               method: request.method,
-              headers: request.encode_headers(protected_keys: @default_headers.keys),
-              body: request.encode_body
+              headers: request.encode_headers(protected_keys: @default_headers.keys + auth_headers.keys),
+              body: request.encode_body,
+              auth_headers: auth_headers
             )
 
             conn = connect(url)
@@ -157,12 +165,27 @@ module Seed
                 "HTTP is only allowed for localhost. Use HTTPS or pass a localhost URL."
         end
 
+        # Resolves the auth headers to send with the next request. Delegates to the
+        # configured auth provider (if any) on every call so that token-based
+        # providers (e.g. OAuth client-credentials) can refresh an expired token
+        # before the request is sent. Returns an empty hash when no provider is set,
+        # which keeps the api-key / basic / bearer / no-auth paths unchanged.
+        # @return [Hash] The auth headers for the current request.
+        def resolve_auth_headers
+          return {} if @auth_provider.nil?
+
+          @auth_provider.auth_headers
+        end
+
         # @param url [URI::Generic] The url to the resource.
         # @param method [String] The HTTP method to use.
         # @param headers [Hash] The headers for the request.
         # @param body [String, nil] The body for the request.
+        # @param auth_headers [Hash] The auth headers resolved for this request. These
+        #   take precedence over the static default headers but not over per-request
+        #   headers, mirroring the previous baked-header precedence.
         # @return [HTTP::Request] The HTTP request.
-        def build_http_request(url:, method:, headers: {}, body: nil)
+        def build_http_request(url:, method:, headers: {}, body: nil, auth_headers: {})
           request = Net::HTTPGenericRequest.new(
             method,
             !body.nil?,
@@ -170,7 +193,7 @@ module Seed
             url
           )
 
-          request_headers = @default_headers.merge(headers)
+          request_headers = @default_headers.merge(auth_headers).merge(headers)
           request_headers.each { |name, value| request[name] = value }
           request.body = body if body
 

--- a/seed/ruby-sdk-v2/package-yml/test/unit/internal/http/test_raw_client.rb
+++ b/seed/ruby-sdk-v2/package-yml/test/unit/internal/http/test_raw_client.rb
@@ -54,4 +54,71 @@ describe Seed::Internal::Http::RawClient do
       assert client.should_retry?(make_response(502), 2)
     end
   end
+
+  # A minimal auth provider whose `auth_headers` returns a *different* token on
+  # each call, simulating a token that is refreshed on expiry.
+  class RefreshingAuthProvider
+    def initialize
+      @count = 0
+    end
+
+    def auth_headers
+      @count += 1
+      { "Authorization" => "Bearer TOKEN_#{@count}" }
+    end
+  end
+
+  describe "#resolve_auth_headers" do
+    it "returns an empty hash when no auth provider is configured" do
+      client = Seed::Internal::Http::RawClient.new(base_url: "https://example.com")
+
+      assert_equal({}, client.resolve_auth_headers)
+    end
+
+    it "consults the auth provider on every call so an expired token is refreshed" do
+      client = Seed::Internal::Http::RawClient.new(
+        base_url: "https://example.com",
+        auth_provider: RefreshingAuthProvider.new
+      )
+
+      assert_equal({ "Authorization" => "Bearer TOKEN_1" }, client.resolve_auth_headers)
+      assert_equal({ "Authorization" => "Bearer TOKEN_2" }, client.resolve_auth_headers)
+    end
+  end
+
+  describe "#build_http_request auth header precedence" do
+    let(:client) do
+      Seed::Internal::Http::RawClient.new(
+        base_url: "https://example.com",
+        headers: { "Authorization" => "Bearer STATIC" }
+      )
+    end
+
+    it "lets resolved auth headers override the static default headers" do
+      request = client.build_http_request(
+        url: URI.parse("https://example.com"),
+        method: "GET",
+        auth_headers: { "Authorization" => "Bearer FRESH" }
+      )
+
+      assert_equal("Bearer FRESH", request["Authorization"])
+    end
+
+    it "lets per-request headers take precedence over auth headers" do
+      request = client.build_http_request(
+        url: URI.parse("https://example.com"),
+        method: "GET",
+        headers: { "Authorization" => "Bearer PER_REQUEST" },
+        auth_headers: { "Authorization" => "Bearer FRESH" }
+      )
+
+      assert_equal("Bearer PER_REQUEST", request["Authorization"])
+    end
+
+    it "defaults auth headers to empty, leaving the default headers unchanged" do
+      request = client.build_http_request(url: URI.parse("https://example.com"), method: "GET")
+
+      assert_equal("Bearer STATIC", request["Authorization"])
+    end
+  end
 end

--- a/seed/ruby-sdk-v2/pagination-custom/lib/seed/internal/http/raw_client.rb
+++ b/seed/ruby-sdk-v2/pagination-custom/lib/seed/internal/http/raw_client.rb
@@ -21,10 +21,14 @@ module Seed
         # @param max_retries [Integer] The number of times to retry a failed request, defaults to 2.
         # @param timeout [Float] The timeout for the request, defaults to 60.0 seconds.
         # @param headers [Hash] The headers for the request.
-        def initialize(base_url:, max_retries: 2, timeout: 60.0, headers: {})
+        # @param auth_provider [Object, nil] An optional auth provider responding to
+        #   `auth_headers`. When present its headers are resolved on every request so
+        #   token-based schemes (e.g. OAuth) can refresh an expired token mid-session.
+        def initialize(base_url:, max_retries: 2, timeout: 60.0, headers: {}, auth_provider: nil)
           @base_url = base_url
           @max_retries = max_retries
           @timeout = timeout
+          @auth_provider = auth_provider
           @default_headers = {
             "X-Fern-Language": "Ruby",
             "X-Fern-SDK-Name": "seed",
@@ -36,6 +40,9 @@ module Seed
         # @return [HTTP::Response] The HTTP response.
         def send(request)
           url = build_url(request)
+          # Resolve auth headers once per request (not per retry) so token-based
+          # providers refresh at most once here; static providers are cheap.
+          auth_headers = resolve_auth_headers
           attempt = 0
           response = nil
 
@@ -43,8 +50,9 @@ module Seed
             http_request = build_http_request(
               url:,
               method: request.method,
-              headers: request.encode_headers(protected_keys: @default_headers.keys),
-              body: request.encode_body
+              headers: request.encode_headers(protected_keys: @default_headers.keys + auth_headers.keys),
+              body: request.encode_body,
+              auth_headers: auth_headers
             )
 
             conn = connect(url)
@@ -157,12 +165,27 @@ module Seed
                 "HTTP is only allowed for localhost. Use HTTPS or pass a localhost URL."
         end
 
+        # Resolves the auth headers to send with the next request. Delegates to the
+        # configured auth provider (if any) on every call so that token-based
+        # providers (e.g. OAuth client-credentials) can refresh an expired token
+        # before the request is sent. Returns an empty hash when no provider is set,
+        # which keeps the api-key / basic / bearer / no-auth paths unchanged.
+        # @return [Hash] The auth headers for the current request.
+        def resolve_auth_headers
+          return {} if @auth_provider.nil?
+
+          @auth_provider.auth_headers
+        end
+
         # @param url [URI::Generic] The url to the resource.
         # @param method [String] The HTTP method to use.
         # @param headers [Hash] The headers for the request.
         # @param body [String, nil] The body for the request.
+        # @param auth_headers [Hash] The auth headers resolved for this request. These
+        #   take precedence over the static default headers but not over per-request
+        #   headers, mirroring the previous baked-header precedence.
         # @return [HTTP::Request] The HTTP request.
-        def build_http_request(url:, method:, headers: {}, body: nil)
+        def build_http_request(url:, method:, headers: {}, body: nil, auth_headers: {})
           request = Net::HTTPGenericRequest.new(
             method,
             !body.nil?,
@@ -170,7 +193,7 @@ module Seed
             url
           )
 
-          request_headers = @default_headers.merge(headers)
+          request_headers = @default_headers.merge(auth_headers).merge(headers)
           request_headers.each { |name, value| request[name] = value }
           request.body = body if body
 

--- a/seed/ruby-sdk-v2/pagination-custom/test/unit/internal/http/test_raw_client.rb
+++ b/seed/ruby-sdk-v2/pagination-custom/test/unit/internal/http/test_raw_client.rb
@@ -54,4 +54,71 @@ describe Seed::Internal::Http::RawClient do
       assert client.should_retry?(make_response(502), 2)
     end
   end
+
+  # A minimal auth provider whose `auth_headers` returns a *different* token on
+  # each call, simulating a token that is refreshed on expiry.
+  class RefreshingAuthProvider
+    def initialize
+      @count = 0
+    end
+
+    def auth_headers
+      @count += 1
+      { "Authorization" => "Bearer TOKEN_#{@count}" }
+    end
+  end
+
+  describe "#resolve_auth_headers" do
+    it "returns an empty hash when no auth provider is configured" do
+      client = Seed::Internal::Http::RawClient.new(base_url: "https://example.com")
+
+      assert_equal({}, client.resolve_auth_headers)
+    end
+
+    it "consults the auth provider on every call so an expired token is refreshed" do
+      client = Seed::Internal::Http::RawClient.new(
+        base_url: "https://example.com",
+        auth_provider: RefreshingAuthProvider.new
+      )
+
+      assert_equal({ "Authorization" => "Bearer TOKEN_1" }, client.resolve_auth_headers)
+      assert_equal({ "Authorization" => "Bearer TOKEN_2" }, client.resolve_auth_headers)
+    end
+  end
+
+  describe "#build_http_request auth header precedence" do
+    let(:client) do
+      Seed::Internal::Http::RawClient.new(
+        base_url: "https://example.com",
+        headers: { "Authorization" => "Bearer STATIC" }
+      )
+    end
+
+    it "lets resolved auth headers override the static default headers" do
+      request = client.build_http_request(
+        url: URI.parse("https://example.com"),
+        method: "GET",
+        auth_headers: { "Authorization" => "Bearer FRESH" }
+      )
+
+      assert_equal("Bearer FRESH", request["Authorization"])
+    end
+
+    it "lets per-request headers take precedence over auth headers" do
+      request = client.build_http_request(
+        url: URI.parse("https://example.com"),
+        method: "GET",
+        headers: { "Authorization" => "Bearer PER_REQUEST" },
+        auth_headers: { "Authorization" => "Bearer FRESH" }
+      )
+
+      assert_equal("Bearer PER_REQUEST", request["Authorization"])
+    end
+
+    it "defaults auth headers to empty, leaving the default headers unchanged" do
+      request = client.build_http_request(url: URI.parse("https://example.com"), method: "GET")
+
+      assert_equal("Bearer STATIC", request["Authorization"])
+    end
+  end
 end

--- a/seed/ruby-sdk-v2/pagination-uri-path/lib/seed/internal/http/raw_client.rb
+++ b/seed/ruby-sdk-v2/pagination-uri-path/lib/seed/internal/http/raw_client.rb
@@ -21,10 +21,14 @@ module Seed
         # @param max_retries [Integer] The number of times to retry a failed request, defaults to 2.
         # @param timeout [Float] The timeout for the request, defaults to 60.0 seconds.
         # @param headers [Hash] The headers for the request.
-        def initialize(base_url:, max_retries: 2, timeout: 60.0, headers: {})
+        # @param auth_provider [Object, nil] An optional auth provider responding to
+        #   `auth_headers`. When present its headers are resolved on every request so
+        #   token-based schemes (e.g. OAuth) can refresh an expired token mid-session.
+        def initialize(base_url:, max_retries: 2, timeout: 60.0, headers: {}, auth_provider: nil)
           @base_url = base_url
           @max_retries = max_retries
           @timeout = timeout
+          @auth_provider = auth_provider
           @default_headers = {
             "X-Fern-Language": "Ruby",
             "X-Fern-SDK-Name": "seed",
@@ -36,6 +40,9 @@ module Seed
         # @return [HTTP::Response] The HTTP response.
         def send(request)
           url = build_url(request)
+          # Resolve auth headers once per request (not per retry) so token-based
+          # providers refresh at most once here; static providers are cheap.
+          auth_headers = resolve_auth_headers
           attempt = 0
           response = nil
 
@@ -43,8 +50,9 @@ module Seed
             http_request = build_http_request(
               url:,
               method: request.method,
-              headers: request.encode_headers(protected_keys: @default_headers.keys),
-              body: request.encode_body
+              headers: request.encode_headers(protected_keys: @default_headers.keys + auth_headers.keys),
+              body: request.encode_body,
+              auth_headers: auth_headers
             )
 
             conn = connect(url)
@@ -157,12 +165,27 @@ module Seed
                 "HTTP is only allowed for localhost. Use HTTPS or pass a localhost URL."
         end
 
+        # Resolves the auth headers to send with the next request. Delegates to the
+        # configured auth provider (if any) on every call so that token-based
+        # providers (e.g. OAuth client-credentials) can refresh an expired token
+        # before the request is sent. Returns an empty hash when no provider is set,
+        # which keeps the api-key / basic / bearer / no-auth paths unchanged.
+        # @return [Hash] The auth headers for the current request.
+        def resolve_auth_headers
+          return {} if @auth_provider.nil?
+
+          @auth_provider.auth_headers
+        end
+
         # @param url [URI::Generic] The url to the resource.
         # @param method [String] The HTTP method to use.
         # @param headers [Hash] The headers for the request.
         # @param body [String, nil] The body for the request.
+        # @param auth_headers [Hash] The auth headers resolved for this request. These
+        #   take precedence over the static default headers but not over per-request
+        #   headers, mirroring the previous baked-header precedence.
         # @return [HTTP::Request] The HTTP request.
-        def build_http_request(url:, method:, headers: {}, body: nil)
+        def build_http_request(url:, method:, headers: {}, body: nil, auth_headers: {})
           request = Net::HTTPGenericRequest.new(
             method,
             !body.nil?,
@@ -170,7 +193,7 @@ module Seed
             url
           )
 
-          request_headers = @default_headers.merge(headers)
+          request_headers = @default_headers.merge(auth_headers).merge(headers)
           request_headers.each { |name, value| request[name] = value }
           request.body = body if body
 

--- a/seed/ruby-sdk-v2/pagination-uri-path/test/unit/internal/http/test_raw_client.rb
+++ b/seed/ruby-sdk-v2/pagination-uri-path/test/unit/internal/http/test_raw_client.rb
@@ -54,4 +54,71 @@ describe Seed::Internal::Http::RawClient do
       assert client.should_retry?(make_response(502), 2)
     end
   end
+
+  # A minimal auth provider whose `auth_headers` returns a *different* token on
+  # each call, simulating a token that is refreshed on expiry.
+  class RefreshingAuthProvider
+    def initialize
+      @count = 0
+    end
+
+    def auth_headers
+      @count += 1
+      { "Authorization" => "Bearer TOKEN_#{@count}" }
+    end
+  end
+
+  describe "#resolve_auth_headers" do
+    it "returns an empty hash when no auth provider is configured" do
+      client = Seed::Internal::Http::RawClient.new(base_url: "https://example.com")
+
+      assert_equal({}, client.resolve_auth_headers)
+    end
+
+    it "consults the auth provider on every call so an expired token is refreshed" do
+      client = Seed::Internal::Http::RawClient.new(
+        base_url: "https://example.com",
+        auth_provider: RefreshingAuthProvider.new
+      )
+
+      assert_equal({ "Authorization" => "Bearer TOKEN_1" }, client.resolve_auth_headers)
+      assert_equal({ "Authorization" => "Bearer TOKEN_2" }, client.resolve_auth_headers)
+    end
+  end
+
+  describe "#build_http_request auth header precedence" do
+    let(:client) do
+      Seed::Internal::Http::RawClient.new(
+        base_url: "https://example.com",
+        headers: { "Authorization" => "Bearer STATIC" }
+      )
+    end
+
+    it "lets resolved auth headers override the static default headers" do
+      request = client.build_http_request(
+        url: URI.parse("https://example.com"),
+        method: "GET",
+        auth_headers: { "Authorization" => "Bearer FRESH" }
+      )
+
+      assert_equal("Bearer FRESH", request["Authorization"])
+    end
+
+    it "lets per-request headers take precedence over auth headers" do
+      request = client.build_http_request(
+        url: URI.parse("https://example.com"),
+        method: "GET",
+        headers: { "Authorization" => "Bearer PER_REQUEST" },
+        auth_headers: { "Authorization" => "Bearer FRESH" }
+      )
+
+      assert_equal("Bearer PER_REQUEST", request["Authorization"])
+    end
+
+    it "defaults auth headers to empty, leaving the default headers unchanged" do
+      request = client.build_http_request(url: URI.parse("https://example.com"), method: "GET")
+
+      assert_equal("Bearer STATIC", request["Authorization"])
+    end
+  end
 end

--- a/seed/ruby-sdk-v2/pagination/no-custom-config/lib/seed/internal/http/raw_client.rb
+++ b/seed/ruby-sdk-v2/pagination/no-custom-config/lib/seed/internal/http/raw_client.rb
@@ -21,10 +21,14 @@ module Seed
         # @param max_retries [Integer] The number of times to retry a failed request, defaults to 2.
         # @param timeout [Float] The timeout for the request, defaults to 60.0 seconds.
         # @param headers [Hash] The headers for the request.
-        def initialize(base_url:, max_retries: 2, timeout: 60.0, headers: {})
+        # @param auth_provider [Object, nil] An optional auth provider responding to
+        #   `auth_headers`. When present its headers are resolved on every request so
+        #   token-based schemes (e.g. OAuth) can refresh an expired token mid-session.
+        def initialize(base_url:, max_retries: 2, timeout: 60.0, headers: {}, auth_provider: nil)
           @base_url = base_url
           @max_retries = max_retries
           @timeout = timeout
+          @auth_provider = auth_provider
           @default_headers = {
             "X-Fern-Language": "Ruby",
             "X-Fern-SDK-Name": "seed",
@@ -36,6 +40,9 @@ module Seed
         # @return [HTTP::Response] The HTTP response.
         def send(request)
           url = build_url(request)
+          # Resolve auth headers once per request (not per retry) so token-based
+          # providers refresh at most once here; static providers are cheap.
+          auth_headers = resolve_auth_headers
           attempt = 0
           response = nil
 
@@ -43,8 +50,9 @@ module Seed
             http_request = build_http_request(
               url:,
               method: request.method,
-              headers: request.encode_headers(protected_keys: @default_headers.keys),
-              body: request.encode_body
+              headers: request.encode_headers(protected_keys: @default_headers.keys + auth_headers.keys),
+              body: request.encode_body,
+              auth_headers: auth_headers
             )
 
             conn = connect(url)
@@ -157,12 +165,27 @@ module Seed
                 "HTTP is only allowed for localhost. Use HTTPS or pass a localhost URL."
         end
 
+        # Resolves the auth headers to send with the next request. Delegates to the
+        # configured auth provider (if any) on every call so that token-based
+        # providers (e.g. OAuth client-credentials) can refresh an expired token
+        # before the request is sent. Returns an empty hash when no provider is set,
+        # which keeps the api-key / basic / bearer / no-auth paths unchanged.
+        # @return [Hash] The auth headers for the current request.
+        def resolve_auth_headers
+          return {} if @auth_provider.nil?
+
+          @auth_provider.auth_headers
+        end
+
         # @param url [URI::Generic] The url to the resource.
         # @param method [String] The HTTP method to use.
         # @param headers [Hash] The headers for the request.
         # @param body [String, nil] The body for the request.
+        # @param auth_headers [Hash] The auth headers resolved for this request. These
+        #   take precedence over the static default headers but not over per-request
+        #   headers, mirroring the previous baked-header precedence.
         # @return [HTTP::Request] The HTTP request.
-        def build_http_request(url:, method:, headers: {}, body: nil)
+        def build_http_request(url:, method:, headers: {}, body: nil, auth_headers: {})
           request = Net::HTTPGenericRequest.new(
             method,
             !body.nil?,
@@ -170,7 +193,7 @@ module Seed
             url
           )
 
-          request_headers = @default_headers.merge(headers)
+          request_headers = @default_headers.merge(auth_headers).merge(headers)
           request_headers.each { |name, value| request[name] = value }
           request.body = body if body
 

--- a/seed/ruby-sdk-v2/pagination/no-custom-config/test/unit/internal/http/test_raw_client.rb
+++ b/seed/ruby-sdk-v2/pagination/no-custom-config/test/unit/internal/http/test_raw_client.rb
@@ -54,4 +54,71 @@ describe Seed::Internal::Http::RawClient do
       assert client.should_retry?(make_response(502), 2)
     end
   end
+
+  # A minimal auth provider whose `auth_headers` returns a *different* token on
+  # each call, simulating a token that is refreshed on expiry.
+  class RefreshingAuthProvider
+    def initialize
+      @count = 0
+    end
+
+    def auth_headers
+      @count += 1
+      { "Authorization" => "Bearer TOKEN_#{@count}" }
+    end
+  end
+
+  describe "#resolve_auth_headers" do
+    it "returns an empty hash when no auth provider is configured" do
+      client = Seed::Internal::Http::RawClient.new(base_url: "https://example.com")
+
+      assert_equal({}, client.resolve_auth_headers)
+    end
+
+    it "consults the auth provider on every call so an expired token is refreshed" do
+      client = Seed::Internal::Http::RawClient.new(
+        base_url: "https://example.com",
+        auth_provider: RefreshingAuthProvider.new
+      )
+
+      assert_equal({ "Authorization" => "Bearer TOKEN_1" }, client.resolve_auth_headers)
+      assert_equal({ "Authorization" => "Bearer TOKEN_2" }, client.resolve_auth_headers)
+    end
+  end
+
+  describe "#build_http_request auth header precedence" do
+    let(:client) do
+      Seed::Internal::Http::RawClient.new(
+        base_url: "https://example.com",
+        headers: { "Authorization" => "Bearer STATIC" }
+      )
+    end
+
+    it "lets resolved auth headers override the static default headers" do
+      request = client.build_http_request(
+        url: URI.parse("https://example.com"),
+        method: "GET",
+        auth_headers: { "Authorization" => "Bearer FRESH" }
+      )
+
+      assert_equal("Bearer FRESH", request["Authorization"])
+    end
+
+    it "lets per-request headers take precedence over auth headers" do
+      request = client.build_http_request(
+        url: URI.parse("https://example.com"),
+        method: "GET",
+        headers: { "Authorization" => "Bearer PER_REQUEST" },
+        auth_headers: { "Authorization" => "Bearer FRESH" }
+      )
+
+      assert_equal("Bearer PER_REQUEST", request["Authorization"])
+    end
+
+    it "defaults auth headers to empty, leaving the default headers unchanged" do
+      request = client.build_http_request(url: URI.parse("https://example.com"), method: "GET")
+
+      assert_equal("Bearer STATIC", request["Authorization"])
+    end
+  end
 end

--- a/seed/ruby-sdk-v2/pagination/page-index-semantics/lib/seed/internal/http/raw_client.rb
+++ b/seed/ruby-sdk-v2/pagination/page-index-semantics/lib/seed/internal/http/raw_client.rb
@@ -21,10 +21,14 @@ module Seed
         # @param max_retries [Integer] The number of times to retry a failed request, defaults to 2.
         # @param timeout [Float] The timeout for the request, defaults to 60.0 seconds.
         # @param headers [Hash] The headers for the request.
-        def initialize(base_url:, max_retries: 2, timeout: 60.0, headers: {})
+        # @param auth_provider [Object, nil] An optional auth provider responding to
+        #   `auth_headers`. When present its headers are resolved on every request so
+        #   token-based schemes (e.g. OAuth) can refresh an expired token mid-session.
+        def initialize(base_url:, max_retries: 2, timeout: 60.0, headers: {}, auth_provider: nil)
           @base_url = base_url
           @max_retries = max_retries
           @timeout = timeout
+          @auth_provider = auth_provider
           @default_headers = {
             "X-Fern-Language": "Ruby",
             "X-Fern-SDK-Name": "seed",
@@ -36,6 +40,9 @@ module Seed
         # @return [HTTP::Response] The HTTP response.
         def send(request)
           url = build_url(request)
+          # Resolve auth headers once per request (not per retry) so token-based
+          # providers refresh at most once here; static providers are cheap.
+          auth_headers = resolve_auth_headers
           attempt = 0
           response = nil
 
@@ -43,8 +50,9 @@ module Seed
             http_request = build_http_request(
               url:,
               method: request.method,
-              headers: request.encode_headers(protected_keys: @default_headers.keys),
-              body: request.encode_body
+              headers: request.encode_headers(protected_keys: @default_headers.keys + auth_headers.keys),
+              body: request.encode_body,
+              auth_headers: auth_headers
             )
 
             conn = connect(url)
@@ -157,12 +165,27 @@ module Seed
                 "HTTP is only allowed for localhost. Use HTTPS or pass a localhost URL."
         end
 
+        # Resolves the auth headers to send with the next request. Delegates to the
+        # configured auth provider (if any) on every call so that token-based
+        # providers (e.g. OAuth client-credentials) can refresh an expired token
+        # before the request is sent. Returns an empty hash when no provider is set,
+        # which keeps the api-key / basic / bearer / no-auth paths unchanged.
+        # @return [Hash] The auth headers for the current request.
+        def resolve_auth_headers
+          return {} if @auth_provider.nil?
+
+          @auth_provider.auth_headers
+        end
+
         # @param url [URI::Generic] The url to the resource.
         # @param method [String] The HTTP method to use.
         # @param headers [Hash] The headers for the request.
         # @param body [String, nil] The body for the request.
+        # @param auth_headers [Hash] The auth headers resolved for this request. These
+        #   take precedence over the static default headers but not over per-request
+        #   headers, mirroring the previous baked-header precedence.
         # @return [HTTP::Request] The HTTP request.
-        def build_http_request(url:, method:, headers: {}, body: nil)
+        def build_http_request(url:, method:, headers: {}, body: nil, auth_headers: {})
           request = Net::HTTPGenericRequest.new(
             method,
             !body.nil?,
@@ -170,7 +193,7 @@ module Seed
             url
           )
 
-          request_headers = @default_headers.merge(headers)
+          request_headers = @default_headers.merge(auth_headers).merge(headers)
           request_headers.each { |name, value| request[name] = value }
           request.body = body if body
 

--- a/seed/ruby-sdk-v2/pagination/page-index-semantics/test/unit/internal/http/test_raw_client.rb
+++ b/seed/ruby-sdk-v2/pagination/page-index-semantics/test/unit/internal/http/test_raw_client.rb
@@ -54,4 +54,71 @@ describe Seed::Internal::Http::RawClient do
       assert client.should_retry?(make_response(502), 2)
     end
   end
+
+  # A minimal auth provider whose `auth_headers` returns a *different* token on
+  # each call, simulating a token that is refreshed on expiry.
+  class RefreshingAuthProvider
+    def initialize
+      @count = 0
+    end
+
+    def auth_headers
+      @count += 1
+      { "Authorization" => "Bearer TOKEN_#{@count}" }
+    end
+  end
+
+  describe "#resolve_auth_headers" do
+    it "returns an empty hash when no auth provider is configured" do
+      client = Seed::Internal::Http::RawClient.new(base_url: "https://example.com")
+
+      assert_equal({}, client.resolve_auth_headers)
+    end
+
+    it "consults the auth provider on every call so an expired token is refreshed" do
+      client = Seed::Internal::Http::RawClient.new(
+        base_url: "https://example.com",
+        auth_provider: RefreshingAuthProvider.new
+      )
+
+      assert_equal({ "Authorization" => "Bearer TOKEN_1" }, client.resolve_auth_headers)
+      assert_equal({ "Authorization" => "Bearer TOKEN_2" }, client.resolve_auth_headers)
+    end
+  end
+
+  describe "#build_http_request auth header precedence" do
+    let(:client) do
+      Seed::Internal::Http::RawClient.new(
+        base_url: "https://example.com",
+        headers: { "Authorization" => "Bearer STATIC" }
+      )
+    end
+
+    it "lets resolved auth headers override the static default headers" do
+      request = client.build_http_request(
+        url: URI.parse("https://example.com"),
+        method: "GET",
+        auth_headers: { "Authorization" => "Bearer FRESH" }
+      )
+
+      assert_equal("Bearer FRESH", request["Authorization"])
+    end
+
+    it "lets per-request headers take precedence over auth headers" do
+      request = client.build_http_request(
+        url: URI.parse("https://example.com"),
+        method: "GET",
+        headers: { "Authorization" => "Bearer PER_REQUEST" },
+        auth_headers: { "Authorization" => "Bearer FRESH" }
+      )
+
+      assert_equal("Bearer PER_REQUEST", request["Authorization"])
+    end
+
+    it "defaults auth headers to empty, leaving the default headers unchanged" do
+      request = client.build_http_request(url: URI.parse("https://example.com"), method: "GET")
+
+      assert_equal("Bearer STATIC", request["Authorization"])
+    end
+  end
 end

--- a/seed/ruby-sdk-v2/path-parameters/lib/seed/internal/http/raw_client.rb
+++ b/seed/ruby-sdk-v2/path-parameters/lib/seed/internal/http/raw_client.rb
@@ -21,10 +21,14 @@ module Seed
         # @param max_retries [Integer] The number of times to retry a failed request, defaults to 2.
         # @param timeout [Float] The timeout for the request, defaults to 60.0 seconds.
         # @param headers [Hash] The headers for the request.
-        def initialize(base_url:, max_retries: 2, timeout: 60.0, headers: {})
+        # @param auth_provider [Object, nil] An optional auth provider responding to
+        #   `auth_headers`. When present its headers are resolved on every request so
+        #   token-based schemes (e.g. OAuth) can refresh an expired token mid-session.
+        def initialize(base_url:, max_retries: 2, timeout: 60.0, headers: {}, auth_provider: nil)
           @base_url = base_url
           @max_retries = max_retries
           @timeout = timeout
+          @auth_provider = auth_provider
           @default_headers = {
             "X-Fern-Language": "Ruby",
             "X-Fern-SDK-Name": "seed",
@@ -36,6 +40,9 @@ module Seed
         # @return [HTTP::Response] The HTTP response.
         def send(request)
           url = build_url(request)
+          # Resolve auth headers once per request (not per retry) so token-based
+          # providers refresh at most once here; static providers are cheap.
+          auth_headers = resolve_auth_headers
           attempt = 0
           response = nil
 
@@ -43,8 +50,9 @@ module Seed
             http_request = build_http_request(
               url:,
               method: request.method,
-              headers: request.encode_headers(protected_keys: @default_headers.keys),
-              body: request.encode_body
+              headers: request.encode_headers(protected_keys: @default_headers.keys + auth_headers.keys),
+              body: request.encode_body,
+              auth_headers: auth_headers
             )
 
             conn = connect(url)
@@ -157,12 +165,27 @@ module Seed
                 "HTTP is only allowed for localhost. Use HTTPS or pass a localhost URL."
         end
 
+        # Resolves the auth headers to send with the next request. Delegates to the
+        # configured auth provider (if any) on every call so that token-based
+        # providers (e.g. OAuth client-credentials) can refresh an expired token
+        # before the request is sent. Returns an empty hash when no provider is set,
+        # which keeps the api-key / basic / bearer / no-auth paths unchanged.
+        # @return [Hash] The auth headers for the current request.
+        def resolve_auth_headers
+          return {} if @auth_provider.nil?
+
+          @auth_provider.auth_headers
+        end
+
         # @param url [URI::Generic] The url to the resource.
         # @param method [String] The HTTP method to use.
         # @param headers [Hash] The headers for the request.
         # @param body [String, nil] The body for the request.
+        # @param auth_headers [Hash] The auth headers resolved for this request. These
+        #   take precedence over the static default headers but not over per-request
+        #   headers, mirroring the previous baked-header precedence.
         # @return [HTTP::Request] The HTTP request.
-        def build_http_request(url:, method:, headers: {}, body: nil)
+        def build_http_request(url:, method:, headers: {}, body: nil, auth_headers: {})
           request = Net::HTTPGenericRequest.new(
             method,
             !body.nil?,
@@ -170,7 +193,7 @@ module Seed
             url
           )
 
-          request_headers = @default_headers.merge(headers)
+          request_headers = @default_headers.merge(auth_headers).merge(headers)
           request_headers.each { |name, value| request[name] = value }
           request.body = body if body
 

--- a/seed/ruby-sdk-v2/path-parameters/test/unit/internal/http/test_raw_client.rb
+++ b/seed/ruby-sdk-v2/path-parameters/test/unit/internal/http/test_raw_client.rb
@@ -54,4 +54,71 @@ describe Seed::Internal::Http::RawClient do
       assert client.should_retry?(make_response(502), 2)
     end
   end
+
+  # A minimal auth provider whose `auth_headers` returns a *different* token on
+  # each call, simulating a token that is refreshed on expiry.
+  class RefreshingAuthProvider
+    def initialize
+      @count = 0
+    end
+
+    def auth_headers
+      @count += 1
+      { "Authorization" => "Bearer TOKEN_#{@count}" }
+    end
+  end
+
+  describe "#resolve_auth_headers" do
+    it "returns an empty hash when no auth provider is configured" do
+      client = Seed::Internal::Http::RawClient.new(base_url: "https://example.com")
+
+      assert_equal({}, client.resolve_auth_headers)
+    end
+
+    it "consults the auth provider on every call so an expired token is refreshed" do
+      client = Seed::Internal::Http::RawClient.new(
+        base_url: "https://example.com",
+        auth_provider: RefreshingAuthProvider.new
+      )
+
+      assert_equal({ "Authorization" => "Bearer TOKEN_1" }, client.resolve_auth_headers)
+      assert_equal({ "Authorization" => "Bearer TOKEN_2" }, client.resolve_auth_headers)
+    end
+  end
+
+  describe "#build_http_request auth header precedence" do
+    let(:client) do
+      Seed::Internal::Http::RawClient.new(
+        base_url: "https://example.com",
+        headers: { "Authorization" => "Bearer STATIC" }
+      )
+    end
+
+    it "lets resolved auth headers override the static default headers" do
+      request = client.build_http_request(
+        url: URI.parse("https://example.com"),
+        method: "GET",
+        auth_headers: { "Authorization" => "Bearer FRESH" }
+      )
+
+      assert_equal("Bearer FRESH", request["Authorization"])
+    end
+
+    it "lets per-request headers take precedence over auth headers" do
+      request = client.build_http_request(
+        url: URI.parse("https://example.com"),
+        method: "GET",
+        headers: { "Authorization" => "Bearer PER_REQUEST" },
+        auth_headers: { "Authorization" => "Bearer FRESH" }
+      )
+
+      assert_equal("Bearer PER_REQUEST", request["Authorization"])
+    end
+
+    it "defaults auth headers to empty, leaving the default headers unchanged" do
+      request = client.build_http_request(url: URI.parse("https://example.com"), method: "GET")
+
+      assert_equal("Bearer STATIC", request["Authorization"])
+    end
+  end
 end

--- a/seed/ruby-sdk-v2/plain-text/lib/seed/internal/http/raw_client.rb
+++ b/seed/ruby-sdk-v2/plain-text/lib/seed/internal/http/raw_client.rb
@@ -21,10 +21,14 @@ module Seed
         # @param max_retries [Integer] The number of times to retry a failed request, defaults to 2.
         # @param timeout [Float] The timeout for the request, defaults to 60.0 seconds.
         # @param headers [Hash] The headers for the request.
-        def initialize(base_url:, max_retries: 2, timeout: 60.0, headers: {})
+        # @param auth_provider [Object, nil] An optional auth provider responding to
+        #   `auth_headers`. When present its headers are resolved on every request so
+        #   token-based schemes (e.g. OAuth) can refresh an expired token mid-session.
+        def initialize(base_url:, max_retries: 2, timeout: 60.0, headers: {}, auth_provider: nil)
           @base_url = base_url
           @max_retries = max_retries
           @timeout = timeout
+          @auth_provider = auth_provider
           @default_headers = {
             "X-Fern-Language": "Ruby",
             "X-Fern-SDK-Name": "seed",
@@ -36,6 +40,9 @@ module Seed
         # @return [HTTP::Response] The HTTP response.
         def send(request)
           url = build_url(request)
+          # Resolve auth headers once per request (not per retry) so token-based
+          # providers refresh at most once here; static providers are cheap.
+          auth_headers = resolve_auth_headers
           attempt = 0
           response = nil
 
@@ -43,8 +50,9 @@ module Seed
             http_request = build_http_request(
               url:,
               method: request.method,
-              headers: request.encode_headers(protected_keys: @default_headers.keys),
-              body: request.encode_body
+              headers: request.encode_headers(protected_keys: @default_headers.keys + auth_headers.keys),
+              body: request.encode_body,
+              auth_headers: auth_headers
             )
 
             conn = connect(url)
@@ -157,12 +165,27 @@ module Seed
                 "HTTP is only allowed for localhost. Use HTTPS or pass a localhost URL."
         end
 
+        # Resolves the auth headers to send with the next request. Delegates to the
+        # configured auth provider (if any) on every call so that token-based
+        # providers (e.g. OAuth client-credentials) can refresh an expired token
+        # before the request is sent. Returns an empty hash when no provider is set,
+        # which keeps the api-key / basic / bearer / no-auth paths unchanged.
+        # @return [Hash] The auth headers for the current request.
+        def resolve_auth_headers
+          return {} if @auth_provider.nil?
+
+          @auth_provider.auth_headers
+        end
+
         # @param url [URI::Generic] The url to the resource.
         # @param method [String] The HTTP method to use.
         # @param headers [Hash] The headers for the request.
         # @param body [String, nil] The body for the request.
+        # @param auth_headers [Hash] The auth headers resolved for this request. These
+        #   take precedence over the static default headers but not over per-request
+        #   headers, mirroring the previous baked-header precedence.
         # @return [HTTP::Request] The HTTP request.
-        def build_http_request(url:, method:, headers: {}, body: nil)
+        def build_http_request(url:, method:, headers: {}, body: nil, auth_headers: {})
           request = Net::HTTPGenericRequest.new(
             method,
             !body.nil?,
@@ -170,7 +193,7 @@ module Seed
             url
           )
 
-          request_headers = @default_headers.merge(headers)
+          request_headers = @default_headers.merge(auth_headers).merge(headers)
           request_headers.each { |name, value| request[name] = value }
           request.body = body if body
 

--- a/seed/ruby-sdk-v2/plain-text/test/unit/internal/http/test_raw_client.rb
+++ b/seed/ruby-sdk-v2/plain-text/test/unit/internal/http/test_raw_client.rb
@@ -54,4 +54,71 @@ describe Seed::Internal::Http::RawClient do
       assert client.should_retry?(make_response(502), 2)
     end
   end
+
+  # A minimal auth provider whose `auth_headers` returns a *different* token on
+  # each call, simulating a token that is refreshed on expiry.
+  class RefreshingAuthProvider
+    def initialize
+      @count = 0
+    end
+
+    def auth_headers
+      @count += 1
+      { "Authorization" => "Bearer TOKEN_#{@count}" }
+    end
+  end
+
+  describe "#resolve_auth_headers" do
+    it "returns an empty hash when no auth provider is configured" do
+      client = Seed::Internal::Http::RawClient.new(base_url: "https://example.com")
+
+      assert_equal({}, client.resolve_auth_headers)
+    end
+
+    it "consults the auth provider on every call so an expired token is refreshed" do
+      client = Seed::Internal::Http::RawClient.new(
+        base_url: "https://example.com",
+        auth_provider: RefreshingAuthProvider.new
+      )
+
+      assert_equal({ "Authorization" => "Bearer TOKEN_1" }, client.resolve_auth_headers)
+      assert_equal({ "Authorization" => "Bearer TOKEN_2" }, client.resolve_auth_headers)
+    end
+  end
+
+  describe "#build_http_request auth header precedence" do
+    let(:client) do
+      Seed::Internal::Http::RawClient.new(
+        base_url: "https://example.com",
+        headers: { "Authorization" => "Bearer STATIC" }
+      )
+    end
+
+    it "lets resolved auth headers override the static default headers" do
+      request = client.build_http_request(
+        url: URI.parse("https://example.com"),
+        method: "GET",
+        auth_headers: { "Authorization" => "Bearer FRESH" }
+      )
+
+      assert_equal("Bearer FRESH", request["Authorization"])
+    end
+
+    it "lets per-request headers take precedence over auth headers" do
+      request = client.build_http_request(
+        url: URI.parse("https://example.com"),
+        method: "GET",
+        headers: { "Authorization" => "Bearer PER_REQUEST" },
+        auth_headers: { "Authorization" => "Bearer FRESH" }
+      )
+
+      assert_equal("Bearer PER_REQUEST", request["Authorization"])
+    end
+
+    it "defaults auth headers to empty, leaving the default headers unchanged" do
+      request = client.build_http_request(url: URI.parse("https://example.com"), method: "GET")
+
+      assert_equal("Bearer STATIC", request["Authorization"])
+    end
+  end
 end

--- a/seed/ruby-sdk-v2/property-access/lib/seed/internal/http/raw_client.rb
+++ b/seed/ruby-sdk-v2/property-access/lib/seed/internal/http/raw_client.rb
@@ -21,10 +21,14 @@ module Seed
         # @param max_retries [Integer] The number of times to retry a failed request, defaults to 2.
         # @param timeout [Float] The timeout for the request, defaults to 60.0 seconds.
         # @param headers [Hash] The headers for the request.
-        def initialize(base_url:, max_retries: 2, timeout: 60.0, headers: {})
+        # @param auth_provider [Object, nil] An optional auth provider responding to
+        #   `auth_headers`. When present its headers are resolved on every request so
+        #   token-based schemes (e.g. OAuth) can refresh an expired token mid-session.
+        def initialize(base_url:, max_retries: 2, timeout: 60.0, headers: {}, auth_provider: nil)
           @base_url = base_url
           @max_retries = max_retries
           @timeout = timeout
+          @auth_provider = auth_provider
           @default_headers = {
             "X-Fern-Language": "Ruby",
             "X-Fern-SDK-Name": "seed",
@@ -36,6 +40,9 @@ module Seed
         # @return [HTTP::Response] The HTTP response.
         def send(request)
           url = build_url(request)
+          # Resolve auth headers once per request (not per retry) so token-based
+          # providers refresh at most once here; static providers are cheap.
+          auth_headers = resolve_auth_headers
           attempt = 0
           response = nil
 
@@ -43,8 +50,9 @@ module Seed
             http_request = build_http_request(
               url:,
               method: request.method,
-              headers: request.encode_headers(protected_keys: @default_headers.keys),
-              body: request.encode_body
+              headers: request.encode_headers(protected_keys: @default_headers.keys + auth_headers.keys),
+              body: request.encode_body,
+              auth_headers: auth_headers
             )
 
             conn = connect(url)
@@ -157,12 +165,27 @@ module Seed
                 "HTTP is only allowed for localhost. Use HTTPS or pass a localhost URL."
         end
 
+        # Resolves the auth headers to send with the next request. Delegates to the
+        # configured auth provider (if any) on every call so that token-based
+        # providers (e.g. OAuth client-credentials) can refresh an expired token
+        # before the request is sent. Returns an empty hash when no provider is set,
+        # which keeps the api-key / basic / bearer / no-auth paths unchanged.
+        # @return [Hash] The auth headers for the current request.
+        def resolve_auth_headers
+          return {} if @auth_provider.nil?
+
+          @auth_provider.auth_headers
+        end
+
         # @param url [URI::Generic] The url to the resource.
         # @param method [String] The HTTP method to use.
         # @param headers [Hash] The headers for the request.
         # @param body [String, nil] The body for the request.
+        # @param auth_headers [Hash] The auth headers resolved for this request. These
+        #   take precedence over the static default headers but not over per-request
+        #   headers, mirroring the previous baked-header precedence.
         # @return [HTTP::Request] The HTTP request.
-        def build_http_request(url:, method:, headers: {}, body: nil)
+        def build_http_request(url:, method:, headers: {}, body: nil, auth_headers: {})
           request = Net::HTTPGenericRequest.new(
             method,
             !body.nil?,
@@ -170,7 +193,7 @@ module Seed
             url
           )
 
-          request_headers = @default_headers.merge(headers)
+          request_headers = @default_headers.merge(auth_headers).merge(headers)
           request_headers.each { |name, value| request[name] = value }
           request.body = body if body
 

--- a/seed/ruby-sdk-v2/property-access/test/unit/internal/http/test_raw_client.rb
+++ b/seed/ruby-sdk-v2/property-access/test/unit/internal/http/test_raw_client.rb
@@ -54,4 +54,71 @@ describe Seed::Internal::Http::RawClient do
       assert client.should_retry?(make_response(502), 2)
     end
   end
+
+  # A minimal auth provider whose `auth_headers` returns a *different* token on
+  # each call, simulating a token that is refreshed on expiry.
+  class RefreshingAuthProvider
+    def initialize
+      @count = 0
+    end
+
+    def auth_headers
+      @count += 1
+      { "Authorization" => "Bearer TOKEN_#{@count}" }
+    end
+  end
+
+  describe "#resolve_auth_headers" do
+    it "returns an empty hash when no auth provider is configured" do
+      client = Seed::Internal::Http::RawClient.new(base_url: "https://example.com")
+
+      assert_equal({}, client.resolve_auth_headers)
+    end
+
+    it "consults the auth provider on every call so an expired token is refreshed" do
+      client = Seed::Internal::Http::RawClient.new(
+        base_url: "https://example.com",
+        auth_provider: RefreshingAuthProvider.new
+      )
+
+      assert_equal({ "Authorization" => "Bearer TOKEN_1" }, client.resolve_auth_headers)
+      assert_equal({ "Authorization" => "Bearer TOKEN_2" }, client.resolve_auth_headers)
+    end
+  end
+
+  describe "#build_http_request auth header precedence" do
+    let(:client) do
+      Seed::Internal::Http::RawClient.new(
+        base_url: "https://example.com",
+        headers: { "Authorization" => "Bearer STATIC" }
+      )
+    end
+
+    it "lets resolved auth headers override the static default headers" do
+      request = client.build_http_request(
+        url: URI.parse("https://example.com"),
+        method: "GET",
+        auth_headers: { "Authorization" => "Bearer FRESH" }
+      )
+
+      assert_equal("Bearer FRESH", request["Authorization"])
+    end
+
+    it "lets per-request headers take precedence over auth headers" do
+      request = client.build_http_request(
+        url: URI.parse("https://example.com"),
+        method: "GET",
+        headers: { "Authorization" => "Bearer PER_REQUEST" },
+        auth_headers: { "Authorization" => "Bearer FRESH" }
+      )
+
+      assert_equal("Bearer PER_REQUEST", request["Authorization"])
+    end
+
+    it "defaults auth headers to empty, leaving the default headers unchanged" do
+      request = client.build_http_request(url: URI.parse("https://example.com"), method: "GET")
+
+      assert_equal("Bearer STATIC", request["Authorization"])
+    end
+  end
 end

--- a/seed/ruby-sdk-v2/public-object/lib/seed/internal/http/raw_client.rb
+++ b/seed/ruby-sdk-v2/public-object/lib/seed/internal/http/raw_client.rb
@@ -21,10 +21,14 @@ module Seed
         # @param max_retries [Integer] The number of times to retry a failed request, defaults to 2.
         # @param timeout [Float] The timeout for the request, defaults to 60.0 seconds.
         # @param headers [Hash] The headers for the request.
-        def initialize(base_url:, max_retries: 2, timeout: 60.0, headers: {})
+        # @param auth_provider [Object, nil] An optional auth provider responding to
+        #   `auth_headers`. When present its headers are resolved on every request so
+        #   token-based schemes (e.g. OAuth) can refresh an expired token mid-session.
+        def initialize(base_url:, max_retries: 2, timeout: 60.0, headers: {}, auth_provider: nil)
           @base_url = base_url
           @max_retries = max_retries
           @timeout = timeout
+          @auth_provider = auth_provider
           @default_headers = {
             "X-Fern-Language": "Ruby",
             "X-Fern-SDK-Name": "seed",
@@ -36,6 +40,9 @@ module Seed
         # @return [HTTP::Response] The HTTP response.
         def send(request)
           url = build_url(request)
+          # Resolve auth headers once per request (not per retry) so token-based
+          # providers refresh at most once here; static providers are cheap.
+          auth_headers = resolve_auth_headers
           attempt = 0
           response = nil
 
@@ -43,8 +50,9 @@ module Seed
             http_request = build_http_request(
               url:,
               method: request.method,
-              headers: request.encode_headers(protected_keys: @default_headers.keys),
-              body: request.encode_body
+              headers: request.encode_headers(protected_keys: @default_headers.keys + auth_headers.keys),
+              body: request.encode_body,
+              auth_headers: auth_headers
             )
 
             conn = connect(url)
@@ -157,12 +165,27 @@ module Seed
                 "HTTP is only allowed for localhost. Use HTTPS or pass a localhost URL."
         end
 
+        # Resolves the auth headers to send with the next request. Delegates to the
+        # configured auth provider (if any) on every call so that token-based
+        # providers (e.g. OAuth client-credentials) can refresh an expired token
+        # before the request is sent. Returns an empty hash when no provider is set,
+        # which keeps the api-key / basic / bearer / no-auth paths unchanged.
+        # @return [Hash] The auth headers for the current request.
+        def resolve_auth_headers
+          return {} if @auth_provider.nil?
+
+          @auth_provider.auth_headers
+        end
+
         # @param url [URI::Generic] The url to the resource.
         # @param method [String] The HTTP method to use.
         # @param headers [Hash] The headers for the request.
         # @param body [String, nil] The body for the request.
+        # @param auth_headers [Hash] The auth headers resolved for this request. These
+        #   take precedence over the static default headers but not over per-request
+        #   headers, mirroring the previous baked-header precedence.
         # @return [HTTP::Request] The HTTP request.
-        def build_http_request(url:, method:, headers: {}, body: nil)
+        def build_http_request(url:, method:, headers: {}, body: nil, auth_headers: {})
           request = Net::HTTPGenericRequest.new(
             method,
             !body.nil?,
@@ -170,7 +193,7 @@ module Seed
             url
           )
 
-          request_headers = @default_headers.merge(headers)
+          request_headers = @default_headers.merge(auth_headers).merge(headers)
           request_headers.each { |name, value| request[name] = value }
           request.body = body if body
 

--- a/seed/ruby-sdk-v2/public-object/test/unit/internal/http/test_raw_client.rb
+++ b/seed/ruby-sdk-v2/public-object/test/unit/internal/http/test_raw_client.rb
@@ -54,4 +54,71 @@ describe Seed::Internal::Http::RawClient do
       assert client.should_retry?(make_response(502), 2)
     end
   end
+
+  # A minimal auth provider whose `auth_headers` returns a *different* token on
+  # each call, simulating a token that is refreshed on expiry.
+  class RefreshingAuthProvider
+    def initialize
+      @count = 0
+    end
+
+    def auth_headers
+      @count += 1
+      { "Authorization" => "Bearer TOKEN_#{@count}" }
+    end
+  end
+
+  describe "#resolve_auth_headers" do
+    it "returns an empty hash when no auth provider is configured" do
+      client = Seed::Internal::Http::RawClient.new(base_url: "https://example.com")
+
+      assert_equal({}, client.resolve_auth_headers)
+    end
+
+    it "consults the auth provider on every call so an expired token is refreshed" do
+      client = Seed::Internal::Http::RawClient.new(
+        base_url: "https://example.com",
+        auth_provider: RefreshingAuthProvider.new
+      )
+
+      assert_equal({ "Authorization" => "Bearer TOKEN_1" }, client.resolve_auth_headers)
+      assert_equal({ "Authorization" => "Bearer TOKEN_2" }, client.resolve_auth_headers)
+    end
+  end
+
+  describe "#build_http_request auth header precedence" do
+    let(:client) do
+      Seed::Internal::Http::RawClient.new(
+        base_url: "https://example.com",
+        headers: { "Authorization" => "Bearer STATIC" }
+      )
+    end
+
+    it "lets resolved auth headers override the static default headers" do
+      request = client.build_http_request(
+        url: URI.parse("https://example.com"),
+        method: "GET",
+        auth_headers: { "Authorization" => "Bearer FRESH" }
+      )
+
+      assert_equal("Bearer FRESH", request["Authorization"])
+    end
+
+    it "lets per-request headers take precedence over auth headers" do
+      request = client.build_http_request(
+        url: URI.parse("https://example.com"),
+        method: "GET",
+        headers: { "Authorization" => "Bearer PER_REQUEST" },
+        auth_headers: { "Authorization" => "Bearer FRESH" }
+      )
+
+      assert_equal("Bearer PER_REQUEST", request["Authorization"])
+    end
+
+    it "defaults auth headers to empty, leaving the default headers unchanged" do
+      request = client.build_http_request(url: URI.parse("https://example.com"), method: "GET")
+
+      assert_equal("Bearer STATIC", request["Authorization"])
+    end
+  end
 end

--- a/seed/ruby-sdk-v2/query-param-name-conflict/lib/seed/internal/http/raw_client.rb
+++ b/seed/ruby-sdk-v2/query-param-name-conflict/lib/seed/internal/http/raw_client.rb
@@ -21,10 +21,14 @@ module Seed
         # @param max_retries [Integer] The number of times to retry a failed request, defaults to 2.
         # @param timeout [Float] The timeout for the request, defaults to 60.0 seconds.
         # @param headers [Hash] The headers for the request.
-        def initialize(base_url:, max_retries: 2, timeout: 60.0, headers: {})
+        # @param auth_provider [Object, nil] An optional auth provider responding to
+        #   `auth_headers`. When present its headers are resolved on every request so
+        #   token-based schemes (e.g. OAuth) can refresh an expired token mid-session.
+        def initialize(base_url:, max_retries: 2, timeout: 60.0, headers: {}, auth_provider: nil)
           @base_url = base_url
           @max_retries = max_retries
           @timeout = timeout
+          @auth_provider = auth_provider
           @default_headers = {
             "X-Fern-Language": "Ruby",
             "X-Fern-SDK-Name": "seed",
@@ -36,6 +40,9 @@ module Seed
         # @return [HTTP::Response] The HTTP response.
         def send(request)
           url = build_url(request)
+          # Resolve auth headers once per request (not per retry) so token-based
+          # providers refresh at most once here; static providers are cheap.
+          auth_headers = resolve_auth_headers
           attempt = 0
           response = nil
 
@@ -43,8 +50,9 @@ module Seed
             http_request = build_http_request(
               url:,
               method: request.method,
-              headers: request.encode_headers(protected_keys: @default_headers.keys),
-              body: request.encode_body
+              headers: request.encode_headers(protected_keys: @default_headers.keys + auth_headers.keys),
+              body: request.encode_body,
+              auth_headers: auth_headers
             )
 
             conn = connect(url)
@@ -157,12 +165,27 @@ module Seed
                 "HTTP is only allowed for localhost. Use HTTPS or pass a localhost URL."
         end
 
+        # Resolves the auth headers to send with the next request. Delegates to the
+        # configured auth provider (if any) on every call so that token-based
+        # providers (e.g. OAuth client-credentials) can refresh an expired token
+        # before the request is sent. Returns an empty hash when no provider is set,
+        # which keeps the api-key / basic / bearer / no-auth paths unchanged.
+        # @return [Hash] The auth headers for the current request.
+        def resolve_auth_headers
+          return {} if @auth_provider.nil?
+
+          @auth_provider.auth_headers
+        end
+
         # @param url [URI::Generic] The url to the resource.
         # @param method [String] The HTTP method to use.
         # @param headers [Hash] The headers for the request.
         # @param body [String, nil] The body for the request.
+        # @param auth_headers [Hash] The auth headers resolved for this request. These
+        #   take precedence over the static default headers but not over per-request
+        #   headers, mirroring the previous baked-header precedence.
         # @return [HTTP::Request] The HTTP request.
-        def build_http_request(url:, method:, headers: {}, body: nil)
+        def build_http_request(url:, method:, headers: {}, body: nil, auth_headers: {})
           request = Net::HTTPGenericRequest.new(
             method,
             !body.nil?,
@@ -170,7 +193,7 @@ module Seed
             url
           )
 
-          request_headers = @default_headers.merge(headers)
+          request_headers = @default_headers.merge(auth_headers).merge(headers)
           request_headers.each { |name, value| request[name] = value }
           request.body = body if body
 

--- a/seed/ruby-sdk-v2/query-param-name-conflict/test/unit/internal/http/test_raw_client.rb
+++ b/seed/ruby-sdk-v2/query-param-name-conflict/test/unit/internal/http/test_raw_client.rb
@@ -54,4 +54,71 @@ describe Seed::Internal::Http::RawClient do
       assert client.should_retry?(make_response(502), 2)
     end
   end
+
+  # A minimal auth provider whose `auth_headers` returns a *different* token on
+  # each call, simulating a token that is refreshed on expiry.
+  class RefreshingAuthProvider
+    def initialize
+      @count = 0
+    end
+
+    def auth_headers
+      @count += 1
+      { "Authorization" => "Bearer TOKEN_#{@count}" }
+    end
+  end
+
+  describe "#resolve_auth_headers" do
+    it "returns an empty hash when no auth provider is configured" do
+      client = Seed::Internal::Http::RawClient.new(base_url: "https://example.com")
+
+      assert_equal({}, client.resolve_auth_headers)
+    end
+
+    it "consults the auth provider on every call so an expired token is refreshed" do
+      client = Seed::Internal::Http::RawClient.new(
+        base_url: "https://example.com",
+        auth_provider: RefreshingAuthProvider.new
+      )
+
+      assert_equal({ "Authorization" => "Bearer TOKEN_1" }, client.resolve_auth_headers)
+      assert_equal({ "Authorization" => "Bearer TOKEN_2" }, client.resolve_auth_headers)
+    end
+  end
+
+  describe "#build_http_request auth header precedence" do
+    let(:client) do
+      Seed::Internal::Http::RawClient.new(
+        base_url: "https://example.com",
+        headers: { "Authorization" => "Bearer STATIC" }
+      )
+    end
+
+    it "lets resolved auth headers override the static default headers" do
+      request = client.build_http_request(
+        url: URI.parse("https://example.com"),
+        method: "GET",
+        auth_headers: { "Authorization" => "Bearer FRESH" }
+      )
+
+      assert_equal("Bearer FRESH", request["Authorization"])
+    end
+
+    it "lets per-request headers take precedence over auth headers" do
+      request = client.build_http_request(
+        url: URI.parse("https://example.com"),
+        method: "GET",
+        headers: { "Authorization" => "Bearer PER_REQUEST" },
+        auth_headers: { "Authorization" => "Bearer FRESH" }
+      )
+
+      assert_equal("Bearer PER_REQUEST", request["Authorization"])
+    end
+
+    it "defaults auth headers to empty, leaving the default headers unchanged" do
+      request = client.build_http_request(url: URI.parse("https://example.com"), method: "GET")
+
+      assert_equal("Bearer STATIC", request["Authorization"])
+    end
+  end
 end

--- a/seed/ruby-sdk-v2/query-parameters-openapi-as-objects/lib/seed/internal/http/raw_client.rb
+++ b/seed/ruby-sdk-v2/query-parameters-openapi-as-objects/lib/seed/internal/http/raw_client.rb
@@ -21,10 +21,14 @@ module Seed
         # @param max_retries [Integer] The number of times to retry a failed request, defaults to 2.
         # @param timeout [Float] The timeout for the request, defaults to 60.0 seconds.
         # @param headers [Hash] The headers for the request.
-        def initialize(base_url:, max_retries: 2, timeout: 60.0, headers: {})
+        # @param auth_provider [Object, nil] An optional auth provider responding to
+        #   `auth_headers`. When present its headers are resolved on every request so
+        #   token-based schemes (e.g. OAuth) can refresh an expired token mid-session.
+        def initialize(base_url:, max_retries: 2, timeout: 60.0, headers: {}, auth_provider: nil)
           @base_url = base_url
           @max_retries = max_retries
           @timeout = timeout
+          @auth_provider = auth_provider
           @default_headers = {
             "X-Fern-Language": "Ruby",
             "X-Fern-SDK-Name": "seed",
@@ -36,6 +40,9 @@ module Seed
         # @return [HTTP::Response] The HTTP response.
         def send(request)
           url = build_url(request)
+          # Resolve auth headers once per request (not per retry) so token-based
+          # providers refresh at most once here; static providers are cheap.
+          auth_headers = resolve_auth_headers
           attempt = 0
           response = nil
 
@@ -43,8 +50,9 @@ module Seed
             http_request = build_http_request(
               url:,
               method: request.method,
-              headers: request.encode_headers(protected_keys: @default_headers.keys),
-              body: request.encode_body
+              headers: request.encode_headers(protected_keys: @default_headers.keys + auth_headers.keys),
+              body: request.encode_body,
+              auth_headers: auth_headers
             )
 
             conn = connect(url)
@@ -157,12 +165,27 @@ module Seed
                 "HTTP is only allowed for localhost. Use HTTPS or pass a localhost URL."
         end
 
+        # Resolves the auth headers to send with the next request. Delegates to the
+        # configured auth provider (if any) on every call so that token-based
+        # providers (e.g. OAuth client-credentials) can refresh an expired token
+        # before the request is sent. Returns an empty hash when no provider is set,
+        # which keeps the api-key / basic / bearer / no-auth paths unchanged.
+        # @return [Hash] The auth headers for the current request.
+        def resolve_auth_headers
+          return {} if @auth_provider.nil?
+
+          @auth_provider.auth_headers
+        end
+
         # @param url [URI::Generic] The url to the resource.
         # @param method [String] The HTTP method to use.
         # @param headers [Hash] The headers for the request.
         # @param body [String, nil] The body for the request.
+        # @param auth_headers [Hash] The auth headers resolved for this request. These
+        #   take precedence over the static default headers but not over per-request
+        #   headers, mirroring the previous baked-header precedence.
         # @return [HTTP::Request] The HTTP request.
-        def build_http_request(url:, method:, headers: {}, body: nil)
+        def build_http_request(url:, method:, headers: {}, body: nil, auth_headers: {})
           request = Net::HTTPGenericRequest.new(
             method,
             !body.nil?,
@@ -170,7 +193,7 @@ module Seed
             url
           )
 
-          request_headers = @default_headers.merge(headers)
+          request_headers = @default_headers.merge(auth_headers).merge(headers)
           request_headers.each { |name, value| request[name] = value }
           request.body = body if body
 

--- a/seed/ruby-sdk-v2/query-parameters-openapi-as-objects/test/unit/internal/http/test_raw_client.rb
+++ b/seed/ruby-sdk-v2/query-parameters-openapi-as-objects/test/unit/internal/http/test_raw_client.rb
@@ -54,4 +54,71 @@ describe Seed::Internal::Http::RawClient do
       assert client.should_retry?(make_response(502), 2)
     end
   end
+
+  # A minimal auth provider whose `auth_headers` returns a *different* token on
+  # each call, simulating a token that is refreshed on expiry.
+  class RefreshingAuthProvider
+    def initialize
+      @count = 0
+    end
+
+    def auth_headers
+      @count += 1
+      { "Authorization" => "Bearer TOKEN_#{@count}" }
+    end
+  end
+
+  describe "#resolve_auth_headers" do
+    it "returns an empty hash when no auth provider is configured" do
+      client = Seed::Internal::Http::RawClient.new(base_url: "https://example.com")
+
+      assert_equal({}, client.resolve_auth_headers)
+    end
+
+    it "consults the auth provider on every call so an expired token is refreshed" do
+      client = Seed::Internal::Http::RawClient.new(
+        base_url: "https://example.com",
+        auth_provider: RefreshingAuthProvider.new
+      )
+
+      assert_equal({ "Authorization" => "Bearer TOKEN_1" }, client.resolve_auth_headers)
+      assert_equal({ "Authorization" => "Bearer TOKEN_2" }, client.resolve_auth_headers)
+    end
+  end
+
+  describe "#build_http_request auth header precedence" do
+    let(:client) do
+      Seed::Internal::Http::RawClient.new(
+        base_url: "https://example.com",
+        headers: { "Authorization" => "Bearer STATIC" }
+      )
+    end
+
+    it "lets resolved auth headers override the static default headers" do
+      request = client.build_http_request(
+        url: URI.parse("https://example.com"),
+        method: "GET",
+        auth_headers: { "Authorization" => "Bearer FRESH" }
+      )
+
+      assert_equal("Bearer FRESH", request["Authorization"])
+    end
+
+    it "lets per-request headers take precedence over auth headers" do
+      request = client.build_http_request(
+        url: URI.parse("https://example.com"),
+        method: "GET",
+        headers: { "Authorization" => "Bearer PER_REQUEST" },
+        auth_headers: { "Authorization" => "Bearer FRESH" }
+      )
+
+      assert_equal("Bearer PER_REQUEST", request["Authorization"])
+    end
+
+    it "defaults auth headers to empty, leaving the default headers unchanged" do
+      request = client.build_http_request(url: URI.parse("https://example.com"), method: "GET")
+
+      assert_equal("Bearer STATIC", request["Authorization"])
+    end
+  end
 end

--- a/seed/ruby-sdk-v2/query-parameters-openapi/lib/seed/internal/http/raw_client.rb
+++ b/seed/ruby-sdk-v2/query-parameters-openapi/lib/seed/internal/http/raw_client.rb
@@ -21,10 +21,14 @@ module Seed
         # @param max_retries [Integer] The number of times to retry a failed request, defaults to 2.
         # @param timeout [Float] The timeout for the request, defaults to 60.0 seconds.
         # @param headers [Hash] The headers for the request.
-        def initialize(base_url:, max_retries: 2, timeout: 60.0, headers: {})
+        # @param auth_provider [Object, nil] An optional auth provider responding to
+        #   `auth_headers`. When present its headers are resolved on every request so
+        #   token-based schemes (e.g. OAuth) can refresh an expired token mid-session.
+        def initialize(base_url:, max_retries: 2, timeout: 60.0, headers: {}, auth_provider: nil)
           @base_url = base_url
           @max_retries = max_retries
           @timeout = timeout
+          @auth_provider = auth_provider
           @default_headers = {
             "X-Fern-Language": "Ruby",
             "X-Fern-SDK-Name": "seed",
@@ -36,6 +40,9 @@ module Seed
         # @return [HTTP::Response] The HTTP response.
         def send(request)
           url = build_url(request)
+          # Resolve auth headers once per request (not per retry) so token-based
+          # providers refresh at most once here; static providers are cheap.
+          auth_headers = resolve_auth_headers
           attempt = 0
           response = nil
 
@@ -43,8 +50,9 @@ module Seed
             http_request = build_http_request(
               url:,
               method: request.method,
-              headers: request.encode_headers(protected_keys: @default_headers.keys),
-              body: request.encode_body
+              headers: request.encode_headers(protected_keys: @default_headers.keys + auth_headers.keys),
+              body: request.encode_body,
+              auth_headers: auth_headers
             )
 
             conn = connect(url)
@@ -157,12 +165,27 @@ module Seed
                 "HTTP is only allowed for localhost. Use HTTPS or pass a localhost URL."
         end
 
+        # Resolves the auth headers to send with the next request. Delegates to the
+        # configured auth provider (if any) on every call so that token-based
+        # providers (e.g. OAuth client-credentials) can refresh an expired token
+        # before the request is sent. Returns an empty hash when no provider is set,
+        # which keeps the api-key / basic / bearer / no-auth paths unchanged.
+        # @return [Hash] The auth headers for the current request.
+        def resolve_auth_headers
+          return {} if @auth_provider.nil?
+
+          @auth_provider.auth_headers
+        end
+
         # @param url [URI::Generic] The url to the resource.
         # @param method [String] The HTTP method to use.
         # @param headers [Hash] The headers for the request.
         # @param body [String, nil] The body for the request.
+        # @param auth_headers [Hash] The auth headers resolved for this request. These
+        #   take precedence over the static default headers but not over per-request
+        #   headers, mirroring the previous baked-header precedence.
         # @return [HTTP::Request] The HTTP request.
-        def build_http_request(url:, method:, headers: {}, body: nil)
+        def build_http_request(url:, method:, headers: {}, body: nil, auth_headers: {})
           request = Net::HTTPGenericRequest.new(
             method,
             !body.nil?,
@@ -170,7 +193,7 @@ module Seed
             url
           )
 
-          request_headers = @default_headers.merge(headers)
+          request_headers = @default_headers.merge(auth_headers).merge(headers)
           request_headers.each { |name, value| request[name] = value }
           request.body = body if body
 

--- a/seed/ruby-sdk-v2/query-parameters-openapi/test/unit/internal/http/test_raw_client.rb
+++ b/seed/ruby-sdk-v2/query-parameters-openapi/test/unit/internal/http/test_raw_client.rb
@@ -54,4 +54,71 @@ describe Seed::Internal::Http::RawClient do
       assert client.should_retry?(make_response(502), 2)
     end
   end
+
+  # A minimal auth provider whose `auth_headers` returns a *different* token on
+  # each call, simulating a token that is refreshed on expiry.
+  class RefreshingAuthProvider
+    def initialize
+      @count = 0
+    end
+
+    def auth_headers
+      @count += 1
+      { "Authorization" => "Bearer TOKEN_#{@count}" }
+    end
+  end
+
+  describe "#resolve_auth_headers" do
+    it "returns an empty hash when no auth provider is configured" do
+      client = Seed::Internal::Http::RawClient.new(base_url: "https://example.com")
+
+      assert_equal({}, client.resolve_auth_headers)
+    end
+
+    it "consults the auth provider on every call so an expired token is refreshed" do
+      client = Seed::Internal::Http::RawClient.new(
+        base_url: "https://example.com",
+        auth_provider: RefreshingAuthProvider.new
+      )
+
+      assert_equal({ "Authorization" => "Bearer TOKEN_1" }, client.resolve_auth_headers)
+      assert_equal({ "Authorization" => "Bearer TOKEN_2" }, client.resolve_auth_headers)
+    end
+  end
+
+  describe "#build_http_request auth header precedence" do
+    let(:client) do
+      Seed::Internal::Http::RawClient.new(
+        base_url: "https://example.com",
+        headers: { "Authorization" => "Bearer STATIC" }
+      )
+    end
+
+    it "lets resolved auth headers override the static default headers" do
+      request = client.build_http_request(
+        url: URI.parse("https://example.com"),
+        method: "GET",
+        auth_headers: { "Authorization" => "Bearer FRESH" }
+      )
+
+      assert_equal("Bearer FRESH", request["Authorization"])
+    end
+
+    it "lets per-request headers take precedence over auth headers" do
+      request = client.build_http_request(
+        url: URI.parse("https://example.com"),
+        method: "GET",
+        headers: { "Authorization" => "Bearer PER_REQUEST" },
+        auth_headers: { "Authorization" => "Bearer FRESH" }
+      )
+
+      assert_equal("Bearer PER_REQUEST", request["Authorization"])
+    end
+
+    it "defaults auth headers to empty, leaving the default headers unchanged" do
+      request = client.build_http_request(url: URI.parse("https://example.com"), method: "GET")
+
+      assert_equal("Bearer STATIC", request["Authorization"])
+    end
+  end
 end

--- a/seed/ruby-sdk-v2/query-parameters/lib/seed/internal/http/raw_client.rb
+++ b/seed/ruby-sdk-v2/query-parameters/lib/seed/internal/http/raw_client.rb
@@ -21,10 +21,14 @@ module Seed
         # @param max_retries [Integer] The number of times to retry a failed request, defaults to 2.
         # @param timeout [Float] The timeout for the request, defaults to 60.0 seconds.
         # @param headers [Hash] The headers for the request.
-        def initialize(base_url:, max_retries: 2, timeout: 60.0, headers: {})
+        # @param auth_provider [Object, nil] An optional auth provider responding to
+        #   `auth_headers`. When present its headers are resolved on every request so
+        #   token-based schemes (e.g. OAuth) can refresh an expired token mid-session.
+        def initialize(base_url:, max_retries: 2, timeout: 60.0, headers: {}, auth_provider: nil)
           @base_url = base_url
           @max_retries = max_retries
           @timeout = timeout
+          @auth_provider = auth_provider
           @default_headers = {
             "X-Fern-Language": "Ruby",
             "X-Fern-SDK-Name": "seed",
@@ -36,6 +40,9 @@ module Seed
         # @return [HTTP::Response] The HTTP response.
         def send(request)
           url = build_url(request)
+          # Resolve auth headers once per request (not per retry) so token-based
+          # providers refresh at most once here; static providers are cheap.
+          auth_headers = resolve_auth_headers
           attempt = 0
           response = nil
 
@@ -43,8 +50,9 @@ module Seed
             http_request = build_http_request(
               url:,
               method: request.method,
-              headers: request.encode_headers(protected_keys: @default_headers.keys),
-              body: request.encode_body
+              headers: request.encode_headers(protected_keys: @default_headers.keys + auth_headers.keys),
+              body: request.encode_body,
+              auth_headers: auth_headers
             )
 
             conn = connect(url)
@@ -157,12 +165,27 @@ module Seed
                 "HTTP is only allowed for localhost. Use HTTPS or pass a localhost URL."
         end
 
+        # Resolves the auth headers to send with the next request. Delegates to the
+        # configured auth provider (if any) on every call so that token-based
+        # providers (e.g. OAuth client-credentials) can refresh an expired token
+        # before the request is sent. Returns an empty hash when no provider is set,
+        # which keeps the api-key / basic / bearer / no-auth paths unchanged.
+        # @return [Hash] The auth headers for the current request.
+        def resolve_auth_headers
+          return {} if @auth_provider.nil?
+
+          @auth_provider.auth_headers
+        end
+
         # @param url [URI::Generic] The url to the resource.
         # @param method [String] The HTTP method to use.
         # @param headers [Hash] The headers for the request.
         # @param body [String, nil] The body for the request.
+        # @param auth_headers [Hash] The auth headers resolved for this request. These
+        #   take precedence over the static default headers but not over per-request
+        #   headers, mirroring the previous baked-header precedence.
         # @return [HTTP::Request] The HTTP request.
-        def build_http_request(url:, method:, headers: {}, body: nil)
+        def build_http_request(url:, method:, headers: {}, body: nil, auth_headers: {})
           request = Net::HTTPGenericRequest.new(
             method,
             !body.nil?,
@@ -170,7 +193,7 @@ module Seed
             url
           )
 
-          request_headers = @default_headers.merge(headers)
+          request_headers = @default_headers.merge(auth_headers).merge(headers)
           request_headers.each { |name, value| request[name] = value }
           request.body = body if body
 

--- a/seed/ruby-sdk-v2/query-parameters/test/unit/internal/http/test_raw_client.rb
+++ b/seed/ruby-sdk-v2/query-parameters/test/unit/internal/http/test_raw_client.rb
@@ -54,4 +54,71 @@ describe Seed::Internal::Http::RawClient do
       assert client.should_retry?(make_response(502), 2)
     end
   end
+
+  # A minimal auth provider whose `auth_headers` returns a *different* token on
+  # each call, simulating a token that is refreshed on expiry.
+  class RefreshingAuthProvider
+    def initialize
+      @count = 0
+    end
+
+    def auth_headers
+      @count += 1
+      { "Authorization" => "Bearer TOKEN_#{@count}" }
+    end
+  end
+
+  describe "#resolve_auth_headers" do
+    it "returns an empty hash when no auth provider is configured" do
+      client = Seed::Internal::Http::RawClient.new(base_url: "https://example.com")
+
+      assert_equal({}, client.resolve_auth_headers)
+    end
+
+    it "consults the auth provider on every call so an expired token is refreshed" do
+      client = Seed::Internal::Http::RawClient.new(
+        base_url: "https://example.com",
+        auth_provider: RefreshingAuthProvider.new
+      )
+
+      assert_equal({ "Authorization" => "Bearer TOKEN_1" }, client.resolve_auth_headers)
+      assert_equal({ "Authorization" => "Bearer TOKEN_2" }, client.resolve_auth_headers)
+    end
+  end
+
+  describe "#build_http_request auth header precedence" do
+    let(:client) do
+      Seed::Internal::Http::RawClient.new(
+        base_url: "https://example.com",
+        headers: { "Authorization" => "Bearer STATIC" }
+      )
+    end
+
+    it "lets resolved auth headers override the static default headers" do
+      request = client.build_http_request(
+        url: URI.parse("https://example.com"),
+        method: "GET",
+        auth_headers: { "Authorization" => "Bearer FRESH" }
+      )
+
+      assert_equal("Bearer FRESH", request["Authorization"])
+    end
+
+    it "lets per-request headers take precedence over auth headers" do
+      request = client.build_http_request(
+        url: URI.parse("https://example.com"),
+        method: "GET",
+        headers: { "Authorization" => "Bearer PER_REQUEST" },
+        auth_headers: { "Authorization" => "Bearer FRESH" }
+      )
+
+      assert_equal("Bearer PER_REQUEST", request["Authorization"])
+    end
+
+    it "defaults auth headers to empty, leaving the default headers unchanged" do
+      request = client.build_http_request(url: URI.parse("https://example.com"), method: "GET")
+
+      assert_equal("Bearer STATIC", request["Authorization"])
+    end
+  end
 end

--- a/seed/ruby-sdk-v2/request-parameters/lib/seed/internal/http/raw_client.rb
+++ b/seed/ruby-sdk-v2/request-parameters/lib/seed/internal/http/raw_client.rb
@@ -21,10 +21,14 @@ module Seed
         # @param max_retries [Integer] The number of times to retry a failed request, defaults to 2.
         # @param timeout [Float] The timeout for the request, defaults to 60.0 seconds.
         # @param headers [Hash] The headers for the request.
-        def initialize(base_url:, max_retries: 2, timeout: 60.0, headers: {})
+        # @param auth_provider [Object, nil] An optional auth provider responding to
+        #   `auth_headers`. When present its headers are resolved on every request so
+        #   token-based schemes (e.g. OAuth) can refresh an expired token mid-session.
+        def initialize(base_url:, max_retries: 2, timeout: 60.0, headers: {}, auth_provider: nil)
           @base_url = base_url
           @max_retries = max_retries
           @timeout = timeout
+          @auth_provider = auth_provider
           @default_headers = {
             "X-Fern-Language": "Ruby",
             "X-Fern-SDK-Name": "seed",
@@ -36,6 +40,9 @@ module Seed
         # @return [HTTP::Response] The HTTP response.
         def send(request)
           url = build_url(request)
+          # Resolve auth headers once per request (not per retry) so token-based
+          # providers refresh at most once here; static providers are cheap.
+          auth_headers = resolve_auth_headers
           attempt = 0
           response = nil
 
@@ -43,8 +50,9 @@ module Seed
             http_request = build_http_request(
               url:,
               method: request.method,
-              headers: request.encode_headers(protected_keys: @default_headers.keys),
-              body: request.encode_body
+              headers: request.encode_headers(protected_keys: @default_headers.keys + auth_headers.keys),
+              body: request.encode_body,
+              auth_headers: auth_headers
             )
 
             conn = connect(url)
@@ -157,12 +165,27 @@ module Seed
                 "HTTP is only allowed for localhost. Use HTTPS or pass a localhost URL."
         end
 
+        # Resolves the auth headers to send with the next request. Delegates to the
+        # configured auth provider (if any) on every call so that token-based
+        # providers (e.g. OAuth client-credentials) can refresh an expired token
+        # before the request is sent. Returns an empty hash when no provider is set,
+        # which keeps the api-key / basic / bearer / no-auth paths unchanged.
+        # @return [Hash] The auth headers for the current request.
+        def resolve_auth_headers
+          return {} if @auth_provider.nil?
+
+          @auth_provider.auth_headers
+        end
+
         # @param url [URI::Generic] The url to the resource.
         # @param method [String] The HTTP method to use.
         # @param headers [Hash] The headers for the request.
         # @param body [String, nil] The body for the request.
+        # @param auth_headers [Hash] The auth headers resolved for this request. These
+        #   take precedence over the static default headers but not over per-request
+        #   headers, mirroring the previous baked-header precedence.
         # @return [HTTP::Request] The HTTP request.
-        def build_http_request(url:, method:, headers: {}, body: nil)
+        def build_http_request(url:, method:, headers: {}, body: nil, auth_headers: {})
           request = Net::HTTPGenericRequest.new(
             method,
             !body.nil?,
@@ -170,7 +193,7 @@ module Seed
             url
           )
 
-          request_headers = @default_headers.merge(headers)
+          request_headers = @default_headers.merge(auth_headers).merge(headers)
           request_headers.each { |name, value| request[name] = value }
           request.body = body if body
 

--- a/seed/ruby-sdk-v2/request-parameters/test/unit/internal/http/test_raw_client.rb
+++ b/seed/ruby-sdk-v2/request-parameters/test/unit/internal/http/test_raw_client.rb
@@ -54,4 +54,71 @@ describe Seed::Internal::Http::RawClient do
       assert client.should_retry?(make_response(502), 2)
     end
   end
+
+  # A minimal auth provider whose `auth_headers` returns a *different* token on
+  # each call, simulating a token that is refreshed on expiry.
+  class RefreshingAuthProvider
+    def initialize
+      @count = 0
+    end
+
+    def auth_headers
+      @count += 1
+      { "Authorization" => "Bearer TOKEN_#{@count}" }
+    end
+  end
+
+  describe "#resolve_auth_headers" do
+    it "returns an empty hash when no auth provider is configured" do
+      client = Seed::Internal::Http::RawClient.new(base_url: "https://example.com")
+
+      assert_equal({}, client.resolve_auth_headers)
+    end
+
+    it "consults the auth provider on every call so an expired token is refreshed" do
+      client = Seed::Internal::Http::RawClient.new(
+        base_url: "https://example.com",
+        auth_provider: RefreshingAuthProvider.new
+      )
+
+      assert_equal({ "Authorization" => "Bearer TOKEN_1" }, client.resolve_auth_headers)
+      assert_equal({ "Authorization" => "Bearer TOKEN_2" }, client.resolve_auth_headers)
+    end
+  end
+
+  describe "#build_http_request auth header precedence" do
+    let(:client) do
+      Seed::Internal::Http::RawClient.new(
+        base_url: "https://example.com",
+        headers: { "Authorization" => "Bearer STATIC" }
+      )
+    end
+
+    it "lets resolved auth headers override the static default headers" do
+      request = client.build_http_request(
+        url: URI.parse("https://example.com"),
+        method: "GET",
+        auth_headers: { "Authorization" => "Bearer FRESH" }
+      )
+
+      assert_equal("Bearer FRESH", request["Authorization"])
+    end
+
+    it "lets per-request headers take precedence over auth headers" do
+      request = client.build_http_request(
+        url: URI.parse("https://example.com"),
+        method: "GET",
+        headers: { "Authorization" => "Bearer PER_REQUEST" },
+        auth_headers: { "Authorization" => "Bearer FRESH" }
+      )
+
+      assert_equal("Bearer PER_REQUEST", request["Authorization"])
+    end
+
+    it "defaults auth headers to empty, leaving the default headers unchanged" do
+      request = client.build_http_request(url: URI.parse("https://example.com"), method: "GET")
+
+      assert_equal("Bearer STATIC", request["Authorization"])
+    end
+  end
 end

--- a/seed/ruby-sdk-v2/required-nullable/lib/seed/internal/http/raw_client.rb
+++ b/seed/ruby-sdk-v2/required-nullable/lib/seed/internal/http/raw_client.rb
@@ -21,10 +21,14 @@ module Seed
         # @param max_retries [Integer] The number of times to retry a failed request, defaults to 2.
         # @param timeout [Float] The timeout for the request, defaults to 60.0 seconds.
         # @param headers [Hash] The headers for the request.
-        def initialize(base_url:, max_retries: 2, timeout: 60.0, headers: {})
+        # @param auth_provider [Object, nil] An optional auth provider responding to
+        #   `auth_headers`. When present its headers are resolved on every request so
+        #   token-based schemes (e.g. OAuth) can refresh an expired token mid-session.
+        def initialize(base_url:, max_retries: 2, timeout: 60.0, headers: {}, auth_provider: nil)
           @base_url = base_url
           @max_retries = max_retries
           @timeout = timeout
+          @auth_provider = auth_provider
           @default_headers = {
             "X-Fern-Language": "Ruby",
             "X-Fern-SDK-Name": "seed",
@@ -36,6 +40,9 @@ module Seed
         # @return [HTTP::Response] The HTTP response.
         def send(request)
           url = build_url(request)
+          # Resolve auth headers once per request (not per retry) so token-based
+          # providers refresh at most once here; static providers are cheap.
+          auth_headers = resolve_auth_headers
           attempt = 0
           response = nil
 
@@ -43,8 +50,9 @@ module Seed
             http_request = build_http_request(
               url:,
               method: request.method,
-              headers: request.encode_headers(protected_keys: @default_headers.keys),
-              body: request.encode_body
+              headers: request.encode_headers(protected_keys: @default_headers.keys + auth_headers.keys),
+              body: request.encode_body,
+              auth_headers: auth_headers
             )
 
             conn = connect(url)
@@ -157,12 +165,27 @@ module Seed
                 "HTTP is only allowed for localhost. Use HTTPS or pass a localhost URL."
         end
 
+        # Resolves the auth headers to send with the next request. Delegates to the
+        # configured auth provider (if any) on every call so that token-based
+        # providers (e.g. OAuth client-credentials) can refresh an expired token
+        # before the request is sent. Returns an empty hash when no provider is set,
+        # which keeps the api-key / basic / bearer / no-auth paths unchanged.
+        # @return [Hash] The auth headers for the current request.
+        def resolve_auth_headers
+          return {} if @auth_provider.nil?
+
+          @auth_provider.auth_headers
+        end
+
         # @param url [URI::Generic] The url to the resource.
         # @param method [String] The HTTP method to use.
         # @param headers [Hash] The headers for the request.
         # @param body [String, nil] The body for the request.
+        # @param auth_headers [Hash] The auth headers resolved for this request. These
+        #   take precedence over the static default headers but not over per-request
+        #   headers, mirroring the previous baked-header precedence.
         # @return [HTTP::Request] The HTTP request.
-        def build_http_request(url:, method:, headers: {}, body: nil)
+        def build_http_request(url:, method:, headers: {}, body: nil, auth_headers: {})
           request = Net::HTTPGenericRequest.new(
             method,
             !body.nil?,
@@ -170,7 +193,7 @@ module Seed
             url
           )
 
-          request_headers = @default_headers.merge(headers)
+          request_headers = @default_headers.merge(auth_headers).merge(headers)
           request_headers.each { |name, value| request[name] = value }
           request.body = body if body
 

--- a/seed/ruby-sdk-v2/required-nullable/test/unit/internal/http/test_raw_client.rb
+++ b/seed/ruby-sdk-v2/required-nullable/test/unit/internal/http/test_raw_client.rb
@@ -54,4 +54,71 @@ describe Seed::Internal::Http::RawClient do
       assert client.should_retry?(make_response(502), 2)
     end
   end
+
+  # A minimal auth provider whose `auth_headers` returns a *different* token on
+  # each call, simulating a token that is refreshed on expiry.
+  class RefreshingAuthProvider
+    def initialize
+      @count = 0
+    end
+
+    def auth_headers
+      @count += 1
+      { "Authorization" => "Bearer TOKEN_#{@count}" }
+    end
+  end
+
+  describe "#resolve_auth_headers" do
+    it "returns an empty hash when no auth provider is configured" do
+      client = Seed::Internal::Http::RawClient.new(base_url: "https://example.com")
+
+      assert_equal({}, client.resolve_auth_headers)
+    end
+
+    it "consults the auth provider on every call so an expired token is refreshed" do
+      client = Seed::Internal::Http::RawClient.new(
+        base_url: "https://example.com",
+        auth_provider: RefreshingAuthProvider.new
+      )
+
+      assert_equal({ "Authorization" => "Bearer TOKEN_1" }, client.resolve_auth_headers)
+      assert_equal({ "Authorization" => "Bearer TOKEN_2" }, client.resolve_auth_headers)
+    end
+  end
+
+  describe "#build_http_request auth header precedence" do
+    let(:client) do
+      Seed::Internal::Http::RawClient.new(
+        base_url: "https://example.com",
+        headers: { "Authorization" => "Bearer STATIC" }
+      )
+    end
+
+    it "lets resolved auth headers override the static default headers" do
+      request = client.build_http_request(
+        url: URI.parse("https://example.com"),
+        method: "GET",
+        auth_headers: { "Authorization" => "Bearer FRESH" }
+      )
+
+      assert_equal("Bearer FRESH", request["Authorization"])
+    end
+
+    it "lets per-request headers take precedence over auth headers" do
+      request = client.build_http_request(
+        url: URI.parse("https://example.com"),
+        method: "GET",
+        headers: { "Authorization" => "Bearer PER_REQUEST" },
+        auth_headers: { "Authorization" => "Bearer FRESH" }
+      )
+
+      assert_equal("Bearer PER_REQUEST", request["Authorization"])
+    end
+
+    it "defaults auth headers to empty, leaving the default headers unchanged" do
+      request = client.build_http_request(url: URI.parse("https://example.com"), method: "GET")
+
+      assert_equal("Bearer STATIC", request["Authorization"])
+    end
+  end
 end

--- a/seed/ruby-sdk-v2/reserved-keywords/lib/seed/internal/http/raw_client.rb
+++ b/seed/ruby-sdk-v2/reserved-keywords/lib/seed/internal/http/raw_client.rb
@@ -21,10 +21,14 @@ module Seed
         # @param max_retries [Integer] The number of times to retry a failed request, defaults to 2.
         # @param timeout [Float] The timeout for the request, defaults to 60.0 seconds.
         # @param headers [Hash] The headers for the request.
-        def initialize(base_url:, max_retries: 2, timeout: 60.0, headers: {})
+        # @param auth_provider [Object, nil] An optional auth provider responding to
+        #   `auth_headers`. When present its headers are resolved on every request so
+        #   token-based schemes (e.g. OAuth) can refresh an expired token mid-session.
+        def initialize(base_url:, max_retries: 2, timeout: 60.0, headers: {}, auth_provider: nil)
           @base_url = base_url
           @max_retries = max_retries
           @timeout = timeout
+          @auth_provider = auth_provider
           @default_headers = {
             "X-Fern-Language": "Ruby",
             "X-Fern-SDK-Name": "seed",
@@ -36,6 +40,9 @@ module Seed
         # @return [HTTP::Response] The HTTP response.
         def send(request)
           url = build_url(request)
+          # Resolve auth headers once per request (not per retry) so token-based
+          # providers refresh at most once here; static providers are cheap.
+          auth_headers = resolve_auth_headers
           attempt = 0
           response = nil
 
@@ -43,8 +50,9 @@ module Seed
             http_request = build_http_request(
               url:,
               method: request.method,
-              headers: request.encode_headers(protected_keys: @default_headers.keys),
-              body: request.encode_body
+              headers: request.encode_headers(protected_keys: @default_headers.keys + auth_headers.keys),
+              body: request.encode_body,
+              auth_headers: auth_headers
             )
 
             conn = connect(url)
@@ -157,12 +165,27 @@ module Seed
                 "HTTP is only allowed for localhost. Use HTTPS or pass a localhost URL."
         end
 
+        # Resolves the auth headers to send with the next request. Delegates to the
+        # configured auth provider (if any) on every call so that token-based
+        # providers (e.g. OAuth client-credentials) can refresh an expired token
+        # before the request is sent. Returns an empty hash when no provider is set,
+        # which keeps the api-key / basic / bearer / no-auth paths unchanged.
+        # @return [Hash] The auth headers for the current request.
+        def resolve_auth_headers
+          return {} if @auth_provider.nil?
+
+          @auth_provider.auth_headers
+        end
+
         # @param url [URI::Generic] The url to the resource.
         # @param method [String] The HTTP method to use.
         # @param headers [Hash] The headers for the request.
         # @param body [String, nil] The body for the request.
+        # @param auth_headers [Hash] The auth headers resolved for this request. These
+        #   take precedence over the static default headers but not over per-request
+        #   headers, mirroring the previous baked-header precedence.
         # @return [HTTP::Request] The HTTP request.
-        def build_http_request(url:, method:, headers: {}, body: nil)
+        def build_http_request(url:, method:, headers: {}, body: nil, auth_headers: {})
           request = Net::HTTPGenericRequest.new(
             method,
             !body.nil?,
@@ -170,7 +193,7 @@ module Seed
             url
           )
 
-          request_headers = @default_headers.merge(headers)
+          request_headers = @default_headers.merge(auth_headers).merge(headers)
           request_headers.each { |name, value| request[name] = value }
           request.body = body if body
 

--- a/seed/ruby-sdk-v2/reserved-keywords/test/unit/internal/http/test_raw_client.rb
+++ b/seed/ruby-sdk-v2/reserved-keywords/test/unit/internal/http/test_raw_client.rb
@@ -54,4 +54,71 @@ describe Seed::Internal::Http::RawClient do
       assert client.should_retry?(make_response(502), 2)
     end
   end
+
+  # A minimal auth provider whose `auth_headers` returns a *different* token on
+  # each call, simulating a token that is refreshed on expiry.
+  class RefreshingAuthProvider
+    def initialize
+      @count = 0
+    end
+
+    def auth_headers
+      @count += 1
+      { "Authorization" => "Bearer TOKEN_#{@count}" }
+    end
+  end
+
+  describe "#resolve_auth_headers" do
+    it "returns an empty hash when no auth provider is configured" do
+      client = Seed::Internal::Http::RawClient.new(base_url: "https://example.com")
+
+      assert_equal({}, client.resolve_auth_headers)
+    end
+
+    it "consults the auth provider on every call so an expired token is refreshed" do
+      client = Seed::Internal::Http::RawClient.new(
+        base_url: "https://example.com",
+        auth_provider: RefreshingAuthProvider.new
+      )
+
+      assert_equal({ "Authorization" => "Bearer TOKEN_1" }, client.resolve_auth_headers)
+      assert_equal({ "Authorization" => "Bearer TOKEN_2" }, client.resolve_auth_headers)
+    end
+  end
+
+  describe "#build_http_request auth header precedence" do
+    let(:client) do
+      Seed::Internal::Http::RawClient.new(
+        base_url: "https://example.com",
+        headers: { "Authorization" => "Bearer STATIC" }
+      )
+    end
+
+    it "lets resolved auth headers override the static default headers" do
+      request = client.build_http_request(
+        url: URI.parse("https://example.com"),
+        method: "GET",
+        auth_headers: { "Authorization" => "Bearer FRESH" }
+      )
+
+      assert_equal("Bearer FRESH", request["Authorization"])
+    end
+
+    it "lets per-request headers take precedence over auth headers" do
+      request = client.build_http_request(
+        url: URI.parse("https://example.com"),
+        method: "GET",
+        headers: { "Authorization" => "Bearer PER_REQUEST" },
+        auth_headers: { "Authorization" => "Bearer FRESH" }
+      )
+
+      assert_equal("Bearer PER_REQUEST", request["Authorization"])
+    end
+
+    it "defaults auth headers to empty, leaving the default headers unchanged" do
+      request = client.build_http_request(url: URI.parse("https://example.com"), method: "GET")
+
+      assert_equal("Bearer STATIC", request["Authorization"])
+    end
+  end
 end

--- a/seed/ruby-sdk-v2/response-property/lib/seed/internal/http/raw_client.rb
+++ b/seed/ruby-sdk-v2/response-property/lib/seed/internal/http/raw_client.rb
@@ -21,10 +21,14 @@ module Seed
         # @param max_retries [Integer] The number of times to retry a failed request, defaults to 2.
         # @param timeout [Float] The timeout for the request, defaults to 60.0 seconds.
         # @param headers [Hash] The headers for the request.
-        def initialize(base_url:, max_retries: 2, timeout: 60.0, headers: {})
+        # @param auth_provider [Object, nil] An optional auth provider responding to
+        #   `auth_headers`. When present its headers are resolved on every request so
+        #   token-based schemes (e.g. OAuth) can refresh an expired token mid-session.
+        def initialize(base_url:, max_retries: 2, timeout: 60.0, headers: {}, auth_provider: nil)
           @base_url = base_url
           @max_retries = max_retries
           @timeout = timeout
+          @auth_provider = auth_provider
           @default_headers = {
             "X-Fern-Language": "Ruby",
             "X-Fern-SDK-Name": "seed",
@@ -36,6 +40,9 @@ module Seed
         # @return [HTTP::Response] The HTTP response.
         def send(request)
           url = build_url(request)
+          # Resolve auth headers once per request (not per retry) so token-based
+          # providers refresh at most once here; static providers are cheap.
+          auth_headers = resolve_auth_headers
           attempt = 0
           response = nil
 
@@ -43,8 +50,9 @@ module Seed
             http_request = build_http_request(
               url:,
               method: request.method,
-              headers: request.encode_headers(protected_keys: @default_headers.keys),
-              body: request.encode_body
+              headers: request.encode_headers(protected_keys: @default_headers.keys + auth_headers.keys),
+              body: request.encode_body,
+              auth_headers: auth_headers
             )
 
             conn = connect(url)
@@ -157,12 +165,27 @@ module Seed
                 "HTTP is only allowed for localhost. Use HTTPS or pass a localhost URL."
         end
 
+        # Resolves the auth headers to send with the next request. Delegates to the
+        # configured auth provider (if any) on every call so that token-based
+        # providers (e.g. OAuth client-credentials) can refresh an expired token
+        # before the request is sent. Returns an empty hash when no provider is set,
+        # which keeps the api-key / basic / bearer / no-auth paths unchanged.
+        # @return [Hash] The auth headers for the current request.
+        def resolve_auth_headers
+          return {} if @auth_provider.nil?
+
+          @auth_provider.auth_headers
+        end
+
         # @param url [URI::Generic] The url to the resource.
         # @param method [String] The HTTP method to use.
         # @param headers [Hash] The headers for the request.
         # @param body [String, nil] The body for the request.
+        # @param auth_headers [Hash] The auth headers resolved for this request. These
+        #   take precedence over the static default headers but not over per-request
+        #   headers, mirroring the previous baked-header precedence.
         # @return [HTTP::Request] The HTTP request.
-        def build_http_request(url:, method:, headers: {}, body: nil)
+        def build_http_request(url:, method:, headers: {}, body: nil, auth_headers: {})
           request = Net::HTTPGenericRequest.new(
             method,
             !body.nil?,
@@ -170,7 +193,7 @@ module Seed
             url
           )
 
-          request_headers = @default_headers.merge(headers)
+          request_headers = @default_headers.merge(auth_headers).merge(headers)
           request_headers.each { |name, value| request[name] = value }
           request.body = body if body
 

--- a/seed/ruby-sdk-v2/response-property/test/unit/internal/http/test_raw_client.rb
+++ b/seed/ruby-sdk-v2/response-property/test/unit/internal/http/test_raw_client.rb
@@ -54,4 +54,71 @@ describe Seed::Internal::Http::RawClient do
       assert client.should_retry?(make_response(502), 2)
     end
   end
+
+  # A minimal auth provider whose `auth_headers` returns a *different* token on
+  # each call, simulating a token that is refreshed on expiry.
+  class RefreshingAuthProvider
+    def initialize
+      @count = 0
+    end
+
+    def auth_headers
+      @count += 1
+      { "Authorization" => "Bearer TOKEN_#{@count}" }
+    end
+  end
+
+  describe "#resolve_auth_headers" do
+    it "returns an empty hash when no auth provider is configured" do
+      client = Seed::Internal::Http::RawClient.new(base_url: "https://example.com")
+
+      assert_equal({}, client.resolve_auth_headers)
+    end
+
+    it "consults the auth provider on every call so an expired token is refreshed" do
+      client = Seed::Internal::Http::RawClient.new(
+        base_url: "https://example.com",
+        auth_provider: RefreshingAuthProvider.new
+      )
+
+      assert_equal({ "Authorization" => "Bearer TOKEN_1" }, client.resolve_auth_headers)
+      assert_equal({ "Authorization" => "Bearer TOKEN_2" }, client.resolve_auth_headers)
+    end
+  end
+
+  describe "#build_http_request auth header precedence" do
+    let(:client) do
+      Seed::Internal::Http::RawClient.new(
+        base_url: "https://example.com",
+        headers: { "Authorization" => "Bearer STATIC" }
+      )
+    end
+
+    it "lets resolved auth headers override the static default headers" do
+      request = client.build_http_request(
+        url: URI.parse("https://example.com"),
+        method: "GET",
+        auth_headers: { "Authorization" => "Bearer FRESH" }
+      )
+
+      assert_equal("Bearer FRESH", request["Authorization"])
+    end
+
+    it "lets per-request headers take precedence over auth headers" do
+      request = client.build_http_request(
+        url: URI.parse("https://example.com"),
+        method: "GET",
+        headers: { "Authorization" => "Bearer PER_REQUEST" },
+        auth_headers: { "Authorization" => "Bearer FRESH" }
+      )
+
+      assert_equal("Bearer PER_REQUEST", request["Authorization"])
+    end
+
+    it "defaults auth headers to empty, leaving the default headers unchanged" do
+      request = client.build_http_request(url: URI.parse("https://example.com"), method: "GET")
+
+      assert_equal("Bearer STATIC", request["Authorization"])
+    end
+  end
 end

--- a/seed/ruby-sdk-v2/ruby-reserved-word-properties/lib/seed/internal/http/raw_client.rb
+++ b/seed/ruby-sdk-v2/ruby-reserved-word-properties/lib/seed/internal/http/raw_client.rb
@@ -21,10 +21,14 @@ module Seed
         # @param max_retries [Integer] The number of times to retry a failed request, defaults to 2.
         # @param timeout [Float] The timeout for the request, defaults to 60.0 seconds.
         # @param headers [Hash] The headers for the request.
-        def initialize(base_url:, max_retries: 2, timeout: 60.0, headers: {})
+        # @param auth_provider [Object, nil] An optional auth provider responding to
+        #   `auth_headers`. When present its headers are resolved on every request so
+        #   token-based schemes (e.g. OAuth) can refresh an expired token mid-session.
+        def initialize(base_url:, max_retries: 2, timeout: 60.0, headers: {}, auth_provider: nil)
           @base_url = base_url
           @max_retries = max_retries
           @timeout = timeout
+          @auth_provider = auth_provider
           @default_headers = {
             "X-Fern-Language": "Ruby",
             "X-Fern-SDK-Name": "seed",
@@ -36,6 +40,9 @@ module Seed
         # @return [HTTP::Response] The HTTP response.
         def send(request)
           url = build_url(request)
+          # Resolve auth headers once per request (not per retry) so token-based
+          # providers refresh at most once here; static providers are cheap.
+          auth_headers = resolve_auth_headers
           attempt = 0
           response = nil
 
@@ -43,8 +50,9 @@ module Seed
             http_request = build_http_request(
               url:,
               method: request.method,
-              headers: request.encode_headers(protected_keys: @default_headers.keys),
-              body: request.encode_body
+              headers: request.encode_headers(protected_keys: @default_headers.keys + auth_headers.keys),
+              body: request.encode_body,
+              auth_headers: auth_headers
             )
 
             conn = connect(url)
@@ -157,12 +165,27 @@ module Seed
                 "HTTP is only allowed for localhost. Use HTTPS or pass a localhost URL."
         end
 
+        # Resolves the auth headers to send with the next request. Delegates to the
+        # configured auth provider (if any) on every call so that token-based
+        # providers (e.g. OAuth client-credentials) can refresh an expired token
+        # before the request is sent. Returns an empty hash when no provider is set,
+        # which keeps the api-key / basic / bearer / no-auth paths unchanged.
+        # @return [Hash] The auth headers for the current request.
+        def resolve_auth_headers
+          return {} if @auth_provider.nil?
+
+          @auth_provider.auth_headers
+        end
+
         # @param url [URI::Generic] The url to the resource.
         # @param method [String] The HTTP method to use.
         # @param headers [Hash] The headers for the request.
         # @param body [String, nil] The body for the request.
+        # @param auth_headers [Hash] The auth headers resolved for this request. These
+        #   take precedence over the static default headers but not over per-request
+        #   headers, mirroring the previous baked-header precedence.
         # @return [HTTP::Request] The HTTP request.
-        def build_http_request(url:, method:, headers: {}, body: nil)
+        def build_http_request(url:, method:, headers: {}, body: nil, auth_headers: {})
           request = Net::HTTPGenericRequest.new(
             method,
             !body.nil?,
@@ -170,7 +193,7 @@ module Seed
             url
           )
 
-          request_headers = @default_headers.merge(headers)
+          request_headers = @default_headers.merge(auth_headers).merge(headers)
           request_headers.each { |name, value| request[name] = value }
           request.body = body if body
 

--- a/seed/ruby-sdk-v2/ruby-reserved-word-properties/test/unit/internal/http/test_raw_client.rb
+++ b/seed/ruby-sdk-v2/ruby-reserved-word-properties/test/unit/internal/http/test_raw_client.rb
@@ -54,4 +54,71 @@ describe Seed::Internal::Http::RawClient do
       assert client.should_retry?(make_response(502), 2)
     end
   end
+
+  # A minimal auth provider whose `auth_headers` returns a *different* token on
+  # each call, simulating a token that is refreshed on expiry.
+  class RefreshingAuthProvider
+    def initialize
+      @count = 0
+    end
+
+    def auth_headers
+      @count += 1
+      { "Authorization" => "Bearer TOKEN_#{@count}" }
+    end
+  end
+
+  describe "#resolve_auth_headers" do
+    it "returns an empty hash when no auth provider is configured" do
+      client = Seed::Internal::Http::RawClient.new(base_url: "https://example.com")
+
+      assert_equal({}, client.resolve_auth_headers)
+    end
+
+    it "consults the auth provider on every call so an expired token is refreshed" do
+      client = Seed::Internal::Http::RawClient.new(
+        base_url: "https://example.com",
+        auth_provider: RefreshingAuthProvider.new
+      )
+
+      assert_equal({ "Authorization" => "Bearer TOKEN_1" }, client.resolve_auth_headers)
+      assert_equal({ "Authorization" => "Bearer TOKEN_2" }, client.resolve_auth_headers)
+    end
+  end
+
+  describe "#build_http_request auth header precedence" do
+    let(:client) do
+      Seed::Internal::Http::RawClient.new(
+        base_url: "https://example.com",
+        headers: { "Authorization" => "Bearer STATIC" }
+      )
+    end
+
+    it "lets resolved auth headers override the static default headers" do
+      request = client.build_http_request(
+        url: URI.parse("https://example.com"),
+        method: "GET",
+        auth_headers: { "Authorization" => "Bearer FRESH" }
+      )
+
+      assert_equal("Bearer FRESH", request["Authorization"])
+    end
+
+    it "lets per-request headers take precedence over auth headers" do
+      request = client.build_http_request(
+        url: URI.parse("https://example.com"),
+        method: "GET",
+        headers: { "Authorization" => "Bearer PER_REQUEST" },
+        auth_headers: { "Authorization" => "Bearer FRESH" }
+      )
+
+      assert_equal("Bearer PER_REQUEST", request["Authorization"])
+    end
+
+    it "defaults auth headers to empty, leaving the default headers unchanged" do
+      request = client.build_http_request(url: URI.parse("https://example.com"), method: "GET")
+
+      assert_equal("Bearer STATIC", request["Authorization"])
+    end
+  end
 end

--- a/seed/ruby-sdk-v2/schemaless-request-body-examples/lib/seed/internal/http/raw_client.rb
+++ b/seed/ruby-sdk-v2/schemaless-request-body-examples/lib/seed/internal/http/raw_client.rb
@@ -21,10 +21,14 @@ module Seed
         # @param max_retries [Integer] The number of times to retry a failed request, defaults to 2.
         # @param timeout [Float] The timeout for the request, defaults to 60.0 seconds.
         # @param headers [Hash] The headers for the request.
-        def initialize(base_url:, max_retries: 2, timeout: 60.0, headers: {})
+        # @param auth_provider [Object, nil] An optional auth provider responding to
+        #   `auth_headers`. When present its headers are resolved on every request so
+        #   token-based schemes (e.g. OAuth) can refresh an expired token mid-session.
+        def initialize(base_url:, max_retries: 2, timeout: 60.0, headers: {}, auth_provider: nil)
           @base_url = base_url
           @max_retries = max_retries
           @timeout = timeout
+          @auth_provider = auth_provider
           @default_headers = {
             "X-Fern-Language": "Ruby",
             "X-Fern-SDK-Name": "seed",
@@ -36,6 +40,9 @@ module Seed
         # @return [HTTP::Response] The HTTP response.
         def send(request)
           url = build_url(request)
+          # Resolve auth headers once per request (not per retry) so token-based
+          # providers refresh at most once here; static providers are cheap.
+          auth_headers = resolve_auth_headers
           attempt = 0
           response = nil
 
@@ -43,8 +50,9 @@ module Seed
             http_request = build_http_request(
               url:,
               method: request.method,
-              headers: request.encode_headers(protected_keys: @default_headers.keys),
-              body: request.encode_body
+              headers: request.encode_headers(protected_keys: @default_headers.keys + auth_headers.keys),
+              body: request.encode_body,
+              auth_headers: auth_headers
             )
 
             conn = connect(url)
@@ -157,12 +165,27 @@ module Seed
                 "HTTP is only allowed for localhost. Use HTTPS or pass a localhost URL."
         end
 
+        # Resolves the auth headers to send with the next request. Delegates to the
+        # configured auth provider (if any) on every call so that token-based
+        # providers (e.g. OAuth client-credentials) can refresh an expired token
+        # before the request is sent. Returns an empty hash when no provider is set,
+        # which keeps the api-key / basic / bearer / no-auth paths unchanged.
+        # @return [Hash] The auth headers for the current request.
+        def resolve_auth_headers
+          return {} if @auth_provider.nil?
+
+          @auth_provider.auth_headers
+        end
+
         # @param url [URI::Generic] The url to the resource.
         # @param method [String] The HTTP method to use.
         # @param headers [Hash] The headers for the request.
         # @param body [String, nil] The body for the request.
+        # @param auth_headers [Hash] The auth headers resolved for this request. These
+        #   take precedence over the static default headers but not over per-request
+        #   headers, mirroring the previous baked-header precedence.
         # @return [HTTP::Request] The HTTP request.
-        def build_http_request(url:, method:, headers: {}, body: nil)
+        def build_http_request(url:, method:, headers: {}, body: nil, auth_headers: {})
           request = Net::HTTPGenericRequest.new(
             method,
             !body.nil?,
@@ -170,7 +193,7 @@ module Seed
             url
           )
 
-          request_headers = @default_headers.merge(headers)
+          request_headers = @default_headers.merge(auth_headers).merge(headers)
           request_headers.each { |name, value| request[name] = value }
           request.body = body if body
 

--- a/seed/ruby-sdk-v2/schemaless-request-body-examples/test/unit/internal/http/test_raw_client.rb
+++ b/seed/ruby-sdk-v2/schemaless-request-body-examples/test/unit/internal/http/test_raw_client.rb
@@ -54,4 +54,71 @@ describe Seed::Internal::Http::RawClient do
       assert client.should_retry?(make_response(502), 2)
     end
   end
+
+  # A minimal auth provider whose `auth_headers` returns a *different* token on
+  # each call, simulating a token that is refreshed on expiry.
+  class RefreshingAuthProvider
+    def initialize
+      @count = 0
+    end
+
+    def auth_headers
+      @count += 1
+      { "Authorization" => "Bearer TOKEN_#{@count}" }
+    end
+  end
+
+  describe "#resolve_auth_headers" do
+    it "returns an empty hash when no auth provider is configured" do
+      client = Seed::Internal::Http::RawClient.new(base_url: "https://example.com")
+
+      assert_equal({}, client.resolve_auth_headers)
+    end
+
+    it "consults the auth provider on every call so an expired token is refreshed" do
+      client = Seed::Internal::Http::RawClient.new(
+        base_url: "https://example.com",
+        auth_provider: RefreshingAuthProvider.new
+      )
+
+      assert_equal({ "Authorization" => "Bearer TOKEN_1" }, client.resolve_auth_headers)
+      assert_equal({ "Authorization" => "Bearer TOKEN_2" }, client.resolve_auth_headers)
+    end
+  end
+
+  describe "#build_http_request auth header precedence" do
+    let(:client) do
+      Seed::Internal::Http::RawClient.new(
+        base_url: "https://example.com",
+        headers: { "Authorization" => "Bearer STATIC" }
+      )
+    end
+
+    it "lets resolved auth headers override the static default headers" do
+      request = client.build_http_request(
+        url: URI.parse("https://example.com"),
+        method: "GET",
+        auth_headers: { "Authorization" => "Bearer FRESH" }
+      )
+
+      assert_equal("Bearer FRESH", request["Authorization"])
+    end
+
+    it "lets per-request headers take precedence over auth headers" do
+      request = client.build_http_request(
+        url: URI.parse("https://example.com"),
+        method: "GET",
+        headers: { "Authorization" => "Bearer PER_REQUEST" },
+        auth_headers: { "Authorization" => "Bearer FRESH" }
+      )
+
+      assert_equal("Bearer PER_REQUEST", request["Authorization"])
+    end
+
+    it "defaults auth headers to empty, leaving the default headers unchanged" do
+      request = client.build_http_request(url: URI.parse("https://example.com"), method: "GET")
+
+      assert_equal("Bearer STATIC", request["Authorization"])
+    end
+  end
 end

--- a/seed/ruby-sdk-v2/server-sent-event-examples/lib/seed/internal/http/raw_client.rb
+++ b/seed/ruby-sdk-v2/server-sent-event-examples/lib/seed/internal/http/raw_client.rb
@@ -21,10 +21,14 @@ module Seed
         # @param max_retries [Integer] The number of times to retry a failed request, defaults to 2.
         # @param timeout [Float] The timeout for the request, defaults to 60.0 seconds.
         # @param headers [Hash] The headers for the request.
-        def initialize(base_url:, max_retries: 2, timeout: 60.0, headers: {})
+        # @param auth_provider [Object, nil] An optional auth provider responding to
+        #   `auth_headers`. When present its headers are resolved on every request so
+        #   token-based schemes (e.g. OAuth) can refresh an expired token mid-session.
+        def initialize(base_url:, max_retries: 2, timeout: 60.0, headers: {}, auth_provider: nil)
           @base_url = base_url
           @max_retries = max_retries
           @timeout = timeout
+          @auth_provider = auth_provider
           @default_headers = {
             "X-Fern-Language": "Ruby",
             "X-Fern-SDK-Name": "seed",
@@ -36,6 +40,9 @@ module Seed
         # @return [HTTP::Response] The HTTP response.
         def send(request)
           url = build_url(request)
+          # Resolve auth headers once per request (not per retry) so token-based
+          # providers refresh at most once here; static providers are cheap.
+          auth_headers = resolve_auth_headers
           attempt = 0
           response = nil
 
@@ -43,8 +50,9 @@ module Seed
             http_request = build_http_request(
               url:,
               method: request.method,
-              headers: request.encode_headers(protected_keys: @default_headers.keys),
-              body: request.encode_body
+              headers: request.encode_headers(protected_keys: @default_headers.keys + auth_headers.keys),
+              body: request.encode_body,
+              auth_headers: auth_headers
             )
 
             conn = connect(url)
@@ -157,12 +165,27 @@ module Seed
                 "HTTP is only allowed for localhost. Use HTTPS or pass a localhost URL."
         end
 
+        # Resolves the auth headers to send with the next request. Delegates to the
+        # configured auth provider (if any) on every call so that token-based
+        # providers (e.g. OAuth client-credentials) can refresh an expired token
+        # before the request is sent. Returns an empty hash when no provider is set,
+        # which keeps the api-key / basic / bearer / no-auth paths unchanged.
+        # @return [Hash] The auth headers for the current request.
+        def resolve_auth_headers
+          return {} if @auth_provider.nil?
+
+          @auth_provider.auth_headers
+        end
+
         # @param url [URI::Generic] The url to the resource.
         # @param method [String] The HTTP method to use.
         # @param headers [Hash] The headers for the request.
         # @param body [String, nil] The body for the request.
+        # @param auth_headers [Hash] The auth headers resolved for this request. These
+        #   take precedence over the static default headers but not over per-request
+        #   headers, mirroring the previous baked-header precedence.
         # @return [HTTP::Request] The HTTP request.
-        def build_http_request(url:, method:, headers: {}, body: nil)
+        def build_http_request(url:, method:, headers: {}, body: nil, auth_headers: {})
           request = Net::HTTPGenericRequest.new(
             method,
             !body.nil?,
@@ -170,7 +193,7 @@ module Seed
             url
           )
 
-          request_headers = @default_headers.merge(headers)
+          request_headers = @default_headers.merge(auth_headers).merge(headers)
           request_headers.each { |name, value| request[name] = value }
           request.body = body if body
 

--- a/seed/ruby-sdk-v2/server-sent-event-examples/test/unit/internal/http/test_raw_client.rb
+++ b/seed/ruby-sdk-v2/server-sent-event-examples/test/unit/internal/http/test_raw_client.rb
@@ -54,4 +54,71 @@ describe Seed::Internal::Http::RawClient do
       assert client.should_retry?(make_response(502), 2)
     end
   end
+
+  # A minimal auth provider whose `auth_headers` returns a *different* token on
+  # each call, simulating a token that is refreshed on expiry.
+  class RefreshingAuthProvider
+    def initialize
+      @count = 0
+    end
+
+    def auth_headers
+      @count += 1
+      { "Authorization" => "Bearer TOKEN_#{@count}" }
+    end
+  end
+
+  describe "#resolve_auth_headers" do
+    it "returns an empty hash when no auth provider is configured" do
+      client = Seed::Internal::Http::RawClient.new(base_url: "https://example.com")
+
+      assert_equal({}, client.resolve_auth_headers)
+    end
+
+    it "consults the auth provider on every call so an expired token is refreshed" do
+      client = Seed::Internal::Http::RawClient.new(
+        base_url: "https://example.com",
+        auth_provider: RefreshingAuthProvider.new
+      )
+
+      assert_equal({ "Authorization" => "Bearer TOKEN_1" }, client.resolve_auth_headers)
+      assert_equal({ "Authorization" => "Bearer TOKEN_2" }, client.resolve_auth_headers)
+    end
+  end
+
+  describe "#build_http_request auth header precedence" do
+    let(:client) do
+      Seed::Internal::Http::RawClient.new(
+        base_url: "https://example.com",
+        headers: { "Authorization" => "Bearer STATIC" }
+      )
+    end
+
+    it "lets resolved auth headers override the static default headers" do
+      request = client.build_http_request(
+        url: URI.parse("https://example.com"),
+        method: "GET",
+        auth_headers: { "Authorization" => "Bearer FRESH" }
+      )
+
+      assert_equal("Bearer FRESH", request["Authorization"])
+    end
+
+    it "lets per-request headers take precedence over auth headers" do
+      request = client.build_http_request(
+        url: URI.parse("https://example.com"),
+        method: "GET",
+        headers: { "Authorization" => "Bearer PER_REQUEST" },
+        auth_headers: { "Authorization" => "Bearer FRESH" }
+      )
+
+      assert_equal("Bearer PER_REQUEST", request["Authorization"])
+    end
+
+    it "defaults auth headers to empty, leaving the default headers unchanged" do
+      request = client.build_http_request(url: URI.parse("https://example.com"), method: "GET")
+
+      assert_equal("Bearer STATIC", request["Authorization"])
+    end
+  end
 end

--- a/seed/ruby-sdk-v2/server-sent-events-openapi/lib/seed/internal/http/raw_client.rb
+++ b/seed/ruby-sdk-v2/server-sent-events-openapi/lib/seed/internal/http/raw_client.rb
@@ -21,10 +21,14 @@ module Seed
         # @param max_retries [Integer] The number of times to retry a failed request, defaults to 2.
         # @param timeout [Float] The timeout for the request, defaults to 60.0 seconds.
         # @param headers [Hash] The headers for the request.
-        def initialize(base_url:, max_retries: 2, timeout: 60.0, headers: {})
+        # @param auth_provider [Object, nil] An optional auth provider responding to
+        #   `auth_headers`. When present its headers are resolved on every request so
+        #   token-based schemes (e.g. OAuth) can refresh an expired token mid-session.
+        def initialize(base_url:, max_retries: 2, timeout: 60.0, headers: {}, auth_provider: nil)
           @base_url = base_url
           @max_retries = max_retries
           @timeout = timeout
+          @auth_provider = auth_provider
           @default_headers = {
             "X-Fern-Language": "Ruby",
             "X-Fern-SDK-Name": "seed",
@@ -36,6 +40,9 @@ module Seed
         # @return [HTTP::Response] The HTTP response.
         def send(request)
           url = build_url(request)
+          # Resolve auth headers once per request (not per retry) so token-based
+          # providers refresh at most once here; static providers are cheap.
+          auth_headers = resolve_auth_headers
           attempt = 0
           response = nil
 
@@ -43,8 +50,9 @@ module Seed
             http_request = build_http_request(
               url:,
               method: request.method,
-              headers: request.encode_headers(protected_keys: @default_headers.keys),
-              body: request.encode_body
+              headers: request.encode_headers(protected_keys: @default_headers.keys + auth_headers.keys),
+              body: request.encode_body,
+              auth_headers: auth_headers
             )
 
             conn = connect(url)
@@ -157,12 +165,27 @@ module Seed
                 "HTTP is only allowed for localhost. Use HTTPS or pass a localhost URL."
         end
 
+        # Resolves the auth headers to send with the next request. Delegates to the
+        # configured auth provider (if any) on every call so that token-based
+        # providers (e.g. OAuth client-credentials) can refresh an expired token
+        # before the request is sent. Returns an empty hash when no provider is set,
+        # which keeps the api-key / basic / bearer / no-auth paths unchanged.
+        # @return [Hash] The auth headers for the current request.
+        def resolve_auth_headers
+          return {} if @auth_provider.nil?
+
+          @auth_provider.auth_headers
+        end
+
         # @param url [URI::Generic] The url to the resource.
         # @param method [String] The HTTP method to use.
         # @param headers [Hash] The headers for the request.
         # @param body [String, nil] The body for the request.
+        # @param auth_headers [Hash] The auth headers resolved for this request. These
+        #   take precedence over the static default headers but not over per-request
+        #   headers, mirroring the previous baked-header precedence.
         # @return [HTTP::Request] The HTTP request.
-        def build_http_request(url:, method:, headers: {}, body: nil)
+        def build_http_request(url:, method:, headers: {}, body: nil, auth_headers: {})
           request = Net::HTTPGenericRequest.new(
             method,
             !body.nil?,
@@ -170,7 +193,7 @@ module Seed
             url
           )
 
-          request_headers = @default_headers.merge(headers)
+          request_headers = @default_headers.merge(auth_headers).merge(headers)
           request_headers.each { |name, value| request[name] = value }
           request.body = body if body
 

--- a/seed/ruby-sdk-v2/server-sent-events-openapi/test/unit/internal/http/test_raw_client.rb
+++ b/seed/ruby-sdk-v2/server-sent-events-openapi/test/unit/internal/http/test_raw_client.rb
@@ -54,4 +54,71 @@ describe Seed::Internal::Http::RawClient do
       assert client.should_retry?(make_response(502), 2)
     end
   end
+
+  # A minimal auth provider whose `auth_headers` returns a *different* token on
+  # each call, simulating a token that is refreshed on expiry.
+  class RefreshingAuthProvider
+    def initialize
+      @count = 0
+    end
+
+    def auth_headers
+      @count += 1
+      { "Authorization" => "Bearer TOKEN_#{@count}" }
+    end
+  end
+
+  describe "#resolve_auth_headers" do
+    it "returns an empty hash when no auth provider is configured" do
+      client = Seed::Internal::Http::RawClient.new(base_url: "https://example.com")
+
+      assert_equal({}, client.resolve_auth_headers)
+    end
+
+    it "consults the auth provider on every call so an expired token is refreshed" do
+      client = Seed::Internal::Http::RawClient.new(
+        base_url: "https://example.com",
+        auth_provider: RefreshingAuthProvider.new
+      )
+
+      assert_equal({ "Authorization" => "Bearer TOKEN_1" }, client.resolve_auth_headers)
+      assert_equal({ "Authorization" => "Bearer TOKEN_2" }, client.resolve_auth_headers)
+    end
+  end
+
+  describe "#build_http_request auth header precedence" do
+    let(:client) do
+      Seed::Internal::Http::RawClient.new(
+        base_url: "https://example.com",
+        headers: { "Authorization" => "Bearer STATIC" }
+      )
+    end
+
+    it "lets resolved auth headers override the static default headers" do
+      request = client.build_http_request(
+        url: URI.parse("https://example.com"),
+        method: "GET",
+        auth_headers: { "Authorization" => "Bearer FRESH" }
+      )
+
+      assert_equal("Bearer FRESH", request["Authorization"])
+    end
+
+    it "lets per-request headers take precedence over auth headers" do
+      request = client.build_http_request(
+        url: URI.parse("https://example.com"),
+        method: "GET",
+        headers: { "Authorization" => "Bearer PER_REQUEST" },
+        auth_headers: { "Authorization" => "Bearer FRESH" }
+      )
+
+      assert_equal("Bearer PER_REQUEST", request["Authorization"])
+    end
+
+    it "defaults auth headers to empty, leaving the default headers unchanged" do
+      request = client.build_http_request(url: URI.parse("https://example.com"), method: "GET")
+
+      assert_equal("Bearer STATIC", request["Authorization"])
+    end
+  end
 end

--- a/seed/ruby-sdk-v2/server-sent-events-resumable/lib/seed/internal/http/raw_client.rb
+++ b/seed/ruby-sdk-v2/server-sent-events-resumable/lib/seed/internal/http/raw_client.rb
@@ -21,10 +21,14 @@ module Seed
         # @param max_retries [Integer] The number of times to retry a failed request, defaults to 2.
         # @param timeout [Float] The timeout for the request, defaults to 60.0 seconds.
         # @param headers [Hash] The headers for the request.
-        def initialize(base_url:, max_retries: 2, timeout: 60.0, headers: {})
+        # @param auth_provider [Object, nil] An optional auth provider responding to
+        #   `auth_headers`. When present its headers are resolved on every request so
+        #   token-based schemes (e.g. OAuth) can refresh an expired token mid-session.
+        def initialize(base_url:, max_retries: 2, timeout: 60.0, headers: {}, auth_provider: nil)
           @base_url = base_url
           @max_retries = max_retries
           @timeout = timeout
+          @auth_provider = auth_provider
           @default_headers = {
             "X-Fern-Language": "Ruby",
             "X-Fern-SDK-Name": "seed",
@@ -36,6 +40,9 @@ module Seed
         # @return [HTTP::Response] The HTTP response.
         def send(request)
           url = build_url(request)
+          # Resolve auth headers once per request (not per retry) so token-based
+          # providers refresh at most once here; static providers are cheap.
+          auth_headers = resolve_auth_headers
           attempt = 0
           response = nil
 
@@ -43,8 +50,9 @@ module Seed
             http_request = build_http_request(
               url:,
               method: request.method,
-              headers: request.encode_headers(protected_keys: @default_headers.keys),
-              body: request.encode_body
+              headers: request.encode_headers(protected_keys: @default_headers.keys + auth_headers.keys),
+              body: request.encode_body,
+              auth_headers: auth_headers
             )
 
             conn = connect(url)
@@ -157,12 +165,27 @@ module Seed
                 "HTTP is only allowed for localhost. Use HTTPS or pass a localhost URL."
         end
 
+        # Resolves the auth headers to send with the next request. Delegates to the
+        # configured auth provider (if any) on every call so that token-based
+        # providers (e.g. OAuth client-credentials) can refresh an expired token
+        # before the request is sent. Returns an empty hash when no provider is set,
+        # which keeps the api-key / basic / bearer / no-auth paths unchanged.
+        # @return [Hash] The auth headers for the current request.
+        def resolve_auth_headers
+          return {} if @auth_provider.nil?
+
+          @auth_provider.auth_headers
+        end
+
         # @param url [URI::Generic] The url to the resource.
         # @param method [String] The HTTP method to use.
         # @param headers [Hash] The headers for the request.
         # @param body [String, nil] The body for the request.
+        # @param auth_headers [Hash] The auth headers resolved for this request. These
+        #   take precedence over the static default headers but not over per-request
+        #   headers, mirroring the previous baked-header precedence.
         # @return [HTTP::Request] The HTTP request.
-        def build_http_request(url:, method:, headers: {}, body: nil)
+        def build_http_request(url:, method:, headers: {}, body: nil, auth_headers: {})
           request = Net::HTTPGenericRequest.new(
             method,
             !body.nil?,
@@ -170,7 +193,7 @@ module Seed
             url
           )
 
-          request_headers = @default_headers.merge(headers)
+          request_headers = @default_headers.merge(auth_headers).merge(headers)
           request_headers.each { |name, value| request[name] = value }
           request.body = body if body
 

--- a/seed/ruby-sdk-v2/server-sent-events-resumable/test/unit/internal/http/test_raw_client.rb
+++ b/seed/ruby-sdk-v2/server-sent-events-resumable/test/unit/internal/http/test_raw_client.rb
@@ -54,4 +54,71 @@ describe Seed::Internal::Http::RawClient do
       assert client.should_retry?(make_response(502), 2)
     end
   end
+
+  # A minimal auth provider whose `auth_headers` returns a *different* token on
+  # each call, simulating a token that is refreshed on expiry.
+  class RefreshingAuthProvider
+    def initialize
+      @count = 0
+    end
+
+    def auth_headers
+      @count += 1
+      { "Authorization" => "Bearer TOKEN_#{@count}" }
+    end
+  end
+
+  describe "#resolve_auth_headers" do
+    it "returns an empty hash when no auth provider is configured" do
+      client = Seed::Internal::Http::RawClient.new(base_url: "https://example.com")
+
+      assert_equal({}, client.resolve_auth_headers)
+    end
+
+    it "consults the auth provider on every call so an expired token is refreshed" do
+      client = Seed::Internal::Http::RawClient.new(
+        base_url: "https://example.com",
+        auth_provider: RefreshingAuthProvider.new
+      )
+
+      assert_equal({ "Authorization" => "Bearer TOKEN_1" }, client.resolve_auth_headers)
+      assert_equal({ "Authorization" => "Bearer TOKEN_2" }, client.resolve_auth_headers)
+    end
+  end
+
+  describe "#build_http_request auth header precedence" do
+    let(:client) do
+      Seed::Internal::Http::RawClient.new(
+        base_url: "https://example.com",
+        headers: { "Authorization" => "Bearer STATIC" }
+      )
+    end
+
+    it "lets resolved auth headers override the static default headers" do
+      request = client.build_http_request(
+        url: URI.parse("https://example.com"),
+        method: "GET",
+        auth_headers: { "Authorization" => "Bearer FRESH" }
+      )
+
+      assert_equal("Bearer FRESH", request["Authorization"])
+    end
+
+    it "lets per-request headers take precedence over auth headers" do
+      request = client.build_http_request(
+        url: URI.parse("https://example.com"),
+        method: "GET",
+        headers: { "Authorization" => "Bearer PER_REQUEST" },
+        auth_headers: { "Authorization" => "Bearer FRESH" }
+      )
+
+      assert_equal("Bearer PER_REQUEST", request["Authorization"])
+    end
+
+    it "defaults auth headers to empty, leaving the default headers unchanged" do
+      request = client.build_http_request(url: URI.parse("https://example.com"), method: "GET")
+
+      assert_equal("Bearer STATIC", request["Authorization"])
+    end
+  end
 end

--- a/seed/ruby-sdk-v2/server-sent-events/lib/seed/internal/http/raw_client.rb
+++ b/seed/ruby-sdk-v2/server-sent-events/lib/seed/internal/http/raw_client.rb
@@ -21,10 +21,14 @@ module Seed
         # @param max_retries [Integer] The number of times to retry a failed request, defaults to 2.
         # @param timeout [Float] The timeout for the request, defaults to 60.0 seconds.
         # @param headers [Hash] The headers for the request.
-        def initialize(base_url:, max_retries: 2, timeout: 60.0, headers: {})
+        # @param auth_provider [Object, nil] An optional auth provider responding to
+        #   `auth_headers`. When present its headers are resolved on every request so
+        #   token-based schemes (e.g. OAuth) can refresh an expired token mid-session.
+        def initialize(base_url:, max_retries: 2, timeout: 60.0, headers: {}, auth_provider: nil)
           @base_url = base_url
           @max_retries = max_retries
           @timeout = timeout
+          @auth_provider = auth_provider
           @default_headers = {
             "X-Fern-Language": "Ruby",
             "X-Fern-SDK-Name": "seed",
@@ -36,6 +40,9 @@ module Seed
         # @return [HTTP::Response] The HTTP response.
         def send(request)
           url = build_url(request)
+          # Resolve auth headers once per request (not per retry) so token-based
+          # providers refresh at most once here; static providers are cheap.
+          auth_headers = resolve_auth_headers
           attempt = 0
           response = nil
 
@@ -43,8 +50,9 @@ module Seed
             http_request = build_http_request(
               url:,
               method: request.method,
-              headers: request.encode_headers(protected_keys: @default_headers.keys),
-              body: request.encode_body
+              headers: request.encode_headers(protected_keys: @default_headers.keys + auth_headers.keys),
+              body: request.encode_body,
+              auth_headers: auth_headers
             )
 
             conn = connect(url)
@@ -157,12 +165,27 @@ module Seed
                 "HTTP is only allowed for localhost. Use HTTPS or pass a localhost URL."
         end
 
+        # Resolves the auth headers to send with the next request. Delegates to the
+        # configured auth provider (if any) on every call so that token-based
+        # providers (e.g. OAuth client-credentials) can refresh an expired token
+        # before the request is sent. Returns an empty hash when no provider is set,
+        # which keeps the api-key / basic / bearer / no-auth paths unchanged.
+        # @return [Hash] The auth headers for the current request.
+        def resolve_auth_headers
+          return {} if @auth_provider.nil?
+
+          @auth_provider.auth_headers
+        end
+
         # @param url [URI::Generic] The url to the resource.
         # @param method [String] The HTTP method to use.
         # @param headers [Hash] The headers for the request.
         # @param body [String, nil] The body for the request.
+        # @param auth_headers [Hash] The auth headers resolved for this request. These
+        #   take precedence over the static default headers but not over per-request
+        #   headers, mirroring the previous baked-header precedence.
         # @return [HTTP::Request] The HTTP request.
-        def build_http_request(url:, method:, headers: {}, body: nil)
+        def build_http_request(url:, method:, headers: {}, body: nil, auth_headers: {})
           request = Net::HTTPGenericRequest.new(
             method,
             !body.nil?,
@@ -170,7 +193,7 @@ module Seed
             url
           )
 
-          request_headers = @default_headers.merge(headers)
+          request_headers = @default_headers.merge(auth_headers).merge(headers)
           request_headers.each { |name, value| request[name] = value }
           request.body = body if body
 

--- a/seed/ruby-sdk-v2/server-sent-events/test/unit/internal/http/test_raw_client.rb
+++ b/seed/ruby-sdk-v2/server-sent-events/test/unit/internal/http/test_raw_client.rb
@@ -54,4 +54,71 @@ describe Seed::Internal::Http::RawClient do
       assert client.should_retry?(make_response(502), 2)
     end
   end
+
+  # A minimal auth provider whose `auth_headers` returns a *different* token on
+  # each call, simulating a token that is refreshed on expiry.
+  class RefreshingAuthProvider
+    def initialize
+      @count = 0
+    end
+
+    def auth_headers
+      @count += 1
+      { "Authorization" => "Bearer TOKEN_#{@count}" }
+    end
+  end
+
+  describe "#resolve_auth_headers" do
+    it "returns an empty hash when no auth provider is configured" do
+      client = Seed::Internal::Http::RawClient.new(base_url: "https://example.com")
+
+      assert_equal({}, client.resolve_auth_headers)
+    end
+
+    it "consults the auth provider on every call so an expired token is refreshed" do
+      client = Seed::Internal::Http::RawClient.new(
+        base_url: "https://example.com",
+        auth_provider: RefreshingAuthProvider.new
+      )
+
+      assert_equal({ "Authorization" => "Bearer TOKEN_1" }, client.resolve_auth_headers)
+      assert_equal({ "Authorization" => "Bearer TOKEN_2" }, client.resolve_auth_headers)
+    end
+  end
+
+  describe "#build_http_request auth header precedence" do
+    let(:client) do
+      Seed::Internal::Http::RawClient.new(
+        base_url: "https://example.com",
+        headers: { "Authorization" => "Bearer STATIC" }
+      )
+    end
+
+    it "lets resolved auth headers override the static default headers" do
+      request = client.build_http_request(
+        url: URI.parse("https://example.com"),
+        method: "GET",
+        auth_headers: { "Authorization" => "Bearer FRESH" }
+      )
+
+      assert_equal("Bearer FRESH", request["Authorization"])
+    end
+
+    it "lets per-request headers take precedence over auth headers" do
+      request = client.build_http_request(
+        url: URI.parse("https://example.com"),
+        method: "GET",
+        headers: { "Authorization" => "Bearer PER_REQUEST" },
+        auth_headers: { "Authorization" => "Bearer FRESH" }
+      )
+
+      assert_equal("Bearer PER_REQUEST", request["Authorization"])
+    end
+
+    it "defaults auth headers to empty, leaving the default headers unchanged" do
+      request = client.build_http_request(url: URI.parse("https://example.com"), method: "GET")
+
+      assert_equal("Bearer STATIC", request["Authorization"])
+    end
+  end
 end

--- a/seed/ruby-sdk-v2/server-url-templating/lib/seed/internal/http/raw_client.rb
+++ b/seed/ruby-sdk-v2/server-url-templating/lib/seed/internal/http/raw_client.rb
@@ -21,10 +21,14 @@ module Seed
         # @param max_retries [Integer] The number of times to retry a failed request, defaults to 2.
         # @param timeout [Float] The timeout for the request, defaults to 60.0 seconds.
         # @param headers [Hash] The headers for the request.
-        def initialize(base_url:, max_retries: 2, timeout: 60.0, headers: {})
+        # @param auth_provider [Object, nil] An optional auth provider responding to
+        #   `auth_headers`. When present its headers are resolved on every request so
+        #   token-based schemes (e.g. OAuth) can refresh an expired token mid-session.
+        def initialize(base_url:, max_retries: 2, timeout: 60.0, headers: {}, auth_provider: nil)
           @base_url = base_url
           @max_retries = max_retries
           @timeout = timeout
+          @auth_provider = auth_provider
           @default_headers = {
             "X-Fern-Language": "Ruby",
             "X-Fern-SDK-Name": "seed",
@@ -36,6 +40,9 @@ module Seed
         # @return [HTTP::Response] The HTTP response.
         def send(request)
           url = build_url(request)
+          # Resolve auth headers once per request (not per retry) so token-based
+          # providers refresh at most once here; static providers are cheap.
+          auth_headers = resolve_auth_headers
           attempt = 0
           response = nil
 
@@ -43,8 +50,9 @@ module Seed
             http_request = build_http_request(
               url:,
               method: request.method,
-              headers: request.encode_headers(protected_keys: @default_headers.keys),
-              body: request.encode_body
+              headers: request.encode_headers(protected_keys: @default_headers.keys + auth_headers.keys),
+              body: request.encode_body,
+              auth_headers: auth_headers
             )
 
             conn = connect(url)
@@ -157,12 +165,27 @@ module Seed
                 "HTTP is only allowed for localhost. Use HTTPS or pass a localhost URL."
         end
 
+        # Resolves the auth headers to send with the next request. Delegates to the
+        # configured auth provider (if any) on every call so that token-based
+        # providers (e.g. OAuth client-credentials) can refresh an expired token
+        # before the request is sent. Returns an empty hash when no provider is set,
+        # which keeps the api-key / basic / bearer / no-auth paths unchanged.
+        # @return [Hash] The auth headers for the current request.
+        def resolve_auth_headers
+          return {} if @auth_provider.nil?
+
+          @auth_provider.auth_headers
+        end
+
         # @param url [URI::Generic] The url to the resource.
         # @param method [String] The HTTP method to use.
         # @param headers [Hash] The headers for the request.
         # @param body [String, nil] The body for the request.
+        # @param auth_headers [Hash] The auth headers resolved for this request. These
+        #   take precedence over the static default headers but not over per-request
+        #   headers, mirroring the previous baked-header precedence.
         # @return [HTTP::Request] The HTTP request.
-        def build_http_request(url:, method:, headers: {}, body: nil)
+        def build_http_request(url:, method:, headers: {}, body: nil, auth_headers: {})
           request = Net::HTTPGenericRequest.new(
             method,
             !body.nil?,
@@ -170,7 +193,7 @@ module Seed
             url
           )
 
-          request_headers = @default_headers.merge(headers)
+          request_headers = @default_headers.merge(auth_headers).merge(headers)
           request_headers.each { |name, value| request[name] = value }
           request.body = body if body
 

--- a/seed/ruby-sdk-v2/server-url-templating/test/unit/internal/http/test_raw_client.rb
+++ b/seed/ruby-sdk-v2/server-url-templating/test/unit/internal/http/test_raw_client.rb
@@ -54,4 +54,71 @@ describe Seed::Internal::Http::RawClient do
       assert client.should_retry?(make_response(502), 2)
     end
   end
+
+  # A minimal auth provider whose `auth_headers` returns a *different* token on
+  # each call, simulating a token that is refreshed on expiry.
+  class RefreshingAuthProvider
+    def initialize
+      @count = 0
+    end
+
+    def auth_headers
+      @count += 1
+      { "Authorization" => "Bearer TOKEN_#{@count}" }
+    end
+  end
+
+  describe "#resolve_auth_headers" do
+    it "returns an empty hash when no auth provider is configured" do
+      client = Seed::Internal::Http::RawClient.new(base_url: "https://example.com")
+
+      assert_equal({}, client.resolve_auth_headers)
+    end
+
+    it "consults the auth provider on every call so an expired token is refreshed" do
+      client = Seed::Internal::Http::RawClient.new(
+        base_url: "https://example.com",
+        auth_provider: RefreshingAuthProvider.new
+      )
+
+      assert_equal({ "Authorization" => "Bearer TOKEN_1" }, client.resolve_auth_headers)
+      assert_equal({ "Authorization" => "Bearer TOKEN_2" }, client.resolve_auth_headers)
+    end
+  end
+
+  describe "#build_http_request auth header precedence" do
+    let(:client) do
+      Seed::Internal::Http::RawClient.new(
+        base_url: "https://example.com",
+        headers: { "Authorization" => "Bearer STATIC" }
+      )
+    end
+
+    it "lets resolved auth headers override the static default headers" do
+      request = client.build_http_request(
+        url: URI.parse("https://example.com"),
+        method: "GET",
+        auth_headers: { "Authorization" => "Bearer FRESH" }
+      )
+
+      assert_equal("Bearer FRESH", request["Authorization"])
+    end
+
+    it "lets per-request headers take precedence over auth headers" do
+      request = client.build_http_request(
+        url: URI.parse("https://example.com"),
+        method: "GET",
+        headers: { "Authorization" => "Bearer PER_REQUEST" },
+        auth_headers: { "Authorization" => "Bearer FRESH" }
+      )
+
+      assert_equal("Bearer PER_REQUEST", request["Authorization"])
+    end
+
+    it "defaults auth headers to empty, leaving the default headers unchanged" do
+      request = client.build_http_request(url: URI.parse("https://example.com"), method: "GET")
+
+      assert_equal("Bearer STATIC", request["Authorization"])
+    end
+  end
 end

--- a/seed/ruby-sdk-v2/simple-api/lib/seed/internal/http/raw_client.rb
+++ b/seed/ruby-sdk-v2/simple-api/lib/seed/internal/http/raw_client.rb
@@ -21,10 +21,14 @@ module Seed
         # @param max_retries [Integer] The number of times to retry a failed request, defaults to 2.
         # @param timeout [Float] The timeout for the request, defaults to 60.0 seconds.
         # @param headers [Hash] The headers for the request.
-        def initialize(base_url:, max_retries: 2, timeout: 60.0, headers: {})
+        # @param auth_provider [Object, nil] An optional auth provider responding to
+        #   `auth_headers`. When present its headers are resolved on every request so
+        #   token-based schemes (e.g. OAuth) can refresh an expired token mid-session.
+        def initialize(base_url:, max_retries: 2, timeout: 60.0, headers: {}, auth_provider: nil)
           @base_url = base_url
           @max_retries = max_retries
           @timeout = timeout
+          @auth_provider = auth_provider
           @default_headers = {
             "X-Fern-Language": "Ruby",
             "X-Fern-SDK-Name": "seed",
@@ -36,6 +40,9 @@ module Seed
         # @return [HTTP::Response] The HTTP response.
         def send(request)
           url = build_url(request)
+          # Resolve auth headers once per request (not per retry) so token-based
+          # providers refresh at most once here; static providers are cheap.
+          auth_headers = resolve_auth_headers
           attempt = 0
           response = nil
 
@@ -43,8 +50,9 @@ module Seed
             http_request = build_http_request(
               url:,
               method: request.method,
-              headers: request.encode_headers(protected_keys: @default_headers.keys),
-              body: request.encode_body
+              headers: request.encode_headers(protected_keys: @default_headers.keys + auth_headers.keys),
+              body: request.encode_body,
+              auth_headers: auth_headers
             )
 
             conn = connect(url)
@@ -157,12 +165,27 @@ module Seed
                 "HTTP is only allowed for localhost. Use HTTPS or pass a localhost URL."
         end
 
+        # Resolves the auth headers to send with the next request. Delegates to the
+        # configured auth provider (if any) on every call so that token-based
+        # providers (e.g. OAuth client-credentials) can refresh an expired token
+        # before the request is sent. Returns an empty hash when no provider is set,
+        # which keeps the api-key / basic / bearer / no-auth paths unchanged.
+        # @return [Hash] The auth headers for the current request.
+        def resolve_auth_headers
+          return {} if @auth_provider.nil?
+
+          @auth_provider.auth_headers
+        end
+
         # @param url [URI::Generic] The url to the resource.
         # @param method [String] The HTTP method to use.
         # @param headers [Hash] The headers for the request.
         # @param body [String, nil] The body for the request.
+        # @param auth_headers [Hash] The auth headers resolved for this request. These
+        #   take precedence over the static default headers but not over per-request
+        #   headers, mirroring the previous baked-header precedence.
         # @return [HTTP::Request] The HTTP request.
-        def build_http_request(url:, method:, headers: {}, body: nil)
+        def build_http_request(url:, method:, headers: {}, body: nil, auth_headers: {})
           request = Net::HTTPGenericRequest.new(
             method,
             !body.nil?,
@@ -170,7 +193,7 @@ module Seed
             url
           )
 
-          request_headers = @default_headers.merge(headers)
+          request_headers = @default_headers.merge(auth_headers).merge(headers)
           request_headers.each { |name, value| request[name] = value }
           request.body = body if body
 

--- a/seed/ruby-sdk-v2/simple-api/test/unit/internal/http/test_raw_client.rb
+++ b/seed/ruby-sdk-v2/simple-api/test/unit/internal/http/test_raw_client.rb
@@ -54,4 +54,71 @@ describe Seed::Internal::Http::RawClient do
       assert client.should_retry?(make_response(502), 2)
     end
   end
+
+  # A minimal auth provider whose `auth_headers` returns a *different* token on
+  # each call, simulating a token that is refreshed on expiry.
+  class RefreshingAuthProvider
+    def initialize
+      @count = 0
+    end
+
+    def auth_headers
+      @count += 1
+      { "Authorization" => "Bearer TOKEN_#{@count}" }
+    end
+  end
+
+  describe "#resolve_auth_headers" do
+    it "returns an empty hash when no auth provider is configured" do
+      client = Seed::Internal::Http::RawClient.new(base_url: "https://example.com")
+
+      assert_equal({}, client.resolve_auth_headers)
+    end
+
+    it "consults the auth provider on every call so an expired token is refreshed" do
+      client = Seed::Internal::Http::RawClient.new(
+        base_url: "https://example.com",
+        auth_provider: RefreshingAuthProvider.new
+      )
+
+      assert_equal({ "Authorization" => "Bearer TOKEN_1" }, client.resolve_auth_headers)
+      assert_equal({ "Authorization" => "Bearer TOKEN_2" }, client.resolve_auth_headers)
+    end
+  end
+
+  describe "#build_http_request auth header precedence" do
+    let(:client) do
+      Seed::Internal::Http::RawClient.new(
+        base_url: "https://example.com",
+        headers: { "Authorization" => "Bearer STATIC" }
+      )
+    end
+
+    it "lets resolved auth headers override the static default headers" do
+      request = client.build_http_request(
+        url: URI.parse("https://example.com"),
+        method: "GET",
+        auth_headers: { "Authorization" => "Bearer FRESH" }
+      )
+
+      assert_equal("Bearer FRESH", request["Authorization"])
+    end
+
+    it "lets per-request headers take precedence over auth headers" do
+      request = client.build_http_request(
+        url: URI.parse("https://example.com"),
+        method: "GET",
+        headers: { "Authorization" => "Bearer PER_REQUEST" },
+        auth_headers: { "Authorization" => "Bearer FRESH" }
+      )
+
+      assert_equal("Bearer PER_REQUEST", request["Authorization"])
+    end
+
+    it "defaults auth headers to empty, leaving the default headers unchanged" do
+      request = client.build_http_request(url: URI.parse("https://example.com"), method: "GET")
+
+      assert_equal("Bearer STATIC", request["Authorization"])
+    end
+  end
 end

--- a/seed/ruby-sdk-v2/simple-fhir/lib/seed/internal/http/raw_client.rb
+++ b/seed/ruby-sdk-v2/simple-fhir/lib/seed/internal/http/raw_client.rb
@@ -21,10 +21,14 @@ module Seed
         # @param max_retries [Integer] The number of times to retry a failed request, defaults to 2.
         # @param timeout [Float] The timeout for the request, defaults to 60.0 seconds.
         # @param headers [Hash] The headers for the request.
-        def initialize(base_url:, max_retries: 2, timeout: 60.0, headers: {})
+        # @param auth_provider [Object, nil] An optional auth provider responding to
+        #   `auth_headers`. When present its headers are resolved on every request so
+        #   token-based schemes (e.g. OAuth) can refresh an expired token mid-session.
+        def initialize(base_url:, max_retries: 2, timeout: 60.0, headers: {}, auth_provider: nil)
           @base_url = base_url
           @max_retries = max_retries
           @timeout = timeout
+          @auth_provider = auth_provider
           @default_headers = {
             "X-Fern-Language": "Ruby",
             "X-Fern-SDK-Name": "seed",
@@ -36,6 +40,9 @@ module Seed
         # @return [HTTP::Response] The HTTP response.
         def send(request)
           url = build_url(request)
+          # Resolve auth headers once per request (not per retry) so token-based
+          # providers refresh at most once here; static providers are cheap.
+          auth_headers = resolve_auth_headers
           attempt = 0
           response = nil
 
@@ -43,8 +50,9 @@ module Seed
             http_request = build_http_request(
               url:,
               method: request.method,
-              headers: request.encode_headers(protected_keys: @default_headers.keys),
-              body: request.encode_body
+              headers: request.encode_headers(protected_keys: @default_headers.keys + auth_headers.keys),
+              body: request.encode_body,
+              auth_headers: auth_headers
             )
 
             conn = connect(url)
@@ -157,12 +165,27 @@ module Seed
                 "HTTP is only allowed for localhost. Use HTTPS or pass a localhost URL."
         end
 
+        # Resolves the auth headers to send with the next request. Delegates to the
+        # configured auth provider (if any) on every call so that token-based
+        # providers (e.g. OAuth client-credentials) can refresh an expired token
+        # before the request is sent. Returns an empty hash when no provider is set,
+        # which keeps the api-key / basic / bearer / no-auth paths unchanged.
+        # @return [Hash] The auth headers for the current request.
+        def resolve_auth_headers
+          return {} if @auth_provider.nil?
+
+          @auth_provider.auth_headers
+        end
+
         # @param url [URI::Generic] The url to the resource.
         # @param method [String] The HTTP method to use.
         # @param headers [Hash] The headers for the request.
         # @param body [String, nil] The body for the request.
+        # @param auth_headers [Hash] The auth headers resolved for this request. These
+        #   take precedence over the static default headers but not over per-request
+        #   headers, mirroring the previous baked-header precedence.
         # @return [HTTP::Request] The HTTP request.
-        def build_http_request(url:, method:, headers: {}, body: nil)
+        def build_http_request(url:, method:, headers: {}, body: nil, auth_headers: {})
           request = Net::HTTPGenericRequest.new(
             method,
             !body.nil?,
@@ -170,7 +193,7 @@ module Seed
             url
           )
 
-          request_headers = @default_headers.merge(headers)
+          request_headers = @default_headers.merge(auth_headers).merge(headers)
           request_headers.each { |name, value| request[name] = value }
           request.body = body if body
 

--- a/seed/ruby-sdk-v2/simple-fhir/test/unit/internal/http/test_raw_client.rb
+++ b/seed/ruby-sdk-v2/simple-fhir/test/unit/internal/http/test_raw_client.rb
@@ -54,4 +54,71 @@ describe Seed::Internal::Http::RawClient do
       assert client.should_retry?(make_response(502), 2)
     end
   end
+
+  # A minimal auth provider whose `auth_headers` returns a *different* token on
+  # each call, simulating a token that is refreshed on expiry.
+  class RefreshingAuthProvider
+    def initialize
+      @count = 0
+    end
+
+    def auth_headers
+      @count += 1
+      { "Authorization" => "Bearer TOKEN_#{@count}" }
+    end
+  end
+
+  describe "#resolve_auth_headers" do
+    it "returns an empty hash when no auth provider is configured" do
+      client = Seed::Internal::Http::RawClient.new(base_url: "https://example.com")
+
+      assert_equal({}, client.resolve_auth_headers)
+    end
+
+    it "consults the auth provider on every call so an expired token is refreshed" do
+      client = Seed::Internal::Http::RawClient.new(
+        base_url: "https://example.com",
+        auth_provider: RefreshingAuthProvider.new
+      )
+
+      assert_equal({ "Authorization" => "Bearer TOKEN_1" }, client.resolve_auth_headers)
+      assert_equal({ "Authorization" => "Bearer TOKEN_2" }, client.resolve_auth_headers)
+    end
+  end
+
+  describe "#build_http_request auth header precedence" do
+    let(:client) do
+      Seed::Internal::Http::RawClient.new(
+        base_url: "https://example.com",
+        headers: { "Authorization" => "Bearer STATIC" }
+      )
+    end
+
+    it "lets resolved auth headers override the static default headers" do
+      request = client.build_http_request(
+        url: URI.parse("https://example.com"),
+        method: "GET",
+        auth_headers: { "Authorization" => "Bearer FRESH" }
+      )
+
+      assert_equal("Bearer FRESH", request["Authorization"])
+    end
+
+    it "lets per-request headers take precedence over auth headers" do
+      request = client.build_http_request(
+        url: URI.parse("https://example.com"),
+        method: "GET",
+        headers: { "Authorization" => "Bearer PER_REQUEST" },
+        auth_headers: { "Authorization" => "Bearer FRESH" }
+      )
+
+      assert_equal("Bearer PER_REQUEST", request["Authorization"])
+    end
+
+    it "defaults auth headers to empty, leaving the default headers unchanged" do
+      request = client.build_http_request(url: URI.parse("https://example.com"), method: "GET")
+
+      assert_equal("Bearer STATIC", request["Authorization"])
+    end
+  end
 end

--- a/seed/ruby-sdk-v2/single-url-environment-default/lib/seed/internal/http/raw_client.rb
+++ b/seed/ruby-sdk-v2/single-url-environment-default/lib/seed/internal/http/raw_client.rb
@@ -21,10 +21,14 @@ module Seed
         # @param max_retries [Integer] The number of times to retry a failed request, defaults to 2.
         # @param timeout [Float] The timeout for the request, defaults to 60.0 seconds.
         # @param headers [Hash] The headers for the request.
-        def initialize(base_url:, max_retries: 2, timeout: 60.0, headers: {})
+        # @param auth_provider [Object, nil] An optional auth provider responding to
+        #   `auth_headers`. When present its headers are resolved on every request so
+        #   token-based schemes (e.g. OAuth) can refresh an expired token mid-session.
+        def initialize(base_url:, max_retries: 2, timeout: 60.0, headers: {}, auth_provider: nil)
           @base_url = base_url
           @max_retries = max_retries
           @timeout = timeout
+          @auth_provider = auth_provider
           @default_headers = {
             "X-Fern-Language": "Ruby",
             "X-Fern-SDK-Name": "seed",
@@ -36,6 +40,9 @@ module Seed
         # @return [HTTP::Response] The HTTP response.
         def send(request)
           url = build_url(request)
+          # Resolve auth headers once per request (not per retry) so token-based
+          # providers refresh at most once here; static providers are cheap.
+          auth_headers = resolve_auth_headers
           attempt = 0
           response = nil
 
@@ -43,8 +50,9 @@ module Seed
             http_request = build_http_request(
               url:,
               method: request.method,
-              headers: request.encode_headers(protected_keys: @default_headers.keys),
-              body: request.encode_body
+              headers: request.encode_headers(protected_keys: @default_headers.keys + auth_headers.keys),
+              body: request.encode_body,
+              auth_headers: auth_headers
             )
 
             conn = connect(url)
@@ -157,12 +165,27 @@ module Seed
                 "HTTP is only allowed for localhost. Use HTTPS or pass a localhost URL."
         end
 
+        # Resolves the auth headers to send with the next request. Delegates to the
+        # configured auth provider (if any) on every call so that token-based
+        # providers (e.g. OAuth client-credentials) can refresh an expired token
+        # before the request is sent. Returns an empty hash when no provider is set,
+        # which keeps the api-key / basic / bearer / no-auth paths unchanged.
+        # @return [Hash] The auth headers for the current request.
+        def resolve_auth_headers
+          return {} if @auth_provider.nil?
+
+          @auth_provider.auth_headers
+        end
+
         # @param url [URI::Generic] The url to the resource.
         # @param method [String] The HTTP method to use.
         # @param headers [Hash] The headers for the request.
         # @param body [String, nil] The body for the request.
+        # @param auth_headers [Hash] The auth headers resolved for this request. These
+        #   take precedence over the static default headers but not over per-request
+        #   headers, mirroring the previous baked-header precedence.
         # @return [HTTP::Request] The HTTP request.
-        def build_http_request(url:, method:, headers: {}, body: nil)
+        def build_http_request(url:, method:, headers: {}, body: nil, auth_headers: {})
           request = Net::HTTPGenericRequest.new(
             method,
             !body.nil?,
@@ -170,7 +193,7 @@ module Seed
             url
           )
 
-          request_headers = @default_headers.merge(headers)
+          request_headers = @default_headers.merge(auth_headers).merge(headers)
           request_headers.each { |name, value| request[name] = value }
           request.body = body if body
 

--- a/seed/ruby-sdk-v2/single-url-environment-default/test/unit/internal/http/test_raw_client.rb
+++ b/seed/ruby-sdk-v2/single-url-environment-default/test/unit/internal/http/test_raw_client.rb
@@ -54,4 +54,71 @@ describe Seed::Internal::Http::RawClient do
       assert client.should_retry?(make_response(502), 2)
     end
   end
+
+  # A minimal auth provider whose `auth_headers` returns a *different* token on
+  # each call, simulating a token that is refreshed on expiry.
+  class RefreshingAuthProvider
+    def initialize
+      @count = 0
+    end
+
+    def auth_headers
+      @count += 1
+      { "Authorization" => "Bearer TOKEN_#{@count}" }
+    end
+  end
+
+  describe "#resolve_auth_headers" do
+    it "returns an empty hash when no auth provider is configured" do
+      client = Seed::Internal::Http::RawClient.new(base_url: "https://example.com")
+
+      assert_equal({}, client.resolve_auth_headers)
+    end
+
+    it "consults the auth provider on every call so an expired token is refreshed" do
+      client = Seed::Internal::Http::RawClient.new(
+        base_url: "https://example.com",
+        auth_provider: RefreshingAuthProvider.new
+      )
+
+      assert_equal({ "Authorization" => "Bearer TOKEN_1" }, client.resolve_auth_headers)
+      assert_equal({ "Authorization" => "Bearer TOKEN_2" }, client.resolve_auth_headers)
+    end
+  end
+
+  describe "#build_http_request auth header precedence" do
+    let(:client) do
+      Seed::Internal::Http::RawClient.new(
+        base_url: "https://example.com",
+        headers: { "Authorization" => "Bearer STATIC" }
+      )
+    end
+
+    it "lets resolved auth headers override the static default headers" do
+      request = client.build_http_request(
+        url: URI.parse("https://example.com"),
+        method: "GET",
+        auth_headers: { "Authorization" => "Bearer FRESH" }
+      )
+
+      assert_equal("Bearer FRESH", request["Authorization"])
+    end
+
+    it "lets per-request headers take precedence over auth headers" do
+      request = client.build_http_request(
+        url: URI.parse("https://example.com"),
+        method: "GET",
+        headers: { "Authorization" => "Bearer PER_REQUEST" },
+        auth_headers: { "Authorization" => "Bearer FRESH" }
+      )
+
+      assert_equal("Bearer PER_REQUEST", request["Authorization"])
+    end
+
+    it "defaults auth headers to empty, leaving the default headers unchanged" do
+      request = client.build_http_request(url: URI.parse("https://example.com"), method: "GET")
+
+      assert_equal("Bearer STATIC", request["Authorization"])
+    end
+  end
 end

--- a/seed/ruby-sdk-v2/single-url-environment-no-default/lib/seed/internal/http/raw_client.rb
+++ b/seed/ruby-sdk-v2/single-url-environment-no-default/lib/seed/internal/http/raw_client.rb
@@ -21,10 +21,14 @@ module Seed
         # @param max_retries [Integer] The number of times to retry a failed request, defaults to 2.
         # @param timeout [Float] The timeout for the request, defaults to 60.0 seconds.
         # @param headers [Hash] The headers for the request.
-        def initialize(base_url:, max_retries: 2, timeout: 60.0, headers: {})
+        # @param auth_provider [Object, nil] An optional auth provider responding to
+        #   `auth_headers`. When present its headers are resolved on every request so
+        #   token-based schemes (e.g. OAuth) can refresh an expired token mid-session.
+        def initialize(base_url:, max_retries: 2, timeout: 60.0, headers: {}, auth_provider: nil)
           @base_url = base_url
           @max_retries = max_retries
           @timeout = timeout
+          @auth_provider = auth_provider
           @default_headers = {
             "X-Fern-Language": "Ruby",
             "X-Fern-SDK-Name": "seed",
@@ -36,6 +40,9 @@ module Seed
         # @return [HTTP::Response] The HTTP response.
         def send(request)
           url = build_url(request)
+          # Resolve auth headers once per request (not per retry) so token-based
+          # providers refresh at most once here; static providers are cheap.
+          auth_headers = resolve_auth_headers
           attempt = 0
           response = nil
 
@@ -43,8 +50,9 @@ module Seed
             http_request = build_http_request(
               url:,
               method: request.method,
-              headers: request.encode_headers(protected_keys: @default_headers.keys),
-              body: request.encode_body
+              headers: request.encode_headers(protected_keys: @default_headers.keys + auth_headers.keys),
+              body: request.encode_body,
+              auth_headers: auth_headers
             )
 
             conn = connect(url)
@@ -157,12 +165,27 @@ module Seed
                 "HTTP is only allowed for localhost. Use HTTPS or pass a localhost URL."
         end
 
+        # Resolves the auth headers to send with the next request. Delegates to the
+        # configured auth provider (if any) on every call so that token-based
+        # providers (e.g. OAuth client-credentials) can refresh an expired token
+        # before the request is sent. Returns an empty hash when no provider is set,
+        # which keeps the api-key / basic / bearer / no-auth paths unchanged.
+        # @return [Hash] The auth headers for the current request.
+        def resolve_auth_headers
+          return {} if @auth_provider.nil?
+
+          @auth_provider.auth_headers
+        end
+
         # @param url [URI::Generic] The url to the resource.
         # @param method [String] The HTTP method to use.
         # @param headers [Hash] The headers for the request.
         # @param body [String, nil] The body for the request.
+        # @param auth_headers [Hash] The auth headers resolved for this request. These
+        #   take precedence over the static default headers but not over per-request
+        #   headers, mirroring the previous baked-header precedence.
         # @return [HTTP::Request] The HTTP request.
-        def build_http_request(url:, method:, headers: {}, body: nil)
+        def build_http_request(url:, method:, headers: {}, body: nil, auth_headers: {})
           request = Net::HTTPGenericRequest.new(
             method,
             !body.nil?,
@@ -170,7 +193,7 @@ module Seed
             url
           )
 
-          request_headers = @default_headers.merge(headers)
+          request_headers = @default_headers.merge(auth_headers).merge(headers)
           request_headers.each { |name, value| request[name] = value }
           request.body = body if body
 

--- a/seed/ruby-sdk-v2/single-url-environment-no-default/test/unit/internal/http/test_raw_client.rb
+++ b/seed/ruby-sdk-v2/single-url-environment-no-default/test/unit/internal/http/test_raw_client.rb
@@ -54,4 +54,71 @@ describe Seed::Internal::Http::RawClient do
       assert client.should_retry?(make_response(502), 2)
     end
   end
+
+  # A minimal auth provider whose `auth_headers` returns a *different* token on
+  # each call, simulating a token that is refreshed on expiry.
+  class RefreshingAuthProvider
+    def initialize
+      @count = 0
+    end
+
+    def auth_headers
+      @count += 1
+      { "Authorization" => "Bearer TOKEN_#{@count}" }
+    end
+  end
+
+  describe "#resolve_auth_headers" do
+    it "returns an empty hash when no auth provider is configured" do
+      client = Seed::Internal::Http::RawClient.new(base_url: "https://example.com")
+
+      assert_equal({}, client.resolve_auth_headers)
+    end
+
+    it "consults the auth provider on every call so an expired token is refreshed" do
+      client = Seed::Internal::Http::RawClient.new(
+        base_url: "https://example.com",
+        auth_provider: RefreshingAuthProvider.new
+      )
+
+      assert_equal({ "Authorization" => "Bearer TOKEN_1" }, client.resolve_auth_headers)
+      assert_equal({ "Authorization" => "Bearer TOKEN_2" }, client.resolve_auth_headers)
+    end
+  end
+
+  describe "#build_http_request auth header precedence" do
+    let(:client) do
+      Seed::Internal::Http::RawClient.new(
+        base_url: "https://example.com",
+        headers: { "Authorization" => "Bearer STATIC" }
+      )
+    end
+
+    it "lets resolved auth headers override the static default headers" do
+      request = client.build_http_request(
+        url: URI.parse("https://example.com"),
+        method: "GET",
+        auth_headers: { "Authorization" => "Bearer FRESH" }
+      )
+
+      assert_equal("Bearer FRESH", request["Authorization"])
+    end
+
+    it "lets per-request headers take precedence over auth headers" do
+      request = client.build_http_request(
+        url: URI.parse("https://example.com"),
+        method: "GET",
+        headers: { "Authorization" => "Bearer PER_REQUEST" },
+        auth_headers: { "Authorization" => "Bearer FRESH" }
+      )
+
+      assert_equal("Bearer PER_REQUEST", request["Authorization"])
+    end
+
+    it "defaults auth headers to empty, leaving the default headers unchanged" do
+      request = client.build_http_request(url: URI.parse("https://example.com"), method: "GET")
+
+      assert_equal("Bearer STATIC", request["Authorization"])
+    end
+  end
 end

--- a/seed/ruby-sdk-v2/streaming-parameter/lib/seed/internal/http/raw_client.rb
+++ b/seed/ruby-sdk-v2/streaming-parameter/lib/seed/internal/http/raw_client.rb
@@ -21,10 +21,14 @@ module Seed
         # @param max_retries [Integer] The number of times to retry a failed request, defaults to 2.
         # @param timeout [Float] The timeout for the request, defaults to 60.0 seconds.
         # @param headers [Hash] The headers for the request.
-        def initialize(base_url:, max_retries: 2, timeout: 60.0, headers: {})
+        # @param auth_provider [Object, nil] An optional auth provider responding to
+        #   `auth_headers`. When present its headers are resolved on every request so
+        #   token-based schemes (e.g. OAuth) can refresh an expired token mid-session.
+        def initialize(base_url:, max_retries: 2, timeout: 60.0, headers: {}, auth_provider: nil)
           @base_url = base_url
           @max_retries = max_retries
           @timeout = timeout
+          @auth_provider = auth_provider
           @default_headers = {
             "X-Fern-Language": "Ruby",
             "X-Fern-SDK-Name": "seed",
@@ -36,6 +40,9 @@ module Seed
         # @return [HTTP::Response] The HTTP response.
         def send(request)
           url = build_url(request)
+          # Resolve auth headers once per request (not per retry) so token-based
+          # providers refresh at most once here; static providers are cheap.
+          auth_headers = resolve_auth_headers
           attempt = 0
           response = nil
 
@@ -43,8 +50,9 @@ module Seed
             http_request = build_http_request(
               url:,
               method: request.method,
-              headers: request.encode_headers(protected_keys: @default_headers.keys),
-              body: request.encode_body
+              headers: request.encode_headers(protected_keys: @default_headers.keys + auth_headers.keys),
+              body: request.encode_body,
+              auth_headers: auth_headers
             )
 
             conn = connect(url)
@@ -157,12 +165,27 @@ module Seed
                 "HTTP is only allowed for localhost. Use HTTPS or pass a localhost URL."
         end
 
+        # Resolves the auth headers to send with the next request. Delegates to the
+        # configured auth provider (if any) on every call so that token-based
+        # providers (e.g. OAuth client-credentials) can refresh an expired token
+        # before the request is sent. Returns an empty hash when no provider is set,
+        # which keeps the api-key / basic / bearer / no-auth paths unchanged.
+        # @return [Hash] The auth headers for the current request.
+        def resolve_auth_headers
+          return {} if @auth_provider.nil?
+
+          @auth_provider.auth_headers
+        end
+
         # @param url [URI::Generic] The url to the resource.
         # @param method [String] The HTTP method to use.
         # @param headers [Hash] The headers for the request.
         # @param body [String, nil] The body for the request.
+        # @param auth_headers [Hash] The auth headers resolved for this request. These
+        #   take precedence over the static default headers but not over per-request
+        #   headers, mirroring the previous baked-header precedence.
         # @return [HTTP::Request] The HTTP request.
-        def build_http_request(url:, method:, headers: {}, body: nil)
+        def build_http_request(url:, method:, headers: {}, body: nil, auth_headers: {})
           request = Net::HTTPGenericRequest.new(
             method,
             !body.nil?,
@@ -170,7 +193,7 @@ module Seed
             url
           )
 
-          request_headers = @default_headers.merge(headers)
+          request_headers = @default_headers.merge(auth_headers).merge(headers)
           request_headers.each { |name, value| request[name] = value }
           request.body = body if body
 

--- a/seed/ruby-sdk-v2/streaming-parameter/test/unit/internal/http/test_raw_client.rb
+++ b/seed/ruby-sdk-v2/streaming-parameter/test/unit/internal/http/test_raw_client.rb
@@ -54,4 +54,71 @@ describe Seed::Internal::Http::RawClient do
       assert client.should_retry?(make_response(502), 2)
     end
   end
+
+  # A minimal auth provider whose `auth_headers` returns a *different* token on
+  # each call, simulating a token that is refreshed on expiry.
+  class RefreshingAuthProvider
+    def initialize
+      @count = 0
+    end
+
+    def auth_headers
+      @count += 1
+      { "Authorization" => "Bearer TOKEN_#{@count}" }
+    end
+  end
+
+  describe "#resolve_auth_headers" do
+    it "returns an empty hash when no auth provider is configured" do
+      client = Seed::Internal::Http::RawClient.new(base_url: "https://example.com")
+
+      assert_equal({}, client.resolve_auth_headers)
+    end
+
+    it "consults the auth provider on every call so an expired token is refreshed" do
+      client = Seed::Internal::Http::RawClient.new(
+        base_url: "https://example.com",
+        auth_provider: RefreshingAuthProvider.new
+      )
+
+      assert_equal({ "Authorization" => "Bearer TOKEN_1" }, client.resolve_auth_headers)
+      assert_equal({ "Authorization" => "Bearer TOKEN_2" }, client.resolve_auth_headers)
+    end
+  end
+
+  describe "#build_http_request auth header precedence" do
+    let(:client) do
+      Seed::Internal::Http::RawClient.new(
+        base_url: "https://example.com",
+        headers: { "Authorization" => "Bearer STATIC" }
+      )
+    end
+
+    it "lets resolved auth headers override the static default headers" do
+      request = client.build_http_request(
+        url: URI.parse("https://example.com"),
+        method: "GET",
+        auth_headers: { "Authorization" => "Bearer FRESH" }
+      )
+
+      assert_equal("Bearer FRESH", request["Authorization"])
+    end
+
+    it "lets per-request headers take precedence over auth headers" do
+      request = client.build_http_request(
+        url: URI.parse("https://example.com"),
+        method: "GET",
+        headers: { "Authorization" => "Bearer PER_REQUEST" },
+        auth_headers: { "Authorization" => "Bearer FRESH" }
+      )
+
+      assert_equal("Bearer PER_REQUEST", request["Authorization"])
+    end
+
+    it "defaults auth headers to empty, leaving the default headers unchanged" do
+      request = client.build_http_request(url: URI.parse("https://example.com"), method: "GET")
+
+      assert_equal("Bearer STATIC", request["Authorization"])
+    end
+  end
 end

--- a/seed/ruby-sdk-v2/streaming/lib/seed/internal/http/raw_client.rb
+++ b/seed/ruby-sdk-v2/streaming/lib/seed/internal/http/raw_client.rb
@@ -21,10 +21,14 @@ module Seed
         # @param max_retries [Integer] The number of times to retry a failed request, defaults to 2.
         # @param timeout [Float] The timeout for the request, defaults to 60.0 seconds.
         # @param headers [Hash] The headers for the request.
-        def initialize(base_url:, max_retries: 2, timeout: 60.0, headers: {})
+        # @param auth_provider [Object, nil] An optional auth provider responding to
+        #   `auth_headers`. When present its headers are resolved on every request so
+        #   token-based schemes (e.g. OAuth) can refresh an expired token mid-session.
+        def initialize(base_url:, max_retries: 2, timeout: 60.0, headers: {}, auth_provider: nil)
           @base_url = base_url
           @max_retries = max_retries
           @timeout = timeout
+          @auth_provider = auth_provider
           @default_headers = {
             "X-Fern-Language": "Ruby",
             "X-Fern-SDK-Name": "seed",
@@ -36,6 +40,9 @@ module Seed
         # @return [HTTP::Response] The HTTP response.
         def send(request)
           url = build_url(request)
+          # Resolve auth headers once per request (not per retry) so token-based
+          # providers refresh at most once here; static providers are cheap.
+          auth_headers = resolve_auth_headers
           attempt = 0
           response = nil
 
@@ -43,8 +50,9 @@ module Seed
             http_request = build_http_request(
               url:,
               method: request.method,
-              headers: request.encode_headers(protected_keys: @default_headers.keys),
-              body: request.encode_body
+              headers: request.encode_headers(protected_keys: @default_headers.keys + auth_headers.keys),
+              body: request.encode_body,
+              auth_headers: auth_headers
             )
 
             conn = connect(url)
@@ -157,12 +165,27 @@ module Seed
                 "HTTP is only allowed for localhost. Use HTTPS or pass a localhost URL."
         end
 
+        # Resolves the auth headers to send with the next request. Delegates to the
+        # configured auth provider (if any) on every call so that token-based
+        # providers (e.g. OAuth client-credentials) can refresh an expired token
+        # before the request is sent. Returns an empty hash when no provider is set,
+        # which keeps the api-key / basic / bearer / no-auth paths unchanged.
+        # @return [Hash] The auth headers for the current request.
+        def resolve_auth_headers
+          return {} if @auth_provider.nil?
+
+          @auth_provider.auth_headers
+        end
+
         # @param url [URI::Generic] The url to the resource.
         # @param method [String] The HTTP method to use.
         # @param headers [Hash] The headers for the request.
         # @param body [String, nil] The body for the request.
+        # @param auth_headers [Hash] The auth headers resolved for this request. These
+        #   take precedence over the static default headers but not over per-request
+        #   headers, mirroring the previous baked-header precedence.
         # @return [HTTP::Request] The HTTP request.
-        def build_http_request(url:, method:, headers: {}, body: nil)
+        def build_http_request(url:, method:, headers: {}, body: nil, auth_headers: {})
           request = Net::HTTPGenericRequest.new(
             method,
             !body.nil?,
@@ -170,7 +193,7 @@ module Seed
             url
           )
 
-          request_headers = @default_headers.merge(headers)
+          request_headers = @default_headers.merge(auth_headers).merge(headers)
           request_headers.each { |name, value| request[name] = value }
           request.body = body if body
 

--- a/seed/ruby-sdk-v2/streaming/test/unit/internal/http/test_raw_client.rb
+++ b/seed/ruby-sdk-v2/streaming/test/unit/internal/http/test_raw_client.rb
@@ -54,4 +54,71 @@ describe Seed::Internal::Http::RawClient do
       assert client.should_retry?(make_response(502), 2)
     end
   end
+
+  # A minimal auth provider whose `auth_headers` returns a *different* token on
+  # each call, simulating a token that is refreshed on expiry.
+  class RefreshingAuthProvider
+    def initialize
+      @count = 0
+    end
+
+    def auth_headers
+      @count += 1
+      { "Authorization" => "Bearer TOKEN_#{@count}" }
+    end
+  end
+
+  describe "#resolve_auth_headers" do
+    it "returns an empty hash when no auth provider is configured" do
+      client = Seed::Internal::Http::RawClient.new(base_url: "https://example.com")
+
+      assert_equal({}, client.resolve_auth_headers)
+    end
+
+    it "consults the auth provider on every call so an expired token is refreshed" do
+      client = Seed::Internal::Http::RawClient.new(
+        base_url: "https://example.com",
+        auth_provider: RefreshingAuthProvider.new
+      )
+
+      assert_equal({ "Authorization" => "Bearer TOKEN_1" }, client.resolve_auth_headers)
+      assert_equal({ "Authorization" => "Bearer TOKEN_2" }, client.resolve_auth_headers)
+    end
+  end
+
+  describe "#build_http_request auth header precedence" do
+    let(:client) do
+      Seed::Internal::Http::RawClient.new(
+        base_url: "https://example.com",
+        headers: { "Authorization" => "Bearer STATIC" }
+      )
+    end
+
+    it "lets resolved auth headers override the static default headers" do
+      request = client.build_http_request(
+        url: URI.parse("https://example.com"),
+        method: "GET",
+        auth_headers: { "Authorization" => "Bearer FRESH" }
+      )
+
+      assert_equal("Bearer FRESH", request["Authorization"])
+    end
+
+    it "lets per-request headers take precedence over auth headers" do
+      request = client.build_http_request(
+        url: URI.parse("https://example.com"),
+        method: "GET",
+        headers: { "Authorization" => "Bearer PER_REQUEST" },
+        auth_headers: { "Authorization" => "Bearer FRESH" }
+      )
+
+      assert_equal("Bearer PER_REQUEST", request["Authorization"])
+    end
+
+    it "defaults auth headers to empty, leaving the default headers unchanged" do
+      request = client.build_http_request(url: URI.parse("https://example.com"), method: "GET")
+
+      assert_equal("Bearer STATIC", request["Authorization"])
+    end
+  end
 end

--- a/seed/ruby-sdk-v2/trace/lib/seed/internal/http/raw_client.rb
+++ b/seed/ruby-sdk-v2/trace/lib/seed/internal/http/raw_client.rb
@@ -21,10 +21,14 @@ module Seed
         # @param max_retries [Integer] The number of times to retry a failed request, defaults to 2.
         # @param timeout [Float] The timeout for the request, defaults to 60.0 seconds.
         # @param headers [Hash] The headers for the request.
-        def initialize(base_url:, max_retries: 2, timeout: 60.0, headers: {})
+        # @param auth_provider [Object, nil] An optional auth provider responding to
+        #   `auth_headers`. When present its headers are resolved on every request so
+        #   token-based schemes (e.g. OAuth) can refresh an expired token mid-session.
+        def initialize(base_url:, max_retries: 2, timeout: 60.0, headers: {}, auth_provider: nil)
           @base_url = base_url
           @max_retries = max_retries
           @timeout = timeout
+          @auth_provider = auth_provider
           @default_headers = {
             "X-Fern-Language": "Ruby",
             "X-Fern-SDK-Name": "seed",
@@ -36,6 +40,9 @@ module Seed
         # @return [HTTP::Response] The HTTP response.
         def send(request)
           url = build_url(request)
+          # Resolve auth headers once per request (not per retry) so token-based
+          # providers refresh at most once here; static providers are cheap.
+          auth_headers = resolve_auth_headers
           attempt = 0
           response = nil
 
@@ -43,8 +50,9 @@ module Seed
             http_request = build_http_request(
               url:,
               method: request.method,
-              headers: request.encode_headers(protected_keys: @default_headers.keys),
-              body: request.encode_body
+              headers: request.encode_headers(protected_keys: @default_headers.keys + auth_headers.keys),
+              body: request.encode_body,
+              auth_headers: auth_headers
             )
 
             conn = connect(url)
@@ -157,12 +165,27 @@ module Seed
                 "HTTP is only allowed for localhost. Use HTTPS or pass a localhost URL."
         end
 
+        # Resolves the auth headers to send with the next request. Delegates to the
+        # configured auth provider (if any) on every call so that token-based
+        # providers (e.g. OAuth client-credentials) can refresh an expired token
+        # before the request is sent. Returns an empty hash when no provider is set,
+        # which keeps the api-key / basic / bearer / no-auth paths unchanged.
+        # @return [Hash] The auth headers for the current request.
+        def resolve_auth_headers
+          return {} if @auth_provider.nil?
+
+          @auth_provider.auth_headers
+        end
+
         # @param url [URI::Generic] The url to the resource.
         # @param method [String] The HTTP method to use.
         # @param headers [Hash] The headers for the request.
         # @param body [String, nil] The body for the request.
+        # @param auth_headers [Hash] The auth headers resolved for this request. These
+        #   take precedence over the static default headers but not over per-request
+        #   headers, mirroring the previous baked-header precedence.
         # @return [HTTP::Request] The HTTP request.
-        def build_http_request(url:, method:, headers: {}, body: nil)
+        def build_http_request(url:, method:, headers: {}, body: nil, auth_headers: {})
           request = Net::HTTPGenericRequest.new(
             method,
             !body.nil?,
@@ -170,7 +193,7 @@ module Seed
             url
           )
 
-          request_headers = @default_headers.merge(headers)
+          request_headers = @default_headers.merge(auth_headers).merge(headers)
           request_headers.each { |name, value| request[name] = value }
           request.body = body if body
 

--- a/seed/ruby-sdk-v2/trace/test/unit/internal/http/test_raw_client.rb
+++ b/seed/ruby-sdk-v2/trace/test/unit/internal/http/test_raw_client.rb
@@ -54,4 +54,71 @@ describe Seed::Internal::Http::RawClient do
       assert client.should_retry?(make_response(502), 2)
     end
   end
+
+  # A minimal auth provider whose `auth_headers` returns a *different* token on
+  # each call, simulating a token that is refreshed on expiry.
+  class RefreshingAuthProvider
+    def initialize
+      @count = 0
+    end
+
+    def auth_headers
+      @count += 1
+      { "Authorization" => "Bearer TOKEN_#{@count}" }
+    end
+  end
+
+  describe "#resolve_auth_headers" do
+    it "returns an empty hash when no auth provider is configured" do
+      client = Seed::Internal::Http::RawClient.new(base_url: "https://example.com")
+
+      assert_equal({}, client.resolve_auth_headers)
+    end
+
+    it "consults the auth provider on every call so an expired token is refreshed" do
+      client = Seed::Internal::Http::RawClient.new(
+        base_url: "https://example.com",
+        auth_provider: RefreshingAuthProvider.new
+      )
+
+      assert_equal({ "Authorization" => "Bearer TOKEN_1" }, client.resolve_auth_headers)
+      assert_equal({ "Authorization" => "Bearer TOKEN_2" }, client.resolve_auth_headers)
+    end
+  end
+
+  describe "#build_http_request auth header precedence" do
+    let(:client) do
+      Seed::Internal::Http::RawClient.new(
+        base_url: "https://example.com",
+        headers: { "Authorization" => "Bearer STATIC" }
+      )
+    end
+
+    it "lets resolved auth headers override the static default headers" do
+      request = client.build_http_request(
+        url: URI.parse("https://example.com"),
+        method: "GET",
+        auth_headers: { "Authorization" => "Bearer FRESH" }
+      )
+
+      assert_equal("Bearer FRESH", request["Authorization"])
+    end
+
+    it "lets per-request headers take precedence over auth headers" do
+      request = client.build_http_request(
+        url: URI.parse("https://example.com"),
+        method: "GET",
+        headers: { "Authorization" => "Bearer PER_REQUEST" },
+        auth_headers: { "Authorization" => "Bearer FRESH" }
+      )
+
+      assert_equal("Bearer PER_REQUEST", request["Authorization"])
+    end
+
+    it "defaults auth headers to empty, leaving the default headers unchanged" do
+      request = client.build_http_request(url: URI.parse("https://example.com"), method: "GET")
+
+      assert_equal("Bearer STATIC", request["Authorization"])
+    end
+  end
 end

--- a/seed/ruby-sdk-v2/undiscriminated-union-with-response-property/lib/seed/internal/http/raw_client.rb
+++ b/seed/ruby-sdk-v2/undiscriminated-union-with-response-property/lib/seed/internal/http/raw_client.rb
@@ -21,10 +21,14 @@ module Seed
         # @param max_retries [Integer] The number of times to retry a failed request, defaults to 2.
         # @param timeout [Float] The timeout for the request, defaults to 60.0 seconds.
         # @param headers [Hash] The headers for the request.
-        def initialize(base_url:, max_retries: 2, timeout: 60.0, headers: {})
+        # @param auth_provider [Object, nil] An optional auth provider responding to
+        #   `auth_headers`. When present its headers are resolved on every request so
+        #   token-based schemes (e.g. OAuth) can refresh an expired token mid-session.
+        def initialize(base_url:, max_retries: 2, timeout: 60.0, headers: {}, auth_provider: nil)
           @base_url = base_url
           @max_retries = max_retries
           @timeout = timeout
+          @auth_provider = auth_provider
           @default_headers = {
             "X-Fern-Language": "Ruby",
             "X-Fern-SDK-Name": "seed",
@@ -36,6 +40,9 @@ module Seed
         # @return [HTTP::Response] The HTTP response.
         def send(request)
           url = build_url(request)
+          # Resolve auth headers once per request (not per retry) so token-based
+          # providers refresh at most once here; static providers are cheap.
+          auth_headers = resolve_auth_headers
           attempt = 0
           response = nil
 
@@ -43,8 +50,9 @@ module Seed
             http_request = build_http_request(
               url:,
               method: request.method,
-              headers: request.encode_headers(protected_keys: @default_headers.keys),
-              body: request.encode_body
+              headers: request.encode_headers(protected_keys: @default_headers.keys + auth_headers.keys),
+              body: request.encode_body,
+              auth_headers: auth_headers
             )
 
             conn = connect(url)
@@ -157,12 +165,27 @@ module Seed
                 "HTTP is only allowed for localhost. Use HTTPS or pass a localhost URL."
         end
 
+        # Resolves the auth headers to send with the next request. Delegates to the
+        # configured auth provider (if any) on every call so that token-based
+        # providers (e.g. OAuth client-credentials) can refresh an expired token
+        # before the request is sent. Returns an empty hash when no provider is set,
+        # which keeps the api-key / basic / bearer / no-auth paths unchanged.
+        # @return [Hash] The auth headers for the current request.
+        def resolve_auth_headers
+          return {} if @auth_provider.nil?
+
+          @auth_provider.auth_headers
+        end
+
         # @param url [URI::Generic] The url to the resource.
         # @param method [String] The HTTP method to use.
         # @param headers [Hash] The headers for the request.
         # @param body [String, nil] The body for the request.
+        # @param auth_headers [Hash] The auth headers resolved for this request. These
+        #   take precedence over the static default headers but not over per-request
+        #   headers, mirroring the previous baked-header precedence.
         # @return [HTTP::Request] The HTTP request.
-        def build_http_request(url:, method:, headers: {}, body: nil)
+        def build_http_request(url:, method:, headers: {}, body: nil, auth_headers: {})
           request = Net::HTTPGenericRequest.new(
             method,
             !body.nil?,
@@ -170,7 +193,7 @@ module Seed
             url
           )
 
-          request_headers = @default_headers.merge(headers)
+          request_headers = @default_headers.merge(auth_headers).merge(headers)
           request_headers.each { |name, value| request[name] = value }
           request.body = body if body
 

--- a/seed/ruby-sdk-v2/undiscriminated-union-with-response-property/test/unit/internal/http/test_raw_client.rb
+++ b/seed/ruby-sdk-v2/undiscriminated-union-with-response-property/test/unit/internal/http/test_raw_client.rb
@@ -54,4 +54,71 @@ describe Seed::Internal::Http::RawClient do
       assert client.should_retry?(make_response(502), 2)
     end
   end
+
+  # A minimal auth provider whose `auth_headers` returns a *different* token on
+  # each call, simulating a token that is refreshed on expiry.
+  class RefreshingAuthProvider
+    def initialize
+      @count = 0
+    end
+
+    def auth_headers
+      @count += 1
+      { "Authorization" => "Bearer TOKEN_#{@count}" }
+    end
+  end
+
+  describe "#resolve_auth_headers" do
+    it "returns an empty hash when no auth provider is configured" do
+      client = Seed::Internal::Http::RawClient.new(base_url: "https://example.com")
+
+      assert_equal({}, client.resolve_auth_headers)
+    end
+
+    it "consults the auth provider on every call so an expired token is refreshed" do
+      client = Seed::Internal::Http::RawClient.new(
+        base_url: "https://example.com",
+        auth_provider: RefreshingAuthProvider.new
+      )
+
+      assert_equal({ "Authorization" => "Bearer TOKEN_1" }, client.resolve_auth_headers)
+      assert_equal({ "Authorization" => "Bearer TOKEN_2" }, client.resolve_auth_headers)
+    end
+  end
+
+  describe "#build_http_request auth header precedence" do
+    let(:client) do
+      Seed::Internal::Http::RawClient.new(
+        base_url: "https://example.com",
+        headers: { "Authorization" => "Bearer STATIC" }
+      )
+    end
+
+    it "lets resolved auth headers override the static default headers" do
+      request = client.build_http_request(
+        url: URI.parse("https://example.com"),
+        method: "GET",
+        auth_headers: { "Authorization" => "Bearer FRESH" }
+      )
+
+      assert_equal("Bearer FRESH", request["Authorization"])
+    end
+
+    it "lets per-request headers take precedence over auth headers" do
+      request = client.build_http_request(
+        url: URI.parse("https://example.com"),
+        method: "GET",
+        headers: { "Authorization" => "Bearer PER_REQUEST" },
+        auth_headers: { "Authorization" => "Bearer FRESH" }
+      )
+
+      assert_equal("Bearer PER_REQUEST", request["Authorization"])
+    end
+
+    it "defaults auth headers to empty, leaving the default headers unchanged" do
+      request = client.build_http_request(url: URI.parse("https://example.com"), method: "GET")
+
+      assert_equal("Bearer STATIC", request["Authorization"])
+    end
+  end
 end

--- a/seed/ruby-sdk-v2/undiscriminated-unions/lib/seed/internal/http/raw_client.rb
+++ b/seed/ruby-sdk-v2/undiscriminated-unions/lib/seed/internal/http/raw_client.rb
@@ -21,10 +21,14 @@ module Seed
         # @param max_retries [Integer] The number of times to retry a failed request, defaults to 2.
         # @param timeout [Float] The timeout for the request, defaults to 60.0 seconds.
         # @param headers [Hash] The headers for the request.
-        def initialize(base_url:, max_retries: 2, timeout: 60.0, headers: {})
+        # @param auth_provider [Object, nil] An optional auth provider responding to
+        #   `auth_headers`. When present its headers are resolved on every request so
+        #   token-based schemes (e.g. OAuth) can refresh an expired token mid-session.
+        def initialize(base_url:, max_retries: 2, timeout: 60.0, headers: {}, auth_provider: nil)
           @base_url = base_url
           @max_retries = max_retries
           @timeout = timeout
+          @auth_provider = auth_provider
           @default_headers = {
             "X-Fern-Language": "Ruby",
             "X-Fern-SDK-Name": "seed",
@@ -36,6 +40,9 @@ module Seed
         # @return [HTTP::Response] The HTTP response.
         def send(request)
           url = build_url(request)
+          # Resolve auth headers once per request (not per retry) so token-based
+          # providers refresh at most once here; static providers are cheap.
+          auth_headers = resolve_auth_headers
           attempt = 0
           response = nil
 
@@ -43,8 +50,9 @@ module Seed
             http_request = build_http_request(
               url:,
               method: request.method,
-              headers: request.encode_headers(protected_keys: @default_headers.keys),
-              body: request.encode_body
+              headers: request.encode_headers(protected_keys: @default_headers.keys + auth_headers.keys),
+              body: request.encode_body,
+              auth_headers: auth_headers
             )
 
             conn = connect(url)
@@ -157,12 +165,27 @@ module Seed
                 "HTTP is only allowed for localhost. Use HTTPS or pass a localhost URL."
         end
 
+        # Resolves the auth headers to send with the next request. Delegates to the
+        # configured auth provider (if any) on every call so that token-based
+        # providers (e.g. OAuth client-credentials) can refresh an expired token
+        # before the request is sent. Returns an empty hash when no provider is set,
+        # which keeps the api-key / basic / bearer / no-auth paths unchanged.
+        # @return [Hash] The auth headers for the current request.
+        def resolve_auth_headers
+          return {} if @auth_provider.nil?
+
+          @auth_provider.auth_headers
+        end
+
         # @param url [URI::Generic] The url to the resource.
         # @param method [String] The HTTP method to use.
         # @param headers [Hash] The headers for the request.
         # @param body [String, nil] The body for the request.
+        # @param auth_headers [Hash] The auth headers resolved for this request. These
+        #   take precedence over the static default headers but not over per-request
+        #   headers, mirroring the previous baked-header precedence.
         # @return [HTTP::Request] The HTTP request.
-        def build_http_request(url:, method:, headers: {}, body: nil)
+        def build_http_request(url:, method:, headers: {}, body: nil, auth_headers: {})
           request = Net::HTTPGenericRequest.new(
             method,
             !body.nil?,
@@ -170,7 +193,7 @@ module Seed
             url
           )
 
-          request_headers = @default_headers.merge(headers)
+          request_headers = @default_headers.merge(auth_headers).merge(headers)
           request_headers.each { |name, value| request[name] = value }
           request.body = body if body
 

--- a/seed/ruby-sdk-v2/undiscriminated-unions/test/unit/internal/http/test_raw_client.rb
+++ b/seed/ruby-sdk-v2/undiscriminated-unions/test/unit/internal/http/test_raw_client.rb
@@ -54,4 +54,71 @@ describe Seed::Internal::Http::RawClient do
       assert client.should_retry?(make_response(502), 2)
     end
   end
+
+  # A minimal auth provider whose `auth_headers` returns a *different* token on
+  # each call, simulating a token that is refreshed on expiry.
+  class RefreshingAuthProvider
+    def initialize
+      @count = 0
+    end
+
+    def auth_headers
+      @count += 1
+      { "Authorization" => "Bearer TOKEN_#{@count}" }
+    end
+  end
+
+  describe "#resolve_auth_headers" do
+    it "returns an empty hash when no auth provider is configured" do
+      client = Seed::Internal::Http::RawClient.new(base_url: "https://example.com")
+
+      assert_equal({}, client.resolve_auth_headers)
+    end
+
+    it "consults the auth provider on every call so an expired token is refreshed" do
+      client = Seed::Internal::Http::RawClient.new(
+        base_url: "https://example.com",
+        auth_provider: RefreshingAuthProvider.new
+      )
+
+      assert_equal({ "Authorization" => "Bearer TOKEN_1" }, client.resolve_auth_headers)
+      assert_equal({ "Authorization" => "Bearer TOKEN_2" }, client.resolve_auth_headers)
+    end
+  end
+
+  describe "#build_http_request auth header precedence" do
+    let(:client) do
+      Seed::Internal::Http::RawClient.new(
+        base_url: "https://example.com",
+        headers: { "Authorization" => "Bearer STATIC" }
+      )
+    end
+
+    it "lets resolved auth headers override the static default headers" do
+      request = client.build_http_request(
+        url: URI.parse("https://example.com"),
+        method: "GET",
+        auth_headers: { "Authorization" => "Bearer FRESH" }
+      )
+
+      assert_equal("Bearer FRESH", request["Authorization"])
+    end
+
+    it "lets per-request headers take precedence over auth headers" do
+      request = client.build_http_request(
+        url: URI.parse("https://example.com"),
+        method: "GET",
+        headers: { "Authorization" => "Bearer PER_REQUEST" },
+        auth_headers: { "Authorization" => "Bearer FRESH" }
+      )
+
+      assert_equal("Bearer PER_REQUEST", request["Authorization"])
+    end
+
+    it "defaults auth headers to empty, leaving the default headers unchanged" do
+      request = client.build_http_request(url: URI.parse("https://example.com"), method: "GET")
+
+      assert_equal("Bearer STATIC", request["Authorization"])
+    end
+  end
 end

--- a/seed/ruby-sdk-v2/union-query-parameters/lib/seed/internal/http/raw_client.rb
+++ b/seed/ruby-sdk-v2/union-query-parameters/lib/seed/internal/http/raw_client.rb
@@ -21,10 +21,14 @@ module Seed
         # @param max_retries [Integer] The number of times to retry a failed request, defaults to 2.
         # @param timeout [Float] The timeout for the request, defaults to 60.0 seconds.
         # @param headers [Hash] The headers for the request.
-        def initialize(base_url:, max_retries: 2, timeout: 60.0, headers: {})
+        # @param auth_provider [Object, nil] An optional auth provider responding to
+        #   `auth_headers`. When present its headers are resolved on every request so
+        #   token-based schemes (e.g. OAuth) can refresh an expired token mid-session.
+        def initialize(base_url:, max_retries: 2, timeout: 60.0, headers: {}, auth_provider: nil)
           @base_url = base_url
           @max_retries = max_retries
           @timeout = timeout
+          @auth_provider = auth_provider
           @default_headers = {
             "X-Fern-Language": "Ruby",
             "X-Fern-SDK-Name": "seed",
@@ -36,6 +40,9 @@ module Seed
         # @return [HTTP::Response] The HTTP response.
         def send(request)
           url = build_url(request)
+          # Resolve auth headers once per request (not per retry) so token-based
+          # providers refresh at most once here; static providers are cheap.
+          auth_headers = resolve_auth_headers
           attempt = 0
           response = nil
 
@@ -43,8 +50,9 @@ module Seed
             http_request = build_http_request(
               url:,
               method: request.method,
-              headers: request.encode_headers(protected_keys: @default_headers.keys),
-              body: request.encode_body
+              headers: request.encode_headers(protected_keys: @default_headers.keys + auth_headers.keys),
+              body: request.encode_body,
+              auth_headers: auth_headers
             )
 
             conn = connect(url)
@@ -157,12 +165,27 @@ module Seed
                 "HTTP is only allowed for localhost. Use HTTPS or pass a localhost URL."
         end
 
+        # Resolves the auth headers to send with the next request. Delegates to the
+        # configured auth provider (if any) on every call so that token-based
+        # providers (e.g. OAuth client-credentials) can refresh an expired token
+        # before the request is sent. Returns an empty hash when no provider is set,
+        # which keeps the api-key / basic / bearer / no-auth paths unchanged.
+        # @return [Hash] The auth headers for the current request.
+        def resolve_auth_headers
+          return {} if @auth_provider.nil?
+
+          @auth_provider.auth_headers
+        end
+
         # @param url [URI::Generic] The url to the resource.
         # @param method [String] The HTTP method to use.
         # @param headers [Hash] The headers for the request.
         # @param body [String, nil] The body for the request.
+        # @param auth_headers [Hash] The auth headers resolved for this request. These
+        #   take precedence over the static default headers but not over per-request
+        #   headers, mirroring the previous baked-header precedence.
         # @return [HTTP::Request] The HTTP request.
-        def build_http_request(url:, method:, headers: {}, body: nil)
+        def build_http_request(url:, method:, headers: {}, body: nil, auth_headers: {})
           request = Net::HTTPGenericRequest.new(
             method,
             !body.nil?,
@@ -170,7 +193,7 @@ module Seed
             url
           )
 
-          request_headers = @default_headers.merge(headers)
+          request_headers = @default_headers.merge(auth_headers).merge(headers)
           request_headers.each { |name, value| request[name] = value }
           request.body = body if body
 

--- a/seed/ruby-sdk-v2/union-query-parameters/test/unit/internal/http/test_raw_client.rb
+++ b/seed/ruby-sdk-v2/union-query-parameters/test/unit/internal/http/test_raw_client.rb
@@ -54,4 +54,71 @@ describe Seed::Internal::Http::RawClient do
       assert client.should_retry?(make_response(502), 2)
     end
   end
+
+  # A minimal auth provider whose `auth_headers` returns a *different* token on
+  # each call, simulating a token that is refreshed on expiry.
+  class RefreshingAuthProvider
+    def initialize
+      @count = 0
+    end
+
+    def auth_headers
+      @count += 1
+      { "Authorization" => "Bearer TOKEN_#{@count}" }
+    end
+  end
+
+  describe "#resolve_auth_headers" do
+    it "returns an empty hash when no auth provider is configured" do
+      client = Seed::Internal::Http::RawClient.new(base_url: "https://example.com")
+
+      assert_equal({}, client.resolve_auth_headers)
+    end
+
+    it "consults the auth provider on every call so an expired token is refreshed" do
+      client = Seed::Internal::Http::RawClient.new(
+        base_url: "https://example.com",
+        auth_provider: RefreshingAuthProvider.new
+      )
+
+      assert_equal({ "Authorization" => "Bearer TOKEN_1" }, client.resolve_auth_headers)
+      assert_equal({ "Authorization" => "Bearer TOKEN_2" }, client.resolve_auth_headers)
+    end
+  end
+
+  describe "#build_http_request auth header precedence" do
+    let(:client) do
+      Seed::Internal::Http::RawClient.new(
+        base_url: "https://example.com",
+        headers: { "Authorization" => "Bearer STATIC" }
+      )
+    end
+
+    it "lets resolved auth headers override the static default headers" do
+      request = client.build_http_request(
+        url: URI.parse("https://example.com"),
+        method: "GET",
+        auth_headers: { "Authorization" => "Bearer FRESH" }
+      )
+
+      assert_equal("Bearer FRESH", request["Authorization"])
+    end
+
+    it "lets per-request headers take precedence over auth headers" do
+      request = client.build_http_request(
+        url: URI.parse("https://example.com"),
+        method: "GET",
+        headers: { "Authorization" => "Bearer PER_REQUEST" },
+        auth_headers: { "Authorization" => "Bearer FRESH" }
+      )
+
+      assert_equal("Bearer PER_REQUEST", request["Authorization"])
+    end
+
+    it "defaults auth headers to empty, leaving the default headers unchanged" do
+      request = client.build_http_request(url: URI.parse("https://example.com"), method: "GET")
+
+      assert_equal("Bearer STATIC", request["Authorization"])
+    end
+  end
 end

--- a/seed/ruby-sdk-v2/unions-with-local-date/lib/seed/internal/http/raw_client.rb
+++ b/seed/ruby-sdk-v2/unions-with-local-date/lib/seed/internal/http/raw_client.rb
@@ -21,10 +21,14 @@ module Seed
         # @param max_retries [Integer] The number of times to retry a failed request, defaults to 2.
         # @param timeout [Float] The timeout for the request, defaults to 60.0 seconds.
         # @param headers [Hash] The headers for the request.
-        def initialize(base_url:, max_retries: 2, timeout: 60.0, headers: {})
+        # @param auth_provider [Object, nil] An optional auth provider responding to
+        #   `auth_headers`. When present its headers are resolved on every request so
+        #   token-based schemes (e.g. OAuth) can refresh an expired token mid-session.
+        def initialize(base_url:, max_retries: 2, timeout: 60.0, headers: {}, auth_provider: nil)
           @base_url = base_url
           @max_retries = max_retries
           @timeout = timeout
+          @auth_provider = auth_provider
           @default_headers = {
             "X-Fern-Language": "Ruby",
             "X-Fern-SDK-Name": "seed",
@@ -36,6 +40,9 @@ module Seed
         # @return [HTTP::Response] The HTTP response.
         def send(request)
           url = build_url(request)
+          # Resolve auth headers once per request (not per retry) so token-based
+          # providers refresh at most once here; static providers are cheap.
+          auth_headers = resolve_auth_headers
           attempt = 0
           response = nil
 
@@ -43,8 +50,9 @@ module Seed
             http_request = build_http_request(
               url:,
               method: request.method,
-              headers: request.encode_headers(protected_keys: @default_headers.keys),
-              body: request.encode_body
+              headers: request.encode_headers(protected_keys: @default_headers.keys + auth_headers.keys),
+              body: request.encode_body,
+              auth_headers: auth_headers
             )
 
             conn = connect(url)
@@ -157,12 +165,27 @@ module Seed
                 "HTTP is only allowed for localhost. Use HTTPS or pass a localhost URL."
         end
 
+        # Resolves the auth headers to send with the next request. Delegates to the
+        # configured auth provider (if any) on every call so that token-based
+        # providers (e.g. OAuth client-credentials) can refresh an expired token
+        # before the request is sent. Returns an empty hash when no provider is set,
+        # which keeps the api-key / basic / bearer / no-auth paths unchanged.
+        # @return [Hash] The auth headers for the current request.
+        def resolve_auth_headers
+          return {} if @auth_provider.nil?
+
+          @auth_provider.auth_headers
+        end
+
         # @param url [URI::Generic] The url to the resource.
         # @param method [String] The HTTP method to use.
         # @param headers [Hash] The headers for the request.
         # @param body [String, nil] The body for the request.
+        # @param auth_headers [Hash] The auth headers resolved for this request. These
+        #   take precedence over the static default headers but not over per-request
+        #   headers, mirroring the previous baked-header precedence.
         # @return [HTTP::Request] The HTTP request.
-        def build_http_request(url:, method:, headers: {}, body: nil)
+        def build_http_request(url:, method:, headers: {}, body: nil, auth_headers: {})
           request = Net::HTTPGenericRequest.new(
             method,
             !body.nil?,
@@ -170,7 +193,7 @@ module Seed
             url
           )
 
-          request_headers = @default_headers.merge(headers)
+          request_headers = @default_headers.merge(auth_headers).merge(headers)
           request_headers.each { |name, value| request[name] = value }
           request.body = body if body
 

--- a/seed/ruby-sdk-v2/unions-with-local-date/test/unit/internal/http/test_raw_client.rb
+++ b/seed/ruby-sdk-v2/unions-with-local-date/test/unit/internal/http/test_raw_client.rb
@@ -54,4 +54,71 @@ describe Seed::Internal::Http::RawClient do
       assert client.should_retry?(make_response(502), 2)
     end
   end
+
+  # A minimal auth provider whose `auth_headers` returns a *different* token on
+  # each call, simulating a token that is refreshed on expiry.
+  class RefreshingAuthProvider
+    def initialize
+      @count = 0
+    end
+
+    def auth_headers
+      @count += 1
+      { "Authorization" => "Bearer TOKEN_#{@count}" }
+    end
+  end
+
+  describe "#resolve_auth_headers" do
+    it "returns an empty hash when no auth provider is configured" do
+      client = Seed::Internal::Http::RawClient.new(base_url: "https://example.com")
+
+      assert_equal({}, client.resolve_auth_headers)
+    end
+
+    it "consults the auth provider on every call so an expired token is refreshed" do
+      client = Seed::Internal::Http::RawClient.new(
+        base_url: "https://example.com",
+        auth_provider: RefreshingAuthProvider.new
+      )
+
+      assert_equal({ "Authorization" => "Bearer TOKEN_1" }, client.resolve_auth_headers)
+      assert_equal({ "Authorization" => "Bearer TOKEN_2" }, client.resolve_auth_headers)
+    end
+  end
+
+  describe "#build_http_request auth header precedence" do
+    let(:client) do
+      Seed::Internal::Http::RawClient.new(
+        base_url: "https://example.com",
+        headers: { "Authorization" => "Bearer STATIC" }
+      )
+    end
+
+    it "lets resolved auth headers override the static default headers" do
+      request = client.build_http_request(
+        url: URI.parse("https://example.com"),
+        method: "GET",
+        auth_headers: { "Authorization" => "Bearer FRESH" }
+      )
+
+      assert_equal("Bearer FRESH", request["Authorization"])
+    end
+
+    it "lets per-request headers take precedence over auth headers" do
+      request = client.build_http_request(
+        url: URI.parse("https://example.com"),
+        method: "GET",
+        headers: { "Authorization" => "Bearer PER_REQUEST" },
+        auth_headers: { "Authorization" => "Bearer FRESH" }
+      )
+
+      assert_equal("Bearer PER_REQUEST", request["Authorization"])
+    end
+
+    it "defaults auth headers to empty, leaving the default headers unchanged" do
+      request = client.build_http_request(url: URI.parse("https://example.com"), method: "GET")
+
+      assert_equal("Bearer STATIC", request["Authorization"])
+    end
+  end
 end

--- a/seed/ruby-sdk-v2/unions/lib/seed/internal/http/raw_client.rb
+++ b/seed/ruby-sdk-v2/unions/lib/seed/internal/http/raw_client.rb
@@ -21,10 +21,14 @@ module Seed
         # @param max_retries [Integer] The number of times to retry a failed request, defaults to 2.
         # @param timeout [Float] The timeout for the request, defaults to 60.0 seconds.
         # @param headers [Hash] The headers for the request.
-        def initialize(base_url:, max_retries: 2, timeout: 60.0, headers: {})
+        # @param auth_provider [Object, nil] An optional auth provider responding to
+        #   `auth_headers`. When present its headers are resolved on every request so
+        #   token-based schemes (e.g. OAuth) can refresh an expired token mid-session.
+        def initialize(base_url:, max_retries: 2, timeout: 60.0, headers: {}, auth_provider: nil)
           @base_url = base_url
           @max_retries = max_retries
           @timeout = timeout
+          @auth_provider = auth_provider
           @default_headers = {
             "X-Fern-Language": "Ruby",
             "X-Fern-SDK-Name": "seed",
@@ -36,6 +40,9 @@ module Seed
         # @return [HTTP::Response] The HTTP response.
         def send(request)
           url = build_url(request)
+          # Resolve auth headers once per request (not per retry) so token-based
+          # providers refresh at most once here; static providers are cheap.
+          auth_headers = resolve_auth_headers
           attempt = 0
           response = nil
 
@@ -43,8 +50,9 @@ module Seed
             http_request = build_http_request(
               url:,
               method: request.method,
-              headers: request.encode_headers(protected_keys: @default_headers.keys),
-              body: request.encode_body
+              headers: request.encode_headers(protected_keys: @default_headers.keys + auth_headers.keys),
+              body: request.encode_body,
+              auth_headers: auth_headers
             )
 
             conn = connect(url)
@@ -157,12 +165,27 @@ module Seed
                 "HTTP is only allowed for localhost. Use HTTPS or pass a localhost URL."
         end
 
+        # Resolves the auth headers to send with the next request. Delegates to the
+        # configured auth provider (if any) on every call so that token-based
+        # providers (e.g. OAuth client-credentials) can refresh an expired token
+        # before the request is sent. Returns an empty hash when no provider is set,
+        # which keeps the api-key / basic / bearer / no-auth paths unchanged.
+        # @return [Hash] The auth headers for the current request.
+        def resolve_auth_headers
+          return {} if @auth_provider.nil?
+
+          @auth_provider.auth_headers
+        end
+
         # @param url [URI::Generic] The url to the resource.
         # @param method [String] The HTTP method to use.
         # @param headers [Hash] The headers for the request.
         # @param body [String, nil] The body for the request.
+        # @param auth_headers [Hash] The auth headers resolved for this request. These
+        #   take precedence over the static default headers but not over per-request
+        #   headers, mirroring the previous baked-header precedence.
         # @return [HTTP::Request] The HTTP request.
-        def build_http_request(url:, method:, headers: {}, body: nil)
+        def build_http_request(url:, method:, headers: {}, body: nil, auth_headers: {})
           request = Net::HTTPGenericRequest.new(
             method,
             !body.nil?,
@@ -170,7 +193,7 @@ module Seed
             url
           )
 
-          request_headers = @default_headers.merge(headers)
+          request_headers = @default_headers.merge(auth_headers).merge(headers)
           request_headers.each { |name, value| request[name] = value }
           request.body = body if body
 

--- a/seed/ruby-sdk-v2/unions/test/unit/internal/http/test_raw_client.rb
+++ b/seed/ruby-sdk-v2/unions/test/unit/internal/http/test_raw_client.rb
@@ -54,4 +54,71 @@ describe Seed::Internal::Http::RawClient do
       assert client.should_retry?(make_response(502), 2)
     end
   end
+
+  # A minimal auth provider whose `auth_headers` returns a *different* token on
+  # each call, simulating a token that is refreshed on expiry.
+  class RefreshingAuthProvider
+    def initialize
+      @count = 0
+    end
+
+    def auth_headers
+      @count += 1
+      { "Authorization" => "Bearer TOKEN_#{@count}" }
+    end
+  end
+
+  describe "#resolve_auth_headers" do
+    it "returns an empty hash when no auth provider is configured" do
+      client = Seed::Internal::Http::RawClient.new(base_url: "https://example.com")
+
+      assert_equal({}, client.resolve_auth_headers)
+    end
+
+    it "consults the auth provider on every call so an expired token is refreshed" do
+      client = Seed::Internal::Http::RawClient.new(
+        base_url: "https://example.com",
+        auth_provider: RefreshingAuthProvider.new
+      )
+
+      assert_equal({ "Authorization" => "Bearer TOKEN_1" }, client.resolve_auth_headers)
+      assert_equal({ "Authorization" => "Bearer TOKEN_2" }, client.resolve_auth_headers)
+    end
+  end
+
+  describe "#build_http_request auth header precedence" do
+    let(:client) do
+      Seed::Internal::Http::RawClient.new(
+        base_url: "https://example.com",
+        headers: { "Authorization" => "Bearer STATIC" }
+      )
+    end
+
+    it "lets resolved auth headers override the static default headers" do
+      request = client.build_http_request(
+        url: URI.parse("https://example.com"),
+        method: "GET",
+        auth_headers: { "Authorization" => "Bearer FRESH" }
+      )
+
+      assert_equal("Bearer FRESH", request["Authorization"])
+    end
+
+    it "lets per-request headers take precedence over auth headers" do
+      request = client.build_http_request(
+        url: URI.parse("https://example.com"),
+        method: "GET",
+        headers: { "Authorization" => "Bearer PER_REQUEST" },
+        auth_headers: { "Authorization" => "Bearer FRESH" }
+      )
+
+      assert_equal("Bearer PER_REQUEST", request["Authorization"])
+    end
+
+    it "defaults auth headers to empty, leaving the default headers unchanged" do
+      request = client.build_http_request(url: URI.parse("https://example.com"), method: "GET")
+
+      assert_equal("Bearer STATIC", request["Authorization"])
+    end
+  end
 end

--- a/seed/ruby-sdk-v2/unknown/lib/seed/internal/http/raw_client.rb
+++ b/seed/ruby-sdk-v2/unknown/lib/seed/internal/http/raw_client.rb
@@ -21,10 +21,14 @@ module Seed
         # @param max_retries [Integer] The number of times to retry a failed request, defaults to 2.
         # @param timeout [Float] The timeout for the request, defaults to 60.0 seconds.
         # @param headers [Hash] The headers for the request.
-        def initialize(base_url:, max_retries: 2, timeout: 60.0, headers: {})
+        # @param auth_provider [Object, nil] An optional auth provider responding to
+        #   `auth_headers`. When present its headers are resolved on every request so
+        #   token-based schemes (e.g. OAuth) can refresh an expired token mid-session.
+        def initialize(base_url:, max_retries: 2, timeout: 60.0, headers: {}, auth_provider: nil)
           @base_url = base_url
           @max_retries = max_retries
           @timeout = timeout
+          @auth_provider = auth_provider
           @default_headers = {
             "X-Fern-Language": "Ruby",
             "X-Fern-SDK-Name": "seed",
@@ -36,6 +40,9 @@ module Seed
         # @return [HTTP::Response] The HTTP response.
         def send(request)
           url = build_url(request)
+          # Resolve auth headers once per request (not per retry) so token-based
+          # providers refresh at most once here; static providers are cheap.
+          auth_headers = resolve_auth_headers
           attempt = 0
           response = nil
 
@@ -43,8 +50,9 @@ module Seed
             http_request = build_http_request(
               url:,
               method: request.method,
-              headers: request.encode_headers(protected_keys: @default_headers.keys),
-              body: request.encode_body
+              headers: request.encode_headers(protected_keys: @default_headers.keys + auth_headers.keys),
+              body: request.encode_body,
+              auth_headers: auth_headers
             )
 
             conn = connect(url)
@@ -157,12 +165,27 @@ module Seed
                 "HTTP is only allowed for localhost. Use HTTPS or pass a localhost URL."
         end
 
+        # Resolves the auth headers to send with the next request. Delegates to the
+        # configured auth provider (if any) on every call so that token-based
+        # providers (e.g. OAuth client-credentials) can refresh an expired token
+        # before the request is sent. Returns an empty hash when no provider is set,
+        # which keeps the api-key / basic / bearer / no-auth paths unchanged.
+        # @return [Hash] The auth headers for the current request.
+        def resolve_auth_headers
+          return {} if @auth_provider.nil?
+
+          @auth_provider.auth_headers
+        end
+
         # @param url [URI::Generic] The url to the resource.
         # @param method [String] The HTTP method to use.
         # @param headers [Hash] The headers for the request.
         # @param body [String, nil] The body for the request.
+        # @param auth_headers [Hash] The auth headers resolved for this request. These
+        #   take precedence over the static default headers but not over per-request
+        #   headers, mirroring the previous baked-header precedence.
         # @return [HTTP::Request] The HTTP request.
-        def build_http_request(url:, method:, headers: {}, body: nil)
+        def build_http_request(url:, method:, headers: {}, body: nil, auth_headers: {})
           request = Net::HTTPGenericRequest.new(
             method,
             !body.nil?,
@@ -170,7 +193,7 @@ module Seed
             url
           )
 
-          request_headers = @default_headers.merge(headers)
+          request_headers = @default_headers.merge(auth_headers).merge(headers)
           request_headers.each { |name, value| request[name] = value }
           request.body = body if body
 

--- a/seed/ruby-sdk-v2/unknown/test/unit/internal/http/test_raw_client.rb
+++ b/seed/ruby-sdk-v2/unknown/test/unit/internal/http/test_raw_client.rb
@@ -54,4 +54,71 @@ describe Seed::Internal::Http::RawClient do
       assert client.should_retry?(make_response(502), 2)
     end
   end
+
+  # A minimal auth provider whose `auth_headers` returns a *different* token on
+  # each call, simulating a token that is refreshed on expiry.
+  class RefreshingAuthProvider
+    def initialize
+      @count = 0
+    end
+
+    def auth_headers
+      @count += 1
+      { "Authorization" => "Bearer TOKEN_#{@count}" }
+    end
+  end
+
+  describe "#resolve_auth_headers" do
+    it "returns an empty hash when no auth provider is configured" do
+      client = Seed::Internal::Http::RawClient.new(base_url: "https://example.com")
+
+      assert_equal({}, client.resolve_auth_headers)
+    end
+
+    it "consults the auth provider on every call so an expired token is refreshed" do
+      client = Seed::Internal::Http::RawClient.new(
+        base_url: "https://example.com",
+        auth_provider: RefreshingAuthProvider.new
+      )
+
+      assert_equal({ "Authorization" => "Bearer TOKEN_1" }, client.resolve_auth_headers)
+      assert_equal({ "Authorization" => "Bearer TOKEN_2" }, client.resolve_auth_headers)
+    end
+  end
+
+  describe "#build_http_request auth header precedence" do
+    let(:client) do
+      Seed::Internal::Http::RawClient.new(
+        base_url: "https://example.com",
+        headers: { "Authorization" => "Bearer STATIC" }
+      )
+    end
+
+    it "lets resolved auth headers override the static default headers" do
+      request = client.build_http_request(
+        url: URI.parse("https://example.com"),
+        method: "GET",
+        auth_headers: { "Authorization" => "Bearer FRESH" }
+      )
+
+      assert_equal("Bearer FRESH", request["Authorization"])
+    end
+
+    it "lets per-request headers take precedence over auth headers" do
+      request = client.build_http_request(
+        url: URI.parse("https://example.com"),
+        method: "GET",
+        headers: { "Authorization" => "Bearer PER_REQUEST" },
+        auth_headers: { "Authorization" => "Bearer FRESH" }
+      )
+
+      assert_equal("Bearer PER_REQUEST", request["Authorization"])
+    end
+
+    it "defaults auth headers to empty, leaving the default headers unchanged" do
+      request = client.build_http_request(url: URI.parse("https://example.com"), method: "GET")
+
+      assert_equal("Bearer STATIC", request["Authorization"])
+    end
+  end
 end

--- a/seed/ruby-sdk-v2/url-form-encoded/lib/seed/internal/http/raw_client.rb
+++ b/seed/ruby-sdk-v2/url-form-encoded/lib/seed/internal/http/raw_client.rb
@@ -21,10 +21,14 @@ module Seed
         # @param max_retries [Integer] The number of times to retry a failed request, defaults to 2.
         # @param timeout [Float] The timeout for the request, defaults to 60.0 seconds.
         # @param headers [Hash] The headers for the request.
-        def initialize(base_url:, max_retries: 2, timeout: 60.0, headers: {})
+        # @param auth_provider [Object, nil] An optional auth provider responding to
+        #   `auth_headers`. When present its headers are resolved on every request so
+        #   token-based schemes (e.g. OAuth) can refresh an expired token mid-session.
+        def initialize(base_url:, max_retries: 2, timeout: 60.0, headers: {}, auth_provider: nil)
           @base_url = base_url
           @max_retries = max_retries
           @timeout = timeout
+          @auth_provider = auth_provider
           @default_headers = {
             "X-Fern-Language": "Ruby",
             "X-Fern-SDK-Name": "seed",
@@ -36,6 +40,9 @@ module Seed
         # @return [HTTP::Response] The HTTP response.
         def send(request)
           url = build_url(request)
+          # Resolve auth headers once per request (not per retry) so token-based
+          # providers refresh at most once here; static providers are cheap.
+          auth_headers = resolve_auth_headers
           attempt = 0
           response = nil
 
@@ -43,8 +50,9 @@ module Seed
             http_request = build_http_request(
               url:,
               method: request.method,
-              headers: request.encode_headers(protected_keys: @default_headers.keys),
-              body: request.encode_body
+              headers: request.encode_headers(protected_keys: @default_headers.keys + auth_headers.keys),
+              body: request.encode_body,
+              auth_headers: auth_headers
             )
 
             conn = connect(url)
@@ -157,12 +165,27 @@ module Seed
                 "HTTP is only allowed for localhost. Use HTTPS or pass a localhost URL."
         end
 
+        # Resolves the auth headers to send with the next request. Delegates to the
+        # configured auth provider (if any) on every call so that token-based
+        # providers (e.g. OAuth client-credentials) can refresh an expired token
+        # before the request is sent. Returns an empty hash when no provider is set,
+        # which keeps the api-key / basic / bearer / no-auth paths unchanged.
+        # @return [Hash] The auth headers for the current request.
+        def resolve_auth_headers
+          return {} if @auth_provider.nil?
+
+          @auth_provider.auth_headers
+        end
+
         # @param url [URI::Generic] The url to the resource.
         # @param method [String] The HTTP method to use.
         # @param headers [Hash] The headers for the request.
         # @param body [String, nil] The body for the request.
+        # @param auth_headers [Hash] The auth headers resolved for this request. These
+        #   take precedence over the static default headers but not over per-request
+        #   headers, mirroring the previous baked-header precedence.
         # @return [HTTP::Request] The HTTP request.
-        def build_http_request(url:, method:, headers: {}, body: nil)
+        def build_http_request(url:, method:, headers: {}, body: nil, auth_headers: {})
           request = Net::HTTPGenericRequest.new(
             method,
             !body.nil?,
@@ -170,7 +193,7 @@ module Seed
             url
           )
 
-          request_headers = @default_headers.merge(headers)
+          request_headers = @default_headers.merge(auth_headers).merge(headers)
           request_headers.each { |name, value| request[name] = value }
           request.body = body if body
 

--- a/seed/ruby-sdk-v2/url-form-encoded/test/unit/internal/http/test_raw_client.rb
+++ b/seed/ruby-sdk-v2/url-form-encoded/test/unit/internal/http/test_raw_client.rb
@@ -54,4 +54,71 @@ describe Seed::Internal::Http::RawClient do
       assert client.should_retry?(make_response(502), 2)
     end
   end
+
+  # A minimal auth provider whose `auth_headers` returns a *different* token on
+  # each call, simulating a token that is refreshed on expiry.
+  class RefreshingAuthProvider
+    def initialize
+      @count = 0
+    end
+
+    def auth_headers
+      @count += 1
+      { "Authorization" => "Bearer TOKEN_#{@count}" }
+    end
+  end
+
+  describe "#resolve_auth_headers" do
+    it "returns an empty hash when no auth provider is configured" do
+      client = Seed::Internal::Http::RawClient.new(base_url: "https://example.com")
+
+      assert_equal({}, client.resolve_auth_headers)
+    end
+
+    it "consults the auth provider on every call so an expired token is refreshed" do
+      client = Seed::Internal::Http::RawClient.new(
+        base_url: "https://example.com",
+        auth_provider: RefreshingAuthProvider.new
+      )
+
+      assert_equal({ "Authorization" => "Bearer TOKEN_1" }, client.resolve_auth_headers)
+      assert_equal({ "Authorization" => "Bearer TOKEN_2" }, client.resolve_auth_headers)
+    end
+  end
+
+  describe "#build_http_request auth header precedence" do
+    let(:client) do
+      Seed::Internal::Http::RawClient.new(
+        base_url: "https://example.com",
+        headers: { "Authorization" => "Bearer STATIC" }
+      )
+    end
+
+    it "lets resolved auth headers override the static default headers" do
+      request = client.build_http_request(
+        url: URI.parse("https://example.com"),
+        method: "GET",
+        auth_headers: { "Authorization" => "Bearer FRESH" }
+      )
+
+      assert_equal("Bearer FRESH", request["Authorization"])
+    end
+
+    it "lets per-request headers take precedence over auth headers" do
+      request = client.build_http_request(
+        url: URI.parse("https://example.com"),
+        method: "GET",
+        headers: { "Authorization" => "Bearer PER_REQUEST" },
+        auth_headers: { "Authorization" => "Bearer FRESH" }
+      )
+
+      assert_equal("Bearer PER_REQUEST", request["Authorization"])
+    end
+
+    it "defaults auth headers to empty, leaving the default headers unchanged" do
+      request = client.build_http_request(url: URI.parse("https://example.com"), method: "GET")
+
+      assert_equal("Bearer STATIC", request["Authorization"])
+    end
+  end
 end

--- a/seed/ruby-sdk-v2/validation/lib/seed/internal/http/raw_client.rb
+++ b/seed/ruby-sdk-v2/validation/lib/seed/internal/http/raw_client.rb
@@ -21,10 +21,14 @@ module Seed
         # @param max_retries [Integer] The number of times to retry a failed request, defaults to 2.
         # @param timeout [Float] The timeout for the request, defaults to 60.0 seconds.
         # @param headers [Hash] The headers for the request.
-        def initialize(base_url:, max_retries: 2, timeout: 60.0, headers: {})
+        # @param auth_provider [Object, nil] An optional auth provider responding to
+        #   `auth_headers`. When present its headers are resolved on every request so
+        #   token-based schemes (e.g. OAuth) can refresh an expired token mid-session.
+        def initialize(base_url:, max_retries: 2, timeout: 60.0, headers: {}, auth_provider: nil)
           @base_url = base_url
           @max_retries = max_retries
           @timeout = timeout
+          @auth_provider = auth_provider
           @default_headers = {
             "X-Fern-Language": "Ruby",
             "X-Fern-SDK-Name": "seed",
@@ -36,6 +40,9 @@ module Seed
         # @return [HTTP::Response] The HTTP response.
         def send(request)
           url = build_url(request)
+          # Resolve auth headers once per request (not per retry) so token-based
+          # providers refresh at most once here; static providers are cheap.
+          auth_headers = resolve_auth_headers
           attempt = 0
           response = nil
 
@@ -43,8 +50,9 @@ module Seed
             http_request = build_http_request(
               url:,
               method: request.method,
-              headers: request.encode_headers(protected_keys: @default_headers.keys),
-              body: request.encode_body
+              headers: request.encode_headers(protected_keys: @default_headers.keys + auth_headers.keys),
+              body: request.encode_body,
+              auth_headers: auth_headers
             )
 
             conn = connect(url)
@@ -157,12 +165,27 @@ module Seed
                 "HTTP is only allowed for localhost. Use HTTPS or pass a localhost URL."
         end
 
+        # Resolves the auth headers to send with the next request. Delegates to the
+        # configured auth provider (if any) on every call so that token-based
+        # providers (e.g. OAuth client-credentials) can refresh an expired token
+        # before the request is sent. Returns an empty hash when no provider is set,
+        # which keeps the api-key / basic / bearer / no-auth paths unchanged.
+        # @return [Hash] The auth headers for the current request.
+        def resolve_auth_headers
+          return {} if @auth_provider.nil?
+
+          @auth_provider.auth_headers
+        end
+
         # @param url [URI::Generic] The url to the resource.
         # @param method [String] The HTTP method to use.
         # @param headers [Hash] The headers for the request.
         # @param body [String, nil] The body for the request.
+        # @param auth_headers [Hash] The auth headers resolved for this request. These
+        #   take precedence over the static default headers but not over per-request
+        #   headers, mirroring the previous baked-header precedence.
         # @return [HTTP::Request] The HTTP request.
-        def build_http_request(url:, method:, headers: {}, body: nil)
+        def build_http_request(url:, method:, headers: {}, body: nil, auth_headers: {})
           request = Net::HTTPGenericRequest.new(
             method,
             !body.nil?,
@@ -170,7 +193,7 @@ module Seed
             url
           )
 
-          request_headers = @default_headers.merge(headers)
+          request_headers = @default_headers.merge(auth_headers).merge(headers)
           request_headers.each { |name, value| request[name] = value }
           request.body = body if body
 

--- a/seed/ruby-sdk-v2/validation/test/unit/internal/http/test_raw_client.rb
+++ b/seed/ruby-sdk-v2/validation/test/unit/internal/http/test_raw_client.rb
@@ -54,4 +54,71 @@ describe Seed::Internal::Http::RawClient do
       assert client.should_retry?(make_response(502), 2)
     end
   end
+
+  # A minimal auth provider whose `auth_headers` returns a *different* token on
+  # each call, simulating a token that is refreshed on expiry.
+  class RefreshingAuthProvider
+    def initialize
+      @count = 0
+    end
+
+    def auth_headers
+      @count += 1
+      { "Authorization" => "Bearer TOKEN_#{@count}" }
+    end
+  end
+
+  describe "#resolve_auth_headers" do
+    it "returns an empty hash when no auth provider is configured" do
+      client = Seed::Internal::Http::RawClient.new(base_url: "https://example.com")
+
+      assert_equal({}, client.resolve_auth_headers)
+    end
+
+    it "consults the auth provider on every call so an expired token is refreshed" do
+      client = Seed::Internal::Http::RawClient.new(
+        base_url: "https://example.com",
+        auth_provider: RefreshingAuthProvider.new
+      )
+
+      assert_equal({ "Authorization" => "Bearer TOKEN_1" }, client.resolve_auth_headers)
+      assert_equal({ "Authorization" => "Bearer TOKEN_2" }, client.resolve_auth_headers)
+    end
+  end
+
+  describe "#build_http_request auth header precedence" do
+    let(:client) do
+      Seed::Internal::Http::RawClient.new(
+        base_url: "https://example.com",
+        headers: { "Authorization" => "Bearer STATIC" }
+      )
+    end
+
+    it "lets resolved auth headers override the static default headers" do
+      request = client.build_http_request(
+        url: URI.parse("https://example.com"),
+        method: "GET",
+        auth_headers: { "Authorization" => "Bearer FRESH" }
+      )
+
+      assert_equal("Bearer FRESH", request["Authorization"])
+    end
+
+    it "lets per-request headers take precedence over auth headers" do
+      request = client.build_http_request(
+        url: URI.parse("https://example.com"),
+        method: "GET",
+        headers: { "Authorization" => "Bearer PER_REQUEST" },
+        auth_headers: { "Authorization" => "Bearer FRESH" }
+      )
+
+      assert_equal("Bearer PER_REQUEST", request["Authorization"])
+    end
+
+    it "defaults auth headers to empty, leaving the default headers unchanged" do
+      request = client.build_http_request(url: URI.parse("https://example.com"), method: "GET")
+
+      assert_equal("Bearer STATIC", request["Authorization"])
+    end
+  end
 end

--- a/seed/ruby-sdk-v2/variables/lib/seed/internal/http/raw_client.rb
+++ b/seed/ruby-sdk-v2/variables/lib/seed/internal/http/raw_client.rb
@@ -21,10 +21,14 @@ module Seed
         # @param max_retries [Integer] The number of times to retry a failed request, defaults to 2.
         # @param timeout [Float] The timeout for the request, defaults to 60.0 seconds.
         # @param headers [Hash] The headers for the request.
-        def initialize(base_url:, max_retries: 2, timeout: 60.0, headers: {})
+        # @param auth_provider [Object, nil] An optional auth provider responding to
+        #   `auth_headers`. When present its headers are resolved on every request so
+        #   token-based schemes (e.g. OAuth) can refresh an expired token mid-session.
+        def initialize(base_url:, max_retries: 2, timeout: 60.0, headers: {}, auth_provider: nil)
           @base_url = base_url
           @max_retries = max_retries
           @timeout = timeout
+          @auth_provider = auth_provider
           @default_headers = {
             "X-Fern-Language": "Ruby",
             "X-Fern-SDK-Name": "seed",
@@ -36,6 +40,9 @@ module Seed
         # @return [HTTP::Response] The HTTP response.
         def send(request)
           url = build_url(request)
+          # Resolve auth headers once per request (not per retry) so token-based
+          # providers refresh at most once here; static providers are cheap.
+          auth_headers = resolve_auth_headers
           attempt = 0
           response = nil
 
@@ -43,8 +50,9 @@ module Seed
             http_request = build_http_request(
               url:,
               method: request.method,
-              headers: request.encode_headers(protected_keys: @default_headers.keys),
-              body: request.encode_body
+              headers: request.encode_headers(protected_keys: @default_headers.keys + auth_headers.keys),
+              body: request.encode_body,
+              auth_headers: auth_headers
             )
 
             conn = connect(url)
@@ -157,12 +165,27 @@ module Seed
                 "HTTP is only allowed for localhost. Use HTTPS or pass a localhost URL."
         end
 
+        # Resolves the auth headers to send with the next request. Delegates to the
+        # configured auth provider (if any) on every call so that token-based
+        # providers (e.g. OAuth client-credentials) can refresh an expired token
+        # before the request is sent. Returns an empty hash when no provider is set,
+        # which keeps the api-key / basic / bearer / no-auth paths unchanged.
+        # @return [Hash] The auth headers for the current request.
+        def resolve_auth_headers
+          return {} if @auth_provider.nil?
+
+          @auth_provider.auth_headers
+        end
+
         # @param url [URI::Generic] The url to the resource.
         # @param method [String] The HTTP method to use.
         # @param headers [Hash] The headers for the request.
         # @param body [String, nil] The body for the request.
+        # @param auth_headers [Hash] The auth headers resolved for this request. These
+        #   take precedence over the static default headers but not over per-request
+        #   headers, mirroring the previous baked-header precedence.
         # @return [HTTP::Request] The HTTP request.
-        def build_http_request(url:, method:, headers: {}, body: nil)
+        def build_http_request(url:, method:, headers: {}, body: nil, auth_headers: {})
           request = Net::HTTPGenericRequest.new(
             method,
             !body.nil?,
@@ -170,7 +193,7 @@ module Seed
             url
           )
 
-          request_headers = @default_headers.merge(headers)
+          request_headers = @default_headers.merge(auth_headers).merge(headers)
           request_headers.each { |name, value| request[name] = value }
           request.body = body if body
 

--- a/seed/ruby-sdk-v2/variables/test/unit/internal/http/test_raw_client.rb
+++ b/seed/ruby-sdk-v2/variables/test/unit/internal/http/test_raw_client.rb
@@ -54,4 +54,71 @@ describe Seed::Internal::Http::RawClient do
       assert client.should_retry?(make_response(502), 2)
     end
   end
+
+  # A minimal auth provider whose `auth_headers` returns a *different* token on
+  # each call, simulating a token that is refreshed on expiry.
+  class RefreshingAuthProvider
+    def initialize
+      @count = 0
+    end
+
+    def auth_headers
+      @count += 1
+      { "Authorization" => "Bearer TOKEN_#{@count}" }
+    end
+  end
+
+  describe "#resolve_auth_headers" do
+    it "returns an empty hash when no auth provider is configured" do
+      client = Seed::Internal::Http::RawClient.new(base_url: "https://example.com")
+
+      assert_equal({}, client.resolve_auth_headers)
+    end
+
+    it "consults the auth provider on every call so an expired token is refreshed" do
+      client = Seed::Internal::Http::RawClient.new(
+        base_url: "https://example.com",
+        auth_provider: RefreshingAuthProvider.new
+      )
+
+      assert_equal({ "Authorization" => "Bearer TOKEN_1" }, client.resolve_auth_headers)
+      assert_equal({ "Authorization" => "Bearer TOKEN_2" }, client.resolve_auth_headers)
+    end
+  end
+
+  describe "#build_http_request auth header precedence" do
+    let(:client) do
+      Seed::Internal::Http::RawClient.new(
+        base_url: "https://example.com",
+        headers: { "Authorization" => "Bearer STATIC" }
+      )
+    end
+
+    it "lets resolved auth headers override the static default headers" do
+      request = client.build_http_request(
+        url: URI.parse("https://example.com"),
+        method: "GET",
+        auth_headers: { "Authorization" => "Bearer FRESH" }
+      )
+
+      assert_equal("Bearer FRESH", request["Authorization"])
+    end
+
+    it "lets per-request headers take precedence over auth headers" do
+      request = client.build_http_request(
+        url: URI.parse("https://example.com"),
+        method: "GET",
+        headers: { "Authorization" => "Bearer PER_REQUEST" },
+        auth_headers: { "Authorization" => "Bearer FRESH" }
+      )
+
+      assert_equal("Bearer PER_REQUEST", request["Authorization"])
+    end
+
+    it "defaults auth headers to empty, leaving the default headers unchanged" do
+      request = client.build_http_request(url: URI.parse("https://example.com"), method: "GET")
+
+      assert_equal("Bearer STATIC", request["Authorization"])
+    end
+  end
 end

--- a/seed/ruby-sdk-v2/version-no-default/lib/seed/internal/http/raw_client.rb
+++ b/seed/ruby-sdk-v2/version-no-default/lib/seed/internal/http/raw_client.rb
@@ -21,10 +21,14 @@ module Seed
         # @param max_retries [Integer] The number of times to retry a failed request, defaults to 2.
         # @param timeout [Float] The timeout for the request, defaults to 60.0 seconds.
         # @param headers [Hash] The headers for the request.
-        def initialize(base_url:, max_retries: 2, timeout: 60.0, headers: {})
+        # @param auth_provider [Object, nil] An optional auth provider responding to
+        #   `auth_headers`. When present its headers are resolved on every request so
+        #   token-based schemes (e.g. OAuth) can refresh an expired token mid-session.
+        def initialize(base_url:, max_retries: 2, timeout: 60.0, headers: {}, auth_provider: nil)
           @base_url = base_url
           @max_retries = max_retries
           @timeout = timeout
+          @auth_provider = auth_provider
           @default_headers = {
             "X-Fern-Language": "Ruby",
             "X-Fern-SDK-Name": "seed",
@@ -36,6 +40,9 @@ module Seed
         # @return [HTTP::Response] The HTTP response.
         def send(request)
           url = build_url(request)
+          # Resolve auth headers once per request (not per retry) so token-based
+          # providers refresh at most once here; static providers are cheap.
+          auth_headers = resolve_auth_headers
           attempt = 0
           response = nil
 
@@ -43,8 +50,9 @@ module Seed
             http_request = build_http_request(
               url:,
               method: request.method,
-              headers: request.encode_headers(protected_keys: @default_headers.keys),
-              body: request.encode_body
+              headers: request.encode_headers(protected_keys: @default_headers.keys + auth_headers.keys),
+              body: request.encode_body,
+              auth_headers: auth_headers
             )
 
             conn = connect(url)
@@ -157,12 +165,27 @@ module Seed
                 "HTTP is only allowed for localhost. Use HTTPS or pass a localhost URL."
         end
 
+        # Resolves the auth headers to send with the next request. Delegates to the
+        # configured auth provider (if any) on every call so that token-based
+        # providers (e.g. OAuth client-credentials) can refresh an expired token
+        # before the request is sent. Returns an empty hash when no provider is set,
+        # which keeps the api-key / basic / bearer / no-auth paths unchanged.
+        # @return [Hash] The auth headers for the current request.
+        def resolve_auth_headers
+          return {} if @auth_provider.nil?
+
+          @auth_provider.auth_headers
+        end
+
         # @param url [URI::Generic] The url to the resource.
         # @param method [String] The HTTP method to use.
         # @param headers [Hash] The headers for the request.
         # @param body [String, nil] The body for the request.
+        # @param auth_headers [Hash] The auth headers resolved for this request. These
+        #   take precedence over the static default headers but not over per-request
+        #   headers, mirroring the previous baked-header precedence.
         # @return [HTTP::Request] The HTTP request.
-        def build_http_request(url:, method:, headers: {}, body: nil)
+        def build_http_request(url:, method:, headers: {}, body: nil, auth_headers: {})
           request = Net::HTTPGenericRequest.new(
             method,
             !body.nil?,
@@ -170,7 +193,7 @@ module Seed
             url
           )
 
-          request_headers = @default_headers.merge(headers)
+          request_headers = @default_headers.merge(auth_headers).merge(headers)
           request_headers.each { |name, value| request[name] = value }
           request.body = body if body
 

--- a/seed/ruby-sdk-v2/version-no-default/test/unit/internal/http/test_raw_client.rb
+++ b/seed/ruby-sdk-v2/version-no-default/test/unit/internal/http/test_raw_client.rb
@@ -54,4 +54,71 @@ describe Seed::Internal::Http::RawClient do
       assert client.should_retry?(make_response(502), 2)
     end
   end
+
+  # A minimal auth provider whose `auth_headers` returns a *different* token on
+  # each call, simulating a token that is refreshed on expiry.
+  class RefreshingAuthProvider
+    def initialize
+      @count = 0
+    end
+
+    def auth_headers
+      @count += 1
+      { "Authorization" => "Bearer TOKEN_#{@count}" }
+    end
+  end
+
+  describe "#resolve_auth_headers" do
+    it "returns an empty hash when no auth provider is configured" do
+      client = Seed::Internal::Http::RawClient.new(base_url: "https://example.com")
+
+      assert_equal({}, client.resolve_auth_headers)
+    end
+
+    it "consults the auth provider on every call so an expired token is refreshed" do
+      client = Seed::Internal::Http::RawClient.new(
+        base_url: "https://example.com",
+        auth_provider: RefreshingAuthProvider.new
+      )
+
+      assert_equal({ "Authorization" => "Bearer TOKEN_1" }, client.resolve_auth_headers)
+      assert_equal({ "Authorization" => "Bearer TOKEN_2" }, client.resolve_auth_headers)
+    end
+  end
+
+  describe "#build_http_request auth header precedence" do
+    let(:client) do
+      Seed::Internal::Http::RawClient.new(
+        base_url: "https://example.com",
+        headers: { "Authorization" => "Bearer STATIC" }
+      )
+    end
+
+    it "lets resolved auth headers override the static default headers" do
+      request = client.build_http_request(
+        url: URI.parse("https://example.com"),
+        method: "GET",
+        auth_headers: { "Authorization" => "Bearer FRESH" }
+      )
+
+      assert_equal("Bearer FRESH", request["Authorization"])
+    end
+
+    it "lets per-request headers take precedence over auth headers" do
+      request = client.build_http_request(
+        url: URI.parse("https://example.com"),
+        method: "GET",
+        headers: { "Authorization" => "Bearer PER_REQUEST" },
+        auth_headers: { "Authorization" => "Bearer FRESH" }
+      )
+
+      assert_equal("Bearer PER_REQUEST", request["Authorization"])
+    end
+
+    it "defaults auth headers to empty, leaving the default headers unchanged" do
+      request = client.build_http_request(url: URI.parse("https://example.com"), method: "GET")
+
+      assert_equal("Bearer STATIC", request["Authorization"])
+    end
+  end
 end

--- a/seed/ruby-sdk-v2/version/lib/seed/internal/http/raw_client.rb
+++ b/seed/ruby-sdk-v2/version/lib/seed/internal/http/raw_client.rb
@@ -21,10 +21,14 @@ module Seed
         # @param max_retries [Integer] The number of times to retry a failed request, defaults to 2.
         # @param timeout [Float] The timeout for the request, defaults to 60.0 seconds.
         # @param headers [Hash] The headers for the request.
-        def initialize(base_url:, max_retries: 2, timeout: 60.0, headers: {})
+        # @param auth_provider [Object, nil] An optional auth provider responding to
+        #   `auth_headers`. When present its headers are resolved on every request so
+        #   token-based schemes (e.g. OAuth) can refresh an expired token mid-session.
+        def initialize(base_url:, max_retries: 2, timeout: 60.0, headers: {}, auth_provider: nil)
           @base_url = base_url
           @max_retries = max_retries
           @timeout = timeout
+          @auth_provider = auth_provider
           @default_headers = {
             "X-Fern-Language": "Ruby",
             "X-Fern-SDK-Name": "seed",
@@ -36,6 +40,9 @@ module Seed
         # @return [HTTP::Response] The HTTP response.
         def send(request)
           url = build_url(request)
+          # Resolve auth headers once per request (not per retry) so token-based
+          # providers refresh at most once here; static providers are cheap.
+          auth_headers = resolve_auth_headers
           attempt = 0
           response = nil
 
@@ -43,8 +50,9 @@ module Seed
             http_request = build_http_request(
               url:,
               method: request.method,
-              headers: request.encode_headers(protected_keys: @default_headers.keys),
-              body: request.encode_body
+              headers: request.encode_headers(protected_keys: @default_headers.keys + auth_headers.keys),
+              body: request.encode_body,
+              auth_headers: auth_headers
             )
 
             conn = connect(url)
@@ -157,12 +165,27 @@ module Seed
                 "HTTP is only allowed for localhost. Use HTTPS or pass a localhost URL."
         end
 
+        # Resolves the auth headers to send with the next request. Delegates to the
+        # configured auth provider (if any) on every call so that token-based
+        # providers (e.g. OAuth client-credentials) can refresh an expired token
+        # before the request is sent. Returns an empty hash when no provider is set,
+        # which keeps the api-key / basic / bearer / no-auth paths unchanged.
+        # @return [Hash] The auth headers for the current request.
+        def resolve_auth_headers
+          return {} if @auth_provider.nil?
+
+          @auth_provider.auth_headers
+        end
+
         # @param url [URI::Generic] The url to the resource.
         # @param method [String] The HTTP method to use.
         # @param headers [Hash] The headers for the request.
         # @param body [String, nil] The body for the request.
+        # @param auth_headers [Hash] The auth headers resolved for this request. These
+        #   take precedence over the static default headers but not over per-request
+        #   headers, mirroring the previous baked-header precedence.
         # @return [HTTP::Request] The HTTP request.
-        def build_http_request(url:, method:, headers: {}, body: nil)
+        def build_http_request(url:, method:, headers: {}, body: nil, auth_headers: {})
           request = Net::HTTPGenericRequest.new(
             method,
             !body.nil?,
@@ -170,7 +193,7 @@ module Seed
             url
           )
 
-          request_headers = @default_headers.merge(headers)
+          request_headers = @default_headers.merge(auth_headers).merge(headers)
           request_headers.each { |name, value| request[name] = value }
           request.body = body if body
 

--- a/seed/ruby-sdk-v2/version/test/unit/internal/http/test_raw_client.rb
+++ b/seed/ruby-sdk-v2/version/test/unit/internal/http/test_raw_client.rb
@@ -54,4 +54,71 @@ describe Seed::Internal::Http::RawClient do
       assert client.should_retry?(make_response(502), 2)
     end
   end
+
+  # A minimal auth provider whose `auth_headers` returns a *different* token on
+  # each call, simulating a token that is refreshed on expiry.
+  class RefreshingAuthProvider
+    def initialize
+      @count = 0
+    end
+
+    def auth_headers
+      @count += 1
+      { "Authorization" => "Bearer TOKEN_#{@count}" }
+    end
+  end
+
+  describe "#resolve_auth_headers" do
+    it "returns an empty hash when no auth provider is configured" do
+      client = Seed::Internal::Http::RawClient.new(base_url: "https://example.com")
+
+      assert_equal({}, client.resolve_auth_headers)
+    end
+
+    it "consults the auth provider on every call so an expired token is refreshed" do
+      client = Seed::Internal::Http::RawClient.new(
+        base_url: "https://example.com",
+        auth_provider: RefreshingAuthProvider.new
+      )
+
+      assert_equal({ "Authorization" => "Bearer TOKEN_1" }, client.resolve_auth_headers)
+      assert_equal({ "Authorization" => "Bearer TOKEN_2" }, client.resolve_auth_headers)
+    end
+  end
+
+  describe "#build_http_request auth header precedence" do
+    let(:client) do
+      Seed::Internal::Http::RawClient.new(
+        base_url: "https://example.com",
+        headers: { "Authorization" => "Bearer STATIC" }
+      )
+    end
+
+    it "lets resolved auth headers override the static default headers" do
+      request = client.build_http_request(
+        url: URI.parse("https://example.com"),
+        method: "GET",
+        auth_headers: { "Authorization" => "Bearer FRESH" }
+      )
+
+      assert_equal("Bearer FRESH", request["Authorization"])
+    end
+
+    it "lets per-request headers take precedence over auth headers" do
+      request = client.build_http_request(
+        url: URI.parse("https://example.com"),
+        method: "GET",
+        headers: { "Authorization" => "Bearer PER_REQUEST" },
+        auth_headers: { "Authorization" => "Bearer FRESH" }
+      )
+
+      assert_equal("Bearer PER_REQUEST", request["Authorization"])
+    end
+
+    it "defaults auth headers to empty, leaving the default headers unchanged" do
+      request = client.build_http_request(url: URI.parse("https://example.com"), method: "GET")
+
+      assert_equal("Bearer STATIC", request["Authorization"])
+    end
+  end
 end

--- a/seed/ruby-sdk-v2/webhook-audience/lib/seed/internal/http/raw_client.rb
+++ b/seed/ruby-sdk-v2/webhook-audience/lib/seed/internal/http/raw_client.rb
@@ -21,10 +21,14 @@ module Seed
         # @param max_retries [Integer] The number of times to retry a failed request, defaults to 2.
         # @param timeout [Float] The timeout for the request, defaults to 60.0 seconds.
         # @param headers [Hash] The headers for the request.
-        def initialize(base_url:, max_retries: 2, timeout: 60.0, headers: {})
+        # @param auth_provider [Object, nil] An optional auth provider responding to
+        #   `auth_headers`. When present its headers are resolved on every request so
+        #   token-based schemes (e.g. OAuth) can refresh an expired token mid-session.
+        def initialize(base_url:, max_retries: 2, timeout: 60.0, headers: {}, auth_provider: nil)
           @base_url = base_url
           @max_retries = max_retries
           @timeout = timeout
+          @auth_provider = auth_provider
           @default_headers = {
             "X-Fern-Language": "Ruby",
             "X-Fern-SDK-Name": "seed",
@@ -36,6 +40,9 @@ module Seed
         # @return [HTTP::Response] The HTTP response.
         def send(request)
           url = build_url(request)
+          # Resolve auth headers once per request (not per retry) so token-based
+          # providers refresh at most once here; static providers are cheap.
+          auth_headers = resolve_auth_headers
           attempt = 0
           response = nil
 
@@ -43,8 +50,9 @@ module Seed
             http_request = build_http_request(
               url:,
               method: request.method,
-              headers: request.encode_headers(protected_keys: @default_headers.keys),
-              body: request.encode_body
+              headers: request.encode_headers(protected_keys: @default_headers.keys + auth_headers.keys),
+              body: request.encode_body,
+              auth_headers: auth_headers
             )
 
             conn = connect(url)
@@ -157,12 +165,27 @@ module Seed
                 "HTTP is only allowed for localhost. Use HTTPS or pass a localhost URL."
         end
 
+        # Resolves the auth headers to send with the next request. Delegates to the
+        # configured auth provider (if any) on every call so that token-based
+        # providers (e.g. OAuth client-credentials) can refresh an expired token
+        # before the request is sent. Returns an empty hash when no provider is set,
+        # which keeps the api-key / basic / bearer / no-auth paths unchanged.
+        # @return [Hash] The auth headers for the current request.
+        def resolve_auth_headers
+          return {} if @auth_provider.nil?
+
+          @auth_provider.auth_headers
+        end
+
         # @param url [URI::Generic] The url to the resource.
         # @param method [String] The HTTP method to use.
         # @param headers [Hash] The headers for the request.
         # @param body [String, nil] The body for the request.
+        # @param auth_headers [Hash] The auth headers resolved for this request. These
+        #   take precedence over the static default headers but not over per-request
+        #   headers, mirroring the previous baked-header precedence.
         # @return [HTTP::Request] The HTTP request.
-        def build_http_request(url:, method:, headers: {}, body: nil)
+        def build_http_request(url:, method:, headers: {}, body: nil, auth_headers: {})
           request = Net::HTTPGenericRequest.new(
             method,
             !body.nil?,
@@ -170,7 +193,7 @@ module Seed
             url
           )
 
-          request_headers = @default_headers.merge(headers)
+          request_headers = @default_headers.merge(auth_headers).merge(headers)
           request_headers.each { |name, value| request[name] = value }
           request.body = body if body
 

--- a/seed/ruby-sdk-v2/webhook-audience/test/unit/internal/http/test_raw_client.rb
+++ b/seed/ruby-sdk-v2/webhook-audience/test/unit/internal/http/test_raw_client.rb
@@ -54,4 +54,71 @@ describe Seed::Internal::Http::RawClient do
       assert client.should_retry?(make_response(502), 2)
     end
   end
+
+  # A minimal auth provider whose `auth_headers` returns a *different* token on
+  # each call, simulating a token that is refreshed on expiry.
+  class RefreshingAuthProvider
+    def initialize
+      @count = 0
+    end
+
+    def auth_headers
+      @count += 1
+      { "Authorization" => "Bearer TOKEN_#{@count}" }
+    end
+  end
+
+  describe "#resolve_auth_headers" do
+    it "returns an empty hash when no auth provider is configured" do
+      client = Seed::Internal::Http::RawClient.new(base_url: "https://example.com")
+
+      assert_equal({}, client.resolve_auth_headers)
+    end
+
+    it "consults the auth provider on every call so an expired token is refreshed" do
+      client = Seed::Internal::Http::RawClient.new(
+        base_url: "https://example.com",
+        auth_provider: RefreshingAuthProvider.new
+      )
+
+      assert_equal({ "Authorization" => "Bearer TOKEN_1" }, client.resolve_auth_headers)
+      assert_equal({ "Authorization" => "Bearer TOKEN_2" }, client.resolve_auth_headers)
+    end
+  end
+
+  describe "#build_http_request auth header precedence" do
+    let(:client) do
+      Seed::Internal::Http::RawClient.new(
+        base_url: "https://example.com",
+        headers: { "Authorization" => "Bearer STATIC" }
+      )
+    end
+
+    it "lets resolved auth headers override the static default headers" do
+      request = client.build_http_request(
+        url: URI.parse("https://example.com"),
+        method: "GET",
+        auth_headers: { "Authorization" => "Bearer FRESH" }
+      )
+
+      assert_equal("Bearer FRESH", request["Authorization"])
+    end
+
+    it "lets per-request headers take precedence over auth headers" do
+      request = client.build_http_request(
+        url: URI.parse("https://example.com"),
+        method: "GET",
+        headers: { "Authorization" => "Bearer PER_REQUEST" },
+        auth_headers: { "Authorization" => "Bearer FRESH" }
+      )
+
+      assert_equal("Bearer PER_REQUEST", request["Authorization"])
+    end
+
+    it "defaults auth headers to empty, leaving the default headers unchanged" do
+      request = client.build_http_request(url: URI.parse("https://example.com"), method: "GET")
+
+      assert_equal("Bearer STATIC", request["Authorization"])
+    end
+  end
 end

--- a/seed/ruby-sdk-v2/webhooks/lib/seed/internal/http/raw_client.rb
+++ b/seed/ruby-sdk-v2/webhooks/lib/seed/internal/http/raw_client.rb
@@ -21,10 +21,14 @@ module Seed
         # @param max_retries [Integer] The number of times to retry a failed request, defaults to 2.
         # @param timeout [Float] The timeout for the request, defaults to 60.0 seconds.
         # @param headers [Hash] The headers for the request.
-        def initialize(base_url:, max_retries: 2, timeout: 60.0, headers: {})
+        # @param auth_provider [Object, nil] An optional auth provider responding to
+        #   `auth_headers`. When present its headers are resolved on every request so
+        #   token-based schemes (e.g. OAuth) can refresh an expired token mid-session.
+        def initialize(base_url:, max_retries: 2, timeout: 60.0, headers: {}, auth_provider: nil)
           @base_url = base_url
           @max_retries = max_retries
           @timeout = timeout
+          @auth_provider = auth_provider
           @default_headers = {
             "X-Fern-Language": "Ruby",
             "X-Fern-SDK-Name": "seed",
@@ -36,6 +40,9 @@ module Seed
         # @return [HTTP::Response] The HTTP response.
         def send(request)
           url = build_url(request)
+          # Resolve auth headers once per request (not per retry) so token-based
+          # providers refresh at most once here; static providers are cheap.
+          auth_headers = resolve_auth_headers
           attempt = 0
           response = nil
 
@@ -43,8 +50,9 @@ module Seed
             http_request = build_http_request(
               url:,
               method: request.method,
-              headers: request.encode_headers(protected_keys: @default_headers.keys),
-              body: request.encode_body
+              headers: request.encode_headers(protected_keys: @default_headers.keys + auth_headers.keys),
+              body: request.encode_body,
+              auth_headers: auth_headers
             )
 
             conn = connect(url)
@@ -157,12 +165,27 @@ module Seed
                 "HTTP is only allowed for localhost. Use HTTPS or pass a localhost URL."
         end
 
+        # Resolves the auth headers to send with the next request. Delegates to the
+        # configured auth provider (if any) on every call so that token-based
+        # providers (e.g. OAuth client-credentials) can refresh an expired token
+        # before the request is sent. Returns an empty hash when no provider is set,
+        # which keeps the api-key / basic / bearer / no-auth paths unchanged.
+        # @return [Hash] The auth headers for the current request.
+        def resolve_auth_headers
+          return {} if @auth_provider.nil?
+
+          @auth_provider.auth_headers
+        end
+
         # @param url [URI::Generic] The url to the resource.
         # @param method [String] The HTTP method to use.
         # @param headers [Hash] The headers for the request.
         # @param body [String, nil] The body for the request.
+        # @param auth_headers [Hash] The auth headers resolved for this request. These
+        #   take precedence over the static default headers but not over per-request
+        #   headers, mirroring the previous baked-header precedence.
         # @return [HTTP::Request] The HTTP request.
-        def build_http_request(url:, method:, headers: {}, body: nil)
+        def build_http_request(url:, method:, headers: {}, body: nil, auth_headers: {})
           request = Net::HTTPGenericRequest.new(
             method,
             !body.nil?,
@@ -170,7 +193,7 @@ module Seed
             url
           )
 
-          request_headers = @default_headers.merge(headers)
+          request_headers = @default_headers.merge(auth_headers).merge(headers)
           request_headers.each { |name, value| request[name] = value }
           request.body = body if body
 

--- a/seed/ruby-sdk-v2/webhooks/test/unit/internal/http/test_raw_client.rb
+++ b/seed/ruby-sdk-v2/webhooks/test/unit/internal/http/test_raw_client.rb
@@ -54,4 +54,71 @@ describe Seed::Internal::Http::RawClient do
       assert client.should_retry?(make_response(502), 2)
     end
   end
+
+  # A minimal auth provider whose `auth_headers` returns a *different* token on
+  # each call, simulating a token that is refreshed on expiry.
+  class RefreshingAuthProvider
+    def initialize
+      @count = 0
+    end
+
+    def auth_headers
+      @count += 1
+      { "Authorization" => "Bearer TOKEN_#{@count}" }
+    end
+  end
+
+  describe "#resolve_auth_headers" do
+    it "returns an empty hash when no auth provider is configured" do
+      client = Seed::Internal::Http::RawClient.new(base_url: "https://example.com")
+
+      assert_equal({}, client.resolve_auth_headers)
+    end
+
+    it "consults the auth provider on every call so an expired token is refreshed" do
+      client = Seed::Internal::Http::RawClient.new(
+        base_url: "https://example.com",
+        auth_provider: RefreshingAuthProvider.new
+      )
+
+      assert_equal({ "Authorization" => "Bearer TOKEN_1" }, client.resolve_auth_headers)
+      assert_equal({ "Authorization" => "Bearer TOKEN_2" }, client.resolve_auth_headers)
+    end
+  end
+
+  describe "#build_http_request auth header precedence" do
+    let(:client) do
+      Seed::Internal::Http::RawClient.new(
+        base_url: "https://example.com",
+        headers: { "Authorization" => "Bearer STATIC" }
+      )
+    end
+
+    it "lets resolved auth headers override the static default headers" do
+      request = client.build_http_request(
+        url: URI.parse("https://example.com"),
+        method: "GET",
+        auth_headers: { "Authorization" => "Bearer FRESH" }
+      )
+
+      assert_equal("Bearer FRESH", request["Authorization"])
+    end
+
+    it "lets per-request headers take precedence over auth headers" do
+      request = client.build_http_request(
+        url: URI.parse("https://example.com"),
+        method: "GET",
+        headers: { "Authorization" => "Bearer PER_REQUEST" },
+        auth_headers: { "Authorization" => "Bearer FRESH" }
+      )
+
+      assert_equal("Bearer PER_REQUEST", request["Authorization"])
+    end
+
+    it "defaults auth headers to empty, leaving the default headers unchanged" do
+      request = client.build_http_request(url: URI.parse("https://example.com"), method: "GET")
+
+      assert_equal("Bearer STATIC", request["Authorization"])
+    end
+  end
 end

--- a/seed/ruby-sdk-v2/websocket-bearer-auth/lib/seed/internal/http/raw_client.rb
+++ b/seed/ruby-sdk-v2/websocket-bearer-auth/lib/seed/internal/http/raw_client.rb
@@ -21,10 +21,14 @@ module Seed
         # @param max_retries [Integer] The number of times to retry a failed request, defaults to 2.
         # @param timeout [Float] The timeout for the request, defaults to 60.0 seconds.
         # @param headers [Hash] The headers for the request.
-        def initialize(base_url:, max_retries: 2, timeout: 60.0, headers: {})
+        # @param auth_provider [Object, nil] An optional auth provider responding to
+        #   `auth_headers`. When present its headers are resolved on every request so
+        #   token-based schemes (e.g. OAuth) can refresh an expired token mid-session.
+        def initialize(base_url:, max_retries: 2, timeout: 60.0, headers: {}, auth_provider: nil)
           @base_url = base_url
           @max_retries = max_retries
           @timeout = timeout
+          @auth_provider = auth_provider
           @default_headers = {
             "X-Fern-Language": "Ruby",
             "X-Fern-SDK-Name": "seed",
@@ -36,6 +40,9 @@ module Seed
         # @return [HTTP::Response] The HTTP response.
         def send(request)
           url = build_url(request)
+          # Resolve auth headers once per request (not per retry) so token-based
+          # providers refresh at most once here; static providers are cheap.
+          auth_headers = resolve_auth_headers
           attempt = 0
           response = nil
 
@@ -43,8 +50,9 @@ module Seed
             http_request = build_http_request(
               url:,
               method: request.method,
-              headers: request.encode_headers(protected_keys: @default_headers.keys),
-              body: request.encode_body
+              headers: request.encode_headers(protected_keys: @default_headers.keys + auth_headers.keys),
+              body: request.encode_body,
+              auth_headers: auth_headers
             )
 
             conn = connect(url)
@@ -157,12 +165,27 @@ module Seed
                 "HTTP is only allowed for localhost. Use HTTPS or pass a localhost URL."
         end
 
+        # Resolves the auth headers to send with the next request. Delegates to the
+        # configured auth provider (if any) on every call so that token-based
+        # providers (e.g. OAuth client-credentials) can refresh an expired token
+        # before the request is sent. Returns an empty hash when no provider is set,
+        # which keeps the api-key / basic / bearer / no-auth paths unchanged.
+        # @return [Hash] The auth headers for the current request.
+        def resolve_auth_headers
+          return {} if @auth_provider.nil?
+
+          @auth_provider.auth_headers
+        end
+
         # @param url [URI::Generic] The url to the resource.
         # @param method [String] The HTTP method to use.
         # @param headers [Hash] The headers for the request.
         # @param body [String, nil] The body for the request.
+        # @param auth_headers [Hash] The auth headers resolved for this request. These
+        #   take precedence over the static default headers but not over per-request
+        #   headers, mirroring the previous baked-header precedence.
         # @return [HTTP::Request] The HTTP request.
-        def build_http_request(url:, method:, headers: {}, body: nil)
+        def build_http_request(url:, method:, headers: {}, body: nil, auth_headers: {})
           request = Net::HTTPGenericRequest.new(
             method,
             !body.nil?,
@@ -170,7 +193,7 @@ module Seed
             url
           )
 
-          request_headers = @default_headers.merge(headers)
+          request_headers = @default_headers.merge(auth_headers).merge(headers)
           request_headers.each { |name, value| request[name] = value }
           request.body = body if body
 

--- a/seed/ruby-sdk-v2/websocket-bearer-auth/test/unit/internal/http/test_raw_client.rb
+++ b/seed/ruby-sdk-v2/websocket-bearer-auth/test/unit/internal/http/test_raw_client.rb
@@ -54,4 +54,71 @@ describe Seed::Internal::Http::RawClient do
       assert client.should_retry?(make_response(502), 2)
     end
   end
+
+  # A minimal auth provider whose `auth_headers` returns a *different* token on
+  # each call, simulating a token that is refreshed on expiry.
+  class RefreshingAuthProvider
+    def initialize
+      @count = 0
+    end
+
+    def auth_headers
+      @count += 1
+      { "Authorization" => "Bearer TOKEN_#{@count}" }
+    end
+  end
+
+  describe "#resolve_auth_headers" do
+    it "returns an empty hash when no auth provider is configured" do
+      client = Seed::Internal::Http::RawClient.new(base_url: "https://example.com")
+
+      assert_equal({}, client.resolve_auth_headers)
+    end
+
+    it "consults the auth provider on every call so an expired token is refreshed" do
+      client = Seed::Internal::Http::RawClient.new(
+        base_url: "https://example.com",
+        auth_provider: RefreshingAuthProvider.new
+      )
+
+      assert_equal({ "Authorization" => "Bearer TOKEN_1" }, client.resolve_auth_headers)
+      assert_equal({ "Authorization" => "Bearer TOKEN_2" }, client.resolve_auth_headers)
+    end
+  end
+
+  describe "#build_http_request auth header precedence" do
+    let(:client) do
+      Seed::Internal::Http::RawClient.new(
+        base_url: "https://example.com",
+        headers: { "Authorization" => "Bearer STATIC" }
+      )
+    end
+
+    it "lets resolved auth headers override the static default headers" do
+      request = client.build_http_request(
+        url: URI.parse("https://example.com"),
+        method: "GET",
+        auth_headers: { "Authorization" => "Bearer FRESH" }
+      )
+
+      assert_equal("Bearer FRESH", request["Authorization"])
+    end
+
+    it "lets per-request headers take precedence over auth headers" do
+      request = client.build_http_request(
+        url: URI.parse("https://example.com"),
+        method: "GET",
+        headers: { "Authorization" => "Bearer PER_REQUEST" },
+        auth_headers: { "Authorization" => "Bearer FRESH" }
+      )
+
+      assert_equal("Bearer PER_REQUEST", request["Authorization"])
+    end
+
+    it "defaults auth headers to empty, leaving the default headers unchanged" do
+      request = client.build_http_request(url: URI.parse("https://example.com"), method: "GET")
+
+      assert_equal("Bearer STATIC", request["Authorization"])
+    end
+  end
 end

--- a/seed/ruby-sdk-v2/websocket-inferred-auth/lib/seed/client.rb
+++ b/seed/ruby-sdk-v2/websocket-inferred-auth/lib/seed/client.rb
@@ -37,7 +37,8 @@ module Seed
         headers: {
           "User-Agent" => "fern_websocket-inferred-auth/0.0.1",
           "X-Fern-Language" => "Ruby"
-        }.merge(@auth_provider.auth_headers),
+        },
+        auth_provider: @auth_provider,
         max_retries: max_retries
       )
     end

--- a/seed/ruby-sdk-v2/websocket-inferred-auth/lib/seed/internal/http/raw_client.rb
+++ b/seed/ruby-sdk-v2/websocket-inferred-auth/lib/seed/internal/http/raw_client.rb
@@ -21,10 +21,14 @@ module Seed
         # @param max_retries [Integer] The number of times to retry a failed request, defaults to 2.
         # @param timeout [Float] The timeout for the request, defaults to 60.0 seconds.
         # @param headers [Hash] The headers for the request.
-        def initialize(base_url:, max_retries: 2, timeout: 60.0, headers: {})
+        # @param auth_provider [Object, nil] An optional auth provider responding to
+        #   `auth_headers`. When present its headers are resolved on every request so
+        #   token-based schemes (e.g. OAuth) can refresh an expired token mid-session.
+        def initialize(base_url:, max_retries: 2, timeout: 60.0, headers: {}, auth_provider: nil)
           @base_url = base_url
           @max_retries = max_retries
           @timeout = timeout
+          @auth_provider = auth_provider
           @default_headers = {
             "X-Fern-Language": "Ruby",
             "X-Fern-SDK-Name": "seed",
@@ -36,6 +40,9 @@ module Seed
         # @return [HTTP::Response] The HTTP response.
         def send(request)
           url = build_url(request)
+          # Resolve auth headers once per request (not per retry) so token-based
+          # providers refresh at most once here; static providers are cheap.
+          auth_headers = resolve_auth_headers
           attempt = 0
           response = nil
 
@@ -43,8 +50,9 @@ module Seed
             http_request = build_http_request(
               url:,
               method: request.method,
-              headers: request.encode_headers(protected_keys: @default_headers.keys),
-              body: request.encode_body
+              headers: request.encode_headers(protected_keys: @default_headers.keys + auth_headers.keys),
+              body: request.encode_body,
+              auth_headers: auth_headers
             )
 
             conn = connect(url)
@@ -157,12 +165,27 @@ module Seed
                 "HTTP is only allowed for localhost. Use HTTPS or pass a localhost URL."
         end
 
+        # Resolves the auth headers to send with the next request. Delegates to the
+        # configured auth provider (if any) on every call so that token-based
+        # providers (e.g. OAuth client-credentials) can refresh an expired token
+        # before the request is sent. Returns an empty hash when no provider is set,
+        # which keeps the api-key / basic / bearer / no-auth paths unchanged.
+        # @return [Hash] The auth headers for the current request.
+        def resolve_auth_headers
+          return {} if @auth_provider.nil?
+
+          @auth_provider.auth_headers
+        end
+
         # @param url [URI::Generic] The url to the resource.
         # @param method [String] The HTTP method to use.
         # @param headers [Hash] The headers for the request.
         # @param body [String, nil] The body for the request.
+        # @param auth_headers [Hash] The auth headers resolved for this request. These
+        #   take precedence over the static default headers but not over per-request
+        #   headers, mirroring the previous baked-header precedence.
         # @return [HTTP::Request] The HTTP request.
-        def build_http_request(url:, method:, headers: {}, body: nil)
+        def build_http_request(url:, method:, headers: {}, body: nil, auth_headers: {})
           request = Net::HTTPGenericRequest.new(
             method,
             !body.nil?,
@@ -170,7 +193,7 @@ module Seed
             url
           )
 
-          request_headers = @default_headers.merge(headers)
+          request_headers = @default_headers.merge(auth_headers).merge(headers)
           request_headers.each { |name, value| request[name] = value }
           request.body = body if body
 

--- a/seed/ruby-sdk-v2/websocket-inferred-auth/test/unit/internal/http/test_raw_client.rb
+++ b/seed/ruby-sdk-v2/websocket-inferred-auth/test/unit/internal/http/test_raw_client.rb
@@ -54,4 +54,71 @@ describe Seed::Internal::Http::RawClient do
       assert client.should_retry?(make_response(502), 2)
     end
   end
+
+  # A minimal auth provider whose `auth_headers` returns a *different* token on
+  # each call, simulating a token that is refreshed on expiry.
+  class RefreshingAuthProvider
+    def initialize
+      @count = 0
+    end
+
+    def auth_headers
+      @count += 1
+      { "Authorization" => "Bearer TOKEN_#{@count}" }
+    end
+  end
+
+  describe "#resolve_auth_headers" do
+    it "returns an empty hash when no auth provider is configured" do
+      client = Seed::Internal::Http::RawClient.new(base_url: "https://example.com")
+
+      assert_equal({}, client.resolve_auth_headers)
+    end
+
+    it "consults the auth provider on every call so an expired token is refreshed" do
+      client = Seed::Internal::Http::RawClient.new(
+        base_url: "https://example.com",
+        auth_provider: RefreshingAuthProvider.new
+      )
+
+      assert_equal({ "Authorization" => "Bearer TOKEN_1" }, client.resolve_auth_headers)
+      assert_equal({ "Authorization" => "Bearer TOKEN_2" }, client.resolve_auth_headers)
+    end
+  end
+
+  describe "#build_http_request auth header precedence" do
+    let(:client) do
+      Seed::Internal::Http::RawClient.new(
+        base_url: "https://example.com",
+        headers: { "Authorization" => "Bearer STATIC" }
+      )
+    end
+
+    it "lets resolved auth headers override the static default headers" do
+      request = client.build_http_request(
+        url: URI.parse("https://example.com"),
+        method: "GET",
+        auth_headers: { "Authorization" => "Bearer FRESH" }
+      )
+
+      assert_equal("Bearer FRESH", request["Authorization"])
+    end
+
+    it "lets per-request headers take precedence over auth headers" do
+      request = client.build_http_request(
+        url: URI.parse("https://example.com"),
+        method: "GET",
+        headers: { "Authorization" => "Bearer PER_REQUEST" },
+        auth_headers: { "Authorization" => "Bearer FRESH" }
+      )
+
+      assert_equal("Bearer PER_REQUEST", request["Authorization"])
+    end
+
+    it "defaults auth headers to empty, leaving the default headers unchanged" do
+      request = client.build_http_request(url: URI.parse("https://example.com"), method: "GET")
+
+      assert_equal("Bearer STATIC", request["Authorization"])
+    end
+  end
 end

--- a/seed/ruby-sdk-v2/websocket-multi-url/lib/seed/internal/http/raw_client.rb
+++ b/seed/ruby-sdk-v2/websocket-multi-url/lib/seed/internal/http/raw_client.rb
@@ -21,10 +21,14 @@ module Seed
         # @param max_retries [Integer] The number of times to retry a failed request, defaults to 2.
         # @param timeout [Float] The timeout for the request, defaults to 60.0 seconds.
         # @param headers [Hash] The headers for the request.
-        def initialize(base_url:, max_retries: 2, timeout: 60.0, headers: {})
+        # @param auth_provider [Object, nil] An optional auth provider responding to
+        #   `auth_headers`. When present its headers are resolved on every request so
+        #   token-based schemes (e.g. OAuth) can refresh an expired token mid-session.
+        def initialize(base_url:, max_retries: 2, timeout: 60.0, headers: {}, auth_provider: nil)
           @base_url = base_url
           @max_retries = max_retries
           @timeout = timeout
+          @auth_provider = auth_provider
           @default_headers = {
             "X-Fern-Language": "Ruby",
             "X-Fern-SDK-Name": "seed",
@@ -36,6 +40,9 @@ module Seed
         # @return [HTTP::Response] The HTTP response.
         def send(request)
           url = build_url(request)
+          # Resolve auth headers once per request (not per retry) so token-based
+          # providers refresh at most once here; static providers are cheap.
+          auth_headers = resolve_auth_headers
           attempt = 0
           response = nil
 
@@ -43,8 +50,9 @@ module Seed
             http_request = build_http_request(
               url:,
               method: request.method,
-              headers: request.encode_headers(protected_keys: @default_headers.keys),
-              body: request.encode_body
+              headers: request.encode_headers(protected_keys: @default_headers.keys + auth_headers.keys),
+              body: request.encode_body,
+              auth_headers: auth_headers
             )
 
             conn = connect(url)
@@ -157,12 +165,27 @@ module Seed
                 "HTTP is only allowed for localhost. Use HTTPS or pass a localhost URL."
         end
 
+        # Resolves the auth headers to send with the next request. Delegates to the
+        # configured auth provider (if any) on every call so that token-based
+        # providers (e.g. OAuth client-credentials) can refresh an expired token
+        # before the request is sent. Returns an empty hash when no provider is set,
+        # which keeps the api-key / basic / bearer / no-auth paths unchanged.
+        # @return [Hash] The auth headers for the current request.
+        def resolve_auth_headers
+          return {} if @auth_provider.nil?
+
+          @auth_provider.auth_headers
+        end
+
         # @param url [URI::Generic] The url to the resource.
         # @param method [String] The HTTP method to use.
         # @param headers [Hash] The headers for the request.
         # @param body [String, nil] The body for the request.
+        # @param auth_headers [Hash] The auth headers resolved for this request. These
+        #   take precedence over the static default headers but not over per-request
+        #   headers, mirroring the previous baked-header precedence.
         # @return [HTTP::Request] The HTTP request.
-        def build_http_request(url:, method:, headers: {}, body: nil)
+        def build_http_request(url:, method:, headers: {}, body: nil, auth_headers: {})
           request = Net::HTTPGenericRequest.new(
             method,
             !body.nil?,
@@ -170,7 +193,7 @@ module Seed
             url
           )
 
-          request_headers = @default_headers.merge(headers)
+          request_headers = @default_headers.merge(auth_headers).merge(headers)
           request_headers.each { |name, value| request[name] = value }
           request.body = body if body
 

--- a/seed/ruby-sdk-v2/websocket-multi-url/test/unit/internal/http/test_raw_client.rb
+++ b/seed/ruby-sdk-v2/websocket-multi-url/test/unit/internal/http/test_raw_client.rb
@@ -54,4 +54,71 @@ describe Seed::Internal::Http::RawClient do
       assert client.should_retry?(make_response(502), 2)
     end
   end
+
+  # A minimal auth provider whose `auth_headers` returns a *different* token on
+  # each call, simulating a token that is refreshed on expiry.
+  class RefreshingAuthProvider
+    def initialize
+      @count = 0
+    end
+
+    def auth_headers
+      @count += 1
+      { "Authorization" => "Bearer TOKEN_#{@count}" }
+    end
+  end
+
+  describe "#resolve_auth_headers" do
+    it "returns an empty hash when no auth provider is configured" do
+      client = Seed::Internal::Http::RawClient.new(base_url: "https://example.com")
+
+      assert_equal({}, client.resolve_auth_headers)
+    end
+
+    it "consults the auth provider on every call so an expired token is refreshed" do
+      client = Seed::Internal::Http::RawClient.new(
+        base_url: "https://example.com",
+        auth_provider: RefreshingAuthProvider.new
+      )
+
+      assert_equal({ "Authorization" => "Bearer TOKEN_1" }, client.resolve_auth_headers)
+      assert_equal({ "Authorization" => "Bearer TOKEN_2" }, client.resolve_auth_headers)
+    end
+  end
+
+  describe "#build_http_request auth header precedence" do
+    let(:client) do
+      Seed::Internal::Http::RawClient.new(
+        base_url: "https://example.com",
+        headers: { "Authorization" => "Bearer STATIC" }
+      )
+    end
+
+    it "lets resolved auth headers override the static default headers" do
+      request = client.build_http_request(
+        url: URI.parse("https://example.com"),
+        method: "GET",
+        auth_headers: { "Authorization" => "Bearer FRESH" }
+      )
+
+      assert_equal("Bearer FRESH", request["Authorization"])
+    end
+
+    it "lets per-request headers take precedence over auth headers" do
+      request = client.build_http_request(
+        url: URI.parse("https://example.com"),
+        method: "GET",
+        headers: { "Authorization" => "Bearer PER_REQUEST" },
+        auth_headers: { "Authorization" => "Bearer FRESH" }
+      )
+
+      assert_equal("Bearer PER_REQUEST", request["Authorization"])
+    end
+
+    it "defaults auth headers to empty, leaving the default headers unchanged" do
+      request = client.build_http_request(url: URI.parse("https://example.com"), method: "GET")
+
+      assert_equal("Bearer STATIC", request["Authorization"])
+    end
+  end
 end

--- a/seed/ruby-sdk-v2/websocket/lib/seed/internal/http/raw_client.rb
+++ b/seed/ruby-sdk-v2/websocket/lib/seed/internal/http/raw_client.rb
@@ -21,10 +21,14 @@ module Seed
         # @param max_retries [Integer] The number of times to retry a failed request, defaults to 2.
         # @param timeout [Float] The timeout for the request, defaults to 60.0 seconds.
         # @param headers [Hash] The headers for the request.
-        def initialize(base_url:, max_retries: 2, timeout: 60.0, headers: {})
+        # @param auth_provider [Object, nil] An optional auth provider responding to
+        #   `auth_headers`. When present its headers are resolved on every request so
+        #   token-based schemes (e.g. OAuth) can refresh an expired token mid-session.
+        def initialize(base_url:, max_retries: 2, timeout: 60.0, headers: {}, auth_provider: nil)
           @base_url = base_url
           @max_retries = max_retries
           @timeout = timeout
+          @auth_provider = auth_provider
           @default_headers = {
             "X-Fern-Language": "Ruby",
             "X-Fern-SDK-Name": "seed",
@@ -36,6 +40,9 @@ module Seed
         # @return [HTTP::Response] The HTTP response.
         def send(request)
           url = build_url(request)
+          # Resolve auth headers once per request (not per retry) so token-based
+          # providers refresh at most once here; static providers are cheap.
+          auth_headers = resolve_auth_headers
           attempt = 0
           response = nil
 
@@ -43,8 +50,9 @@ module Seed
             http_request = build_http_request(
               url:,
               method: request.method,
-              headers: request.encode_headers(protected_keys: @default_headers.keys),
-              body: request.encode_body
+              headers: request.encode_headers(protected_keys: @default_headers.keys + auth_headers.keys),
+              body: request.encode_body,
+              auth_headers: auth_headers
             )
 
             conn = connect(url)
@@ -157,12 +165,27 @@ module Seed
                 "HTTP is only allowed for localhost. Use HTTPS or pass a localhost URL."
         end
 
+        # Resolves the auth headers to send with the next request. Delegates to the
+        # configured auth provider (if any) on every call so that token-based
+        # providers (e.g. OAuth client-credentials) can refresh an expired token
+        # before the request is sent. Returns an empty hash when no provider is set,
+        # which keeps the api-key / basic / bearer / no-auth paths unchanged.
+        # @return [Hash] The auth headers for the current request.
+        def resolve_auth_headers
+          return {} if @auth_provider.nil?
+
+          @auth_provider.auth_headers
+        end
+
         # @param url [URI::Generic] The url to the resource.
         # @param method [String] The HTTP method to use.
         # @param headers [Hash] The headers for the request.
         # @param body [String, nil] The body for the request.
+        # @param auth_headers [Hash] The auth headers resolved for this request. These
+        #   take precedence over the static default headers but not over per-request
+        #   headers, mirroring the previous baked-header precedence.
         # @return [HTTP::Request] The HTTP request.
-        def build_http_request(url:, method:, headers: {}, body: nil)
+        def build_http_request(url:, method:, headers: {}, body: nil, auth_headers: {})
           request = Net::HTTPGenericRequest.new(
             method,
             !body.nil?,
@@ -170,7 +193,7 @@ module Seed
             url
           )
 
-          request_headers = @default_headers.merge(headers)
+          request_headers = @default_headers.merge(auth_headers).merge(headers)
           request_headers.each { |name, value| request[name] = value }
           request.body = body if body
 

--- a/seed/ruby-sdk-v2/websocket/test/unit/internal/http/test_raw_client.rb
+++ b/seed/ruby-sdk-v2/websocket/test/unit/internal/http/test_raw_client.rb
@@ -54,4 +54,71 @@ describe Seed::Internal::Http::RawClient do
       assert client.should_retry?(make_response(502), 2)
     end
   end
+
+  # A minimal auth provider whose `auth_headers` returns a *different* token on
+  # each call, simulating a token that is refreshed on expiry.
+  class RefreshingAuthProvider
+    def initialize
+      @count = 0
+    end
+
+    def auth_headers
+      @count += 1
+      { "Authorization" => "Bearer TOKEN_#{@count}" }
+    end
+  end
+
+  describe "#resolve_auth_headers" do
+    it "returns an empty hash when no auth provider is configured" do
+      client = Seed::Internal::Http::RawClient.new(base_url: "https://example.com")
+
+      assert_equal({}, client.resolve_auth_headers)
+    end
+
+    it "consults the auth provider on every call so an expired token is refreshed" do
+      client = Seed::Internal::Http::RawClient.new(
+        base_url: "https://example.com",
+        auth_provider: RefreshingAuthProvider.new
+      )
+
+      assert_equal({ "Authorization" => "Bearer TOKEN_1" }, client.resolve_auth_headers)
+      assert_equal({ "Authorization" => "Bearer TOKEN_2" }, client.resolve_auth_headers)
+    end
+  end
+
+  describe "#build_http_request auth header precedence" do
+    let(:client) do
+      Seed::Internal::Http::RawClient.new(
+        base_url: "https://example.com",
+        headers: { "Authorization" => "Bearer STATIC" }
+      )
+    end
+
+    it "lets resolved auth headers override the static default headers" do
+      request = client.build_http_request(
+        url: URI.parse("https://example.com"),
+        method: "GET",
+        auth_headers: { "Authorization" => "Bearer FRESH" }
+      )
+
+      assert_equal("Bearer FRESH", request["Authorization"])
+    end
+
+    it "lets per-request headers take precedence over auth headers" do
+      request = client.build_http_request(
+        url: URI.parse("https://example.com"),
+        method: "GET",
+        headers: { "Authorization" => "Bearer PER_REQUEST" },
+        auth_headers: { "Authorization" => "Bearer FRESH" }
+      )
+
+      assert_equal("Bearer PER_REQUEST", request["Authorization"])
+    end
+
+    it "defaults auth headers to empty, leaving the default headers unchanged" do
+      request = client.build_http_request(url: URI.parse("https://example.com"), method: "GET")
+
+      assert_equal("Bearer STATIC", request["Authorization"])
+    end
+  end
 end

--- a/seed/ruby-sdk-v2/x-fern-default/lib/seed/internal/http/raw_client.rb
+++ b/seed/ruby-sdk-v2/x-fern-default/lib/seed/internal/http/raw_client.rb
@@ -21,10 +21,14 @@ module Seed
         # @param max_retries [Integer] The number of times to retry a failed request, defaults to 2.
         # @param timeout [Float] The timeout for the request, defaults to 60.0 seconds.
         # @param headers [Hash] The headers for the request.
-        def initialize(base_url:, max_retries: 2, timeout: 60.0, headers: {})
+        # @param auth_provider [Object, nil] An optional auth provider responding to
+        #   `auth_headers`. When present its headers are resolved on every request so
+        #   token-based schemes (e.g. OAuth) can refresh an expired token mid-session.
+        def initialize(base_url:, max_retries: 2, timeout: 60.0, headers: {}, auth_provider: nil)
           @base_url = base_url
           @max_retries = max_retries
           @timeout = timeout
+          @auth_provider = auth_provider
           @default_headers = {
             "X-Fern-Language": "Ruby",
             "X-Fern-SDK-Name": "seed",
@@ -36,6 +40,9 @@ module Seed
         # @return [HTTP::Response] The HTTP response.
         def send(request)
           url = build_url(request)
+          # Resolve auth headers once per request (not per retry) so token-based
+          # providers refresh at most once here; static providers are cheap.
+          auth_headers = resolve_auth_headers
           attempt = 0
           response = nil
 
@@ -43,8 +50,9 @@ module Seed
             http_request = build_http_request(
               url:,
               method: request.method,
-              headers: request.encode_headers(protected_keys: @default_headers.keys),
-              body: request.encode_body
+              headers: request.encode_headers(protected_keys: @default_headers.keys + auth_headers.keys),
+              body: request.encode_body,
+              auth_headers: auth_headers
             )
 
             conn = connect(url)
@@ -157,12 +165,27 @@ module Seed
                 "HTTP is only allowed for localhost. Use HTTPS or pass a localhost URL."
         end
 
+        # Resolves the auth headers to send with the next request. Delegates to the
+        # configured auth provider (if any) on every call so that token-based
+        # providers (e.g. OAuth client-credentials) can refresh an expired token
+        # before the request is sent. Returns an empty hash when no provider is set,
+        # which keeps the api-key / basic / bearer / no-auth paths unchanged.
+        # @return [Hash] The auth headers for the current request.
+        def resolve_auth_headers
+          return {} if @auth_provider.nil?
+
+          @auth_provider.auth_headers
+        end
+
         # @param url [URI::Generic] The url to the resource.
         # @param method [String] The HTTP method to use.
         # @param headers [Hash] The headers for the request.
         # @param body [String, nil] The body for the request.
+        # @param auth_headers [Hash] The auth headers resolved for this request. These
+        #   take precedence over the static default headers but not over per-request
+        #   headers, mirroring the previous baked-header precedence.
         # @return [HTTP::Request] The HTTP request.
-        def build_http_request(url:, method:, headers: {}, body: nil)
+        def build_http_request(url:, method:, headers: {}, body: nil, auth_headers: {})
           request = Net::HTTPGenericRequest.new(
             method,
             !body.nil?,
@@ -170,7 +193,7 @@ module Seed
             url
           )
 
-          request_headers = @default_headers.merge(headers)
+          request_headers = @default_headers.merge(auth_headers).merge(headers)
           request_headers.each { |name, value| request[name] = value }
           request.body = body if body
 

--- a/seed/ruby-sdk-v2/x-fern-default/test/unit/internal/http/test_raw_client.rb
+++ b/seed/ruby-sdk-v2/x-fern-default/test/unit/internal/http/test_raw_client.rb
@@ -54,4 +54,71 @@ describe Seed::Internal::Http::RawClient do
       assert client.should_retry?(make_response(502), 2)
     end
   end
+
+  # A minimal auth provider whose `auth_headers` returns a *different* token on
+  # each call, simulating a token that is refreshed on expiry.
+  class RefreshingAuthProvider
+    def initialize
+      @count = 0
+    end
+
+    def auth_headers
+      @count += 1
+      { "Authorization" => "Bearer TOKEN_#{@count}" }
+    end
+  end
+
+  describe "#resolve_auth_headers" do
+    it "returns an empty hash when no auth provider is configured" do
+      client = Seed::Internal::Http::RawClient.new(base_url: "https://example.com")
+
+      assert_equal({}, client.resolve_auth_headers)
+    end
+
+    it "consults the auth provider on every call so an expired token is refreshed" do
+      client = Seed::Internal::Http::RawClient.new(
+        base_url: "https://example.com",
+        auth_provider: RefreshingAuthProvider.new
+      )
+
+      assert_equal({ "Authorization" => "Bearer TOKEN_1" }, client.resolve_auth_headers)
+      assert_equal({ "Authorization" => "Bearer TOKEN_2" }, client.resolve_auth_headers)
+    end
+  end
+
+  describe "#build_http_request auth header precedence" do
+    let(:client) do
+      Seed::Internal::Http::RawClient.new(
+        base_url: "https://example.com",
+        headers: { "Authorization" => "Bearer STATIC" }
+      )
+    end
+
+    it "lets resolved auth headers override the static default headers" do
+      request = client.build_http_request(
+        url: URI.parse("https://example.com"),
+        method: "GET",
+        auth_headers: { "Authorization" => "Bearer FRESH" }
+      )
+
+      assert_equal("Bearer FRESH", request["Authorization"])
+    end
+
+    it "lets per-request headers take precedence over auth headers" do
+      request = client.build_http_request(
+        url: URI.parse("https://example.com"),
+        method: "GET",
+        headers: { "Authorization" => "Bearer PER_REQUEST" },
+        auth_headers: { "Authorization" => "Bearer FRESH" }
+      )
+
+      assert_equal("Bearer PER_REQUEST", request["Authorization"])
+    end
+
+    it "defaults auth headers to empty, leaving the default headers unchanged" do
+      request = client.build_http_request(url: URI.parse("https://example.com"), method: "GET")
+
+      assert_equal("Bearer STATIC", request["Authorization"])
+    end
+  end
 end

--- a/seed/ruby-sdk-v2/x-fern-global-parameters/lib/seed/internal/http/raw_client.rb
+++ b/seed/ruby-sdk-v2/x-fern-global-parameters/lib/seed/internal/http/raw_client.rb
@@ -21,10 +21,14 @@ module Seed
         # @param max_retries [Integer] The number of times to retry a failed request, defaults to 2.
         # @param timeout [Float] The timeout for the request, defaults to 60.0 seconds.
         # @param headers [Hash] The headers for the request.
-        def initialize(base_url:, max_retries: 2, timeout: 60.0, headers: {})
+        # @param auth_provider [Object, nil] An optional auth provider responding to
+        #   `auth_headers`. When present its headers are resolved on every request so
+        #   token-based schemes (e.g. OAuth) can refresh an expired token mid-session.
+        def initialize(base_url:, max_retries: 2, timeout: 60.0, headers: {}, auth_provider: nil)
           @base_url = base_url
           @max_retries = max_retries
           @timeout = timeout
+          @auth_provider = auth_provider
           @default_headers = {
             "X-Fern-Language": "Ruby",
             "X-Fern-SDK-Name": "seed",
@@ -36,6 +40,9 @@ module Seed
         # @return [HTTP::Response] The HTTP response.
         def send(request)
           url = build_url(request)
+          # Resolve auth headers once per request (not per retry) so token-based
+          # providers refresh at most once here; static providers are cheap.
+          auth_headers = resolve_auth_headers
           attempt = 0
           response = nil
 
@@ -43,8 +50,9 @@ module Seed
             http_request = build_http_request(
               url:,
               method: request.method,
-              headers: request.encode_headers(protected_keys: @default_headers.keys),
-              body: request.encode_body
+              headers: request.encode_headers(protected_keys: @default_headers.keys + auth_headers.keys),
+              body: request.encode_body,
+              auth_headers: auth_headers
             )
 
             conn = connect(url)
@@ -157,12 +165,27 @@ module Seed
                 "HTTP is only allowed for localhost. Use HTTPS or pass a localhost URL."
         end
 
+        # Resolves the auth headers to send with the next request. Delegates to the
+        # configured auth provider (if any) on every call so that token-based
+        # providers (e.g. OAuth client-credentials) can refresh an expired token
+        # before the request is sent. Returns an empty hash when no provider is set,
+        # which keeps the api-key / basic / bearer / no-auth paths unchanged.
+        # @return [Hash] The auth headers for the current request.
+        def resolve_auth_headers
+          return {} if @auth_provider.nil?
+
+          @auth_provider.auth_headers
+        end
+
         # @param url [URI::Generic] The url to the resource.
         # @param method [String] The HTTP method to use.
         # @param headers [Hash] The headers for the request.
         # @param body [String, nil] The body for the request.
+        # @param auth_headers [Hash] The auth headers resolved for this request. These
+        #   take precedence over the static default headers but not over per-request
+        #   headers, mirroring the previous baked-header precedence.
         # @return [HTTP::Request] The HTTP request.
-        def build_http_request(url:, method:, headers: {}, body: nil)
+        def build_http_request(url:, method:, headers: {}, body: nil, auth_headers: {})
           request = Net::HTTPGenericRequest.new(
             method,
             !body.nil?,
@@ -170,7 +193,7 @@ module Seed
             url
           )
 
-          request_headers = @default_headers.merge(headers)
+          request_headers = @default_headers.merge(auth_headers).merge(headers)
           request_headers.each { |name, value| request[name] = value }
           request.body = body if body
 

--- a/seed/ruby-sdk-v2/x-fern-global-parameters/test/unit/internal/http/test_raw_client.rb
+++ b/seed/ruby-sdk-v2/x-fern-global-parameters/test/unit/internal/http/test_raw_client.rb
@@ -54,4 +54,71 @@ describe Seed::Internal::Http::RawClient do
       assert client.should_retry?(make_response(502), 2)
     end
   end
+
+  # A minimal auth provider whose `auth_headers` returns a *different* token on
+  # each call, simulating a token that is refreshed on expiry.
+  class RefreshingAuthProvider
+    def initialize
+      @count = 0
+    end
+
+    def auth_headers
+      @count += 1
+      { "Authorization" => "Bearer TOKEN_#{@count}" }
+    end
+  end
+
+  describe "#resolve_auth_headers" do
+    it "returns an empty hash when no auth provider is configured" do
+      client = Seed::Internal::Http::RawClient.new(base_url: "https://example.com")
+
+      assert_equal({}, client.resolve_auth_headers)
+    end
+
+    it "consults the auth provider on every call so an expired token is refreshed" do
+      client = Seed::Internal::Http::RawClient.new(
+        base_url: "https://example.com",
+        auth_provider: RefreshingAuthProvider.new
+      )
+
+      assert_equal({ "Authorization" => "Bearer TOKEN_1" }, client.resolve_auth_headers)
+      assert_equal({ "Authorization" => "Bearer TOKEN_2" }, client.resolve_auth_headers)
+    end
+  end
+
+  describe "#build_http_request auth header precedence" do
+    let(:client) do
+      Seed::Internal::Http::RawClient.new(
+        base_url: "https://example.com",
+        headers: { "Authorization" => "Bearer STATIC" }
+      )
+    end
+
+    it "lets resolved auth headers override the static default headers" do
+      request = client.build_http_request(
+        url: URI.parse("https://example.com"),
+        method: "GET",
+        auth_headers: { "Authorization" => "Bearer FRESH" }
+      )
+
+      assert_equal("Bearer FRESH", request["Authorization"])
+    end
+
+    it "lets per-request headers take precedence over auth headers" do
+      request = client.build_http_request(
+        url: URI.parse("https://example.com"),
+        method: "GET",
+        headers: { "Authorization" => "Bearer PER_REQUEST" },
+        auth_headers: { "Authorization" => "Bearer FRESH" }
+      )
+
+      assert_equal("Bearer PER_REQUEST", request["Authorization"])
+    end
+
+    it "defaults auth headers to empty, leaving the default headers unchanged" do
+      request = client.build_http_request(url: URI.parse("https://example.com"), method: "GET")
+
+      assert_equal("Bearer STATIC", request["Authorization"])
+    end
+  end
 end


### PR DESCRIPTION
## FER-11562 — Ruby SDK: OAuth token not refreshed on expiry

### Root cause
The Ruby v2 generator resolved the OAuth access token **once, at client construction**, and merged the `Authorization: Bearer` header into the `RawClient`'s frozen `@default_headers`:

```ruby
@raw_client = RawClient.new(headers: {...}.merge(@auth_provider.auth_headers), ...)
```

That `.merge(...)` was the only post-construction use of the provider. `RawClient` re-sent the same static hash every request, so the provider's (already-correct) `token` / `token_needs_refresh?` / `refresh` logic was **never reachable at request time**. An expired token was never refreshed mid-session — reported by a customer (Payabli/Elijah) whose second call kept sending the stale token.

### Fix
Resolve auth headers **per request** instead of baking them once — matching the pattern every other Fern SDK already uses (see cross-SDK note below):

- **`RootClientGenerator.ts`** — stop merging `auth_headers` into static headers; pass `auth_provider: @auth_provider` into `RawClient`. Covers OAuth, inferred-auth, and `any`-composed multi-scheme (`@auth_provider` reads as `nil` when creds weren't supplied).
- **`raw_client.Template.rb`** — constructor takes an optional `auth_provider: nil`; new `resolve_auth_headers` (returns `{}` when nil) is called once per `send`; `build_http_request` merges `@default_headers.merge(auth_headers).merge(headers)` — preserving the previous precedence (per-request > auth > defaults) and extending `protected_keys` so additional-headers can't clobber auth.
- **`test_raw_client.Template.rb`** — unit tests proving (a) the provider is consulted on every call (`TOKEN_1` then `TOKEN_2`) and (b) header precedence.
- **changelog** — added `changes/unreleased/fix-oauth-token-refresh.yml` (`type: fix`); the release bot writes the `versions.yml` entry at release time.

**Backward compatibility:** when no provider is configured, `resolve_auth_headers` returns `{}` and the merge is a no-op → **byte-identical** request behavior for api-key / basic / bearer / no-auth SDKs. Inferred-auth also now refreshes per-request (same provider shape).

### Additional scope — cross-SDK OAuth refresh audit
Verified how every other generator wires the OAuth client-credentials token, per the issue's request to use a correct SDK as the reference:

| SDK | Refreshes on expiry (per-request)? |
|---|---|
| TypeScript / Python / Go / Rust | ✅ |
| Java | ✅ (`getAuthHeaders()` → `getToken()`, volatile cache + `synchronized` refresh on `expiresAt.isBefore(now)`) |
| PHP | ✅ (`getAuthHeaders` closure → `oauthTokenProvider->getToken()` refreshing as needed) |
| **Ruby** | ❌ baked-once — **this bug; fixed here** |

**Ruby was the sole outlier** — no follow-up issues needed for the other languages. The Ruby fix mirrors PHP's per-request `getAuthHeaders` closure / Python's per-request `auth_headers` call rather than inventing a new mechanism.

### Verification
- Generator compiles; generator vitest 6/6.
- Regenerated **all 137** ruby-sdk-v2 fixtures cleanly. Diff scope: shared `raw_client.rb` + `test_raw_client.rb` across all fixtures, and 17 `client.rb` auth-provider swaps (17 removed `.merge(@auth_provider…)` ↔ 17 added `auth_provider:`, 1:1) — nothing stray.
- **7 fixtures run full Docker `ruby:3.3` `rubocop` + `rake test` → all green**: 3 OAuth (incl. the new refresh tests), any-auth, inferred-auth, basic-auth, bearer.

Fixes FER-11562.

Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/17036" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


---
_Rebased onto latest `main` (was 6 commits behind, incl. the IR-v67 upgrade + a `1.15.1` release). Dropped 137 spurious local-vs-CI `metadata.json` stamp changes, and moved the changelog from a manual `versions.yml` edit to a `changes/unreleased/` entry (the correct convention) — PR diff is now 295 files of real content._

