### PR TITLE
chore(cli): bump @fern-api/generator-cli to 0.9.49

### DIFF
--- a/packages/cli/cli/changes/unreleased/bump-generator-cli-0-9-49.yml
+++ b/packages/cli/cli/changes/unreleased/bump-generator-cli-0-9-49.yml
@@ -1,0 +1,5 @@
+- summary: |
+    Bump @fern-api/generator-cli to 0.9.49. Self-hosted push/PR commits created with a
+    personal access token (`ghp_`/`github_pat_`) are now attributed to `fern-api[bot]`
+    as author and committer instead of the PAT owner.
+  type: fix

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -37,8 +37,8 @@ catalogs:
       specifier: 0.0.6-2ee1b7e28
       version: 0.0.6-2ee1b7e28
     '@fern-api/generator-cli':
-      specifier: 0.9.44
-      version: 0.9.44
+      specifier: 0.9.49
+      version: 0.9.49
     '@fern-api/venus-api-sdk':
       specifier: 5.0.0
       version: 5.0.0
@@ -630,7 +630,7 @@ importers:
         version: link:packages/configs
       '@fern-api/generator-cli':
         specifier: 'catalog:'
-        version: 0.9.44
+        version: 0.9.49
       '@rolldown/binding-darwin-arm64':
         specifier: 'catalog:'
         version: 1.1.3
@@ -699,7 +699,7 @@ importers:
         version: link:../../packages/commons/fs-utils
       '@fern-api/generator-cli':
         specifier: 'catalog:'
-        version: 0.9.44
+        version: 0.9.49
       '@fern-api/ir-sdk':
         specifier: workspace:*
         version: link:../../packages/ir-sdk
@@ -2490,7 +2490,7 @@ importers:
         version: link:../../../packages/commons/fs-utils
       '@fern-api/generator-cli':
         specifier: 'catalog:'
-        version: 0.9.44
+        version: 0.9.49
       '@fern-api/logger':
         specifier: workspace:*
         version: link:../../../packages/cli/logger
@@ -9543,8 +9543,8 @@ packages:
   '@fern-api/fdr-sdk@1.2.66-cc15e6c17a':
     resolution: {integrity: sha512-BbeStxpRjQfPchdukIoyWywa95nh3CVdEV3AGWqW7I+Ttg2mBGJ1/o7TWaCeJb7MJLZ6f9ArkArBYizOlnFO7Q==}
 
-  '@fern-api/generator-cli@0.9.44':
-    resolution: {integrity: sha512-nxuN5V59AadmK1eMY741UkCPMIbP69oP1E2TE+6Lzhu7gOycJtZ/K8+LneY0U9HSMyDvk/4TmVqFT0yq1FlBvg==}
+  '@fern-api/generator-cli@0.9.49':
+    resolution: {integrity: sha512-bHU9E+v0zddW2gbyja8h6iHAmiSuYQi1jeW/8WLLPnkEO9xfTmNpDye1Sbt8eRwGsv7AaR0wLQSPFFlFbaTxaA==}
     hasBin: true
 
   '@fern-api/replay@0.19.0':
@@ -16538,7 +16538,7 @@ snapshots:
       - encoding
       - typescript
 
-  '@fern-api/generator-cli@0.9.44':
+  '@fern-api/generator-cli@0.9.49':
     dependencies:
       '@boundaryml/baml': 0.219.0
       '@fern-api/replay': 0.19.0

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -62,7 +62,7 @@ catalog:
   "@bufbuild/protoplugin": 2.2.5
   "@fern-api/fai-sdk": 0.0.6-2ee1b7e28
   "@fern-api/fdr-sdk": 1.2.66-cc15e6c17a
-  "@fern-api/generator-cli": 0.9.44
+  "@fern-api/generator-cli": 0.9.49
   "@fern-api/ui-core-utils": 0.129.4-b6c699ad2
   "@fern-api/venus-api-sdk": 5.0.0
   "@fern-fern/docs-config": 0.0.80


### PR DESCRIPTION
## Description
Follow-up to #17072. That fix shipped in `@fern-api/generator-cli` 0.9.49 on npm, but the CLI catalog still pinned 0.9.44, so `fern generate --local` with self-hosted GitHub output kept the old `pushSignedCommit` and PAT-authenticated commits were still attributed to the PAT owner. Bumping the pin makes the next CLI release attribute those commits to `fern-api[bot]` again.

## Changes Made
- Bump `@fern-api/generator-cli` catalog pin in `pnpm-workspace.yaml` from 0.9.44 to 0.9.49 (lockfile regenerated)
- CLI changelog entry under `packages/cli/cli/changes/unreleased/`
- [ ] Updated README.md generator (if applicable)

## Testing
- [ ] Unit tests added/updated (dependency pin bump only; behavior covered by tests in #17072)
- [x] Manual testing completed (`pnpm install` resolves 0.9.49 cleanly)

Link to Devin session: https://app.devin.ai/sessions/efb00b0049f74743a4587b9a823c978e
Requested by: @iamnamananand996