### PR TITLE
fix(generator-cli): pin fern-api[bot] identity on PAT-authenticated API commits

### DIFF
--- a/packages/generator-cli/changes/unreleased/fix-pat-committer-attribution.yml
+++ b/packages/generator-cli/changes/unreleased/fix-pat-committer-attribution.yml
@@ -1,0 +1,8 @@
+- summary: |
+    Pin the Fern bot identity as author/committer on API-created commits when the
+    GitHub token is a personal access token (`ghp_`/`github_pat_`). PATs cannot
+    auto-sign commits, so omitting the identity fields (the 0.9.40 behavior)
+    attributed self-hosted push/PR commits to the PAT owner, breaking CI filters
+    that key off the `fern-api[bot]` committer. Signing-capable tokens (App
+    installation, OAuth) are unchanged and keep the "Verified" signature.
+  type: fix

--- a/packages/generator-cli/src/__test__/pushSignedCommit.test.ts
+++ b/packages/generator-cli/src/__test__/pushSignedCommit.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from "vitest";
 
-import { isNonFastForwardError, pushSignedCommit } from "../pipeline/github/pushSignedCommit.js";
+import { isNonFastForwardError, pushSignedCommit, resolveCommitAuthor } from "../pipeline/github/pushSignedCommit.js";
 
 interface MockedRepository {
     getHeadSha: ReturnType<typeof vi.fn>;
@@ -435,6 +435,30 @@ describe("pushSignedCommit", () => {
         ).rejects.toBe(boom);
 
         expect(octokit.git.deleteRef).toHaveBeenCalled();
+    });
+});
+
+describe("resolveCommitAuthor", () => {
+    const fernBot = { name: "fern-api", email: "115122769+fern-api[bot]@users.noreply.github.com" };
+
+    it("returns the explicit author when provided", () => {
+        const author = { name: "custom", email: "custom@example.com" };
+        expect(resolveCommitAuthor("ghp_abc123", author)).toBe(author);
+        expect(resolveCommitAuthor("ghs_abc123", author)).toBe(author);
+    });
+
+    it("pins the Fern bot identity for classic PATs", () => {
+        expect(resolveCommitAuthor("ghp_abc123", undefined)).toEqual(fernBot);
+    });
+
+    it("pins the Fern bot identity for fine-grained PATs", () => {
+        expect(resolveCommitAuthor("github_pat_abc123", undefined)).toEqual(fernBot);
+    });
+
+    it("returns undefined for signing-capable tokens", () => {
+        expect(resolveCommitAuthor("ghs_installation", undefined)).toBeUndefined();
+        expect(resolveCommitAuthor("gho_oauth", undefined)).toBeUndefined();
+        expect(resolveCommitAuthor("unknown-token", undefined)).toBeUndefined();
     });
 });
 

--- a/packages/generator-cli/src/pipeline/github/pushSignedCommit.ts
+++ b/packages/generator-cli/src/pipeline/github/pushSignedCommit.ts
@@ -3,6 +3,7 @@ import type { ClonedRepository } from "@fern-api/github";
 import type { Octokit } from "@octokit/rest";
 
 import type { PipelineLogger } from "../PipelineLogger";
+import { FERN_BOT_EMAIL, FERN_BOT_NAME } from "./constants";
 
 const MAX_CONCURRENT_PUSH_RETRIES = 3;
 
