### PR TITLE
fix(typescript,csharp,php,ruby): send grant_type in OAuth token requests and wire OAuth under any-composed auth

### DIFF
--- a/generators/csharp/sdk/changes/unreleased/fix-oauth-any-auth-wiring.yml
+++ b/generators/csharp/sdk/changes/unreleased/fix-oauth-any-auth-wiring.yml
@@ -1,0 +1,9 @@
+- summary: |
+    Wire OAuth client-credentials authentication into the root client when the OAuth
+    scheme is not the first scheme in the API's auth configuration (e.g.
+    `auth: any` with basic auth listed before OAuth). Previously the OAuth token
+    provider was only generated when OAuth was the first auth scheme, so the root
+    client silently fell back to the other schemes and never used the OAuth
+    credentials. When both an OAuth and an inferred auth scheme are present, the
+    provider-based scheme that appears first in the auth configuration is used.
+  type: fix

--- a/generators/csharp/sdk/changes/unreleased/fix-oauth-grant-type.yml
+++ b/generators/csharp/sdk/changes/unreleased/fix-oauth-grant-type.yml
@@ -1,0 +1,7 @@
+- summary: |
+    Send `grant_type: "client_credentials"` in the OAuth token request when the
+    token endpoint's `grant_type` property is a non-literal string. Previously the
+    property was omitted (when optional) or surfaced as a required constructor
+    parameter (when required), so token endpoints that require `grant_type`
+    rejected the request.
+  type: fix

