### PR TITLE
fix(ci): publish @fern-api/dynamic-ir-sdk from the runner via OIDC

### DIFF
--- a/.github/workflows/ir-release.yml
+++ b/.github/workflows/ir-release.yml
@@ -57,25 +57,27 @@ jobs:
         run: npm install -g fern-api
 
       # `fern generate --local` runs the generator in Docker on this runner and writes the full
-      # @fern-api/dynamic-ir-sdk package to a temp dir WITHOUT publishing (remote generation would
-      # publish from Fiddle, where GitHub's OIDC token isn't available). We then publish that package
-      # from the runner via OIDC in a later step. The package name/version come from the generators.yml
+      # @fern-api/dynamic-ir-sdk package WITHOUT publishing (remote generation would publish from
+      # Fiddle, where GitHub's OIDC token isn't available). We then publish that package from the
+      # runner via OIDC in a later step. `--lfs-override` redirects the output to a deterministic
+      # directory (local-file-system output at the given path) so we don't have to scrape fern's
+      # stdout for the location; the package name/version still come from the generators.yml
       # `package-name` and `--version`.
       - name: Generate dynamic IR SDK package (no publish)
         env:
           FERN_TOKEN: ${{ secrets.FERN_TOKEN }}
+          DYNAMIC_IR_OUTPUT: ${{ runner.temp }}/dynamic-ir-sdk
         run: |
+          set -euo pipefail
           cd packages/ir-sdk
           version=$(cat fern/apis/ir-types-latest/VERSION)
-          gen_output=$(fern generate --api ir-types-latest --group dynamic-ir --version "$version" --local 2>&1)
-          echo "$gen_output"
-          outdir=$(echo "$gen_output" | grep -oE "Wrote files to .+" | tail -1 | sed 's/^.*Wrote files to //')
-          if [ -z "$outdir" ] || [ ! -d "$outdir" ]; then
-            echo "::error::could not determine the generated output directory from fern output"
+          fern generate --api ir-types-latest --group dynamic-ir --version "$version" --local \
+            --lfs-override "$DYNAMIC_IR_OUTPUT"
+          if [ ! -f "$DYNAMIC_IR_OUTPUT/package.json" ]; then
+            echo "::error::fern did not write a package to $DYNAMIC_IR_OUTPUT"
             exit 1
           fi
-          echo "Generated package at: $outdir"
-          echo "DYNAMIC_IR_OUTPUT=$outdir" >> "$GITHUB_ENV"
+          echo "Generated package at: $DYNAMIC_IR_OUTPUT"
 
       # OIDC trusted publishing requires npm >= 11.5.1 / Node >= 22.14 and runs on the runner (inside
       # this job) so the id-token is available. No NPM_TOKEN — see the package's Trusted Publisher on npmjs.
@@ -86,11 +88,16 @@ jobs:
           registry-url: https://registry.npmjs.org
           scope: "@fern-api"
 
+      # Pin to the first npm that supports OIDC trusted publishing; a floating `npm@11` tag could
+      # in principle resolve below 11.5.1.
       - name: Update npm for OIDC publishing
         run: npm install -g npm@^11.5.1
 
       - name: Publish @fern-api/dynamic-ir-sdk via OIDC
+        env:
+          DYNAMIC_IR_OUTPUT: ${{ runner.temp }}/dynamic-ir-sdk
         run: |
+          set -euo pipefail
           cd "$DYNAMIC_IR_OUTPUT"
           echo "Publishing from $DYNAMIC_IR_OUTPUT"
           cat package.json

--- a/.github/workflows/ir-release.yml
+++ b/.github/workflows/ir-release.yml
@@ -87,7 +87,7 @@ jobs:
           scope: "@fern-api"
 
       - name: Update npm for OIDC publishing
-        run: npm install -g npm@11
+        run: npm install -g npm@^11.5.1
 
       - name: Publish @fern-api/dynamic-ir-sdk via OIDC
         run: |

--- a/.github/workflows/ir-release.yml
+++ b/.github/workflows/ir-release.yml
@@ -56,17 +56,46 @@ jobs:
       - name: Install Fern
         run: npm install -g fern-api
 
-      - name: Release SDKs
+      # `fern generate --local` runs the generator in Docker on this runner and writes the full
+      # @fern-api/dynamic-ir-sdk package to a temp dir WITHOUT publishing (remote generation would
+      # publish from Fiddle, where GitHub's OIDC token isn't available). We then publish that package
+      # from the runner via OIDC in a later step. The package name/version come from the generators.yml
+      # `package-name` and `--version`.
+      - name: Generate dynamic IR SDK package (no publish)
         env:
           FERN_TOKEN: ${{ secrets.FERN_TOKEN }}
         run: |
           cd packages/ir-sdk
           version=$(cat fern/apis/ir-types-latest/VERSION)
