### PR TITLE
fix(go): unbreak go-v2 compile in optional-header env fallback

### DIFF
--- a/generators/go-v2/sdk/src/client/ClientGenerator.ts
+++ b/generators/go-v2/sdk/src/client/ClientGenerator.ts
@@ -476,7 +476,7 @@ export class ClientGenerator extends FileGenerator<GoFile, SdkCustomConfigSchema
     private writeHeaderEnvironmentVariables({ writer }: { writer: go.Writer }): void {
         for (const header of this.context.ir.headers) {
             if (header.env != null) {
-                if (isTypeReferenceOptional(header.valueType)) {
+                if (isTypeReferencePointer(header.valueType, this.context.ir.types)) {
                     this.writeOptionalEnvConditional({
                         writer,
                         propertyReference: this.getOptionsPropertyReference(header.name),

--- a/generators/go/sdk/changes/unreleased/fix-go-v2-compile-optional-header-env.yml
+++ b/generators/go/sdk/changes/unreleased/fix-go-v2-compile-optional-header-env.yml
@@ -1,0 +1,6 @@
+- summary: |
+    Fix a generator compile error introduced by two concurrent changes: the optional
+    global-header env fallback now uses `isTypeReferencePointer` (which also covers
+    `nullable` and aliased optional headers) instead of the removed
+    `isTypeReferenceOptional` export.
+  type: fix


### PR DESCRIPTION
## Description
Linear ticket: N/A

The go-sdk 1.49.2 release failed to publish: `@fern-api/go-sdk` no longer compiles on main.

```
src/client/ClientGenerator.ts(479,21): error TS2552: Cannot find name 'isTypeReferenceOptional'. Did you mean 'isTypeReferencePointer'?
```

Two concurrently merged PRs conflicted semantically: #17062 called the exported `isTypeReferenceOptional(header.valueType)` from `authUtils.ts`, while another change un-exported it and changed its signature to `(typeRef, irTypes)`, adding `isTypeReferencePointer`. The call site now uses `isTypeReferencePointer(header.valueType, this.context.ir.types)`, which also covers `nullable` and aliased optional headers.

## Changes Made
- `generators/go-v2/sdk/src/client/ClientGenerator.ts`: replace the stale `isTypeReferenceOptional(header.valueType)` call with `isTypeReferencePointer(header.valueType, this.context.ir.types)`
- Changelog: `generators/go/sdk/changes/unreleased/fix-go-v2-compile-optional-header-env.yml`
- [ ] Updated README.md generator (if applicable)

## Testing
- [x] Unit tests added/updated: existing `go-optional-header-env` seed fixture passes (`pnpm seed test --generator go-sdk --fixture go-optional-header-env` — generation + go build + go test, output unchanged)
- [x] Manual testing completed: `pnpm turbo run compile --filter @fern-api/go-sdk` succeeds

Link to Devin session: https://app.devin.ai/sessions/2d0b1166b9014d149763c18c42124a4b
Requested by: @iamnamananand996