### PR TITLE
fix(cli): dedupe servers so multi-API environment grouping keeps per-API URLs

### DIFF
--- a/packages/cli/api-importers/openapi/openapi-ir-parser/src/parse.ts
+++ b/packages/cli/api-importers/openapi/openapi-ir-parser/src/parse.ts
@@ -353,6 +353,27 @@ function detectMultipleBaseUrls(servers1: AnyServerInput[], servers2: AnyServerI
     return allMatch && allDifferent;
 }
 
+/**
+ * Removes duplicate single servers that share the same environment name and URL.
+ * Without deduplication, merging many specs with identical servers accumulates
+ * duplicates, which prevents detectMultipleBaseUrls from matching server lists
+ * on subsequent merges.
+ */
+function dedupeServers(servers: AnyServerInput[]): AnyServerInput[] {
+    const seen = new Set<string>();
+    return servers.filter((server) => {
+        if (server.type === "grouped") {
+            return true;
+        }
+        const key = `${getEnvironmentName(server)}\u0000${server.url}`;
+        if (seen.has(key)) {
+            return false;
+        }
+        seen.add(key);
+        return true;
+    });
+}
+
 function getPreferredUrlForNameExtraction(server: SingleServerInput): string {
     return server.defaultUrl ?? server.url;
 }
@@ -610,7 +631,8 @@ function merge(
         };
     }
 