--- a/generators/csharp/sdk/src/SdkGeneratorContext.ts
+++ b/generators/csharp/sdk/src/SdkGeneratorContext.ts
@@ -346,12 +346,13 @@ export class SdkGeneratorContext extends GeneratorContext {
     }
 
     public getOauth(): FernIr.OAuthScheme | undefined {
-        if (
-            this.ir.auth.schemes[0] != null &&
-            this.ir.auth.schemes[0].type === "oauth" &&
-            this.config.generateOauthClients
-        ) {
-            return this.ir.auth.schemes[0];
+        if (!this.config.generateOauthClients) {
+            return undefined;
+        }
+        for (const scheme of this.ir.auth.schemes) {
+            if (scheme.type === "oauth") {
+                return scheme;
+            }
         }
         return undefined;
     }

--- a/generators/csharp/sdk/src/oauth/OauthTokenProviderGenerator.ts
+++ b/generators/csharp/sdk/src/oauth/OauthTokenProviderGenerator.ts
@@ -1,4 +1,4 @@
-import { GeneratorError } from "@fern-api/base-generator";
+import { GeneratorError, getOriginalName } from "@fern-api/base-generator";
 import { CSharpFile, FileGenerator } from "@fern-api/csharp-base";
 import { ast, is, lazy } from "@fern-api/csharp-codegen";
 import { join, RelativeFilePath } from "@fern-api/fs-utils";
@@ -37,6 +37,7 @@ export class OauthTokenProviderGenerator extends FileGenerator<CSharpFile, SdkGe
     private expiresIn: ResponseProperty | undefined;
     private requestType: ast.ClassReference;
     private additionalRequestFields = new Map<string, ast.Field>();
+    private grantTypePropertyName: string | undefined;
 
     constructor({ context, scheme }: OauthTokenProviderGenerator.Args) {
         super(context);
@@ -110,6 +111,12 @@ export class OauthTokenProviderGenerator extends FileGenerator<CSharpFile, SdkGe
         // properties as required constructor parameters.
         for (const customProperty of this.scheme.configuration.tokenEndpoint.requestProperties.customProperties ?? []) {
             if (isLiteralTypeReference(customProperty.property.valueType)) {
+                continue;
+            }
+            if (isGrantTypeProperty(customProperty)) {
+                this.grantTypePropertyName = this.model.getPropertyNameFor(
+                    this.case.resolveNameAndWireValue(customProperty.property.name)
+                );
                 continue;
             }
             const typeRef = this.context.csharpTypeMapper.convert({
@@ -225,6 +232,16 @@ export class OauthTokenProviderGenerator extends FileGenerator<CSharpFile, SdkGe
                                             name: this.request.secret,
                                             assignment: this.csharp.codeblock(this.clientSecretField.name)
                                         },
+                                        ...(this.grantTypePropertyName != null
+                                            ? [
+                                                  {
+                                                      name: this.grantTypePropertyName,
+                                                      assignment: this.csharp.codeblock(
+                                                          `"${CLIENT_CREDENTIALS_GRANT_TYPE}"`
+                                                      )
+                                                  }
+                                              ]
+                                            : []),
                                         ...this.additionalRequestFields.entries().map(([name, field]) => {
                                             return {
                                                 name,
@@ -369,4 +386,15 @@ export class OauthTokenProviderGenerator extends FileGenerator<CSharpFile, SdkGe
  */
 function isLiteralTypeReference(typeReference: FernIr.TypeReference): boolean {
     return typeReference.type === "container" && typeReference.container.type === "literal";
+}
+
+const GRANT_TYPE_WIRE_VALUE = "grant_type";
+const CLIENT_CREDENTIALS_GRANT_TYPE = "client_credentials";
+
+/**
+ * The client-credentials grant type is synthesized in the token request
+ * rather than surfaced as a constructor parameter.
+ */
+function isGrantTypeProperty(requestProperty: FernIr.RequestProperty): boolean {
+    return getOriginalName(requestProperty.property.name) === GRANT_TYPE_WIRE_VALUE;
 }

--- a/generators/csharp/sdk/src/root-client/RootClientGenerator.ts
+++ b/generators/csharp/sdk/src/root-client/RootClientGenerator.ts
@@ -85,6 +85,31 @@ export class RootClientGenerator extends FileGenerator<CSharpFile, SdkGeneratorC
             this.serviceId != null ? this.context.getGrpcClientInfoForServiceId(this.serviceId) : undefined;
     }
 
+    /**
+     * Both OAuth and inferred auth attach their Authorization header through a
+     * token provider, and only one provider can drive the root client's auth
+     * header. When both schemes are present (e.g. `auth: any` with an OAuth and
+     * an inferred scheme), pick the provider-based scheme that appears first in
+     * `ir.auth.schemes`, which mirrors the declared `any` order.
+     */
+    private shouldUseOAuthProvider(): boolean {
+        if (this.oauth == null) {
+            return false;
+        }
+        if (this.inferred == null) {
+            return true;
+        }
+        for (const scheme of this.context.ir.auth.schemes) {
+            if (scheme.type === "oauth") {
+                return true;
+            }
+            if (scheme.type === "inferred") {
+                return false;
+            }
+        }
+        return true;
+    }
+
     private members = lazy({
         clientOptionsParameterName: () => "clientOptions",
         client: () => this.Types.RootClient.explicit("_client"),
@@ -613,7 +638,7 @@ export class RootClientGenerator extends FileGenerator<CSharpFile, SdkGeneratorC
                         }
                     }
 
-                    if (this.oauth != null) {
+                    if (this.oauth != null && this.shouldUseOAuthProvider()) {
                         const authClientClassReference = this.context.getSubpackageClassReferenceForServiceId(
                             this.oauth.configuration.tokenEndpoint.endpointReference.serviceId
                         );
@@ -659,7 +684,7 @@ export class RootClientGenerator extends FileGenerator<CSharpFile, SdkGeneratorC
                         }
                     }
 
-                    if (this.inferred != null) {
+                    if (this.inferred != null && !this.shouldUseOAuthProvider()) {
                         const authClientClassReference = this.context.getSubpackageClassReferenceForServiceId(
                             this.inferred.tokenEndpoint.endpoint.serviceId
                         );

--- a/generators/php/sdk/changes/unreleased/fix-oauth-any-auth-wiring.yml
+++ b/generators/php/sdk/changes/unreleased/fix-oauth-any-auth-wiring.yml
@@ -1,0 +1,9 @@
+- summary: |
+    Wire OAuth client-credentials authentication into the root client when the OAuth
+    scheme is not the first scheme in the API's auth configuration (e.g.
+    `auth: any` with basic auth listed before OAuth). Previously the OAuth token
+    provider was only generated when OAuth was the first auth scheme, so the root
+    client silently fell back to the other schemes and never used the OAuth
+    credentials. When both an OAuth and an inferred auth scheme are present, the
+    provider-based scheme that appears first in the auth configuration is used.
+  type: fix

--- a/generators/php/sdk/changes/unreleased/fix-oauth-grant-type.yml
+++ b/generators/php/sdk/changes/unreleased/fix-oauth-grant-type.yml
@@ -1,0 +1,7 @@
+- summary: |
+    Send `grant_type: "client_credentials"` in the OAuth token request when the
+    token endpoint's `grant_type` property is a non-literal string. Previously the
+    property was omitted (when optional) or surfaced as a required constructor
+    parameter (when required), so token endpoints that require `grant_type`
+    rejected the request.
+  type: fix

--- a/generators/php/sdk/src/SdkGeneratorContext.ts
+++ b/generators/php/sdk/src/SdkGeneratorContext.ts
@@ -814,12 +814,13 @@ export class SdkGeneratorContext extends AbstractPhpGeneratorContext<SdkCustomCo
     }
 
     public getOauth(): FernIr.OAuthScheme | undefined {
-        if (
-            this.ir.auth.schemes[0] != null &&
-            this.ir.auth.schemes[0].type === "oauth" &&
-            this.config.generateOauthClients
-        ) {
-            return this.ir.auth.schemes[0];
+        if (!this.config.generateOauthClients) {
+            return undefined;
+        }
+        for (const scheme of this.ir.auth.schemes) {
+            if (scheme.type === "oauth") {
+                return scheme;
+            }
         }
         return undefined;
     }

--- a/generators/php/sdk/src/oauth/OauthTokenProviderGenerator.ts
+++ b/generators/php/sdk/src/oauth/OauthTokenProviderGenerator.ts
@@ -6,7 +6,11 @@ import { FernIr } from "@fern-fern/ir-sdk";
 
 import { SdkCustomConfigSchema } from "../SdkCustomConfig.js";
 import { SdkGeneratorContext } from "../SdkGeneratorContext.js";
-import { getOAuthTokenRequestProperties, OAuthTokenRequestProperty } from "./oauthTokenRequestProperties.js";
+import {
+    getOAuthTokenRequestProperties,
+    isGrantTypeProperty,
+    OAuthTokenRequestProperty
+} from "./oauthTokenRequestProperties.js";
 
 export declare namespace OauthTokenProviderGenerator {
     interface Args {
@@ -18,6 +22,7 @@ export declare namespace OauthTokenProviderGenerator {
 export class OauthTokenProviderGenerator extends FileGenerator<PhpFile, SdkCustomConfigSchema, SdkGeneratorContext> {
     private static readonly CLASS_NAME = "OAuthTokenProvider";
     private static readonly BUFFER_IN_MINUTES = 2;
+    private static readonly CLIENT_CREDENTIALS_GRANT_TYPE = "client_credentials";
 
     private readonly case: CaseConverter;
     private scheme: FernIr.OAuthScheme;
@@ -252,6 +257,10 @@ export class OauthTokenProviderGenerator extends FileGenerator<PhpFile, SdkCusto
                     const literal = this.context.maybeLiteral(customProperty.property.valueType);
                     if (literal != null) {
                         writer.writeLine(`'${propName}' => ${this.context.getLiteralAsString(literal)},`);
+                    } else if (isGrantTypeProperty(customProperty)) {
+                        writer.writeLine(
+                            `'${propName}' => '${OauthTokenProviderGenerator.CLIENT_CREDENTIALS_GRANT_TYPE}',`
+                        );
                     }
                 }
 

--- a/generators/php/sdk/src/oauth/oauthTokenRequestProperties.ts
+++ b/generators/php/sdk/src/oauth/oauthTokenRequestProperties.ts
@@ -1,3 +1,4 @@
+import { getOriginalName } from "@fern-api/base-generator";
 import { FernIr } from "@fern-fern/ir-sdk";
 
 import { SdkGeneratorContext } from "../SdkGeneratorContext.js";
@@ -15,6 +16,16 @@ export interface OAuthTokenRequestProperty {
     valueType: FernIr.TypeReference;
     /** Whether the property is optional on the token request. */
     isOptional: boolean;
+}
+
+const GRANT_TYPE_WIRE_VALUE = "grant_type";
+
+/**
+ * The client-credentials grant type is synthesized in the token request
+ * rather than surfaced as a constructor parameter.
+ */
+export function isGrantTypeProperty(requestProperty: FernIr.RequestProperty): boolean {
+    return getOriginalName(requestProperty.property.name) === GRANT_TYPE_WIRE_VALUE;
 }
 
 /**
@@ -40,6 +51,9 @@ export function getOAuthTokenRequestProperties(
             continue;
         }
         if (context.isOptional(valueType)) {
+            continue;
+        }
+        if (isGrantTypeProperty(candidate)) {
             continue;
         }
         properties.push({

--- a/generators/php/sdk/src/root-client/RootClientGenerator.ts
+++ b/generators/php/sdk/src/root-client/RootClientGenerator.ts
@@ -101,7 +101,7 @@ export class RootClientGenerator extends FileGenerator<PhpFile, SdkCustomConfigS
 
         // Add field for OAuth token provider if using client credentials OAuth
         const oauth = this.context.getOauth();
-        if (oauth != null && oauth.configuration.type === "clientCredentials") {
+        if (oauth != null && oauth.configuration.type === "clientCredentials" && this.shouldUseOAuthProvider()) {
             class_.addField(
                 php.field({
                     name: "$oauthTokenProvider",
@@ -118,7 +118,7 @@ export class RootClientGenerator extends FileGenerator<PhpFile, SdkCustomConfigS
 
         // Add field for inferred auth provider if using inferred auth
         const inferredAuth = this.context.getInferredAuth();
-        if (inferredAuth != null) {
+        if (inferredAuth != null && !this.shouldUseOAuthProvider()) {
             class_.addField(
                 php.field({
                     name: "$inferredAuthProvider",
@@ -483,8 +483,9 @@ export class RootClientGenerator extends FileGenerator<PhpFile, SdkCustomConfigS
                 // OAuth and inferred auth provider setup - moved after environment setup
                 const oauth = this.context.getOauth();
                 const inferredAuth = this.context.getInferredAuth();
-                const hasOAuth = oauth != null && oauth.configuration.type === "clientCredentials";
-                const hasInferredAuth = inferredAuth != null;
+                const hasOAuth =
+                    oauth != null && oauth.configuration.type === "clientCredentials" && this.shouldUseOAuthProvider();
+                const hasInferredAuth = inferredAuth != null && !this.shouldUseOAuthProvider();
                 const oauthCredGuard = "$clientId !== null && $clientSecret !== null";
                 const inferredCredGuard =
                     inferredAuth != null ? this.getInferredAuthCredentialGuard(inferredAuth) : null;
@@ -1212,6 +1213,32 @@ export class RootClientGenerator extends FileGenerator<PhpFile, SdkCustomConfigS
      * exactly one scheme's creds), so we must not throw for missing creds and must
      * only wire up a scheme's token provider / header when its creds are present.
      */
+    /**
+     * Both OAuth and inferred auth attach their auth headers through a token
+     * provider, and only one provider can drive the root client's
+     * `getAuthHeaders` callback. When both schemes are present (e.g. `auth: any`
+     * with an OAuth and an inferred scheme), pick the provider-based scheme that
+     * appears first in `ir.auth.schemes`, which mirrors the declared `any` order.
+     */
+    private shouldUseOAuthProvider(): boolean {
+        const oauth = this.context.getOauth();
+        if (oauth == null || oauth.configuration.type !== "clientCredentials") {
+            return false;
+        }
+        if (this.context.getInferredAuth() == null) {
+            return true;
+        }
+        for (const scheme of this.context.ir.auth.schemes) {
+            if (scheme.type === "oauth") {
+                return true;
+            }
+            if (scheme.type === "inferred") {
+                return false;
+            }
+        }
+        return true;
+    }
+
     private isAnyAuthWithMultipleSchemes(): boolean {
         return this.context.ir.auth.requirement === "ANY" && this.context.ir.auth.schemes.length > 1;
     }

--- a/generators/php/sdk/src/root-client/RootClientGenerator.ts
+++ b/generators/php/sdk/src/root-client/RootClientGenerator.ts
@@ -1009,10 +1009,18 @@ export class RootClientGenerator extends FileGenerator<PhpFile, SdkCustomConfigS
         writer.writeNode(oauthTokenProviderClassReference);
         // When wrapped in a credential guard (any-composed auth), clientId/clientSecret
         // are non-null inside the block, so the `?? ''` fallback would be redundant.
+        // Env-var-backed params are also non-null, but only when the OAuth scheme's own
+        // constructor parameters were generated (they are skipped when a bearer scheme
+        // exists) — the env-or-throw assignment is tied to those parameters.
+        const oauthParamsSkipped = this.context.ir.auth.schemes.some((s) => s.type === "bearer");
         const clientIdFallback =
-            guarded || oauth.configuration.clientIdEnvVar != null ? "$clientId" : "$clientId ?? ''";
+            guarded || (oauth.configuration.clientIdEnvVar != null && !oauthParamsSkipped)
+                ? "$clientId"
+                : "$clientId ?? ''";
         const clientSecretFallback =
-            guarded || oauth.configuration.clientSecretEnvVar != null ? "$clientSecret" : "$clientSecret ?? ''";
+            guarded || (oauth.configuration.clientSecretEnvVar != null && !oauthParamsSkipped)
+                ? "$clientSecret"
+                : "$clientSecret ?? ''";
         const isAuthMandatory = this.context.ir.sdkConfig.isAuthMandatory;
         const extraArgs = getOAuthTokenRequestProperties(
             this.context,

--- a/generators/ruby-v2/sdk/changes/unreleased/fix-oauth-grant-type.yml
+++ b/generators/ruby-v2/sdk/changes/unreleased/fix-oauth-grant-type.yml
@@ -1,0 +1,7 @@
+- summary: |
+    Send `grant_type: "client_credentials"` in the OAuth token request when the
+    token endpoint's `grant_type` property is a non-literal string. Previously the
+    property was omitted (when optional) or surfaced as a required constructor
+    parameter (when required), so token endpoints that require `grant_type`
+    rejected the request.
+  type: fix

--- a/generators/ruby-v2/sdk/src/oauth/OAuthProviderGenerator.ts
+++ b/generators/ruby-v2/sdk/src/oauth/OAuthProviderGenerator.ts
@@ -15,10 +15,21 @@ export declare namespace OAuthProviderGenerator {
     }
 }
 
+const GRANT_TYPE_SNAKE_NAME = "grant_type";
+const CLIENT_CREDENTIALS_GRANT_TYPE = "client_credentials";
+
 interface TokenEndpointProperty {
     snakeName: string;
     isOptional: boolean;
     literal?: FernIr.Literal;
+}
+
+/**
+ * The client-credentials grant type is synthesized in the token request
+ * rather than surfaced as a constructor parameter.
+ */
+function isGrantTypeProperty(property: TokenEndpointProperty): boolean {
+    return property.snakeName === GRANT_TYPE_SNAKE_NAME;
 }
 
 /**
@@ -317,6 +328,11 @@ export class OAuthProviderGenerator extends FileGenerator<RubyFile, SdkCustomCon
                 });
             } else if (property.literal != null) {
                 entries.push({ wireName: property.snakeName, value: this.getLiteralAsRubyString(property.literal) });
+            } else if (isGrantTypeProperty(property)) {
+                entries.push({
+                    wireName: property.snakeName,
+                    value: `"${CLIENT_CREDENTIALS_GRANT_TYPE}"`
+                });
             } else if (!property.isOptional) {
                 entries.push({ wireName: property.snakeName, value: `@options[:${property.snakeName}]` });
             }
@@ -344,7 +360,7 @@ export class OAuthProviderGenerator extends FileGenerator<RubyFile, SdkCustomCon
             if (property.snakeName === clientIdWire || property.snakeName === clientSecretWire) {
                 continue;
             }
-            if (property.literal != null || property.isOptional) {
+            if (property.literal != null || property.isOptional || isGrantTypeProperty(property)) {
                 continue;
             }
             names.push(property.snakeName);

--- a/generators/typescript/sdk/changes/unreleased/fix-oauth-grant-type.yml
+++ b/generators/typescript/sdk/changes/unreleased/fix-oauth-grant-type.yml
@@ -1,0 +1,8 @@
+- summary: |
+    Send `grant_type: "client_credentials"` in the OAuth token request when the token
+    endpoint models `grant_type` as a plain (non-literal) string. Previously the
+    generated `OAuthAuthProvider` omitted `grant_type` entirely, so token requests
+    against OpenAPI-imported specs (where `grant_type` is an optional string rather
+    than a literal) failed. A required non-literal `grant_type` is no longer surfaced
+    as a user-supplied client-credentials option; it is synthesized automatically.
+  type: fix

--- a/generators/typescript/sdk/client-class-generator/src/auth-provider/OAuthAuthProviderGenerator.ts
+++ b/generators/typescript/sdk/client-class-generator/src/auth-provider/OAuthAuthProviderGenerator.ts
@@ -33,6 +33,8 @@ const EXPIRES_AT_FIELD_NAME = "expiresAt";
 const REFRESH_PROMISE_FIELD_NAME = "refreshPromise";
 const DEFAULT_TOKEN_OVERRIDE_PROPERTY_NAME = "token";
 const DEFAULT_EXPIRES_IN_SECONDS = 3600; // 1 hour
+const GRANT_TYPE_WIRE_VALUE = "grant_type";
+const CLIENT_CREDENTIALS_GRANT_TYPE = "client_credentials";
 
 export class OAuthAuthProviderGenerator implements AuthProviderGenerator {
     public static readonly CLASS_NAME = CLASS_NAME;
@@ -901,13 +903,19 @@ export class OAuthAuthProviderGenerator implements AuthProviderGenerator {
         // cause TypeScript excess-property errors because the generated request
         // type excludes those literals. We only need to emit them when the
         // request type keeps them as required fields (i.e. non-inlined bodies).
-        if (endpoint.requestBody?.type === "inlinedRequestBody") {
-            return "";
-        }
+        //
+        // A non-literal grant_type property is always emitted with the
+        // "client_credentials" value: the client credentials flow requires
+        // grant_type=client_credentials (RFC 6749 §4.4.2), and nothing else
+        // supplies it when the spec models it as a plain string.
+        const isInlinedRequestBody = endpoint.requestBody?.type === "inlinedRequestBody";
         const assignments: string[] = [];
         for (const customProperty of requestProperties.customProperties ?? []) {
             const resolvedType = context.type.resolveTypeReference(customProperty.property.valueType);
             if (resolvedType.type === "container" && resolvedType.container.type === "literal") {
+                if (isInlinedRequestBody) {
+                    continue;
+                }
                 const propertyName = this.getName(customProperty.property.name, context);
                 const literalValue = resolvedType.container.literal._visit<string>({
                     string: (val: string) => JSON.stringify(val),
@@ -917,6 +925,11 @@ export class OAuthAuthProviderGenerator implements AuthProviderGenerator {
                     }
                 });
                 assignments.push(`\n                    ${propertyName}: ${literalValue},`);
+            } else if (this.isGrantTypeProperty(customProperty)) {
+                const propertyName = this.getName(customProperty.property.name, context);
+                assignments.push(
+                    `\n                    ${getPropertyKey(propertyName)}: ${JSON.stringify(CLIENT_CREDENTIALS_GRANT_TYPE)},`
+                );
             }
         }
         return assignments.join("");
@@ -945,7 +958,9 @@ export class OAuthAuthProviderGenerator implements AuthProviderGenerator {
             additionalProperties.push(requestProperties.scopes);
         }
         for (const customProperty of requestProperties.customProperties ?? []) {
-            if (isRequiredNonLiteral(customProperty)) {
+            // grant_type is synthesized as "client_credentials" in the token
+            // request, so it is never surfaced as a user-supplied option.
+            if (isRequiredNonLiteral(customProperty) && !this.isGrantTypeProperty(customProperty)) {
                 additionalProperties.push(customProperty);
             }
         }
@@ -966,6 +981,10 @@ export class OAuthAuthProviderGenerator implements AuthProviderGenerator {
                     `\n                    ${getPropertyKey(property.name)}: this.${OPTIONS_FIELD_NAME}${wrapperAccess}[${JSON.stringify(property.name)}],`
             )
             .join("");
+    }
+
+    private isGrantTypeProperty(requestProperty: FernIr.RequestProperty): boolean {
+        return getOriginalName(requestProperty.property.name) === GRANT_TYPE_WIRE_VALUE;
     }
 
     private getName(name: FernIr.Name | FernIr.NameAndWireValue | string, context: FileContext): string {

--- a/seed/csharp-sdk/any-auth/src/SeedAnyAuth.Test/Unit/MockServer/BaseMockServerTest.cs
+++ b/seed/csharp-sdk/any-auth/src/SeedAnyAuth.Test/Unit/MockServer/BaseMockServerTest.cs
@@ -14,6 +14,35 @@ public class BaseMockServerTest
 
     protected RequestOptions RequestOptions { get; set; } = new();
 
+    private void MockOAuthEndpoint()
+    {
+        const string requestJson = """
+            {
+              "client_id": "client_id",
+              "client_secret": "client_secret",
+              "audience": "https://api.example.com",
+              "grant_type": "client_credentials"
+            }
+            """;
+
+        const string mockResponse = """
+            {
+              "access_token": "access_token",
+              "expires_in": 1,
+              "refresh_token": "refresh_token"
+            }
+            """;
+
+        Server
+            .Given(WireMock.RequestBuilders.Request.Create().WithPath("/token").UsingPost())
+            .RespondWith(
+                WireMock
+                    .ResponseBuilders.Response.Create()
+                    .WithStatusCode(200)
+                    .WithBody(mockResponse)
+            );
+    }
+
     private void MockInferredAuthEndpoint()
     {
         const string requestJson = """
@@ -67,6 +96,7 @@ public class BaseMockServerTest
             "PASSWORD",
             clientOptions: new ClientOptions { BaseUrl = Server.Urls[0], MaxRetries = 0 }
         );
+        MockOAuthEndpoint();
         MockInferredAuthEndpoint();
     }
 

--- a/seed/csharp-sdk/any-auth/src/SeedAnyAuth/Core/OAuthTokenProvider.cs
+++ b/seed/csharp-sdk/any-auth/src/SeedAnyAuth/Core/OAuthTokenProvider.cs
@@ -1,0 +1,42 @@
+using SeedAnyAuth;
+
+namespace SeedAnyAuth.Core;
+
+public partial class OAuthTokenProvider
+{
+    private const double BufferInMinutes = 2;
+
+    private AuthClient _client;
+
+    private string? _accessToken;
+
+    private DateTime? _expiresAt;
+
+    private string _clientId;
+
+    private string _clientSecret;
+
+    public OAuthTokenProvider(string clientId, string clientSecret, AuthClient client)
+    {
+        _clientId = clientId;
+        _clientSecret = clientSecret;
+        _client = client;
+    }
+
+    public async Task<string> GetAccessTokenAsync()
+    {
+        if (_accessToken == null || DateTime.UtcNow >= _expiresAt)
+        {
+            var tokenResponse = await _client
+                .GetTokenAsync(
+                    new GetTokenRequest { ClientId = _clientId, ClientSecret = _clientSecret }
+                )
+                .ConfigureAwait(false);
+            _accessToken = tokenResponse.AccessToken;
+            _expiresAt = DateTime
+                .UtcNow.AddSeconds(tokenResponse.ExpiresIn)
+                .AddMinutes(-BufferInMinutes);
+        }
+        return $"Bearer {_accessToken}";
+    }
+}

--- a/seed/csharp-sdk/any-auth/src/SeedAnyAuth/SeedAnyAuthClient.cs
+++ b/seed/csharp-sdk/any-auth/src/SeedAnyAuth/SeedAnyAuthClient.cs
@@ -55,16 +55,14 @@ public partial class SeedAnyAuthClient : ISeedAnyAuthClient
         }
         if (clientId != null && clientSecret != null)
         {
-            var inferredAuthProvider = new InferredAuthTokenProvider(
+            var tokenProvider = new OAuthTokenProvider(
                 clientId,
                 clientSecret,
                 new AuthClient(new RawClient(clientOptions))
             );
             clientOptionsWithAuth.Headers["Authorization"] =
                 new Func<global::System.Threading.Tasks.ValueTask<string>>(async () =>
-                    (await inferredAuthProvider.GetAuthHeadersAsync().ConfigureAwait(false))
-                        .First()
-                        .Value
+                    await tokenProvider.GetAccessTokenAsync().ConfigureAwait(false)
                 );
         }
         _client = new RawClient(clientOptionsWithAuth);

--- a/seed/csharp-sdk/endpoint-security-auth/src/SeedEndpointSecurityAuth.Test/Unit/MockServer/BaseMockServerTest.cs
+++ b/seed/csharp-sdk/endpoint-security-auth/src/SeedEndpointSecurityAuth.Test/Unit/MockServer/BaseMockServerTest.cs
@@ -14,6 +14,35 @@ public class BaseMockServerTest
 
     protected RequestOptions RequestOptions { get; set; } = new();
 
+    private void MockOAuthEndpoint()
+    {
+        const string requestJson = """
+            {
+              "client_id": "client_id",
+              "client_secret": "client_secret",
+              "audience": "https://api.example.com",
+              "grant_type": "client_credentials"
+            }
+            """;
+
+        const string mockResponse = """
+            {
+              "access_token": "access_token",
+              "expires_in": 1,
+              "refresh_token": "refresh_token"
+            }
+            """;
+
+        Server
+            .Given(WireMock.RequestBuilders.Request.Create().WithPath("/token").UsingPost())
+            .RespondWith(
+                WireMock
+                    .ResponseBuilders.Response.Create()
+                    .WithStatusCode(200)
+                    .WithBody(mockResponse)
+            );
+    }
+
     private void MockInferredAuthEndpoint()
     {
         const string requestJson = """
@@ -67,6 +96,7 @@ public class BaseMockServerTest
             "PASSWORD",
             clientOptions: new ClientOptions { BaseUrl = Server.Urls[0], MaxRetries = 0 }
         );
+        MockOAuthEndpoint();
         MockInferredAuthEndpoint();
     }
 

--- a/seed/csharp-sdk/endpoint-security-auth/src/SeedEndpointSecurityAuth/Core/OAuthTokenProvider.cs
+++ b/seed/csharp-sdk/endpoint-security-auth/src/SeedEndpointSecurityAuth/Core/OAuthTokenProvider.cs
@@ -1,0 +1,42 @@
+using SeedEndpointSecurityAuth;
+
+namespace SeedEndpointSecurityAuth.Core;
+
+public partial class OAuthTokenProvider
+{
+    private const double BufferInMinutes = 2;
+
+    private AuthClient _client;
+
+    private string? _accessToken;
+
+    private DateTime? _expiresAt;
+
+    private string _clientId;
+
+    private string _clientSecret;
+
+    public OAuthTokenProvider(string clientId, string clientSecret, AuthClient client)
+    {
+        _clientId = clientId;
+        _clientSecret = clientSecret;
+        _client = client;
+    }
+
+    public async Task<string> GetAccessTokenAsync()
+    {
+        if (_accessToken == null || DateTime.UtcNow >= _expiresAt)
+        {
+            var tokenResponse = await _client
+                .GetTokenAsync(
+                    new GetTokenRequest { ClientId = _clientId, ClientSecret = _clientSecret }
+                )
+                .ConfigureAwait(false);
+            _accessToken = tokenResponse.AccessToken;
+            _expiresAt = DateTime
+                .UtcNow.AddSeconds(tokenResponse.ExpiresIn)
+                .AddMinutes(-BufferInMinutes);
+        }
+        return $"Bearer {_accessToken}";
+    }
+}

--- a/seed/csharp-sdk/endpoint-security-auth/src/SeedEndpointSecurityAuth/SeedEndpointSecurityAuthClient.cs
+++ b/seed/csharp-sdk/endpoint-security-auth/src/SeedEndpointSecurityAuth/SeedEndpointSecurityAuthClient.cs
@@ -74,16 +74,14 @@ public partial class SeedEndpointSecurityAuthClient : ISeedEndpointSecurityAuthC
             clientOptionsWithAuth.Headers["Authorization"] =
                 $"Basic {Convert.ToBase64String(global::System.Text.Encoding.UTF8.GetBytes($"{username}:{password}"))}";
         }
-        var inferredAuthProvider = new InferredAuthTokenProvider(
+        var tokenProvider = new OAuthTokenProvider(
             clientId,
             clientSecret,
             new AuthClient(new RawClient(clientOptions))
         );
         clientOptionsWithAuth.Headers["Authorization"] =
             new Func<global::System.Threading.Tasks.ValueTask<string>>(async () =>
-                (await inferredAuthProvider.GetAuthHeadersAsync().ConfigureAwait(false))
-                    .First()
-                    .Value
+                await tokenProvider.GetAccessTokenAsync().ConfigureAwait(false)
             );
         _client = new RawClient(clientOptionsWithAuth);
         Auth = new AuthClient(_client);

--- a/seed/php-sdk/any-auth/src/Core/OAuthTokenProvider.php
+++ b/seed/php-sdk/any-auth/src/Core/OAuthTokenProvider.php
@@ -1,0 +1,116 @@
+<?php
+
+namespace Seed\Core;
+
+use Seed\Auth\AuthClient;
+use DateTime;
+use Seed\Auth\Requests\GetTokenRequest;
+use Seed\Exceptions\SeedException;
+
+/**
+ * The OAuthTokenProvider retrieves an OAuth access token, refreshing it as needed.
+ * The access token is then used as the bearer token in every authenticated request.
+ */
+class OAuthTokenProvider
+{
+    /**
+     * @var int $BUFFER_IN_MINUTES
+     */
+    private int $BUFFER_IN_MINUTES = 2;
+
+    /**
+     * @var string $clientId
+     */
+    private string $clientId;
+
+    /**
+     * @var string $clientSecret
+     */
+    private string $clientSecret;
+
+    /**
+     * @var AuthClient $authClient
+     */
+    private AuthClient $authClient;
+
+    /**
+     * @var ?string $accessToken
+     */
+    private ?string $accessToken;
+
+    /**
+     * @var ?DateTime $expiresAt
+     */
+    private ?DateTime $expiresAt;
+
+    /**
+     * @param string $clientId The client ID for OAuth authentication.
+     * @param string $clientSecret The client secret for OAuth authentication.
+     * @param AuthClient $authClient The client used to retrieve the OAuth token.
+     */
+    public function __construct(
+        string $clientId,
+        string $clientSecret,
+        AuthClient $authClient,
+    ) {
+        $this->clientId = $clientId;
+        $this->clientSecret = $clientSecret;
+        $this->authClient = $authClient;
+        $this->accessToken = null;
+        $this->expiresAt = null;
+    }
+
+    /**
+     * Returns a cached access token, refreshing if necessary.
+     *
+     * @return string
+     */
+    public function getToken(): string
+    {
+        if ($this->accessToken !== null && ($this->expiresAt === null || $this->expiresAt > new DateTime())) {
+            return $this->accessToken;
+        }
+        return $this->refresh();
+    }
+
+    /**
+     * Refreshes the access token by calling the token endpoint.
+     *
+     * @return string
+     */
+    private function refresh(): string
+    {
+        $request = new GetTokenRequest([
+            'clientId' => $this->clientId,
+            'clientSecret' => $this->clientSecret,
+            'audience' => 'https://api.example.com',
+            'grantType' => 'client_credentials',
+        ]);
+
+        $tokenResponse = $this->authClient->getToken($request);
+
+        if ($tokenResponse === null) {
+            throw new SeedException(message: "Expected a token response, but received an empty response.");
+        }
+
+        $this->accessToken = $tokenResponse->accessToken;
+        $this->expiresAt = $this->getExpiresAt($tokenResponse->expiresIn, $this->BUFFER_IN_MINUTES);
+
+        return $this->accessToken;
+    }
+
+    /**
+     * Calculates the expiration time with a buffer.
+     *
+     * @param int $expiresInSeconds The number of seconds until the token expires.
+     * @param int $bufferInMinutes The buffer time in minutes to subtract from the expiration.
+     * @return DateTime
+     */
+    private function getExpiresAt(int $expiresInSeconds, int $bufferInMinutes): DateTime
+    {
+        $now = new DateTime();
+        $expiresInSecondsWithBuffer = $expiresInSeconds - ($bufferInMinutes * 60);
+        $now->modify("+{$expiresInSecondsWithBuffer} seconds");
+        return $now;
+    }
+}

--- a/seed/php-sdk/any-auth/src/SeedClient.php
+++ b/seed/php-sdk/any-auth/src/SeedClient.php
@@ -6,7 +6,7 @@ use Seed\Auth\AuthClient;
 use Seed\User\UserClient;
 use Psr\Http\Client\ClientInterface;
 use Seed\Core\Client\RawClient;
-use Seed\Core\InferredAuthProvider;
+use Seed\Core\OAuthTokenProvider;
 
 class SeedClient
 {
@@ -37,9 +37,9 @@ class SeedClient
     private RawClient $client;
 
     /**
-     * @var InferredAuthProvider $inferredAuthProvider
+     * @var OAuthTokenProvider $oauthTokenProvider
      */
-    private InferredAuthProvider $inferredAuthProvider;
+    private OAuthTokenProvider $oauthTokenProvider;
 
     /**
      * @param ?string $token The token to use for authentication.
@@ -90,13 +90,7 @@ class SeedClient
         if ($clientId !== null && $clientSecret !== null) {
             $authRawClient = new RawClient(['headers' => []]);
             $authClient = new AuthClient($authRawClient);
-            $inferredAuthOptions = [
-                'clientId' => $clientId,
-                'clientSecret' => $clientSecret,
-                'audience' => 'https://api.example.com',
-                'grantType' => 'client_credentials',
-            ];
-            $this->inferredAuthProvider = new InferredAuthProvider($authClient, $inferredAuthOptions);
+            $this->oauthTokenProvider = new OAuthTokenProvider($clientId, $clientSecret, $authClient);
 
         }
         $this->options['headers'] = array_merge(
@@ -106,7 +100,7 @@ class SeedClient
 
         if ($clientId !== null && $clientSecret !== null) {
             $this->options['getAuthHeaders'] = fn () =>
-                $this->inferredAuthProvider->getAuthHeaders();
+                ['Authorization' => "Bearer " . $this->oauthTokenProvider->getToken()];
         }
 
         $this->client = new RawClient(

--- a/seed/php-sdk/endpoint-security-auth/src/Core/OAuthTokenProvider.php
+++ b/seed/php-sdk/endpoint-security-auth/src/Core/OAuthTokenProvider.php
@@ -1,0 +1,116 @@
+<?php
+
+namespace Seed\Core;
+
+use Seed\Auth\AuthClient;
+use DateTime;
+use Seed\Auth\Requests\GetTokenRequest;
+use Seed\Exceptions\SeedException;
+
+/**
+ * The OAuthTokenProvider retrieves an OAuth access token, refreshing it as needed.
+ * The access token is then used as the bearer token in every authenticated request.
+ */
+class OAuthTokenProvider
+{
+    /**
+     * @var int $BUFFER_IN_MINUTES
+     */
+    private int $BUFFER_IN_MINUTES = 2;
+
+    /**
+     * @var string $clientId
+     */
+    private string $clientId;
+
+    /**
+     * @var string $clientSecret
+     */
+    private string $clientSecret;
+
+    /**
+     * @var AuthClient $authClient
+     */
+    private AuthClient $authClient;
+
+    /**
+     * @var ?string $accessToken
+     */
+    private ?string $accessToken;
+
+    /**
+     * @var ?DateTime $expiresAt
+     */
+    private ?DateTime $expiresAt;
+
+    /**
+     * @param string $clientId The client ID for OAuth authentication.
+     * @param string $clientSecret The client secret for OAuth authentication.
+     * @param AuthClient $authClient The client used to retrieve the OAuth token.
+     */
+    public function __construct(
+        string $clientId,
+        string $clientSecret,
+        AuthClient $authClient,
+    ) {
+        $this->clientId = $clientId;
+        $this->clientSecret = $clientSecret;
+        $this->authClient = $authClient;
+        $this->accessToken = null;
+        $this->expiresAt = null;
+    }
+
+    /**
+     * Returns a cached access token, refreshing if necessary.
+     *
+     * @return string
+     */
+    public function getToken(): string
+    {
+        if ($this->accessToken !== null && ($this->expiresAt === null || $this->expiresAt > new DateTime())) {
+            return $this->accessToken;
+        }
+        return $this->refresh();
+    }
+
+    /**
+     * Refreshes the access token by calling the token endpoint.
+     *
+     * @return string
+     */
+    private function refresh(): string
+    {
+        $request = new GetTokenRequest([
+            'clientId' => $this->clientId,
+            'clientSecret' => $this->clientSecret,
+            'audience' => 'https://api.example.com',
+            'grantType' => 'client_credentials',
+        ]);
+
+        $tokenResponse = $this->authClient->getToken($request);
+
+        if ($tokenResponse === null) {
+            throw new SeedException(message: "Expected a token response, but received an empty response.");
+        }
+
+        $this->accessToken = $tokenResponse->accessToken;
+        $this->expiresAt = $this->getExpiresAt($tokenResponse->expiresIn, $this->BUFFER_IN_MINUTES);
+
+        return $this->accessToken;
+    }
+
+    /**
+     * Calculates the expiration time with a buffer.
+     *
+     * @param int $expiresInSeconds The number of seconds until the token expires.
+     * @param int $bufferInMinutes The buffer time in minutes to subtract from the expiration.
+     * @return DateTime
+     */
+    private function getExpiresAt(int $expiresInSeconds, int $bufferInMinutes): DateTime
+    {
+        $now = new DateTime();
+        $expiresInSecondsWithBuffer = $expiresInSeconds - ($bufferInMinutes * 60);
+        $now->modify("+{$expiresInSecondsWithBuffer} seconds");
+        return $now;
+    }
+}

--- a/seed/php-sdk/endpoint-security-auth/src/SeedClient.php
+++ b/seed/php-sdk/endpoint-security-auth/src/SeedClient.php
@@ -6,7 +6,7 @@ use Seed\Auth\AuthClient;
 use Seed\User\UserClient;
 use Psr\Http\Client\ClientInterface;
 use Seed\Core\Client\RawClient;
-use Seed\Core\InferredAuthProvider;
+use Seed\Core\OAuthTokenProvider;
 use Exception;
 
 class SeedClient
@@ -38,9 +38,9 @@ class SeedClient
     private RawClient $client;
 
     /**
-     * @var InferredAuthProvider $inferredAuthProvider
+     * @var OAuthTokenProvider $oauthTokenProvider
      */
-    private InferredAuthProvider $inferredAuthProvider;
+    private OAuthTokenProvider $oauthTokenProvider;
 
     /**
      * @param ?string $token The token to use for authentication.
@@ -84,13 +84,7 @@ class SeedClient
 
         $authRawClient = new RawClient(['headers' => []]);
         $authClient = new AuthClient($authRawClient);
-        $inferredAuthOptions = [
-            'clientId' => $clientId ?? '',
-            'clientSecret' => $clientSecret ?? '',
-            'audience' => 'https://api.example.com',
-            'grantType' => 'client_credentials',
-        ];
-        $this->inferredAuthProvider = new InferredAuthProvider($authClient, $inferredAuthOptions);
+        $this->oauthTokenProvider = new OAuthTokenProvider($clientId ?? '', $clientSecret ?? '', $authClient);
 
         $this->options['headers'] = array_merge(
             $defaultHeaders,
@@ -98,7 +92,7 @@ class SeedClient
         );
 
         $this->options['getAuthHeaders'] = fn () =>
-            $this->inferredAuthProvider->getAuthHeaders();
+            ['Authorization' => "Bearer " . $this->oauthTokenProvider->getToken()];
 
         $this->client = new RawClient(
             options: $this->options,

--- a/seed/ts-sdk/ts-oauth-token-optional/no-custom-config/README.md
+++ b/seed/ts-sdk/ts-oauth-token-optional/no-custom-config/README.md
@@ -46,7 +46,8 @@ import { SeedTsOauthTokenOptionalClient } from "@fern/ts-oauth-token-optional";
 const client = new SeedTsOauthTokenOptionalClient({ baseUrl: "YOUR_BASE_URL", clientId: "YOUR_CLIENT_ID", clientSecret: "YOUR_CLIENT_SECRET" });
 await client.auth.createOauth2Token({
     client_id: "my_oauth_app_123",
-    client_secret: "sk_live_abcdef123456789"
+    client_secret: "sk_live_abcdef123456789",
+    grant_type: "client_credentials"
 });
 ```
 

--- a/seed/ts-sdk/ts-oauth-token-optional/no-custom-config/reference.md
+++ b/seed/ts-sdk/ts-oauth-token-optional/no-custom-config/reference.md
@@ -15,7 +15,8 @@
 ```typescript
 await client.auth.createOauth2Token({
     client_id: "my_oauth_app_123",
-    client_secret: "sk_live_abcdef123456789"
+    client_secret: "sk_live_abcdef123456789",
+    grant_type: "client_credentials"
 });
 
 ```

--- a/seed/ts-sdk/ts-oauth-token-optional/no-custom-config/snippet.json
+++ b/seed/ts-sdk/ts-oauth-token-optional/no-custom-config/snippet.json
@@ -8,7 +8,7 @@
             },
             "snippet": {
                 "type": "typescript",
-                "client": "import { SeedTsOauthTokenOptionalClient } from \"@fern/ts-oauth-token-optional\";\n\nconst client = new SeedTsOauthTokenOptionalClient({ baseUrl: \"YOUR_BASE_URL\", clientId: \"YOUR_CLIENT_ID\", clientSecret: \"YOUR_CLIENT_SECRET\" });\nawait client.auth.createOauth2Token({\n    client_id: \"my_oauth_app_123\",\n    client_secret: \"sk_live_abcdef123456789\"\n});\n"
+                "client": "import { SeedTsOauthTokenOptionalClient } from \"@fern/ts-oauth-token-optional\";\n\nconst client = new SeedTsOauthTokenOptionalClient({ baseUrl: \"YOUR_BASE_URL\", clientId: \"YOUR_CLIENT_ID\", clientSecret: \"YOUR_CLIENT_SECRET\" });\nawait client.auth.createOauth2Token({\n    client_id: \"my_oauth_app_123\",\n    client_secret: \"sk_live_abcdef123456789\",\n    grant_type: \"client_credentials\"\n});\n"
             }
         }
     ],

--- a/seed/ts-sdk/ts-oauth-token-optional/no-custom-config/src/api/resources/auth/client/Client.ts
+++ b/seed/ts-sdk/ts-oauth-token-optional/no-custom-config/src/api/resources/auth/client/Client.ts
@@ -29,7 +29,8 @@ export class AuthClient {
      * @example
      *     await client.auth.createOauth2Token({
      *         client_id: "my_oauth_app_123",
-     *         client_secret: "sk_live_abcdef123456789"
+     *         client_secret: "sk_live_abcdef123456789",
+     *         grant_type: "client_credentials"
      *     })
      */
     public createOauth2Token(
@@ -55,10 +56,7 @@ export class AuthClient {
             contentType: "application/x-www-form-urlencoded",
             queryString: core.url.queryBuilder().mergeAdditional(requestOptions?.queryParams).build(),
             requestType: "form",
-            body: mergeAdditionalBodyParameters(
-                { ...request, grant_type: "client_credentials" },
-                requestOptions?.additionalBodyParameters,
-            ),
+            body: mergeAdditionalBodyParameters(request, requestOptions?.additionalBodyParameters),
             timeoutMs: (requestOptions?.timeoutInSeconds ?? this._options?.timeoutInSeconds ?? 60) * 1000,
             maxRetries: requestOptions?.maxRetries ?? this._options?.maxRetries,
             abortSignal: requestOptions?.abortSignal,

--- a/seed/ts-sdk/ts-oauth-token-optional/no-custom-config/src/api/resources/auth/client/requests/CreateOauth2TokenRequest.ts
+++ b/seed/ts-sdk/ts-oauth-token-optional/no-custom-config/src/api/resources/auth/client/requests/CreateOauth2TokenRequest.ts
@@ -4,10 +4,12 @@
  * @example
  *     {
  *         client_id: "my_oauth_app_123",
- *         client_secret: "sk_live_abcdef123456789"
+ *         client_secret: "sk_live_abcdef123456789",
+ *         grant_type: "client_credentials"
  *     }
  */
 export interface CreateOauth2TokenRequest {
     client_id: string;
     client_secret: string;
+    grant_type?: string;
 }

--- a/seed/ts-sdk/ts-oauth-token-optional/no-custom-config/src/auth/OAuthAuthProvider.ts
+++ b/seed/ts-sdk/ts-oauth-token-optional/no-custom-config/src/auth/OAuthAuthProvider.ts
@@ -91,6 +91,7 @@ export class OAuthAuthProvider implements core.AuthProvider {
                 const tokenResponse = await this.authClient.createOauth2Token({
                     client_id: clientId,
                     client_secret: clientSecret,
+                    grant_type: "client_credentials",
                 });
 
                 const accessToken = tokenResponse.access_token;

--- a/seed/ts-sdk/ts-oauth-token-optional/no-custom-config/tests/wire/auth.test.ts
+++ b/seed/ts-sdk/ts-oauth-token-optional/no-custom-config/tests/wire/auth.test.ts
@@ -34,6 +34,7 @@ describe("AuthClient", () => {
         const response = await client.auth.createOauth2Token({
             client_id: "my_oauth_app_123",
             client_secret: "sk_live_abcdef123456789",
+            grant_type: "client_credentials",
         });
         expect(response).toEqual(rawResponseBody);
     });

--- a/test-definitions/fern/apis/ts-oauth-token-optional/definition/auth.yml
+++ b/test-definitions/fern/apis/ts-oauth-token-optional/definition/auth.yml
@@ -21,7 +21,7 @@ service:
           properties:
             client_id: string
             client_secret: string
-            grant_type: literal<"client_credentials">
+            grant_type: optional<string>
       response: TokenResponse
       examples:
         - request:


### PR DESCRIPTION
## Description

Fixes OAuth client-credentials bugs reported against a customer spec (Twilio) where the token endpoint models `grant_type` as a plain (non-literal) string and OAuth is composed under `auth: any` behind another scheme:

1. **TypeScript**: the generated `OAuthAuthProvider` omitted `grant_type` from the token request when the spec models it as a non-literal string, so token endpoints that require it rejected the call.
2. **C# / PHP**: `getOauth()` only looked at the *first* auth scheme, so with `auth: any: [BasicAuth, OAuth]` the OAuth credentials were accepted but never wired into the root client — only Basic auth was configured.
3. **C# / PHP / Ruby**: the generated `OAuthTokenProvider`s also omitted `grant_type` from their token request bodies (only `client_id`/`client_secret`), or surfaced it as a required constructor parameter.

## Changes Made
- TypeScript: synthesize `grant_type: "client_credentials"` in the token request when the `grant_type` property is a non-literal string; exclude it from user-supplied auth options.
- C#: `getOauth()` scans all auth schemes; root client wires `OAuthTokenProvider` (Bearer header) under `any`-composed auth, with deterministic precedence when both OAuth and inferred schemes exist; `OauthTokenProviderGenerator` now emits `GrantType = "client_credentials"` in the token request instead of omitting it / requiring a constructor parameter.
- PHP: same `getOauth()` scan + root-client wiring; `OAuthTokenProvider::refresh()` now sends `'grantType' => 'client_credentials'`; grant_type excluded from constructor parameters.
- Ruby (ruby-v2): `OAuthProvider#refresh` now sends `grant_type: "client_credentials"` when the property is a non-literal string, instead of omitting it or surfacing it as a root-client constructor parameter.
- Added `ts-oauth-token-optional` regression fixture (non-literal `grant_type`) and regenerated affected seed outputs.
- Added unreleased changelog entries for typescript, csharp, php, and ruby-v2 SDK generators.
- [ ] Updated README.md generator (if applicable)

## Testing
- [x] Seed tests pass for ts-sdk, csharp-sdk, php-sdk, and ruby-sdk-v2 OAuth fixtures (`oauth-client-credentials*`, `any-auth`, `endpoint-security-auth`) with no unintended snapshot changes (existing fixtures use literal `grant_type` and are unaffected).
- [x] Manual verification against the actual Twilio spec with locally built generators: TS sends `grant_type: "client_credentials"`; C#/PHP root clients construct `OAuthTokenProvider` and set the Bearer Authorization header; C# emits `GrantType = "client_credentials"`, PHP emits `'grantType' => 'client_credentials'`, and Ruby emits `grant_type: "client_credentials"` in the token request — none surface grant_type as a constructor parameter.


Link to Devin session: https://app.devin.ai/sessions/bcf4b7c2276949d289d2a40c1977e832
Requested by: @iamnamananand996
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/17049" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->