### PR TITLE
fix(ruby): show keyword-argument path parameters in reference.md titles

### DIFF
--- a/generators/ruby-v2/sdk/changes/unreleased/fix-reference-title-keyword-path-params.yml
+++ b/generators/ruby-v2/sdk/changes/unreleased/fix-reference-title-keyword-path-params.yml
@@ -1,0 +1,5 @@
+- summary: |
+    Fix `reference.md` endpoint titles to show path parameters in keyword-argument form
+    (e.g. `fetch_store(store_id:)` instead of `fetch_store(store_id)`). Generated Ruby methods
+    only accept keyword arguments, so the previous positional-looking titles were misleading.
+  type: fix

--- a/generators/ruby-v2/sdk/src/reference/buildReference.ts
+++ b/generators/ruby-v2/sdk/src/reference/buildReference.ts
@@ -156,7 +156,7 @@ function getReferenceEndpointInvocationParameters({
     const parameters: string[] = [];
 
     endpoint.allPathParameters.forEach((pathParam) => {
-        parameters.push(context.caseConverter.snakeSafe(pathParam.name));
+        parameters.push(`${context.caseConverter.snakeSafe(pathParam.name)}:`);
     });
 
     if (endpoint.requestBody != null) {

--- a/seed/ruby-sdk-v2/alias/reference.md
+++ b/seed/ruby-sdk-v2/alias/reference.md
@@ -1,5 +1,5 @@
 # Reference
-<details><summary><code>client.<a href="/lib/seed/client.rb">get</a>(type_id) -> </code></summary>
+<details><summary><code>client.<a href="/lib/seed/client.rb">get</a>(type_id:) -> </code></summary>
 <dl>
 <dd>
 

--- a/seed/ruby-sdk-v2/api-wide-base-path-with-default/reference.md
+++ b/seed/ruby-sdk-v2/api-wide-base-path-with-default/reference.md
@@ -1,6 +1,6 @@
 # Reference
 ## Widgets
-<details><summary><code>client.widgets.<a href="/lib/seed/widgets/client.rb">create</a>(api_version, request) -> Seed::Types::Widget</code></summary>
+<details><summary><code>client.widgets.<a href="/lib/seed/widgets/client.rb">create</a>(api_version:, request) -> Seed::Types::Widget</code></summary>
 <dl>
 <dd>
 

--- a/seed/ruby-sdk-v2/api-wide-base-path/reference.md
+++ b/seed/ruby-sdk-v2/api-wide-base-path/reference.md
@@ -1,6 +1,6 @@
 # Reference
 ## Service
-<details><summary><code>client.service.<a href="/lib/seed/service/client.rb">post</a>(path_param, service_param, endpoint_param, resource_param) -> </code></summary>
+<details><summary><code>client.service.<a href="/lib/seed/service/client.rb">post</a>(path_param:, service_param:, endpoint_param:, resource_param:) -> </code></summary>
 <dl>
 <dd>
 

--- a/seed/ruby-sdk-v2/cli-multi-spec/reference.md
+++ b/seed/ruby-sdk-v2/cli-multi-spec/reference.md
@@ -39,7 +39,7 @@ client.list_users
 </dl>
 </details>
 
-<details><summary><code>client.<a href="/lib/seed/client.rb">get_user</a>(user_id) -> Seed::Types::User</code></summary>
+<details><summary><code>client.<a href="/lib/seed/client.rb">get_user</a>(user_id:) -> Seed::Types::User</code></summary>
 <dl>
 <dd>
 
@@ -127,7 +127,7 @@ client.list_invoices
 </dl>
 </details>
 
-<details><summary><code>client.<a href="/lib/seed/client.rb">get_invoice</a>(invoice_id) -> Seed::Types::Invoice</code></summary>
+<details><summary><code>client.<a href="/lib/seed/client.rb">get_invoice</a>(invoice_id:) -> Seed::Types::Invoice</code></summary>
 <dl>
 <dd>
 

--- a/seed/ruby-sdk-v2/client-side-params/reference.md
+++ b/seed/ruby-sdk-v2/client-side-params/reference.md
@@ -118,7 +118,7 @@ client.service.list_resources(
 </dl>
 </details>
 
-<details><summary><code>client.service.<a href="/lib/seed/service/client.rb">get_resource</a>(resource_id) -> Seed::Types::Types::Resource</code></summary>
+<details><summary><code>client.service.<a href="/lib/seed/service/client.rb">get_resource</a>(resource_id:) -> Seed::Types::Types::Resource</code></summary>
 <dl>
 <dd>
 
@@ -422,7 +422,7 @@ client.service.list_users(
 </dl>
 </details>
 
-<details><summary><code>client.service.<a href="/lib/seed/service/client.rb">get_user_by_id</a>(user_id) -> Seed::Types::Types::User</code></summary>
+<details><summary><code>client.service.<a href="/lib/seed/service/client.rb">get_user_by_id</a>(user_id:) -> Seed::Types::Types::User</code></summary>
 <dl>
 <dd>
 
@@ -584,7 +584,7 @@ client.service.create_user(
 </dl>
 </details>
 
-<details><summary><code>client.service.<a href="/lib/seed/service/client.rb">update_user</a>(user_id, request) -> Seed::Types::Types::User</code></summary>
+<details><summary><code>client.service.<a href="/lib/seed/service/client.rb">update_user</a>(user_id:, request) -> Seed::Types::Types::User</code></summary>
 <dl>
 <dd>
 
@@ -673,7 +673,7 @@ client.service.update_user(
 </dl>
 </details>
 
-<details><summary><code>client.service.<a href="/lib/seed/service/client.rb">delete_user</a>(user_id) -> </code></summary>
+<details><summary><code>client.service.<a href="/lib/seed/service/client.rb">delete_user</a>(user_id:) -> </code></summary>
 <dl>
 <dd>
 
@@ -817,7 +817,7 @@ client.service.list_connections(
 </dl>
 </details>
 
-<details><summary><code>client.service.<a href="/lib/seed/service/client.rb">get_connection</a>(connection_id) -> Seed::Types::Types::Connection</code></summary>
+<details><summary><code>client.service.<a href="/lib/seed/service/client.rb">get_connection</a>(connection_id:) -> Seed::Types::Types::Connection</code></summary>
 <dl>
 <dd>
 
@@ -1017,7 +1017,7 @@ client.service.list_clients(
 </dl>
 </details>
 
-<details><summary><code>client.service.<a href="/lib/seed/service/client.rb">get_client</a>(client_id) -> Seed::Types::Types::Client</code></summary>
+<details><summary><code>client.service.<a href="/lib/seed/service/client.rb">get_client</a>(client_id:) -> Seed::Types::Types::Client</code></summary>
 <dl>
 <dd>
 

--- a/seed/ruby-sdk-v2/content-type/reference.md
+++ b/seed/ruby-sdk-v2/content-type/reference.md
@@ -59,7 +59,7 @@ client.service.patch(
 </dl>
 </details>
 
-<details><summary><code>client.service.<a href="/lib/seed/service/client.rb">patch_complex</a>(id, request) -> </code></summary>
+<details><summary><code>client.service.<a href="/lib/seed/service/client.rb">patch_complex</a>(id:, request) -> </code></summary>
 <dl>
 <dd>
 
@@ -224,7 +224,7 @@ client.service.patch_complex(
 </dl>
 </details>
 
-<details><summary><code>client.service.<a href="/lib/seed/service/client.rb">named_patch_with_mixed</a>(id, request) -> </code></summary>
+<details><summary><code>client.service.<a href="/lib/seed/service/client.rb">named_patch_with_mixed</a>(id:, request) -> </code></summary>
 <dl>
 <dd>
 
@@ -419,7 +419,7 @@ client.service.optional_merge_patch_test(
 </dl>
 </details>
 
-<details><summary><code>client.service.<a href="/lib/seed/service/client.rb">regular_patch</a>(id, request) -> </code></summary>
+<details><summary><code>client.service.<a href="/lib/seed/service/client.rb">regular_patch</a>(id:, request) -> </code></summary>
 <dl>
 <dd>
 

--- a/seed/ruby-sdk-v2/enum/reference.md
+++ b/seed/ruby-sdk-v2/enum/reference.md
@@ -154,7 +154,7 @@ client.inlined_request.send_(
 
 ## MultipartForm
 ## PathParam
-<details><summary><code>client.path_param.<a href="/lib/seed/path_param/client.rb">send_</a>(operand, operand_or_color) -> </code></summary>
+<details><summary><code>client.path_param.<a href="/lib/seed/path_param/client.rb">send_</a>(operand:, operand_or_color:) -> </code></summary>
 <dl>
 <dd>
 

--- a/seed/ruby-sdk-v2/examples/include-platform-headers/reference.md
+++ b/seed/ruby-sdk-v2/examples/include-platform-headers/reference.md
@@ -96,7 +96,7 @@ client.echo(request: "primitive")
 </details>
 
 ## File Notification Service
-<details><summary><code>client.file.notification.service.<a href="/lib/seed/file/notification/service/client.rb">get_exception</a>(notification_id) -> Seed::Types::Types::Exception</code></summary>
+<details><summary><code>client.file.notification.service.<a href="/lib/seed/file/notification/service/client.rb">get_exception</a>(notification_id:) -> Seed::Types::Types::Exception</code></summary>
 <dl>
 <dd>
 
@@ -145,7 +145,7 @@ client.file.notification.service.get_exception(notification_id: "notification-hs
 </details>
 
 ## File Service
-<details><summary><code>client.file.service.<a href="/lib/seed/file/service/client.rb">get_file</a>(filename) -> Seed::Types::Types::File</code></summary>
+<details><summary><code>client.file.service.<a href="/lib/seed/file/service/client.rb">get_file</a>(filename:) -> Seed::Types::Types::File</code></summary>
 <dl>
 <dd>
 
@@ -211,7 +211,7 @@ client.file.service.get_file(
 </details>
 
 ## Health Service
-<details><summary><code>client.health.service.<a href="/lib/seed/health/service/client.rb">check</a>(id) -> </code></summary>
+<details><summary><code>client.health.service.<a href="/lib/seed/health/service/client.rb">check</a>(id:) -> </code></summary>
 <dl>
 <dd>
 
@@ -328,7 +328,7 @@ client.health.service.ping
 </details>
 
 ## Service
-<details><summary><code>client.service.<a href="/lib/seed/service/client.rb">get_movie</a>(movie_id) -> Seed::Types::Types::Movie</code></summary>
+<details><summary><code>client.service.<a href="/lib/seed/service/client.rb">get_movie</a>(movie_id:) -> Seed::Types::Types::Movie</code></summary>
 <dl>
 <dd>
 

--- a/seed/ruby-sdk-v2/examples/no-custom-config/reference.md
+++ b/seed/ruby-sdk-v2/examples/no-custom-config/reference.md
@@ -96,7 +96,7 @@ client.echo(request: "primitive")
 </details>
 
 ## File Notification Service
-<details><summary><code>client.file.notification.service.<a href="/lib/seed/file/notification/service/client.rb">get_exception</a>(notification_id) -> Seed::Types::Types::Exception</code></summary>
+<details><summary><code>client.file.notification.service.<a href="/lib/seed/file/notification/service/client.rb">get_exception</a>(notification_id:) -> Seed::Types::Types::Exception</code></summary>
 <dl>
 <dd>
 
@@ -145,7 +145,7 @@ client.file.notification.service.get_exception(notification_id: "notification-hs
 </details>
 
 ## File Service
-<details><summary><code>client.file.service.<a href="/lib/seed/file/service/client.rb">get_file</a>(filename) -> Seed::Types::Types::File</code></summary>
+<details><summary><code>client.file.service.<a href="/lib/seed/file/service/client.rb">get_file</a>(filename:) -> Seed::Types::Types::File</code></summary>
 <dl>
 <dd>
 
@@ -211,7 +211,7 @@ client.file.service.get_file(
 </details>
 
 ## Health Service
-<details><summary><code>client.health.service.<a href="/lib/seed/health/service/client.rb">check</a>(id) -> </code></summary>
+<details><summary><code>client.health.service.<a href="/lib/seed/health/service/client.rb">check</a>(id:) -> </code></summary>
 <dl>
 <dd>
 
@@ -328,7 +328,7 @@ client.health.service.ping
 </details>
 
 ## Service
-<details><summary><code>client.service.<a href="/lib/seed/service/client.rb">get_movie</a>(movie_id) -> Seed::Types::Types::Movie</code></summary>
+<details><summary><code>client.service.<a href="/lib/seed/service/client.rb">get_movie</a>(movie_id:) -> Seed::Types::Types::Movie</code></summary>
 <dl>
 <dd>
 

--- a/seed/ruby-sdk-v2/examples/omit-fern-headers/reference.md
+++ b/seed/ruby-sdk-v2/examples/omit-fern-headers/reference.md
@@ -96,7 +96,7 @@ client.echo(request: "primitive")
 </details>
 
 ## File Notification Service
-<details><summary><code>client.file.notification.service.<a href="/lib/seed/file/notification/service/client.rb">get_exception</a>(notification_id) -> Seed::Types::Types::Exception</code></summary>
+<details><summary><code>client.file.notification.service.<a href="/lib/seed/file/notification/service/client.rb">get_exception</a>(notification_id:) -> Seed::Types::Types::Exception</code></summary>
 <dl>
 <dd>
 
@@ -145,7 +145,7 @@ client.file.notification.service.get_exception(notification_id: "notification-hs
 </details>
 
 ## File Service
-<details><summary><code>client.file.service.<a href="/lib/seed/file/service/client.rb">get_file</a>(filename) -> Seed::Types::Types::File</code></summary>
+<details><summary><code>client.file.service.<a href="/lib/seed/file/service/client.rb">get_file</a>(filename:) -> Seed::Types::Types::File</code></summary>
 <dl>
 <dd>
 
@@ -211,7 +211,7 @@ client.file.service.get_file(
 </details>
 
 ## Health Service
-<details><summary><code>client.health.service.<a href="/lib/seed/health/service/client.rb">check</a>(id) -> </code></summary>
+<details><summary><code>client.health.service.<a href="/lib/seed/health/service/client.rb">check</a>(id:) -> </code></summary>
 <dl>
 <dd>
 
@@ -328,7 +328,7 @@ client.health.service.ping
 </details>
 
 ## Service
-<details><summary><code>client.service.<a href="/lib/seed/service/client.rb">get_movie</a>(movie_id) -> Seed::Types::Types::Movie</code></summary>
+<details><summary><code>client.service.<a href="/lib/seed/service/client.rb">get_movie</a>(movie_id:) -> Seed::Types::Types::Movie</code></summary>
 <dl>
 <dd>
 

--- a/seed/ruby-sdk-v2/examples/readme-config/reference.md
+++ b/seed/ruby-sdk-v2/examples/readme-config/reference.md
@@ -96,7 +96,7 @@ client.echo(request: "primitive")
 </details>
 
 ## File Notification Service
-<details><summary><code>client.file.notification.service.<a href="/lib/seed/file/notification/service/client.rb">get_exception</a>(notification_id) -> Seed::Types::Types::Exception</code></summary>
+<details><summary><code>client.file.notification.service.<a href="/lib/seed/file/notification/service/client.rb">get_exception</a>(notification_id:) -> Seed::Types::Types::Exception</code></summary>
 <dl>
 <dd>
 
@@ -145,7 +145,7 @@ client.file.notification.service.get_exception(notification_id: "notification-hs
 </details>
 
 ## File Service
-<details><summary><code>client.file.service.<a href="/lib/seed/file/service/client.rb">get_file</a>(filename) -> Seed::Types::Types::File</code></summary>
+<details><summary><code>client.file.service.<a href="/lib/seed/file/service/client.rb">get_file</a>(filename:) -> Seed::Types::Types::File</code></summary>
 <dl>
 <dd>
 
@@ -211,7 +211,7 @@ client.file.service.get_file(
 </details>
 
 ## Health Service
-<details><summary><code>client.health.service.<a href="/lib/seed/health/service/client.rb">check</a>(id) -> </code></summary>
+<details><summary><code>client.health.service.<a href="/lib/seed/health/service/client.rb">check</a>(id:) -> </code></summary>
 <dl>
 <dd>
 
@@ -328,7 +328,7 @@ client.health.service.ping
 </details>
 
 ## Service
-<details><summary><code>client.service.<a href="/lib/seed/service/client.rb">get_movie</a>(movie_id) -> Seed::Types::Types::Movie</code></summary>
+<details><summary><code>client.service.<a href="/lib/seed/service/client.rb">get_movie</a>(movie_id:) -> Seed::Types::Types::Movie</code></summary>
 <dl>
 <dd>
 

--- a/seed/ruby-sdk-v2/examples/require-paths/reference.md
+++ b/seed/ruby-sdk-v2/examples/require-paths/reference.md
@@ -96,7 +96,7 @@ client.echo(request: "primitive")
 </details>
 
 ## File Notification Service
-<details><summary><code>client.file.notification.service.<a href="/lib/seed/file/notification/service/client.rb">get_exception</a>(notification_id) -> Seed::Types::Types::Exception</code></summary>
+<details><summary><code>client.file.notification.service.<a href="/lib/seed/file/notification/service/client.rb">get_exception</a>(notification_id:) -> Seed::Types::Types::Exception</code></summary>
 <dl>
 <dd>
 
@@ -145,7 +145,7 @@ client.file.notification.service.get_exception(notification_id: "notification-hs
 </details>
 
 ## File Service
-<details><summary><code>client.file.service.<a href="/lib/seed/file/service/client.rb">get_file</a>(filename) -> Seed::Types::Types::File</code></summary>
+<details><summary><code>client.file.service.<a href="/lib/seed/file/service/client.rb">get_file</a>(filename:) -> Seed::Types::Types::File</code></summary>
 <dl>
 <dd>
 
@@ -211,7 +211,7 @@ client.file.service.get_file(
 </details>
 
 ## Health Service
-<details><summary><code>client.health.service.<a href="/lib/seed/health/service/client.rb">check</a>(id) -> </code></summary>
+<details><summary><code>client.health.service.<a href="/lib/seed/health/service/client.rb">check</a>(id:) -> </code></summary>
 <dl>
 <dd>
 
@@ -328,7 +328,7 @@ client.health.service.ping
 </details>
 
 ## Service
-<details><summary><code>client.service.<a href="/lib/seed/service/client.rb">get_movie</a>(movie_id) -> Seed::Types::Types::Movie</code></summary>
+<details><summary><code>client.service.<a href="/lib/seed/service/client.rb">get_movie</a>(movie_id:) -> Seed::Types::Types::Movie</code></summary>
 <dl>
 <dd>
 

--- a/seed/ruby-sdk-v2/examples/wire-tests/reference.md
+++ b/seed/ruby-sdk-v2/examples/wire-tests/reference.md
@@ -96,7 +96,7 @@ client.echo(request: "primitive")
 </details>
 
 ## File Notification Service
-<details><summary><code>client.file.notification.service.<a href="/lib/seed/file/notification/service/client.rb">get_exception</a>(notification_id) -> Seed::Types::Types::Exception</code></summary>
+<details><summary><code>client.file.notification.service.<a href="/lib/seed/file/notification/service/client.rb">get_exception</a>(notification_id:) -> Seed::Types::Types::Exception</code></summary>
 <dl>
 <dd>
 
@@ -145,7 +145,7 @@ client.file.notification.service.get_exception(notification_id: "notification-hs
 </details>
 
 ## File Service
-<details><summary><code>client.file.service.<a href="/lib/seed/file/service/client.rb">get_file</a>(filename) -> Seed::Types::Types::File</code></summary>
+<details><summary><code>client.file.service.<a href="/lib/seed/file/service/client.rb">get_file</a>(filename:) -> Seed::Types::Types::File</code></summary>
 <dl>
 <dd>
 
@@ -211,7 +211,7 @@ client.file.service.get_file(
 </details>
 
 ## Health Service
-<details><summary><code>client.health.service.<a href="/lib/seed/health/service/client.rb">check</a>(id) -> </code></summary>
+<details><summary><code>client.health.service.<a href="/lib/seed/health/service/client.rb">check</a>(id:) -> </code></summary>
 <dl>
 <dd>
 
@@ -328,7 +328,7 @@ client.health.service.ping
 </details>
 
 ## Service
-<details><summary><code>client.service.<a href="/lib/seed/service/client.rb">get_movie</a>(movie_id) -> Seed::Types::Types::Movie</code></summary>
+<details><summary><code>client.service.<a href="/lib/seed/service/client.rb">get_movie</a>(movie_id:) -> Seed::Types::Types::Movie</code></summary>
 <dl>
 <dd>
 

--- a/seed/ruby-sdk-v2/exhaustive/wire-tests/reference.md
+++ b/seed/ruby-sdk-v2/exhaustive/wire-tests/reference.md
@@ -579,7 +579,7 @@ client.endpoints.enum.get_and_return_enum(request: "SUNNY")
 </details>
 
 ## Endpoints HTTPMethods
-<details><summary><code>client.endpoints.http_methods.<a href="/lib/seed/endpoints/http_methods/client.rb">test_get</a>(id) -> String</code></summary>
+<details><summary><code>client.endpoints.http_methods.<a href="/lib/seed/endpoints/http_methods/client.rb">test_get</a>(id:) -> String</code></summary>
 <dl>
 <dd>
 
@@ -675,7 +675,7 @@ client.endpoints.http_methods.test_post(string: "string")
 </dl>
 </details>
 
-<details><summary><code>client.endpoints.http_methods.<a href="/lib/seed/endpoints/http_methods/client.rb">test_put</a>(id, request) -> Seed::Types::Object_::Types::ObjectWithOptionalField</code></summary>
+<details><summary><code>client.endpoints.http_methods.<a href="/lib/seed/endpoints/http_methods/client.rb">test_put</a>(id:, request) -> Seed::Types::Object_::Types::ObjectWithOptionalField</code></summary>
 <dl>
 <dd>
 
@@ -734,7 +734,7 @@ client.endpoints.http_methods.test_put(
 </dl>
 </details>
 
-<details><summary><code>client.endpoints.http_methods.<a href="/lib/seed/endpoints/http_methods/client.rb">test_patch</a>(id, request) -> Seed::Types::Object_::Types::ObjectWithOptionalField</code></summary>
+<details><summary><code>client.endpoints.http_methods.<a href="/lib/seed/endpoints/http_methods/client.rb">test_patch</a>(id:, request) -> Seed::Types::Object_::Types::ObjectWithOptionalField</code></summary>
 <dl>
 <dd>
 
@@ -807,7 +807,7 @@ client.endpoints.http_methods.test_patch(
 </dl>
 </details>
 
-<details><summary><code>client.endpoints.http_methods.<a href="/lib/seed/endpoints/http_methods/client.rb">test_delete</a>(id) -> Internal::Types::Boolean</code></summary>
+<details><summary><code>client.endpoints.http_methods.<a href="/lib/seed/endpoints/http_methods/client.rb">test_delete</a>(id:) -> Internal::Types::Boolean</code></summary>
 <dl>
 <dd>
 
@@ -1087,7 +1087,7 @@ client.endpoints.object.get_and_return_nested_with_optional_field(
 </dl>
 </details>
 
-<details><summary><code>client.endpoints.object.<a href="/lib/seed/endpoints/object/client.rb">get_and_return_nested_with_required_field</a>(string, request) -> Seed::Types::Object_::Types::NestedObjectWithRequiredField</code></summary>
+<details><summary><code>client.endpoints.object.<a href="/lib/seed/endpoints/object/client.rb">get_and_return_nested_with_required_field</a>(string:, request) -> Seed::Types::Object_::Types::NestedObjectWithRequiredField</code></summary>
 <dl>
 <dd>
 
@@ -1681,7 +1681,7 @@ client.endpoints.pagination.list_items(
 </details>
 
 ## Endpoints Params
-<details><summary><code>client.endpoints.params.<a href="/lib/seed/endpoints/params/client.rb">get_with_path</a>(param) -> String</code></summary>
+<details><summary><code>client.endpoints.params.<a href="/lib/seed/endpoints/params/client.rb">get_with_path</a>(param:) -> String</code></summary>
 <dl>
 <dd>
 
@@ -1743,7 +1743,7 @@ client.endpoints.params.get_with_path(param: "param")
 </dl>
 </details>
 
-<details><summary><code>client.endpoints.params.<a href="/lib/seed/endpoints/params/client.rb">get_with_inline_path</a>(param) -> String</code></summary>
+<details><summary><code>client.endpoints.params.<a href="/lib/seed/endpoints/params/client.rb">get_with_inline_path</a>(param:) -> String</code></summary>
 <dl>
 <dd>
 
@@ -1951,7 +1951,7 @@ client.endpoints.params.get_with_query(
 </dl>
 </details>
 
-<details><summary><code>client.endpoints.params.<a href="/lib/seed/endpoints/params/client.rb">get_with_path_and_query</a>(param) -> </code></summary>
+<details><summary><code>client.endpoints.params.<a href="/lib/seed/endpoints/params/client.rb">get_with_path_and_query</a>(param:) -> </code></summary>
 <dl>
 <dd>
 
@@ -2024,7 +2024,7 @@ client.endpoints.params.get_with_path_and_query(
 </dl>
 </details>
 
-<details><summary><code>client.endpoints.params.<a href="/lib/seed/endpoints/params/client.rb">get_with_inline_path_and_query</a>(param) -> </code></summary>
+<details><summary><code>client.endpoints.params.<a href="/lib/seed/endpoints/params/client.rb">get_with_inline_path_and_query</a>(param:) -> </code></summary>
 <dl>
 <dd>
 
@@ -2097,7 +2097,7 @@ client.endpoints.params.get_with_path_and_query(
 </dl>
 </details>
 
-<details><summary><code>client.endpoints.params.<a href="/lib/seed/endpoints/params/client.rb">modify_with_path</a>(param, request) -> String</code></summary>
+<details><summary><code>client.endpoints.params.<a href="/lib/seed/endpoints/params/client.rb">modify_with_path</a>(param:, request) -> String</code></summary>
 <dl>
 <dd>
 
@@ -2170,7 +2170,7 @@ client.endpoints.params.modify_with_path(
 </dl>
 </details>
 
-<details><summary><code>client.endpoints.params.<a href="/lib/seed/endpoints/params/client.rb">modify_with_inline_path</a>(param, request) -> String</code></summary>
+<details><summary><code>client.endpoints.params.<a href="/lib/seed/endpoints/params/client.rb">modify_with_inline_path</a>(param:, request) -> String</code></summary>
 <dl>
 <dd>
 
@@ -2243,7 +2243,7 @@ client.endpoints.params.modify_with_path(
 </dl>
 </details>
 
-<details><summary><code>client.endpoints.params.<a href="/lib/seed/endpoints/params/client.rb">upload_with_path</a>(param, request) -> Seed::Types::Object_::Types::ObjectWithRequiredField</code></summary>
+<details><summary><code>client.endpoints.params.<a href="/lib/seed/endpoints/params/client.rb">upload_with_path</a>(param:, request) -> Seed::Types::Object_::Types::ObjectWithRequiredField</code></summary>
 <dl>
 <dd>
 
@@ -2378,7 +2378,7 @@ client.endpoints.params.create_with_body_and_query(
 </dl>
 </details>
 
-<details><summary><code>client.endpoints.params.<a href="/lib/seed/endpoints/params/client.rb">get_with_boolean_path</a>(param) -> String</code></summary>
+<details><summary><code>client.endpoints.params.<a href="/lib/seed/endpoints/params/client.rb">get_with_boolean_path</a>(param:) -> String</code></summary>
 <dl>
 <dd>
 
@@ -2440,7 +2440,7 @@ client.endpoints.params.get_with_boolean_path(param: true)
 </dl>
 </details>
 
-<details><summary><code>client.endpoints.params.<a href="/lib/seed/endpoints/params/client.rb">get_with_path_and_errors</a>(param) -> String</code></summary>
+<details><summary><code>client.endpoints.params.<a href="/lib/seed/endpoints/params/client.rb">get_with_path_and_errors</a>(param:) -> String</code></summary>
 <dl>
 <dd>
 
@@ -2936,7 +2936,7 @@ client.endpoints.primitive.get_and_return_base64(request: "SGVsbG8gd29ybGQh")
 </details>
 
 ## Endpoints Put
-<details><summary><code>client.endpoints.put.<a href="/lib/seed/endpoints/put/client.rb">add</a>(id) -> Seed::Endpoints::Put::Types::PutResponse</code></summary>
+<details><summary><code>client.endpoints.put.<a href="/lib/seed/endpoints/put/client.rb">add</a>(id:) -> Seed::Endpoints::Put::Types::PutResponse</code></summary>
 <dl>
 <dd>
 

--- a/seed/ruby-sdk-v2/idempotency-headers/reference.md
+++ b/seed/ruby-sdk-v2/idempotency-headers/reference.md
@@ -59,7 +59,7 @@ client.payment.create(
 </dl>
 </details>
 
-<details><summary><code>client.payment.<a href="/lib/seed/payment/client.rb">delete</a>(payment_id) -> </code></summary>
+<details><summary><code>client.payment.<a href="/lib/seed/payment/client.rb">delete</a>(payment_id:) -> </code></summary>
 <dl>
 <dd>
 

--- a/seed/ruby-sdk-v2/imdb/reference.md
+++ b/seed/ruby-sdk-v2/imdb/reference.md
@@ -73,7 +73,7 @@ client.imdb.create_movie(
 </dl>
 </details>
 
-<details><summary><code>client.imdb.<a href="/lib/seed/imdb/client.rb">get_movie</a>(movie_id) -> Seed::Types::Movie</code></summary>
+<details><summary><code>client.imdb.<a href="/lib/seed/imdb/client.rb">get_movie</a>(movie_id:) -> Seed::Types::Movie</code></summary>
 <dl>
 <dd>
 

--- a/seed/ruby-sdk-v2/literal/reference.md
+++ b/seed/ruby-sdk-v2/literal/reference.md
@@ -187,7 +187,7 @@ client.inlined.send_(
 </details>
 
 ## Path
-<details><summary><code>client.path.<a href="/lib/seed/path/client.rb">send_</a>(id) -> Seed::Types::SendResponse</code></summary>
+<details><summary><code>client.path.<a href="/lib/seed/path/client.rb">send_</a>(id:) -> Seed::Types::SendResponse</code></summary>
 <dl>
 <dd>
 

--- a/seed/ruby-sdk-v2/mixed-case/reference.md
+++ b/seed/ruby-sdk-v2/mixed-case/reference.md
@@ -1,6 +1,6 @@
 # Reference
 ## Service
-<details><summary><code>client.service.<a href="/lib/seed/service/client.rb">get_resource</a>(resource_id) -> Seed::Service::Types::Resource</code></summary>
+<details><summary><code>client.service.<a href="/lib/seed/service/client.rb">get_resource</a>(resource_id:) -> Seed::Service::Types::Resource</code></summary>
 <dl>
 <dd>
 

--- a/seed/ruby-sdk-v2/multi-line-docs/reference.md
+++ b/seed/ruby-sdk-v2/multi-line-docs/reference.md
@@ -1,6 +1,6 @@
 # Reference
 ## User
-<details><summary><code>client.user.<a href="/lib/seed/user/client.rb">get_user</a>(user_id) -> </code></summary>
+<details><summary><code>client.user.<a href="/lib/seed/user/client.rb">get_user</a>(user_id:) -> </code></summary>
 <dl>
 <dd>
 

--- a/seed/ruby-sdk-v2/no-content-response/reference.md
+++ b/seed/ruby-sdk-v2/no-content-response/reference.md
@@ -70,7 +70,7 @@ client.contacts.create(name: "name")
 </dl>
 </details>
 
-<details><summary><code>client.contacts.<a href="/lib/seed/contacts/client.rb">get</a>(id) -> Seed::Types::Contact</code></summary>
+<details><summary><code>client.contacts.<a href="/lib/seed/contacts/client.rb">get</a>(id:) -> Seed::Types::Contact</code></summary>
 <dl>
 <dd>
 

--- a/seed/ruby-sdk-v2/null-type/reference.md
+++ b/seed/ruby-sdk-v2/null-type/reference.md
@@ -71,7 +71,7 @@ client.conversations.outbound_call(to_phone_number: "to_phone_number")
 </details>
 
 ## Users
-<details><summary><code>client.users.<a href="/lib/seed/users/client.rb">get</a>(id) -> Seed::Types::User</code></summary>
+<details><summary><code>client.users.<a href="/lib/seed/users/client.rb">get</a>(id:) -> Seed::Types::User</code></summary>
 <dl>
 <dd>
 

--- a/seed/ruby-sdk-v2/nullable-optional/reference.md
+++ b/seed/ruby-sdk-v2/nullable-optional/reference.md
@@ -1,6 +1,6 @@
 # Reference
 ## NullableOptional
-<details><summary><code>client.nullable_optional.<a href="/lib/seed/nullable_optional/client.rb">get_user</a>(user_id) -> Seed::NullableOptional::Types::UserResponse</code></summary>
+<details><summary><code>client.nullable_optional.<a href="/lib/seed/nullable_optional/client.rb">get_user</a>(user_id:) -> Seed::NullableOptional::Types::UserResponse</code></summary>
 <dl>
 <dd>
 
@@ -137,7 +137,7 @@ client.nullable_optional.create_user(
 </dl>
 </details>
 
-<details><summary><code>client.nullable_optional.<a href="/lib/seed/nullable_optional/client.rb">update_user</a>(user_id, request) -> Seed::NullableOptional::Types::UserResponse</code></summary>
+<details><summary><code>client.nullable_optional.<a href="/lib/seed/nullable_optional/client.rb">update_user</a>(user_id:, request) -> Seed::NullableOptional::Types::UserResponse</code></summary>
 <dl>
 <dd>
 
@@ -492,7 +492,7 @@ client.nullable_optional.create_complex_profile(
 </dl>
 </details>
 
-<details><summary><code>client.nullable_optional.<a href="/lib/seed/nullable_optional/client.rb">get_complex_profile</a>(profile_id) -> Seed::NullableOptional::Types::ComplexProfile</code></summary>
+<details><summary><code>client.nullable_optional.<a href="/lib/seed/nullable_optional/client.rb">get_complex_profile</a>(profile_id:) -> Seed::NullableOptional::Types::ComplexProfile</code></summary>
 <dl>
 <dd>
 
@@ -554,7 +554,7 @@ client.nullable_optional.get_complex_profile(profile_id: "profileId")
 </dl>
 </details>
 
-<details><summary><code>client.nullable_optional.<a href="/lib/seed/nullable_optional/client.rb">update_complex_profile</a>(profile_id, request) -> Seed::NullableOptional::Types::ComplexProfile</code></summary>
+<details><summary><code>client.nullable_optional.<a href="/lib/seed/nullable_optional/client.rb">update_complex_profile</a>(profile_id:, request) -> Seed::NullableOptional::Types::ComplexProfile</code></summary>
 <dl>
 <dd>
 
@@ -831,7 +831,7 @@ client.nullable_optional.filter_by_role(
 </dl>
 </details>
 
-<details><summary><code>client.nullable_optional.<a href="/lib/seed/nullable_optional/client.rb">get_notification_settings</a>(user_id) -> Seed::NullableOptional::Types::NotificationMethod</code></summary>
+<details><summary><code>client.nullable_optional.<a href="/lib/seed/nullable_optional/client.rb">get_notification_settings</a>(user_id:) -> Seed::NullableOptional::Types::NotificationMethod</code></summary>
 <dl>
 <dd>
 
@@ -893,7 +893,7 @@ client.nullable_optional.get_notification_settings(user_id: "userId")
 </dl>
 </details>
 
-<details><summary><code>client.nullable_optional.<a href="/lib/seed/nullable_optional/client.rb">update_tags</a>(user_id, request) -> Internal::Types::Array[String]</code></summary>
+<details><summary><code>client.nullable_optional.<a href="/lib/seed/nullable_optional/client.rb">update_tags</a>(user_id:, request) -> Internal::Types::Array[String]</code></summary>
 <dl>
 <dd>
 

--- a/seed/ruby-sdk-v2/nullable-request-body/reference.md
+++ b/seed/ruby-sdk-v2/nullable-request-body/reference.md
@@ -1,6 +1,6 @@
 # Reference
 ## TestGroup
-<details><summary><code>client.test_group.<a href="/lib/seed/test_group/client.rb">test_method_name</a>(path_param, request) -> Object</code></summary>
+<details><summary><code>client.test_group.<a href="/lib/seed/test_group/client.rb">test_method_name</a>(path_param:, request) -> Object</code></summary>
 <dl>
 <dd>
 

--- a/seed/ruby-sdk-v2/oauth-client-credentials-openapi/reference.md
+++ b/seed/ruby-sdk-v2/oauth-client-credentials-openapi/reference.md
@@ -100,7 +100,7 @@ client.plants.list
 </dl>
 </details>
 
-<details><summary><code>client.plants.<a href="/lib/seed/plants/client.rb">get</a>(plant_id) -> Seed::Types::Plant</code></summary>
+<details><summary><code>client.plants.<a href="/lib/seed/plants/client.rb">get</a>(plant_id:) -> Seed::Types::Plant</code></summary>
 <dl>
 <dd>
 

--- a/seed/ruby-sdk-v2/oauth-client-credentials-with-variables/reference.md
+++ b/seed/ruby-sdk-v2/oauth-client-credentials-with-variables/reference.md
@@ -264,7 +264,7 @@ client.nested.api.get_something
 </details>
 
 ## Service
-<details><summary><code>client.service.<a href="/lib/seed/service/client.rb">post</a>(endpoint_param) -> </code></summary>
+<details><summary><code>client.service.<a href="/lib/seed/service/client.rb">post</a>(endpoint_param:) -> </code></summary>
 <dl>
 <dd>
 

--- a/seed/ruby-sdk-v2/openapi-request-body-ref/reference.md
+++ b/seed/ruby-sdk-v2/openapi-request-body-ref/reference.md
@@ -1,6 +1,6 @@
 # Reference
 ## Vendor
-<details><summary><code>client.vendor.<a href="/lib/seed/vendor/client.rb">update_vendor</a>(vendor_id, request) -> Seed::Types::Vendor</code></summary>
+<details><summary><code>client.vendor.<a href="/lib/seed/vendor/client.rb">update_vendor</a>(vendor_id:, request) -> Seed::Types::Vendor</code></summary>
 <dl>
 <dd>
 
@@ -164,7 +164,7 @@ client.catalog.create_catalog_image
 </dl>
 </details>
 
-<details><summary><code>client.catalog.<a href="/lib/seed/catalog/client.rb">get_catalog_image</a>(image_id) -> Seed::Types::CatalogImage</code></summary>
+<details><summary><code>client.catalog.<a href="/lib/seed/catalog/client.rb">get_catalog_image</a>(image_id:) -> Seed::Types::CatalogImage</code></summary>
 <dl>
 <dd>
 
@@ -213,7 +213,7 @@ client.catalog.get_catalog_image(image_id: "image_id")
 </details>
 
 ## TeamMember
-<details><summary><code>client.team_member.<a href="/lib/seed/team_member/client.rb">update_team_member</a>(team_member_id, request) -> Seed::Types::TeamMember</code></summary>
+<details><summary><code>client.team_member.<a href="/lib/seed/team_member/client.rb">update_team_member</a>(team_member_id:, request) -> Seed::Types::TeamMember</code></summary>
 <dl>
 <dd>
 

--- a/seed/ruby-sdk-v2/openapi-subtitle/reference.md
+++ b/seed/ruby-sdk-v2/openapi-subtitle/reference.md
@@ -53,7 +53,7 @@ client.list_plants
 </dl>
 </details>
 
-<details><summary><code>client.<a href="/lib/seed/client.rb">get_plant</a>(plant_id) -> Seed::Types::Plant</code></summary>
+<details><summary><code>client.<a href="/lib/seed/client.rb">get_plant</a>(plant_id:) -> Seed::Types::Plant</code></summary>
 <dl>
 <dd>
 

--- a/seed/ruby-sdk-v2/optional/reference.md
+++ b/seed/ruby-sdk-v2/optional/reference.md
@@ -102,7 +102,7 @@ client.optional.send_optional_typed_body(request: {
 </dl>
 </details>
 
-<details><summary><code>client.optional.<a href="/lib/seed/optional/client.rb">send_optional_nullable_with_all_optional_properties</a>(action_id, id, request) -> Seed::Optional::Types::DeployResponse</code></summary>
+<details><summary><code>client.optional.<a href="/lib/seed/optional/client.rb">send_optional_nullable_with_all_optional_properties</a>(action_id:, id:, request) -> Seed::Optional::Types::DeployResponse</code></summary>
 <dl>
 <dd>
 

--- a/seed/ruby-sdk-v2/package-yml/reference.md
+++ b/seed/ruby-sdk-v2/package-yml/reference.md
@@ -1,5 +1,5 @@
 # Reference
-<details><summary><code>client.<a href="/lib/seed/client.rb">echo</a>(id, request) -> String</code></summary>
+<details><summary><code>client.<a href="/lib/seed/client.rb">echo</a>(id:, request) -> String</code></summary>
 <dl>
 <dd>
 
@@ -60,7 +60,7 @@ client.echo(
 </details>
 
 ## Service
-<details><summary><code>client.service.<a href="/lib/seed/service/client.rb">nop</a>(id, nested_id) -> </code></summary>
+<details><summary><code>client.service.<a href="/lib/seed/service/client.rb">nop</a>(id:, nested_id:) -> </code></summary>
 <dl>
 <dd>
 

--- a/seed/ruby-sdk-v2/pagination/no-custom-config/reference.md
+++ b/seed/ruby-sdk-v2/pagination/no-custom-config/reference.md
@@ -1,6 +1,6 @@
 # Reference
 ## Conversations
-<details><summary><code>client.complex.<a href="/lib/seed/complex/client.rb">search</a>(index, request) -> Seed::Complex::Types::PaginatedConversationResponse</code></summary>
+<details><summary><code>client.complex.<a href="/lib/seed/complex/client.rb">search</a>(index:, request) -> Seed::Complex::Types::PaginatedConversationResponse</code></summary>
 <dl>
 <dd>
 

--- a/seed/ruby-sdk-v2/pagination/page-index-semantics/reference.md
+++ b/seed/ruby-sdk-v2/pagination/page-index-semantics/reference.md
@@ -1,6 +1,6 @@
 # Reference
 ## Conversations
-<details><summary><code>client.complex.<a href="/lib/seed/complex/client.rb">search</a>(index, request) -> Seed::Complex::Types::PaginatedConversationResponse</code></summary>
+<details><summary><code>client.complex.<a href="/lib/seed/complex/client.rb">search</a>(index:, request) -> Seed::Complex::Types::PaginatedConversationResponse</code></summary>
 <dl>
 <dd>
 

--- a/seed/ruby-sdk-v2/path-parameters/reference.md
+++ b/seed/ruby-sdk-v2/path-parameters/reference.md
@@ -1,6 +1,6 @@
 # Reference
 ## Organizations
-<details><summary><code>client.organizations.<a href="/lib/seed/organizations/client.rb">get_organization</a>(tenant_id, organization_id) -> Seed::Organizations::Types::Organization</code></summary>
+<details><summary><code>client.organizations.<a href="/lib/seed/organizations/client.rb">get_organization</a>(tenant_id:, organization_id:) -> Seed::Organizations::Types::Organization</code></summary>
 <dl>
 <dd>
 
@@ -59,7 +59,7 @@ client.organizations.get_organization(
 </dl>
 </details>
 
-<details><summary><code>client.organizations.<a href="/lib/seed/organizations/client.rb">get_organization_user</a>(tenant_id, organization_id, user_id) -> Seed::User::Types::User</code></summary>
+<details><summary><code>client.organizations.<a href="/lib/seed/organizations/client.rb">get_organization_user</a>(tenant_id:, organization_id:, user_id:) -> Seed::User::Types::User</code></summary>
 <dl>
 <dd>
 
@@ -127,7 +127,7 @@ client.organizations.get_organization_user(
 </dl>
 </details>
 
-<details><summary><code>client.organizations.<a href="/lib/seed/organizations/client.rb">search_organizations</a>(tenant_id, organization_id) -> Internal::Types::Array[Seed::Organizations::Types::Organization]</code></summary>
+<details><summary><code>client.organizations.<a href="/lib/seed/organizations/client.rb">search_organizations</a>(tenant_id:, organization_id:) -> Internal::Types::Array[Seed::Organizations::Types::Organization]</code></summary>
 <dl>
 <dd>
 
@@ -196,7 +196,7 @@ client.organizations.search_organizations(
 </details>
 
 ## User
-<details><summary><code>client.user.<a href="/lib/seed/user/client.rb">get_user</a>(tenant_id, user_id) -> Seed::User::Types::User</code></summary>
+<details><summary><code>client.user.<a href="/lib/seed/user/client.rb">get_user</a>(tenant_id:, user_id:) -> Seed::User::Types::User</code></summary>
 <dl>
 <dd>
 
@@ -255,7 +255,7 @@ client.user.get_user(
 </dl>
 </details>
 
-<details><summary><code>client.user.<a href="/lib/seed/user/client.rb">create_user</a>(tenant_id, request) -> Seed::User::Types::User</code></summary>
+<details><summary><code>client.user.<a href="/lib/seed/user/client.rb">create_user</a>(tenant_id:, request) -> Seed::User::Types::User</code></summary>
 <dl>
 <dd>
 
@@ -315,7 +315,7 @@ client.user.create_user(
 </dl>
 </details>
 
-<details><summary><code>client.user.<a href="/lib/seed/user/client.rb">update_user</a>(tenant_id, user_id, request) -> Seed::User::Types::User</code></summary>
+<details><summary><code>client.user.<a href="/lib/seed/user/client.rb">update_user</a>(tenant_id:, user_id:, request) -> Seed::User::Types::User</code></summary>
 <dl>
 <dd>
 
@@ -384,7 +384,7 @@ client.user.update_user(
 </dl>
 </details>
 
-<details><summary><code>client.user.<a href="/lib/seed/user/client.rb">search_users</a>(tenant_id, user_id) -> Internal::Types::Array[Seed::User::Types::User]</code></summary>
+<details><summary><code>client.user.<a href="/lib/seed/user/client.rb">search_users</a>(tenant_id:, user_id:) -> Internal::Types::Array[Seed::User::Types::User]</code></summary>
 <dl>
 <dd>
 
@@ -452,7 +452,7 @@ client.user.search_users(
 </dl>
 </details>
 
-<details><summary><code>client.user.<a href="/lib/seed/user/client.rb">get_user_metadata</a>(tenant_id, user_id, version) -> Seed::User::Types::User</code></summary>
+<details><summary><code>client.user.<a href="/lib/seed/user/client.rb">get_user_metadata</a>(tenant_id:, user_id:, version:) -> Seed::User::Types::User</code></summary>
 <dl>
 <dd>
 
@@ -534,7 +534,7 @@ client.user.get_user_metadata(
 </dl>
 </details>
 
-<details><summary><code>client.user.<a href="/lib/seed/user/client.rb">get_user_specifics</a>(tenant_id, user_id, version, thought) -> Seed::User::Types::User</code></summary>
+<details><summary><code>client.user.<a href="/lib/seed/user/client.rb">get_user_specifics</a>(tenant_id:, user_id:, version:, thought:) -> Seed::User::Types::User</code></summary>
 <dl>
 <dd>
 

--- a/seed/ruby-sdk-v2/required-nullable/reference.md
+++ b/seed/ruby-sdk-v2/required-nullable/reference.md
@@ -74,7 +74,7 @@ client.get_foo(
 </dl>
 </details>
 
-<details><summary><code>client.<a href="/lib/seed/client.rb">update_foo</a>(id, request) -> Seed::Types::Foo</code></summary>
+<details><summary><code>client.<a href="/lib/seed/client.rb">update_foo</a>(id:, request) -> Seed::Types::Foo</code></summary>
 <dl>
 <dd>
 

--- a/seed/ruby-sdk-v2/schemaless-request-body-examples/reference.md
+++ b/seed/ruby-sdk-v2/schemaless-request-body-examples/reference.md
@@ -70,7 +70,7 @@ client.create_plant(request: {
 </dl>
 </details>
 
-<details><summary><code>client.<a href="/lib/seed/client.rb">update_plant</a>(plant_id, request) -> Seed::Types::UpdatePlantResponse</code></summary>
+<details><summary><code>client.<a href="/lib/seed/client.rb">update_plant</a>(plant_id:, request) -> Seed::Types::UpdatePlantResponse</code></summary>
 <dl>
 <dd>
 

--- a/seed/ruby-sdk-v2/server-url-templating/reference.md
+++ b/seed/ruby-sdk-v2/server-url-templating/reference.md
@@ -39,7 +39,7 @@ client.get_users
 </dl>
 </details>
 
-<details><summary><code>client.<a href="/lib/seed/client.rb">get_user</a>(user_id) -> Seed::Types::User</code></summary>
+<details><summary><code>client.<a href="/lib/seed/client.rb">get_user</a>(user_id:) -> Seed::Types::User</code></summary>
 <dl>
 <dd>
 

--- a/seed/ruby-sdk-v2/simple-api/reference.md
+++ b/seed/ruby-sdk-v2/simple-api/reference.md
@@ -1,6 +1,6 @@
 # Reference
 ## User
-<details><summary><code>client.user.<a href="/lib/seed/user/client.rb">get</a>(id) -> Seed::User::Types::User</code></summary>
+<details><summary><code>client.user.<a href="/lib/seed/user/client.rb">get</a>(id:) -> Seed::User::Types::User</code></summary>
 <dl>
 <dd>
 

--- a/seed/ruby-sdk-v2/simple-fhir/reference.md
+++ b/seed/ruby-sdk-v2/simple-fhir/reference.md
@@ -1,5 +1,5 @@
 # Reference
-<details><summary><code>client.<a href="/lib/seed/client.rb">get_account</a>(account_id) -> Seed::Types::Account</code></summary>
+<details><summary><code>client.<a href="/lib/seed/client.rb">get_account</a>(account_id:) -> Seed::Types::Account</code></summary>
 <dl>
 <dd>
 

--- a/seed/ruby-sdk-v2/trace/reference.md
+++ b/seed/ruby-sdk-v2/trace/reference.md
@@ -41,7 +41,7 @@ client.v2.test
 </details>
 
 ## Admin
-<details><summary><code>client.admin.<a href="/lib/seed/admin/client.rb">update_test_submission_status</a>(submission_id, request) -> </code></summary>
+<details><summary><code>client.admin.<a href="/lib/seed/admin/client.rb">update_test_submission_status</a>(submission_id:, request) -> </code></summary>
 <dl>
 <dd>
 
@@ -100,7 +100,7 @@ client.admin.update_test_submission_status(
 </dl>
 </details>
 
-<details><summary><code>client.admin.<a href="/lib/seed/admin/client.rb">send_test_submission_update</a>(submission_id, request) -> </code></summary>
+<details><summary><code>client.admin.<a href="/lib/seed/admin/client.rb">send_test_submission_update</a>(submission_id:, request) -> </code></summary>
 <dl>
 <dd>
 
@@ -160,7 +160,7 @@ client.admin.send_test_submission_update(
 </dl>
 </details>
 
-<details><summary><code>client.admin.<a href="/lib/seed/admin/client.rb">update_workspace_submission_status</a>(submission_id, request) -> </code></summary>
+<details><summary><code>client.admin.<a href="/lib/seed/admin/client.rb">update_workspace_submission_status</a>(submission_id:, request) -> </code></summary>
 <dl>
 <dd>
 
@@ -219,7 +219,7 @@ client.admin.update_workspace_submission_status(
 </dl>
 </details>
 
-<details><summary><code>client.admin.<a href="/lib/seed/admin/client.rb">send_workspace_submission_update</a>(submission_id, request) -> </code></summary>
+<details><summary><code>client.admin.<a href="/lib/seed/admin/client.rb">send_workspace_submission_update</a>(submission_id:, request) -> </code></summary>
 <dl>
 <dd>
 
@@ -279,7 +279,7 @@ client.admin.send_workspace_submission_update(
 </dl>
 </details>
 
-<details><summary><code>client.admin.<a href="/lib/seed/admin/client.rb">store_traced_test_case</a>(submission_id, test_case_id, request) -> </code></summary>
+<details><summary><code>client.admin.<a href="/lib/seed/admin/client.rb">store_traced_test_case</a>(submission_id:, test_case_id:, request) -> </code></summary>
 <dl>
 <dd>
 
@@ -415,7 +415,7 @@ client.admin.store_traced_test_case(
 </dl>
 </details>
 
-<details><summary><code>client.admin.<a href="/lib/seed/admin/client.rb">store_traced_test_case_v2</a>(submission_id, test_case_id, request) -> </code></summary>
+<details><summary><code>client.admin.<a href="/lib/seed/admin/client.rb">store_traced_test_case_v2</a>(submission_id:, test_case_id:, request) -> </code></summary>
 <dl>
 <dd>
 
@@ -541,7 +541,7 @@ client.admin.store_traced_test_case_v2(
 </dl>
 </details>
 
-<details><summary><code>client.admin.<a href="/lib/seed/admin/client.rb">store_traced_workspace</a>(submission_id, request) -> </code></summary>
+<details><summary><code>client.admin.<a href="/lib/seed/admin/client.rb">store_traced_workspace</a>(submission_id:, request) -> </code></summary>
 <dl>
 <dd>
 
@@ -666,7 +666,7 @@ client.admin.store_traced_workspace(
 </dl>
 </details>
 
-<details><summary><code>client.admin.<a href="/lib/seed/admin/client.rb">store_traced_workspace_v2</a>(submission_id, request) -> </code></summary>
+<details><summary><code>client.admin.<a href="/lib/seed/admin/client.rb">store_traced_workspace_v2</a>(submission_id:, request) -> </code></summary>
 <dl>
 <dd>
 
@@ -922,7 +922,7 @@ client.migration.get_attempted_migrations(admin_key_header: "admin-key-header")
 </details>
 
 ## Playlist
-<details><summary><code>client.playlist.<a href="/lib/seed/playlist/client.rb">create_playlist</a>(service_param, request) -> Seed::Playlist::Types::Playlist</code></summary>
+<details><summary><code>client.playlist.<a href="/lib/seed/playlist/client.rb">create_playlist</a>(service_param:, request) -> Seed::Playlist::Types::Playlist</code></summary>
 <dl>
 <dd>
 
@@ -1014,7 +1014,7 @@ client.playlist.create_playlist(
 </dl>
 </details>
 
-<details><summary><code>client.playlist.<a href="/lib/seed/playlist/client.rb">get_playlists</a>(service_param) -> Internal::Types::Array[Seed::Playlist::Types::Playlist]</code></summary>
+<details><summary><code>client.playlist.<a href="/lib/seed/playlist/client.rb">get_playlists</a>(service_param:) -> Internal::Types::Array[Seed::Playlist::Types::Playlist]</code></summary>
 <dl>
 <dd>
 
@@ -1124,7 +1124,7 @@ description
 </dl>
 </details>
 
-<details><summary><code>client.playlist.<a href="/lib/seed/playlist/client.rb">get_playlist</a>(service_param, playlist_id) -> Seed::Playlist::Types::Playlist</code></summary>
+<details><summary><code>client.playlist.<a href="/lib/seed/playlist/client.rb">get_playlist</a>(service_param:, playlist_id:) -> Seed::Playlist::Types::Playlist</code></summary>
 <dl>
 <dd>
 
@@ -1197,7 +1197,7 @@ client.playlist.get_playlist(
 </dl>
 </details>
 
-<details><summary><code>client.playlist.<a href="/lib/seed/playlist/client.rb">update_playlist</a>(service_param, playlist_id, request) -> Seed::Playlist::Types::Playlist</code></summary>
+<details><summary><code>client.playlist.<a href="/lib/seed/playlist/client.rb">update_playlist</a>(service_param:, playlist_id:, request) -> Seed::Playlist::Types::Playlist</code></summary>
 <dl>
 <dd>
 
@@ -1282,7 +1282,7 @@ client.playlist.update_playlist(
 </dl>
 </details>
 
-<details><summary><code>client.playlist.<a href="/lib/seed/playlist/client.rb">delete_playlist</a>(service_param, playlist_id) -> </code></summary>
+<details><summary><code>client.playlist.<a href="/lib/seed/playlist/client.rb">delete_playlist</a>(service_param:, playlist_id:) -> </code></summary>
 <dl>
 <dd>
 
@@ -1460,7 +1460,7 @@ client.problem.create_problem(
 </dl>
 </details>
 
-<details><summary><code>client.problem.<a href="/lib/seed/problem/client.rb">update_problem</a>(problem_id, request) -> Seed::Problem::Types::UpdateProblemResponse</code></summary>
+<details><summary><code>client.problem.<a href="/lib/seed/problem/client.rb">update_problem</a>(problem_id:, request) -> Seed::Problem::Types::UpdateProblemResponse</code></summary>
 <dl>
 <dd>
 
@@ -1573,7 +1573,7 @@ client.problem.update_problem(
 </dl>
 </details>
 
-<details><summary><code>client.problem.<a href="/lib/seed/problem/client.rb">delete_problem</a>(problem_id) -> </code></summary>
+<details><summary><code>client.problem.<a href="/lib/seed/problem/client.rb">delete_problem</a>(problem_id:) -> </code></summary>
 <dl>
 <dd>
 
@@ -1731,7 +1731,7 @@ The method name cannot include the following characters:
 </details>
 
 ## Submission
-<details><summary><code>client.submission.<a href="/lib/seed/submission/client.rb">create_execution_session</a>(language) -> Seed::Submission::Types::ExecutionSessionResponse</code></summary>
+<details><summary><code>client.submission.<a href="/lib/seed/submission/client.rb">create_execution_session</a>(language:) -> Seed::Submission::Types::ExecutionSessionResponse</code></summary>
 <dl>
 <dd>
 
@@ -1793,7 +1793,7 @@ client.submission.create_execution_session(language: "JAVA")
 </dl>
 </details>
 
-<details><summary><code>client.submission.<a href="/lib/seed/submission/client.rb">get_execution_session</a>(session_id) -> Seed::Submission::Types::ExecutionSessionResponse</code></summary>
+<details><summary><code>client.submission.<a href="/lib/seed/submission/client.rb">get_execution_session</a>(session_id:) -> Seed::Submission::Types::ExecutionSessionResponse</code></summary>
 <dl>
 <dd>
 
@@ -1855,7 +1855,7 @@ client.submission.get_execution_session(session_id: "sessionId")
 </dl>
 </details>
 
-<details><summary><code>client.submission.<a href="/lib/seed/submission/client.rb">stop_execution_session</a>(session_id) -> </code></summary>
+<details><summary><code>client.submission.<a href="/lib/seed/submission/client.rb">stop_execution_session</a>(session_id:) -> </code></summary>
 <dl>
 <dd>
 
@@ -1958,7 +1958,7 @@ client.submission.get_execution_sessions_state
 </details>
 
 ## Sysprop
-<details><summary><code>client.sysprop.<a href="/lib/seed/sysprop/client.rb">set_num_warm_instances</a>(language, num_warm_instances) -> </code></summary>
+<details><summary><code>client.sysprop.<a href="/lib/seed/sysprop/client.rb">set_num_warm_instances</a>(language:, num_warm_instances:) -> </code></summary>
 <dl>
 <dd>
 
@@ -2166,7 +2166,7 @@ client.v2.problem.get_problems
 </dl>
 </details>
 
-<details><summary><code>client.v2.problem.<a href="/lib/seed/v2/problem/client.rb">get_latest_problem</a>(problem_id) -> Seed::V2::Problem::Types::ProblemInfoV2</code></summary>
+<details><summary><code>client.v2.problem.<a href="/lib/seed/v2/problem/client.rb">get_latest_problem</a>(problem_id:) -> Seed::V2::Problem::Types::ProblemInfoV2</code></summary>
 <dl>
 <dd>
 
@@ -2228,7 +2228,7 @@ client.v2.problem.get_latest_problem(problem_id: "problemId")
 </dl>
 </details>
 
-<details><summary><code>client.v2.problem.<a href="/lib/seed/v2/problem/client.rb">get_problem_version</a>(problem_id, problem_version) -> Seed::V2::Problem::Types::ProblemInfoV2</code></summary>
+<details><summary><code>client.v2.problem.<a href="/lib/seed/v2/problem/client.rb">get_problem_version</a>(problem_id:, problem_version:) -> Seed::V2::Problem::Types::ProblemInfoV2</code></summary>
 <dl>
 <dd>
 
@@ -2410,7 +2410,7 @@ client.v2.problem.get_problems
 </dl>
 </details>
 
-<details><summary><code>client.v2.v3.problem.<a href="/lib/seed/v2/v3/problem/client.rb">get_latest_problem</a>(problem_id) -> Seed::V2::V3::Problem::Types::ProblemInfoV2</code></summary>
+<details><summary><code>client.v2.v3.problem.<a href="/lib/seed/v2/v3/problem/client.rb">get_latest_problem</a>(problem_id:) -> Seed::V2::V3::Problem::Types::ProblemInfoV2</code></summary>
 <dl>
 <dd>
 
@@ -2472,7 +2472,7 @@ client.v2.problem.get_latest_problem(problem_id: "problemId")
 </dl>
 </details>
 
-<details><summary><code>client.v2.v3.problem.<a href="/lib/seed/v2/v3/problem/client.rb">get_problem_version</a>(problem_id, problem_version) -> Seed::V2::V3::Problem::Types::ProblemInfoV2</code></summary>
+<details><summary><code>client.v2.v3.problem.<a href="/lib/seed/v2/v3/problem/client.rb">get_problem_version</a>(problem_id:, problem_version:) -> Seed::V2::V3::Problem::Types::ProblemInfoV2</code></summary>
 <dl>
 <dd>
 

--- a/seed/ruby-sdk-v2/unions-with-local-date/reference.md
+++ b/seed/ruby-sdk-v2/unions-with-local-date/reference.md
@@ -1,6 +1,6 @@
 # Reference
 ## Bigunion
-<details><summary><code>client.bigunion.<a href="/lib/seed/bigunion/client.rb">get</a>(id) -> Seed::Bigunion::Types::BigUnion</code></summary>
+<details><summary><code>client.bigunion.<a href="/lib/seed/bigunion/client.rb">get</a>(id:) -> Seed::Bigunion::Types::BigUnion</code></summary>
 <dl>
 <dd>
 
@@ -145,7 +145,7 @@ client.bigunion.update_many(request: [])
 </details>
 
 ## Types
-<details><summary><code>client.types.<a href="/lib/seed/types/client.rb">get</a>(id) -> Seed::Types::Types::UnionWithTime</code></summary>
+<details><summary><code>client.types.<a href="/lib/seed/types/client.rb">get</a>(id:) -> Seed::Types::Types::UnionWithTime</code></summary>
 <dl>
 <dd>
 
@@ -242,7 +242,7 @@ client.types.update(request: {})
 </details>
 
 ## Union
-<details><summary><code>client.union.<a href="/lib/seed/union/client.rb">get</a>(id) -> Seed::Union::Types::Shape</code></summary>
+<details><summary><code>client.union.<a href="/lib/seed/union/client.rb">get</a>(id:) -> Seed::Union::Types::Shape</code></summary>
 <dl>
 <dd>
 

--- a/seed/ruby-sdk-v2/unions/reference.md
+++ b/seed/ruby-sdk-v2/unions/reference.md
@@ -1,6 +1,6 @@
 # Reference
 ## Bigunion
-<details><summary><code>client.bigunion.<a href="/lib/seed/bigunion/client.rb">get</a>(id) -> Seed::Bigunion::Types::BigUnion</code></summary>
+<details><summary><code>client.bigunion.<a href="/lib/seed/bigunion/client.rb">get</a>(id:) -> Seed::Bigunion::Types::BigUnion</code></summary>
 <dl>
 <dd>
 
@@ -145,7 +145,7 @@ client.bigunion.update_many(request: [])
 </details>
 
 ## Union
-<details><summary><code>client.union.<a href="/lib/seed/union/client.rb">get</a>(id) -> Seed::Union::Types::Shape</code></summary>
+<details><summary><code>client.union.<a href="/lib/seed/union/client.rb">get</a>(id:) -> Seed::Union::Types::Shape</code></summary>
 <dl>
 <dd>
 

--- a/seed/ruby-sdk-v2/variables/reference.md
+++ b/seed/ruby-sdk-v2/variables/reference.md
@@ -1,6 +1,6 @@
 # Reference
 ## Service
-<details><summary><code>client.service.<a href="/lib/seed/service/client.rb">post</a>(endpoint_param) -> </code></summary>
+<details><summary><code>client.service.<a href="/lib/seed/service/client.rb">post</a>(endpoint_param:) -> </code></summary>
 <dl>
 <dd>
 

--- a/seed/ruby-sdk-v2/version-no-default/reference.md
+++ b/seed/ruby-sdk-v2/version-no-default/reference.md
@@ -1,6 +1,6 @@
 # Reference
 ## User
-<details><summary><code>client.user.<a href="/lib/seed/user/client.rb">get_user</a>(user_id) -> Seed::User::Types::User</code></summary>
+<details><summary><code>client.user.<a href="/lib/seed/user/client.rb">get_user</a>(user_id:) -> Seed::User::Types::User</code></summary>
 <dl>
 <dd>
 

--- a/seed/ruby-sdk-v2/version/reference.md
+++ b/seed/ruby-sdk-v2/version/reference.md
@@ -1,6 +1,6 @@
 # Reference
 ## User
-<details><summary><code>client.user.<a href="/lib/seed/user/client.rb">get_user</a>(user_id) -> Seed::User::Types::User</code></summary>
+<details><summary><code>client.user.<a href="/lib/seed/user/client.rb">get_user</a>(user_id:) -> Seed::User::Types::User</code></summary>
 <dl>
 <dd>
 

--- a/seed/ruby-sdk-v2/x-fern-default/reference.md
+++ b/seed/ruby-sdk-v2/x-fern-default/reference.md
@@ -1,5 +1,5 @@
 # Reference
-<details><summary><code>client.<a href="/lib/seed/client.rb">test_get</a>(region) -> Seed::Types::TestGetResponse</code></summary>
+<details><summary><code>client.<a href="/lib/seed/client.rb">test_get</a>(region:) -> Seed::Types::TestGetResponse</code></summary>
 <dl>
 <dd>
 

--- a/seed/ruby-sdk-v2/x-fern-global-parameters/reference.md
+++ b/seed/ruby-sdk-v2/x-fern-global-parameters/reference.md
@@ -1,6 +1,6 @@
 # Reference
 ## Products
-<details><summary><code>client.products.<a href="/lib/seed/products/client.rb">search</a>(region_id, request) -> Seed::Products::Types::SearchProductsResponse</code></summary>
+<details><summary><code>client.products.<a href="/lib/seed/products/client.rb">search</a>(region_id:, request) -> Seed::Products::Types::SearchProductsResponse</code></summary>
 <dl>
 <dd>
 
@@ -64,7 +64,7 @@ client.products.search(region_id: "regionId")
 </dl>
 </details>
 
-<details><summary><code>client.products.<a href="/lib/seed/products/client.rb">get</a>(region_id, product_id) -> Seed::Types::Product</code></summary>
+<details><summary><code>client.products.<a href="/lib/seed/products/client.rb">get</a>(region_id:, product_id:) -> Seed::Types::Product</code></summary>
 <dl>
 <dd>
 


### PR DESCRIPTION
## Description
Generated Ruby (ruby-v2) client methods only accept keyword arguments (`def fetch_store(request_options: {}, **params)`), but the `reference.md` endpoint titles rendered path parameters positionally — e.g. `fetch_store(store_id)` — which misleads users into calling `fetch_store("id")` and getting `wrong number of arguments (given 1, expected 0)`. (Reported by Twilio in FERN_SDK_ISSUES.md issue #8; the usage snippets already show the correct keyword form.)

## Changes Made
- `buildReference.ts` (`getReferenceEndpointInvocationParameters`): render path parameters in keyword form, e.g. `fetch_store(store_id:)` / `get_user(tenant_id:, user_id:)`
- Regenerated `seed/ruby-sdk-v2` reference.md snapshots (45 fixtures, title lines only)
- Added changelog entry under `generators/ruby-v2/sdk/changes/unreleased/`
- [ ] Updated README.md generator (if applicable)

## Testing
- [x] `pnpm seed test --generator ruby-sdk-v2 --skip-scripts` — 137/137 passed
- [x] Manual review of snapshot diff: only `<details><summary>` title lines changed

Link to Devin session: https://app.devin.ai/sessions/2d0b1166b9014d149763c18c42124a4b
Requested by: @iamnamananand996