### PR TITLE
fix(python): treat refresh_token as optional in OAuth token provider

### DIFF
--- a/generators/python/sdk/changes/unreleased/fix-oauth-refresh-token-optional.yml
+++ b/generators/python/sdk/changes/unreleased/fix-oauth-refresh-token-optional.yml
@@ -1,0 +1,6 @@
+- summary: |
+    Fix the OAuth token provider crashing with "Access token not present in OAuth response"
+    when the token response does not include a refresh token. Client-credentials token
+    responses often omit `refresh_token`; the provider now treats it as optional instead
+    of raising.
+  type: fix

--- a/generators/python/src/fern_python/generators/sdk/client_generator/oauth_token_provider_generator.py
+++ b/generators/python/src/fern_python/generators/sdk/client_generator/oauth_token_provider_generator.py
@@ -439,6 +439,7 @@ class OAuthTokenProviderGenerator:
                         self._get_write_response_property_setter(
                             response_property=refresh_token_property,
                             member_name=self._get_refresh_token_member_name(),
+                            raise_if_none=False,
                         ),
                     ),
                 )
@@ -471,6 +472,7 @@ class OAuthTokenProviderGenerator:
         self,
         response_property: ir_types.ResponseProperty,
         member_name: str,
+        raise_if_none: bool = True,
     ) -> AST.CodeWriterFunction:
         def _write_response_property_setter(writer: AST.NodeWriter) -> None:
             property_path = response_property.property_path
@@ -481,7 +483,7 @@ class OAuthTokenProviderGenerator:
             property_type = response_property.property.value_type
             property_is_optional = self._context.resolved_schema_is_optional_or_unknown(property_type)
 
-            if property_is_optional:
+            if property_is_optional and raise_if_none:
                 # For optional access tokens, raise an exception if None
                 writer.write_line(f"if {property_value} is None:")
                 with writer.indent():

--- a/seed/python-sdk/oauth-client-credentials-openapi/src/seed/core/oauth_token_provider.py
+++ b/seed/python-sdk/oauth-client-credentials-openapi/src/seed/core/oauth_token_provider.py
@@ -34,8 +34,6 @@ class OAuthTokenProvider:
     def _refresh(self) -> str:
         token_response = self._auth_client.get_token(username=self._client_id, password=self._client_secret)
         self._access_token = token_response.access_token
-        if token_response.refresh_token is None:
-            raise RuntimeError("Access token not present in OAuth response")
         self._refresh_token = token_response.refresh_token
         self._expires_at = self._get_expires_at(
             expires_in_seconds=token_response.expires_in, buffer_in_minutes=self.BUFFER_IN_MINUTES
@@ -69,8 +67,6 @@ class AsyncOAuthTokenProvider:
     async def _refresh(self) -> str:
         token_response = await self._auth_client.get_token(username=self._client_id, password=self._client_secret)
         self._access_token = token_response.access_token
-        if token_response.refresh_token is None:
-            raise RuntimeError("Access token not present in OAuth response")
         self._refresh_token = token_response.refresh_token
         self._expires_at = self._get_expires_at(
             expires_in_seconds=token_response.expires_in, buffer_in_minutes=self.BUFFER_IN_MINUTES

--- a/seed/python-sdk/python-oauth-token-optional/no-custom-config/src/seed/core/oauth_token_provider.py
+++ b/seed/python-sdk/python-oauth-token-optional/no-custom-config/src/seed/core/oauth_token_provider.py
@@ -19,6 +19,7 @@ class OAuthTokenProvider:
         self._client_secret = client_secret
         self._access_token: typing.Optional[str] = None
         self._expires_at: dt.datetime = dt.datetime.now()
+        self._refresh_token: typing.Optional[str] = None
         self._auth_client = AuthClient(client_wrapper=client_wrapper)
         self._lock: threading_Lock = threading.Lock()
 
@@ -37,6 +38,7 @@ class OAuthTokenProvider:
         if token_response.access_token is None:
             raise RuntimeError("Access token not present in OAuth response")
         self._access_token = token_response.access_token
+        self._refresh_token = token_response.refresh_token
         self._expires_at = self._get_expires_at(
             expires_in_seconds=token_response.expires_in if token_response.expires_in is not None else 3600,
             buffer_in_minutes=self.BUFFER_IN_MINUTES,
@@ -55,6 +57,7 @@ class AsyncOAuthTokenProvider:
         self._client_secret = client_secret
         self._access_token: typing.Optional[str] = None
         self._expires_at: dt.datetime = dt.datetime.now()
+        self._refresh_token: typing.Optional[str] = None
         self._auth_client = AsyncAuthClient(client_wrapper=client_wrapper)
         self._lock: asyncio_Lock = asyncio.Lock()
 
@@ -73,6 +76,7 @@ class AsyncOAuthTokenProvider:
         if token_response.access_token is None:
             raise RuntimeError("Access token not present in OAuth response")
         self._access_token = token_response.access_token
+        self._refresh_token = token_response.refresh_token
         self._expires_at = self._get_expires_at(
             expires_in_seconds=token_response.expires_in if token_response.expires_in is not None else 3600,
             buffer_in_minutes=self.BUFFER_IN_MINUTES,

--- a/test-definitions/fern/apis/python-oauth-token-optional/definition/api.yml
+++ b/test-definitions/fern/apis/python-oauth-token-optional/definition/api.yml
@@ -12,3 +12,4 @@ auth-schemes:
       response-properties:
         access-token: $response.access_token
         expires-in: $response.expires_in
+        refresh-token: $response.refresh_token


### PR DESCRIPTION
## Description
The generated Python `OAuthTokenProvider` raised `RuntimeError("Access token not present in OAuth response")` when the token response omitted `refresh_token`. Client-credentials token responses commonly omit `refresh_token` (e.g. Twilio staging returns only `access_token` + `expires_in`), so a fully successful token fetch crashed the provider. Found during live OAuth testing of the Twilio SDKs after fern#17076.

## Changes Made
- `oauth_token_provider_generator.py`: `_get_write_response_property_setter` gains a `raise_if_none` flag (default `True`); the refresh-token setter passes `raise_if_none=False`, so generated code is now a plain `self._refresh_token = token_response.refresh_token` instead of raising when it is `None`. Access-token behavior is unchanged.
- `python-oauth-token-optional` fixture: added `refresh-token: $response.refresh_token` to `response-properties` to cover an optional refresh token on the token endpoint.
- Regenerated seed for `python-oauth-token-optional` and `oauth-client-credentials-openapi` (the misleading raise-on-refresh-token block is removed).
- Changelog entry under `generators/python/sdk/changes/unreleased/`.

## Testing
- [x] Seed tests: `python-oauth-token-optional`, `oauth-client-credentials`, `oauth-client-credentials-openapi` all pass; diffs reviewed.
- [x] ir-to-jsonschema tests pass after fixture change (no snapshot updates needed).
- [ ] Updated README.md generator (not applicable)

Link to Devin session: https://app.devin.ai/sessions/a29c2938df814a4b805775ac2301f104
Requested by: @iamnamananand996