-    // When not grouping, just concatenate without modification
+    // When not grouping, concatenate while deduplicating identical servers so
+    // that repeated servers across specs don't block grouping on later merges
     return {
         apiVersion: ir1.apiVersion ?? ir2.apiVersion,
         specVersion: ir1.specVersion ?? ir2.specVersion,
@@ -618,7 +640,7 @@ function merge(
         description: ir1.description ?? ir2.description,
         basePath: ir1.basePath ?? ir2.basePath,
         basePathParameters: ir1.basePathParameters ?? ir2.basePathParameters,
-        servers: [...ir1.servers, ...ir2.servers],
+        servers: dedupeServers([...ir1.servers, ...ir2.servers] as AnyServerInput[]) as Server[],
         websocketServers: [...ir1.websocketServers, ...ir2.websocketServers],
         tags: {
             tagsById: {

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir/multi-api-duplicate-servers.json
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir/multi-api-duplicate-servers.json
@@ -1,0 +1,249 @@
+{
+  "specVersion": "1.0.0",
+  "title": "Messages API",
+  "servers": [
+    {
+      "type": "grouped",
+      "name": "STG",
+      "description": "STG environment",
+      "urls": {
+        "stage": {
+          "url": "https://api.stage.example.com"
+        },
+        "oauth": {
+          "url": "https://oauth.stage.example.com"
+        }
+      }
+    }
+  ],
+  "websocketServers": [],
+  "tags": {
+    "tagsById": {}
+  },
+  "hasEndpointsMarkedInternal": false,
+  "endpoints": [
+    {
+      "audiences": [],
+      "operationId": "listMessages",
+      "tags": [
+        "messages"
+      ],
+      "namespace": "messages",
+      "pathParameters": [],
+      "queryParameters": [],
+      "headers": [],
+      "generatedRequestName": "ListMessagesRequest",
+      "response": {
+        "description": "Success",
+        "schema": {
+          "schema": {
+            "type": "string"
+          },
+          "generatedName": "ListMessagesResponse",
+          "namespace": "messages",
+          "groupName": [
+            {
+              "type": "namespace",
+              "name": "messages"
+            }
+          ],
+          "type": "primitive"
+        },
+        "fullExamples": [],
+        "source": {
+          "file": "../messages-api.yml",
+          "type": "openapi"
+        },
+        "statusCode": 200,
+        "type": "json"
+      },
+      "errors": {},
+      "authed": false,
+      "method": "GET",
+      "path": "/messages",
+      "examples": [
+        {
+          "pathParameters": [],
+          "queryParameters": [],
+          "headers": [],
+          "response": {
+            "value": {
+              "value": {
+                "value": "string",
+                "type": "string"
+              },
+              "type": "primitive"
+            },
+            "type": "withoutStreaming"
+          },
+          "codeSamples": [],
+          "type": "full"
+        }
+      ],
+      "source": {
+        "file": "../messages-api.yml",
+        "type": "openapi"
+      },
+      "__apiName": "stage",
+      "servers": [
+        {
+          "name": "stage"
+        }
+      ]
+    },
+    {
+      "audiences": [],
+      "operationId": "listConversations",
+      "tags": [
+        "conversations"
+      ],
+      "namespace": "conversations",
+      "pathParameters": [],
+      "queryParameters": [],
+      "headers": [],
+      "generatedRequestName": "ListConversationsRequest",
+      "response": {
+        "description": "Success",
+        "schema": {
+          "schema": {
+            "type": "string"
+          },
+          "generatedName": "ListConversationsResponse",
+          "namespace": "conversations",
+          "groupName": [
+            {
+              "type": "namespace",
+              "name": "conversations"
+            }
+          ],
+          "type": "primitive"
+        },
+        "fullExamples": [],
+        "source": {
+          "file": "../conversations-api.yml",
+          "type": "openapi"
+        },
+        "statusCode": 200,
+        "type": "json"
+      },
+      "errors": {},
+      "authed": false,
+      "method": "GET",
+      "path": "/conversations",
+      "examples": [
+        {
+          "pathParameters": [],
+          "queryParameters": [],
+          "headers": [],
+          "response": {
+            "value": {
+              "value": {
+                "value": "string",
+                "type": "string"
+              },
+              "type": "primitive"
+            },
+            "type": "withoutStreaming"
+          },
+          "codeSamples": [],
+          "type": "full"
+        }
+      ],
+      "source": {
+        "file": "../conversations-api.yml",
+        "type": "openapi"
+      },
+      "__apiName": "stage",
+      "servers": [
+        {
+          "name": "stage"
+        }
+      ]
+    },
+    {
+      "audiences": [],
+      "operationId": "createToken",
+      "tags": [
+        "oauth"
+      ],
+      "namespace": "oauth",
+      "pathParameters": [],
+      "queryParameters": [],
+      "headers": [],
+      "generatedRequestName": "CreateTokenRequest",
+      "response": {
+        "description": "Success",
+        "schema": {
+          "schema": {
+            "type": "string"
+          },
+          "generatedName": "CreateTokenResponse",
+          "namespace": "oauth",
+          "groupName": [
+            {
+              "type": "namespace",
+              "name": "oauth"
+            }
+          ],
+          "type": "primitive"
+        },
+        "fullExamples": [],
+        "source": {
+          "file": "../oauth-api.yml",
+          "type": "openapi"
+        },
+        "statusCode": 200,
+        "type": "json"
+      },
+      "errors": {},
+      "authed": false,
+      "method": "POST",
+      "path": "/token",
+      "examples": [
+        {
+          "pathParameters": [],
+          "queryParameters": [],
+          "headers": [],
+          "response": {
+            "value": {
+              "value": {
+                "value": "string",
+                "type": "string"
+              },
+              "type": "primitive"
+            },
+            "type": "withoutStreaming"
+          },
+          "codeSamples": [],
+          "type": "full"
+        }
+      ],
+      "source": {
+        "file": "../oauth-api.yml",
+        "type": "openapi"
+      },
+      "__apiName": "oauth",
+      "servers": [
+        {
+          "name": "oauth"
+        }
+      ]
+    }
+  ],
+  "webhooks": [],
+  "channels": {},
+  "groupedSchemas": {
+    "rootSchemas": {},
+    "namespacedSchemas": {
+      "messages": {},
+      "conversations": {},
+      "oauth": {}
+    }
+  },
+  "variables": {},
+  "nonRequestReferencedSchemas": {},
+  "securitySchemes": {},
+  "globalHeaders": [],
+  "idempotencyHeaders": [],
+  "groups": {}
+}

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi/multi-api-duplicate-servers.json
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi/multi-api-duplicate-servers.json
@@ -1,0 +1,217 @@
+{
+  "absoluteFilePath": "/DUMMY_PATH",
+  "importedDefinitions": {},
+  "namedDefinitionFiles": {
+    "__package__.yml": {
+      "absoluteFilepath": "/DUMMY_PATH",
+      "contents": {},
+      "rawContents": "{}
+",
+    },
+    "conversations/__package__.yml": {
+      "absoluteFilepath": "/DUMMY_PATH",
+      "contents": {
+        "service": {
+          "auth": false,
+          "base-path": "",
+          "endpoints": {
+            "listConversations": {
+              "auth": undefined,
+              "docs": undefined,
+              "examples": [
+                {
+                  "response": {
+                    "body": "string",
+                  },
+                },
+              ],
+              "method": "GET",
+              "pagination": undefined,
+              "path": "/conversations",
+              "response": {
+                "docs": "Success",
+                "status-code": 200,
+                "type": "string",
+              },
+              "source": {
+                "openapi": "../conversations-api.yml",
+              },
+              "url": "stage",
+            },
+          },
+          "source": {
+            "openapi": "../conversations-api.yml",
+          },
+        },
+      },
+      "rawContents": "service:
+  auth: false
+  base-path: ''
+  endpoints:
+    listConversations:
+      path: /conversations
+      method: GET
+      source:
+        openapi: ../conversations-api.yml
+      response:
+        docs: Success
+        type: string
+        status-code: 200
+      url: stage
+      examples:
+        - response:
+            body: string
+  source:
+    openapi: ../conversations-api.yml
+",
+    },
+    "messages/__package__.yml": {
+      "absoluteFilepath": "/DUMMY_PATH",
+      "contents": {
+        "service": {
+          "auth": false,
+          "base-path": "",
+          "endpoints": {
+            "listMessages": {
+              "auth": undefined,
+              "docs": undefined,
+              "examples": [
+                {
+                  "response": {
+                    "body": "string",
+                  },
+                },
+              ],
+              "method": "GET",
+              "pagination": undefined,
+              "path": "/messages",
+              "response": {
+                "docs": "Success",
+                "status-code": 200,
+                "type": "string",
+              },
+              "source": {
+                "openapi": "../messages-api.yml",
+              },
+              "url": "stage",
+            },
+          },
+          "source": {
+            "openapi": "../messages-api.yml",
+          },
+        },
+      },
+      "rawContents": "service:
+  auth: false
+  base-path: ''
+  endpoints:
+    listMessages:
+      path: /messages
+      method: GET
+      source:
+        openapi: ../messages-api.yml
+      response:
+        docs: Success
+        type: string
+        status-code: 200
+      url: stage
+      examples:
+        - response:
+            body: string
+  source:
+    openapi: ../messages-api.yml
+",
+    },
+    "oauth/__package__.yml": {
+      "absoluteFilepath": "/DUMMY_PATH",
+      "contents": {
+        "service": {
+          "auth": false,
+          "base-path": "",
+          "endpoints": {
+            "createToken": {
+              "auth": undefined,
+              "docs": undefined,
+              "examples": [
+                {
+                  "response": {
+                    "body": "string",
+                  },
+                },
+              ],
+              "method": "POST",
+              "pagination": undefined,
+              "path": "/token",
+              "response": {
+                "docs": "Success",
+                "status-code": 200,
+                "type": "string",
+              },
+              "source": {
+                "openapi": "../oauth-api.yml",
+              },
+              "url": "oauth",
+            },
+          },
+          "source": {
+            "openapi": "../oauth-api.yml",
+          },
+        },
+      },
+      "rawContents": "service:
+  auth: false
+  base-path: ''
+  endpoints:
+    createToken:
+      path: /token
+      method: POST
+      source:
+        openapi: ../oauth-api.yml
+      response:
+        docs: Success
+        type: string
+        status-code: 200
+      url: oauth
+      examples:
+        - response:
+            body: string
+  source:
+    openapi: ../oauth-api.yml
+",
+    },
+  },
+  "packageMarkers": {},
+  "rootApiFile": {
+    "contents": {
+      "default-environment": "STG",
+      "default-url": "stage",
+      "display-name": "Messages API",
+      "environments": {
+        "STG": {
+          "urls": {
+            "oauth": "https://oauth.stage.example.com",
+            "stage": "https://api.stage.example.com",
+          },
+        },
+      },
+      "error-discrimination": {
+        "strategy": "status-code",
+      },
+      "name": "api",
+    },
+    "defaultUrl": "stage",
+    "rawContents": "name: api
+error-discrimination:
+  strategy: status-code
+display-name: Messages API
+environments:
+  STG:
+    urls:
+      stage: https://api.stage.example.com
+      oauth: https://oauth.stage.example.com
+default-environment: STG
+default-url: stage
+",
+  },
+  "specVersion": "1.0.0",
+}

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/fixtures/multi-api-duplicate-servers/conversations-api.yml
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/fixtures/multi-api-duplicate-servers/conversations-api.yml
@@ -1,0 +1,18 @@
+openapi: 3.0.3
+info:
+  title: Conversations API
+  version: 1.0.0
+servers:
+  - url: https://api.stage.example.com
+    x-fern-server-name: Staging
+paths:
+  /conversations:
+    get:
+      operationId: listConversations
+      responses:
+        "200":
+          description: Success
+          content:
+            application/json:
+              schema:
+                type: string

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/fixtures/multi-api-duplicate-servers/fern.config.json
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/fixtures/multi-api-duplicate-servers/fern.config.json
@@ -1,0 +1,4 @@
+{
+  "organization": "seed",
+  "version": "0.0.0"
+}

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/fixtures/multi-api-duplicate-servers/fern/generators.yml
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/fixtures/multi-api-duplicate-servers/fern/generators.yml
@@ -1,0 +1,11 @@
+# yaml-language-server: $schema=https://schema.buildwithfern.dev/generators-yml.json
+api:
+  specs:
+    - openapi: ../messages-api.yml
+      namespace: messages
+    - openapi: ../conversations-api.yml
+      namespace: conversations
+    - openapi: ../oauth-api.yml
+      namespace: oauth
+  settings:
+    group-multi-api-environments: true

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/fixtures/multi-api-duplicate-servers/messages-api.yml
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/fixtures/multi-api-duplicate-servers/messages-api.yml
@@ -1,0 +1,18 @@
+openapi: 3.0.3
+info:
+  title: Messages API
+  version: 1.0.0
+servers:
+  - url: https://api.stage.example.com
+    x-fern-server-name: Staging
+paths:
+  /messages:
+    get:
+      operationId: listMessages
+      responses:
+        "200":
+          description: Success
+          content:
+            application/json:
+              schema:
+                type: string

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/fixtures/multi-api-duplicate-servers/oauth-api.yml
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/fixtures/multi-api-duplicate-servers/oauth-api.yml
@@ -1,0 +1,18 @@
+openapi: 3.0.3
+info:
+  title: OAuth API
+  version: 1.0.0
+servers:
+  - url: https://oauth.stage.example.com
+    x-fern-server-name: Staging
+paths:
+  /token:
+    post:
+      operationId: createToken
+      responses:
+        "200":
+          description: Success
+          content:
+            application/json:
+              schema:
+                type: string

--- a/packages/cli/cli/changes/unreleased/fix-multi-api-environment-grouping-duplicate-servers.yml
+++ b/packages/cli/cli/changes/unreleased/fix-multi-api-environment-grouping-duplicate-servers.yml
@@ -1,0 +1,7 @@
+- summary: |
+    Fix multi-API environment grouping (`group-multi-api-environments`) selecting the wrong
+    base URL when more than two specs are merged and several specs share identical servers.
+    Duplicate servers no longer accumulate across merges, so environments with the same name
+    but different URLs are now grouped into a multi-URL environment instead of collapsing to
+    the last spec's URL.
+  type: fix


### PR DESCRIPTION
## Description
Linear ticket: Refs N/A

With `group-multi-api-environments: true`, merging more than two OpenAPI specs where several specs share identical servers (same environment name + same URL) caused the grouping to break: the environment collapsed to a single base URL and the *last* spec's URL won.

Root cause in `openapi-ir-parser/src/parse.ts` `merge()`: when consecutive specs had identical servers, the non-grouping concat path accumulated duplicate server entries (`servers: [...ir1.servers, ...ir2.servers]`). By the time a spec with a *different* URL (e.g. an OAuth spec) was merged, `detectMultipleBaseUrls` bailed out on `servers1.length !== servers2.length`, so grouping never triggered, and downstream environment building resolved the duplicated `Staging` name last-wins to the wrong host.

Reproduced with the Twilio config (`fern-demo/twilio-core-fern-config`, 7 specs on `https://api.stage.twilio.com` + 1 OAuth spec on `https://oauth.stage.twilio.com`): generated Java SDK had
```java
public static final Environment STAGING = new Environment("https://oauth.stage.twilio.com");
```
so all non-OAuth endpoints hit the OAuth host.

## Changes Made
- `merge()` now dedupes single servers with the same environment name + URL in the grouping-enabled concat path (`dedupeServers`), so identical servers across specs don't accumulate and grouping triggers when a spec with different URLs appears
- New fixture `multi-api-duplicate-servers` (2 specs sharing a Staging server + 1 OAuth spec with a different Staging URL) with snapshots showing the grouped result:
  ```yaml
  environments:
    STG:
      urls:
        oauth: https://oauth.stage.example.com
        stage: https://api.stage.example.com
  ```
- CLI changelog entry under `packages/cli/cli/changes/unreleased/`

## Testing
- [x] Unit tests added/updated (`@fern-api/openapi-ir-to-fern-tests`: 303 passed, 2 new snapshots)
- [x] Manual testing completed — rebuilt the CLI and ran it against the Twilio multi-API config: IR now has `multipleBaseUrls` with both URLs, endpoints route 157→stage / 1→oauth, and the generated Java `Environment` exposes `getStageURL()`/`getOauthURL()` with OAuth clients using the OAuth URL


Link to Devin session: https://app.devin.ai/sessions/2d0b1166b9014d149763c18c42124a4b
Requested by: @iamnamananand996
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/17047" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->