-          # Generate locally (in Docker on this runner) rather than remotely, so the npm publish runs
-          # inside the GitHub Actions job and can authenticate to the trusted publisher via OIDC
-          # (id-token: write above). runDocker forwards ACTIONS_ID_TOKEN_REQUEST_* into the container;
-          # no NPM_TOKEN is needed — see the package's Trusted Publisher config on npmjs.
-          fern generate --api ir-types-latest --group dynamic-ir --version $version --local
+          gen_output=$(fern generate --api ir-types-latest --group dynamic-ir --version "$version" --local 2>&1)
+          echo "$gen_output"
+          outdir=$(echo "$gen_output" | grep -oE "Wrote files to .+" | tail -1 | sed 's/^.*Wrote files to //')
+          if [ -z "$outdir" ] || [ ! -d "$outdir" ]; then
+            echo "::error::could not determine the generated output directory from fern output"
+            exit 1
+          fi
+          echo "Generated package at: $outdir"
+          echo "DYNAMIC_IR_OUTPUT=$outdir" >> "$GITHUB_ENV"
+
+      # OIDC trusted publishing requires npm >= 11.5.1 / Node >= 22.14 and runs on the runner (inside
+      # this job) so the id-token is available. No NPM_TOKEN — see the package's Trusted Publisher on npmjs.
+      - name: Setup Node for OIDC npm publish
+        uses: actions/setup-node@v6
+        with:
+          node-version: 24
+          registry-url: https://registry.npmjs.org
+          scope: "@fern-api"
+
+      - name: Update npm for OIDC publishing
+        run: npm install -g npm@11
+
+      - name: Publish @fern-api/dynamic-ir-sdk via OIDC
+        run: |
+          cd "$DYNAMIC_IR_OUTPUT"
+          echo "Publishing from $DYNAMIC_IR_OUTPUT"
+          cat package.json
+          npm install
+          npm publish --provenance --access public
 
   python:
     if: ${{ github.event_name != 'workflow_dispatch' || inputs.group == 'all' || inputs.group == 'python' }}


### PR DESCRIPTION
## Description
Linear ticket: Refs 

Follow-up to #17070. That PR switched the `dynamic-ir` release job to `fern generate --group dynamic-ir --local` on the theory that publishing from a local Docker container would let OIDC work. But a `workflow_dispatch` run showed **`--local` writes the package to a temp dir and does not publish**:

```
[ir-types-latest]: dynamic-ir fernapi/fern-typescript-sdk Wrote files to /tmp/tmp-2382-Yh4plarJNZgV
```

So the job now goes green while publishing nothing — `@fern-api/dynamic-ir-sdk` is still stuck at `67.2.0`.

## Fix
Publish from the **runner** (where GitHub's OIDC id-token is available), mirroring the working `publish-generator-migrations.yml`:
1. `fern generate --group dynamic-ir --version $version --local` → produces the full package (correct name/version from generators.yml `package-name` + `--version`) in a temp dir, no publish.
2. Capture that dir from fern's `Wrote files to …` output.
3. `actions/setup-node@v6` (Node 24, `registry-url: https://registry.npmjs.org`, `scope: @fern-api`) + `npm install -g npm@11` (OIDC needs npm ≥ 11.5.1).
4. `cd <dir>` → `npm install` → `npm publish --provenance --access public` — authenticates via the **Trusted Publisher** (OIDC), no `NPM_TOKEN`.

`id-token: write` is already granted. The `runDocker.ts` OIDC env-forwarding added in #17070 is now unused (publish is on the runner, not in a container) but harmless; it can be cleaned up separately.

## Why not remote / token
- Remote (`fern generate` without `--local`) publishes from Fiddle, where GitHub's OIDC token isn't available → can't use the trusted publisher.
- `--local` alone doesn't publish (this PR's finding).
- Publishing on the runner is the only place OIDC works, and it's the pattern already proven by `publish-generator-migrations.yml`.

## Validation (required — I can't exercise a publish locally)
Dispatch on this branch, dynamic-ir only:
```
gh workflow run ir-release.yml --ref will/dynamic-ir-oidc-runner-publish -f group=dynamic-ir
```
- [ ] `dynamic-ir` job succeeds **and** `@fern-api/dynamic-ir-sdk@<VERSION>` actually appears on npm.
- [ ] If publish fails on build/deps, the `npm install` / build-on-publish step may need adjusting once we see the generated `package.json` (the step prints it).
- [ ] Confirm the published package includes `inheritedBaseProperties` / `deferredUnionBaseProperties`.

Once it publishes `67.12.0`, the snippet halves of the Go/C# PRs (#17042 / #17043) unblock.

Generated with [Claude Code](https://claude.com/claude-code)