@@ -16,6 +17,28 @@ const MAX_SIGNED_CHAIN_LENGTH = 20;
 export interface CommitAuthor {
     name: string;
     email: string;
+}
+
+const PAT_TOKEN_PREFIXES = ["ghp_", "github_pat_"];
+
+/**
+ * Resolves the commit identity to send to the Git Data API for the given auth token.
+ *
+ * Personal access tokens cannot auto-sign API-created commits, and omitting the
+ * identity fields attributes them to the PAT owner. Pinning the Fern bot identity
+ * keeps author/committer stable for tooling that filters on them (e.g. CI
+ * ignore-committer rules). Signing-capable principals (App installation `ghs_`,
+ * OAuth `gho_`) keep the omitted default so GitHub attributes the commit to the
+ * bot user and stamps the "Verified" signature.
+ */
+export function resolveCommitAuthor(token: string, author: CommitAuthor | undefined): CommitAuthor | undefined {
+    if (author != null) {
+        return author;
+    }
+    if (PAT_TOKEN_PREFIXES.some((prefix) => token.startsWith(prefix))) {
+        return { name: FERN_BOT_NAME, email: FERN_BOT_EMAIL };
+    }
+    return undefined;
 }
 
 export interface PushSignedCommitOptions {

--- a/packages/generator-cli/src/pipeline/steps/GithubStep.ts
+++ b/packages/generator-cli/src/pipeline/steps/GithubStep.ts
@@ -7,7 +7,7 @@ import { changelogContainsVersion, prependChangelogBlock } from "../../autoversi
 import { createReplayBranch } from "../github/createReplayBranch";
 import { findExistingUpdatablePR } from "../github/findExistingUpdatablePR";
 import { parseCommitMessageForPR } from "../github/parseCommitMessage";
-import { pushSignedCommit } from "../github/pushSignedCommit";
+import { pushSignedCommit, resolveCommitAuthor } from "../github/pushSignedCommit";
 import type { PipelineLogger } from "../PipelineLogger";
 import { formatReplayPrBody } from "../replay-summary";
 import type {
@@ -210,7 +210,7 @@ export class GithubStep extends BaseStep {
                 repo,
                 branch: prBranch,
                 force: isUpdatingExistingPR,
-                author: this.config.author,
+                author: resolveCommitAuthor(this.config.token, this.config.author),
                 logger: this.logger
             });
             const pushedBranch = await repository.getCurrentBranch();
@@ -370,7 +370,7 @@ export class GithubStep extends BaseStep {
                 branch: baseBranch,
                 force: false,
                 rebaseOnConflict: true,
-                author: this.config.author,
+                author: resolveCommitAuthor(this.config.token, this.config.author),
                 logger: this.logger
             });
 
@@ -425,7 +425,7 @@ export class GithubStep extends BaseStep {
                 branch: baseBranch,
                 force: false,
                 rebaseOnConflict: true,
-                author: this.config.author,
+                author: resolveCommitAuthor(this.config.token, this.config.author),
                 logger: this.logger
             });
 


### PR DESCRIPTION
## Description
Self-hosted `mode: push` / `pull-request` generations authenticated with a personal access token (`ghp_` / `github_pat_`) have been landing commits attributed to the PAT owner instead of `fern-api[bot]` since generator-cli 0.9.40, which removed the default author on API-created commits (`pushSignedCommit` omits `author`/`committer` so GitHub can auto-sign — but PATs are never signing-capable, so GitHub fills both fields in from the PAT owner). This breaks downstream CI filters that key off the bot committer (e.g. Jenkins multibranch `Ignore Committer Strategy`).

This restores the 0.9.28 attribution behavior for PAT tokens only, keeping the 0.9.40 auto-signing behavior for signing-capable tokens.

## Changes Made
- Add `resolveCommitAuthor(token, author)` in `pushSignedCommit.ts`:
  ```
  author provided        -> use it (unchanged)
  token is ghp_/github_pat_ -> pin { FERN_BOT_NAME, FERN_BOT_EMAIL } as author+committer
  otherwise (ghs_/gho_/...) -> omit both so GitHub attributes to the App/OAuth bot user and signs
  ```
- `GithubStep` now passes `resolveCommitAuthor(this.config.token, this.config.author)` to all three `pushSignedCommit` call sites (PR branch push, push mode, commit-and-release mode)
- Changelog entry under `packages/generator-cli/changes/unreleased/`
- [ ] Updated README.md generator (if applicable)

## Testing
- [x] Unit tests added/updated (`resolveCommitAuthor` cases in `pushSignedCommit.test.ts`; existing signing tests unchanged)
- [x] Manual testing completed (`pnpm turbo run compile/test --filter @fern-api/generator-cli` green)

Link to Devin session: https://app.devin.ai/sessions/efb00b0049f74743a4587b9a823c978e
Requested by: @iamnamananand996