### PR TITLE
fix(generator-cli): initialize replay.lock on the first generation

### DIFF
--- a/packages/generator-cli/src/__test__/replay-core.test.ts
+++ b/packages/generator-cli/src/__test__/replay-core.test.ts
@@ -145,29 +145,45 @@ describe("first generation - no lockfile, no prior generation commits", { tags: 
 
         initRepo(repoPath);
 
-        // Only a user commit — no [fern-generated] commit for bootstrap to anchor on.
+        // Base branch has only a customer commit — no [fern-generated] commit for
+        // bootstrap to anchor on. This is the pull-request-mode repro (FER): every
+        // `fern generate` forks from a base branch that never accrued a generation
+        // commit, so bootstrap can never anchor.
         writeFileSync(join(repoPath, "README.md"), "# SDK\n");
         commitAsUser(repoPath, "initial commit");
+
+        // The generator has just written SDK output to the working tree
+        // (uncommitted), exactly as it exists when the post-generation pipeline
+        // runs replay.
+        mkdirSync(join(repoPath, "src"), { recursive: true });
+        writeFileSync(
+            join(repoPath, "src/client.ts"),
+            'export class Client {\n  baseUrl = "https://api.example.com";\n}\n'
+        );
     });
 
     afterAll(async () => {
         await cleanup?.();
     });
 
-    it("returns null report when bootstrap finds no prior generation", async () => {
+    it("initializes replay.lock on the first generation via FirstGenerationFlow", async () => {
         const result = await replayRun({ outputDir: repoPath });
 
-        // bootstrap returned generationCommit:null → replayPrepare returns null →
-        // replayRun returns a null-report result. The next `fern generate` that
-        // creates a [fern-generated] commit will establish the baseline.
-        expect(result.report).toBeNull();
-        expect(result.autoBootstrapped).toBe(false);
-        // bootstrapAttempted IS true: we entered the lockfile-missing branch and
-        // tried bootstrap, even though it couldn't anchor.
+        // With no lockfile and no prior generation commit, replay must still
+        // establish the baseline itself: FirstGenerationFlow commits the freshly
+        // generated output as [fern-generated] and writes the lockfile. This is
+        // what makes replay.lock land in the very first PR — essential for
+        // pull-request mode, where generation commits never accumulate on the
+        // base branch each `fern generate` forks from.
+        expect(result.report).not.toBeNull();
+        expect(result.report?.flow).toBe("first-generation");
+        expect(result.autoBootstrapped).toBe(true);
         expect(result.bootstrapAttempted).toBe(true);
-        expect(result.fernignoreUpdated).toBe(false);
+        expect(existsSync(join(repoPath, ".fern", "replay.lock"))).toBe(true);
+
+        // Baseline anchored on a newly created generation commit, not a prior one.
         expect(result.previousGenerationSha).toBeNull();
-        expect(result.currentGenerationSha).toBeNull();
+        expect(result.currentGenerationSha).not.toBeNull();
     });
 });
 

--- a/packages/generator-cli/src/replay/replay-run.ts
+++ b/packages/generator-cli/src/replay/replay-run.ts
@@ -136,14 +136,28 @@ export async function replayPrepare(
             state.bootstrapAttempted = true;
         }
         try {
-            const bootstrapResult = await bootstrap(outputDir, {
+            await bootstrap(outputDir, {
                 fernignoreAction: "skip",
                 force: false,
                 importHistory: false
             });
-            if (bootstrapResult.generationCommit == null) {
-                return null;
-            }
+            // Two shapes reach here, both of which we now let proceed to
+            // prepareReplay():
+            //   1. bootstrap anchored on a reachable prior `[fern-generated]`
+            //      commit and wrote the lockfile — prepareReplay reads it and
+            //      runs the normal / no-patches flow.
+            //   2. bootstrap found no prior generation commit (`generationCommit`
+            //      is null) and wrote nothing. Previously we `return null`-ed here
+            //      and skipped replay for the run, deferring initialization to a
+            //      "next" generation. That deferral never lands in pull-request
+            //      mode: each `fern generate` forks a fresh branch off the base,
+            //      which never accrues a generation commit, so bootstrap can never
+            //      anchor and replay.lock is never created. Instead, fall through:
+            //      with no lockfile on disk, prepareReplay selects
+            //      FirstGenerationFlow, which commits the freshly generated output
+            //      as the `[fern-generated]` baseline and writes the lockfile. This
+            //      initializes replay on the very first generation.
+            // Either way we auto-initialized replay from `fern generate`.
             autoBootstrapped = true;
         } catch (error) {
             logger?.warn("Replay auto-bootstrap failed, continuing without replay: " + String(error));


### PR DESCRIPTION
## Problem

In **pull-request mode**, `.fern/replay.lock` is never created, so Replay never activates and customer customizations are never preserved.

Reproduced with `mlanlazc/pokedex-fern-sdk`: two open regeneration PRs, neither containing a `replay.lock`, `main` still at the initial commit.

## Root cause

`fern generate` auto-bootstraps Replay in `replayPrepare` (`packages/generator-cli/src/replay/replay-run.ts`). When `bootstrap()` finds no prior `[fern-generated]` commit reachable from HEAD it returns `generationCommit == null`, and `replayPrepare` did `return null` — skipping Replay for the run and deferring initialization to "the next generation that establishes a baseline."

That deferral never lands in pull-request mode: each `fern generate` forks a fresh branch off the base branch, which never accrues a generation commit (the PRs aren't merged). So `bootstrap()` can never anchor, and `replay.lock` is never created — on every run, forever. (`fern replay init` bails on the same condition.)

Meanwhile `ReplayService` already has `FirstGenerationFlow`, which is purpose-built for exactly this: it commits the freshly generated output as the `[fern-generated]` baseline and writes the lockfile — needing **no** prior generation commit. Auto-bootstrap was short-circuiting it.

## Fix

When `bootstrap()` can't anchor (and has therefore written nothing), fall through to `prepareReplay()` instead of returning `null`. With no lockfile on disk, `prepareReplay` selects `FirstGenerationFlow`, which establishes the baseline and writes `replay.lock`. `GithubStep` already commits & pushes the lockfile for the first-generation flow (`deriveSkipCommit === false`), so it lands in the very first PR.

Behavior for repos with a reachable prior generation commit is **unchanged** (that path already set `autoBootstrapped = true` and proceeded).

## Test

`packages/generator-cli/src/__test__/replay-core.test.ts` — the case that previously asserted "returns null report when bootstrap finds no prior generation" now asserts the correct behavior: with generator output on disk and no prior generation commit, `replayRun` runs `FirstGenerationFlow`, writes `replay.lock`, and reports `flow: "first-generation"`, `autoBootstrapped: true`.

## Test plan

- [x] `replay-core`, `replay-advanced`, `replay-squash-merge`, `replay-legacy-lockfile`, `replay-pure`, `buildReplayTelemetryProps` — pass
- [x] step/pipeline suites (`auto-version-step`, `github-step-*`, adversarial baseline-recovery) — pass in isolation
- [x] End-to-end simulation on the customer repro: lockfile initializes, a customer edit is tracked, and it survives a subsequent regeneration

Generated with [Claude Code](https://claude.com/claude-code)