### PR TITLE
fix(php): send form-urlencoded request bodies for urlencoded endpoints

### DIFF
--- a/generators/php/base/src/AsIs.ts
+++ b/generators/php/base/src/AsIs.ts
@@ -8,6 +8,7 @@ export enum AsIsFiles {
 
     // Core/Client files.
     BaseApiRequest = "Client/BaseApiRequest.Template.php",
+    UrlEncodedApiRequest = "Client/UrlEncodedApiRequest.Template.php",
     HttpMethod = "Client/HttpMethod.Template.php",
     RawClient = "Client/RawClient.Template.php",
     IdempotencyKey = "Client/IdempotencyKey.Template.php",

--- a/generators/php/base/src/asIs/Client/RawClient.Template.php
+++ b/generators/php/base/src/asIs/Client/RawClient.Template.php
@@ -159,6 +159,16 @@ class RawClient
                 $request->headers,
                 $options['headers'] ?? [],
             ),
+            UrlEncodedApiRequest::class => array_merge(
+                [
+                    "Content-Type" => "application/x-www-form-urlencoded",
+                    "Accept" => "*/*",
+                ],
+                $this->headers,
+                $authHeaders,
+                $request->headers,
+                $options['headers'] ?? [],
+            ),
             MultipartApiRequest::class => array_merge(
                 $this->headers,
                 $authHeaders,
@@ -190,6 +200,24 @@ class RawClient
                     ),
                 )
             );
+        }
+
+        if ($request instanceof UrlEncodedApiRequest) {
+            if ($request->body === null) {
+                return null;
+            }
+            $body = $this->buildJsonBody($request->body, $options);
+            if ($body instanceof JsonSerializable) {
+                $body = $body->jsonSerialize();
+            }
+            if ($body instanceof \stdClass) {
+                $body = (array)$body;
+            }
+            if (!is_array($body)) {
+                throw new InvalidArgumentException('Form-urlencoded request body must serialize to an array');
+            }
+            $body = array_filter($body, static fn ($value) => $value !== null);
+            return $this->streamFactory->createStream(http_build_query($body));
         }
 
         if ($request instanceof MultipartApiRequest) {

--- a/generators/php/base/src/asIs/Client/UrlEncodedApiRequest.Template.php
+++ b/generators/php/base/src/asIs/Client/UrlEncodedApiRequest.Template.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace <%= namespace%>;
+
+class UrlEncodedApiRequest extends BaseApiRequest
+{
+    /**
+     * @param string $baseUrl The base URL for the request
+     * @param string $path The path for the request
+     * @param HttpMethod $method The HTTP method for the request
+     * @param array<string, string> $headers Additional headers for the request (optional)
+     * @param array<string, mixed> $query Query parameters for the request (optional)
+     * @param mixed|null $body The form-urlencoded request body (optional)
+     */
+    public function __construct(
+        string $baseUrl,
+        string $path,
+        HttpMethod $method,
+        array $headers = [],
+        array $query = [],
+        public readonly mixed $body = null
+    ) {
+        parent::__construct($baseUrl, $path, $method, $headers, $query);
+    }
+}

--- a/generators/php/sdk/changes/unreleased/fix-urlencoded-request-bodies.yml
+++ b/generators/php/sdk/changes/unreleased/fix-urlencoded-request-bodies.yml
@@ -1,0 +1,5 @@
+- summary: |
+    Endpoints with `application/x-www-form-urlencoded` request bodies (e.g. OAuth token
+    endpoints) now send form-encoded bodies with the correct `Content-Type` header instead
+    of serializing the body as JSON.
+  type: fix

--- a/generators/php/sdk/src/SdkGeneratorContext.ts
+++ b/generators/php/sdk/src/SdkGeneratorContext.ts
@@ -179,6 +179,10 @@ export class SdkGeneratorContext extends AbstractPhpGeneratorContext<SdkCustomCo
         return this.getCoreJsonClassReference("JsonApiRequest");
     }
 
+    public getUrlEncodedApiRequestClassReference(): php.ClassReference {
+        return this.getCoreClientClassReference("UrlEncodedApiRequest");
+    }
+
     public getJsonDecoderClassReference(): php.ClassReference {
         return this.getCoreJsonClassReference("JsonDecoder");
     }
@@ -604,6 +608,7 @@ export class SdkGeneratorContext extends AbstractPhpGeneratorContext<SdkCustomCo
     public getCoreAsIsFiles(): string[] {
         const files = [
             AsIsFiles.BaseApiRequest,
+            AsIsFiles.UrlEncodedApiRequest,
             AsIsFiles.HttpMethod,
             AsIsFiles.JsonApiRequest,
             AsIsFiles.RawClient,

--- a/generators/php/sdk/src/endpoint/http/HttpEndpointGenerator.ts
+++ b/generators/php/sdk/src/endpoint/http/HttpEndpointGenerator.ts
@@ -725,8 +725,14 @@ export class HttpEndpointGenerator extends AbstractEndpointGenerator {
 
     private getRequestTypeClassReference(requestBody: FernIr.HttpRequestBody): php.ClassReference {
         return requestBody._visit({
-            inlinedRequestBody: () => this.context.getJsonApiRequestClassReference(),
-            reference: () => this.context.getJsonApiRequestClassReference(),
+            inlinedRequestBody: (inlinedRequestBody) =>
+                inlinedRequestBody.contentType === "application/x-www-form-urlencoded"
+                    ? this.context.getUrlEncodedApiRequestClassReference()
+                    : this.context.getJsonApiRequestClassReference(),
+            reference: (reference) =>
+                reference.contentType === "application/x-www-form-urlencoded"
+                    ? this.context.getUrlEncodedApiRequestClassReference()
+                    : this.context.getJsonApiRequestClassReference(),
             fileUpload: () => this.context.getMultipartApiRequestClassReference(),
             bytes: () => this.context.getJsonApiRequestClassReference(), // TODO: Add support for BytesApiRequest
             _other: () => this.context.getJsonApiRequestClassReference()

--- a/seed/php-sdk/accept-header/.fern/metadata.json
+++ b/seed/php-sdk/accept-header/.fern/metadata.json
@@ -3,8 +3,7 @@
   "generatorName": "fernapi/fern-php-sdk",
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/php-sdk/accept-header/src/Core/Client/RawClient.php
+++ b/seed/php-sdk/accept-header/src/Core/Client/RawClient.php
@@ -155,6 +155,16 @@ class RawClient
                 $request->headers,
                 $options['headers'] ?? [],
             ),
+            UrlEncodedApiRequest::class => array_merge(
+                [
+                    "Content-Type" => "application/x-www-form-urlencoded",
+                    "Accept" => "*/*",
+                ],
+                $this->headers,
+                $authHeaders,
+                $request->headers,
+                $options['headers'] ?? [],
+            ),
             MultipartApiRequest::class => array_merge(
                 $this->headers,
                 $authHeaders,
@@ -185,6 +195,24 @@ class RawClient
                     ),
                 )
             );
+        }
+
+        if ($request instanceof UrlEncodedApiRequest) {
+            if ($request->body === null) {
+                return null;
+            }
+            $body = $this->buildJsonBody($request->body, $options);
+            if ($body instanceof JsonSerializable) {
+                $body = $body->jsonSerialize();
+            }
+            if ($body instanceof \stdClass) {
+                $body = (array)$body;
+            }
+            if (!is_array($body)) {
+                throw new InvalidArgumentException('Form-urlencoded request body must serialize to an array');
+            }
+            $body = array_filter($body, static fn ($value) => $value !== null);
+            return $this->streamFactory->createStream(http_build_query($body));
         }
 
         if ($request instanceof MultipartApiRequest) {

--- a/seed/php-sdk/accept-header/src/Core/Client/UrlEncodedApiRequest.php
+++ b/seed/php-sdk/accept-header/src/Core/Client/UrlEncodedApiRequest.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Seed\Core\Client;
+
+class UrlEncodedApiRequest extends BaseApiRequest
+{
+    /**
+     * @param string $baseUrl The base URL for the request
+     * @param string $path The path for the request
+     * @param HttpMethod $method The HTTP method for the request
+     * @param array<string, string> $headers Additional headers for the request (optional)
+     * @param array<string, mixed> $query Query parameters for the request (optional)
+     * @param mixed|null $body The form-urlencoded request body (optional)
+     */
+    public function __construct(
+        string $baseUrl,
+        string $path,
+        HttpMethod $method,
+        array $headers = [],
+        array $query = [],
+        public readonly mixed $body = null
+    ) {
+        parent::__construct($baseUrl, $path, $method, $headers, $query);
+    }
+}

--- a/seed/php-sdk/alias-extends/.fern/metadata.json
+++ b/seed/php-sdk/alias-extends/.fern/metadata.json
@@ -3,8 +3,7 @@
   "generatorName": "fernapi/fern-php-sdk",
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/php-sdk/alias-extends/src/Core/Client/RawClient.php
+++ b/seed/php-sdk/alias-extends/src/Core/Client/RawClient.php
@@ -155,6 +155,16 @@ class RawClient
                 $request->headers,
                 $options['headers'] ?? [],
             ),
+            UrlEncodedApiRequest::class => array_merge(
+                [
+                    "Content-Type" => "application/x-www-form-urlencoded",
+                    "Accept" => "*/*",
+                ],
+                $this->headers,
+                $authHeaders,
+                $request->headers,
+                $options['headers'] ?? [],
+            ),
             MultipartApiRequest::class => array_merge(
                 $this->headers,
                 $authHeaders,
@@ -185,6 +195,24 @@ class RawClient
                     ),
                 )
             );
+        }
+
+        if ($request instanceof UrlEncodedApiRequest) {
+            if ($request->body === null) {
+                return null;
+            }
+            $body = $this->buildJsonBody($request->body, $options);
+            if ($body instanceof JsonSerializable) {
+                $body = $body->jsonSerialize();
+            }
+            if ($body instanceof \stdClass) {
+                $body = (array)$body;
+            }
+            if (!is_array($body)) {
+                throw new InvalidArgumentException('Form-urlencoded request body must serialize to an array');
+            }
+            $body = array_filter($body, static fn ($value) => $value !== null);
+            return $this->streamFactory->createStream(http_build_query($body));
         }
 
         if ($request instanceof MultipartApiRequest) {

--- a/seed/php-sdk/alias-extends/src/Core/Client/UrlEncodedApiRequest.php
+++ b/seed/php-sdk/alias-extends/src/Core/Client/UrlEncodedApiRequest.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Seed\Core\Client;
+
+class UrlEncodedApiRequest extends BaseApiRequest
+{
+    /**
+     * @param string $baseUrl The base URL for the request
+     * @param string $path The path for the request
+     * @param HttpMethod $method The HTTP method for the request
+     * @param array<string, string> $headers Additional headers for the request (optional)
+     * @param array<string, mixed> $query Query parameters for the request (optional)
+     * @param mixed|null $body The form-urlencoded request body (optional)
+     */
+    public function __construct(
+        string $baseUrl,
+        string $path,
+        HttpMethod $method,
+        array $headers = [],
+        array $query = [],
+        public readonly mixed $body = null
+    ) {
+        parent::__construct($baseUrl, $path, $method, $headers, $query);
+    }
+}

--- a/seed/php-sdk/alias/composer-json/.fern/metadata.json
+++ b/seed/php-sdk/alias/composer-json/.fern/metadata.json
@@ -25,8 +25,7 @@
     }
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/php-sdk/alias/composer-json/src/Core/Client/RawClient.php
+++ b/seed/php-sdk/alias/composer-json/src/Core/Client/RawClient.php
@@ -155,6 +155,16 @@ class RawClient
                 $request->headers,
                 $options['headers'] ?? [],
             ),
+            UrlEncodedApiRequest::class => array_merge(
+                [
+                    "Content-Type" => "application/x-www-form-urlencoded",
+                    "Accept" => "*/*",
+                ],
+                $this->headers,
+                $authHeaders,
+                $request->headers,
+                $options['headers'] ?? [],
+            ),
             MultipartApiRequest::class => array_merge(
                 $this->headers,
                 $authHeaders,
@@ -185,6 +195,24 @@ class RawClient
                     ),
                 )
             );
+        }
+
+        if ($request instanceof UrlEncodedApiRequest) {
+            if ($request->body === null) {
+                return null;
+            }
+            $body = $this->buildJsonBody($request->body, $options);
+            if ($body instanceof JsonSerializable) {
+                $body = $body->jsonSerialize();
+            }
+            if ($body instanceof \stdClass) {
+                $body = (array)$body;
+            }
+            if (!is_array($body)) {
+                throw new InvalidArgumentException('Form-urlencoded request body must serialize to an array');
+            }
+            $body = array_filter($body, static fn ($value) => $value !== null);
+            return $this->streamFactory->createStream(http_build_query($body));
         }
 
         if ($request instanceof MultipartApiRequest) {

--- a/seed/php-sdk/alias/composer-json/src/Core/Client/UrlEncodedApiRequest.php
+++ b/seed/php-sdk/alias/composer-json/src/Core/Client/UrlEncodedApiRequest.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Seed\Core\Client;
+
+class UrlEncodedApiRequest extends BaseApiRequest
+{
+    /**
+     * @param string $baseUrl The base URL for the request
+     * @param string $path The path for the request
+     * @param HttpMethod $method The HTTP method for the request
+     * @param array<string, string> $headers Additional headers for the request (optional)
+     * @param array<string, mixed> $query Query parameters for the request (optional)
+     * @param mixed|null $body The form-urlencoded request body (optional)
+     */
+    public function __construct(
+        string $baseUrl,
+        string $path,
+        HttpMethod $method,
+        array $headers = [],
+        array $query = [],
+        public readonly mixed $body = null
+    ) {
+        parent::__construct($baseUrl, $path, $method, $headers, $query);
+    }
+}

--- a/seed/php-sdk/alias/no-custom-config/.fern/metadata.json
+++ b/seed/php-sdk/alias/no-custom-config/.fern/metadata.json
@@ -3,8 +3,7 @@
   "generatorName": "fernapi/fern-php-sdk",
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/php-sdk/alias/no-custom-config/src/Core/Client/RawClient.php
+++ b/seed/php-sdk/alias/no-custom-config/src/Core/Client/RawClient.php
@@ -155,6 +155,16 @@ class RawClient
                 $request->headers,
                 $options['headers'] ?? [],
             ),
+            UrlEncodedApiRequest::class => array_merge(
+                [
+                    "Content-Type" => "application/x-www-form-urlencoded",
+                    "Accept" => "*/*",
+                ],
+                $this->headers,
+                $authHeaders,
+                $request->headers,
+                $options['headers'] ?? [],
+            ),
             MultipartApiRequest::class => array_merge(
                 $this->headers,
                 $authHeaders,
@@ -185,6 +195,24 @@ class RawClient
                     ),
                 )
             );
+        }
+
+        if ($request instanceof UrlEncodedApiRequest) {
+            if ($request->body === null) {
+                return null;
+            }
+            $body = $this->buildJsonBody($request->body, $options);
+            if ($body instanceof JsonSerializable) {
+                $body = $body->jsonSerialize();
+            }
+            if ($body instanceof \stdClass) {
+                $body = (array)$body;
+            }
+            if (!is_array($body)) {
+                throw new InvalidArgumentException('Form-urlencoded request body must serialize to an array');
+            }
+            $body = array_filter($body, static fn ($value) => $value !== null);
+            return $this->streamFactory->createStream(http_build_query($body));
         }
 
         if ($request instanceof MultipartApiRequest) {

--- a/seed/php-sdk/alias/no-custom-config/src/Core/Client/UrlEncodedApiRequest.php
+++ b/seed/php-sdk/alias/no-custom-config/src/Core/Client/UrlEncodedApiRequest.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Seed\Core\Client;
+
+class UrlEncodedApiRequest extends BaseApiRequest
+{
+    /**
+     * @param string $baseUrl The base URL for the request
+     * @param string $path The path for the request
+     * @param HttpMethod $method The HTTP method for the request
+     * @param array<string, string> $headers Additional headers for the request (optional)
+     * @param array<string, mixed> $query Query parameters for the request (optional)
+     * @param mixed|null $body The form-urlencoded request body (optional)
+     */
+    public function __construct(
+        string $baseUrl,
+        string $path,
+        HttpMethod $method,
+        array $headers = [],
+        array $query = [],
+        public readonly mixed $body = null
+    ) {
+        parent::__construct($baseUrl, $path, $method, $headers, $query);
+    }
+}

--- a/seed/php-sdk/allof-inline/.fern/metadata.json
+++ b/seed/php-sdk/allof-inline/.fern/metadata.json
@@ -3,8 +3,7 @@
   "generatorName": "fernapi/fern-php-sdk",
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/php-sdk/allof-inline/src/Core/Client/RawClient.php
+++ b/seed/php-sdk/allof-inline/src/Core/Client/RawClient.php
@@ -155,6 +155,16 @@ class RawClient
                 $request->headers,
                 $options['headers'] ?? [],
             ),
+            UrlEncodedApiRequest::class => array_merge(
+                [
+                    "Content-Type" => "application/x-www-form-urlencoded",
+                    "Accept" => "*/*",
+                ],
+                $this->headers,
+                $authHeaders,
+                $request->headers,
+                $options['headers'] ?? [],
+            ),
             MultipartApiRequest::class => array_merge(
                 $this->headers,
                 $authHeaders,
@@ -185,6 +195,24 @@ class RawClient
                     ),
                 )
             );
+        }
+
+        if ($request instanceof UrlEncodedApiRequest) {
+            if ($request->body === null) {
+                return null;
+            }
+            $body = $this->buildJsonBody($request->body, $options);
+            if ($body instanceof JsonSerializable) {
+                $body = $body->jsonSerialize();
+            }
+            if ($body instanceof \stdClass) {
+                $body = (array)$body;
+            }
+            if (!is_array($body)) {
+                throw new InvalidArgumentException('Form-urlencoded request body must serialize to an array');
+            }
+            $body = array_filter($body, static fn ($value) => $value !== null);
+            return $this->streamFactory->createStream(http_build_query($body));
         }
 
         if ($request instanceof MultipartApiRequest) {

--- a/seed/php-sdk/allof-inline/src/Core/Client/UrlEncodedApiRequest.php
+++ b/seed/php-sdk/allof-inline/src/Core/Client/UrlEncodedApiRequest.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Seed\Core\Client;
+
+class UrlEncodedApiRequest extends BaseApiRequest
+{
+    /**
+     * @param string $baseUrl The base URL for the request
+     * @param string $path The path for the request
+     * @param HttpMethod $method The HTTP method for the request
+     * @param array<string, string> $headers Additional headers for the request (optional)
+     * @param array<string, mixed> $query Query parameters for the request (optional)
+     * @param mixed|null $body The form-urlencoded request body (optional)
+     */
+    public function __construct(
+        string $baseUrl,
+        string $path,
+        HttpMethod $method,
+        array $headers = [],
+        array $query = [],
+        public readonly mixed $body = null
+    ) {
+        parent::__construct($baseUrl, $path, $method, $headers, $query);
+    }
+}

--- a/seed/php-sdk/allof/.fern/metadata.json
+++ b/seed/php-sdk/allof/.fern/metadata.json
@@ -3,8 +3,7 @@
   "generatorName": "fernapi/fern-php-sdk",
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/php-sdk/allof/src/Core/Client/RawClient.php
+++ b/seed/php-sdk/allof/src/Core/Client/RawClient.php
@@ -155,6 +155,16 @@ class RawClient
                 $request->headers,
                 $options['headers'] ?? [],
             ),
+            UrlEncodedApiRequest::class => array_merge(
+                [
+                    "Content-Type" => "application/x-www-form-urlencoded",
+                    "Accept" => "*/*",
+                ],
+                $this->headers,
+                $authHeaders,
+                $request->headers,
+                $options['headers'] ?? [],
+            ),
             MultipartApiRequest::class => array_merge(
                 $this->headers,
                 $authHeaders,
@@ -185,6 +195,24 @@ class RawClient
                     ),
                 )
             );
+        }
+
+        if ($request instanceof UrlEncodedApiRequest) {
+            if ($request->body === null) {
+                return null;
+            }
+            $body = $this->buildJsonBody($request->body, $options);
+            if ($body instanceof JsonSerializable) {
+                $body = $body->jsonSerialize();
+            }
+            if ($body instanceof \stdClass) {
+                $body = (array)$body;
+            }
+            if (!is_array($body)) {
+                throw new InvalidArgumentException('Form-urlencoded request body must serialize to an array');
+            }
+            $body = array_filter($body, static fn ($value) => $value !== null);
+            return $this->streamFactory->createStream(http_build_query($body));
         }
 
         if ($request instanceof MultipartApiRequest) {

--- a/seed/php-sdk/allof/src/Core/Client/UrlEncodedApiRequest.php
+++ b/seed/php-sdk/allof/src/Core/Client/UrlEncodedApiRequest.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Seed\Core\Client;
+
+class UrlEncodedApiRequest extends BaseApiRequest
+{
+    /**
+     * @param string $baseUrl The base URL for the request
+     * @param string $path The path for the request
+     * @param HttpMethod $method The HTTP method for the request
+     * @param array<string, string> $headers Additional headers for the request (optional)
+     * @param array<string, mixed> $query Query parameters for the request (optional)
+     * @param mixed|null $body The form-urlencoded request body (optional)
+     */
+    public function __construct(
+        string $baseUrl,
+        string $path,
+        HttpMethod $method,
+        array $headers = [],
+        array $query = [],
+        public readonly mixed $body = null
+    ) {
+        parent::__construct($baseUrl, $path, $method, $headers, $query);
+    }
+}

--- a/seed/php-sdk/any-auth/.fern/metadata.json
+++ b/seed/php-sdk/any-auth/.fern/metadata.json
@@ -3,8 +3,7 @@
   "generatorName": "fernapi/fern-php-sdk",
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/php-sdk/any-auth/src/Core/Client/RawClient.php
+++ b/seed/php-sdk/any-auth/src/Core/Client/RawClient.php
@@ -155,6 +155,16 @@ class RawClient
                 $request->headers,
                 $options['headers'] ?? [],
             ),
+            UrlEncodedApiRequest::class => array_merge(
+                [
+                    "Content-Type" => "application/x-www-form-urlencoded",
+                    "Accept" => "*/*",
+                ],
+                $this->headers,
+                $authHeaders,
+                $request->headers,
+                $options['headers'] ?? [],
+            ),
             MultipartApiRequest::class => array_merge(
                 $this->headers,
                 $authHeaders,
@@ -185,6 +195,24 @@ class RawClient
                     ),
                 )
             );
+        }
+
+        if ($request instanceof UrlEncodedApiRequest) {
+            if ($request->body === null) {
+                return null;
+            }
+            $body = $this->buildJsonBody($request->body, $options);
+            if ($body instanceof JsonSerializable) {
+                $body = $body->jsonSerialize();
+            }
+            if ($body instanceof \stdClass) {
+                $body = (array)$body;
+            }
+            if (!is_array($body)) {
+                throw new InvalidArgumentException('Form-urlencoded request body must serialize to an array');
+            }
+            $body = array_filter($body, static fn ($value) => $value !== null);
+            return $this->streamFactory->createStream(http_build_query($body));
         }
 
         if ($request instanceof MultipartApiRequest) {

--- a/seed/php-sdk/any-auth/src/Core/Client/UrlEncodedApiRequest.php
+++ b/seed/php-sdk/any-auth/src/Core/Client/UrlEncodedApiRequest.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Seed\Core\Client;
+
+class UrlEncodedApiRequest extends BaseApiRequest
+{
+    /**
+     * @param string $baseUrl The base URL for the request
+     * @param string $path The path for the request
+     * @param HttpMethod $method The HTTP method for the request
+     * @param array<string, string> $headers Additional headers for the request (optional)
+     * @param array<string, mixed> $query Query parameters for the request (optional)
+     * @param mixed|null $body The form-urlencoded request body (optional)
+     */
+    public function __construct(
+        string $baseUrl,
+        string $path,
+        HttpMethod $method,
+        array $headers = [],
+        array $query = [],
+        public readonly mixed $body = null
+    ) {
+        parent::__construct($baseUrl, $path, $method, $headers, $query);
+    }
+}

--- a/seed/php-sdk/api-wide-base-path-with-default/.fern/metadata.json
+++ b/seed/php-sdk/api-wide-base-path-with-default/.fern/metadata.json
@@ -3,8 +3,7 @@
   "generatorName": "fernapi/fern-php-sdk",
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/php-sdk/api-wide-base-path-with-default/src/Core/Client/RawClient.php
+++ b/seed/php-sdk/api-wide-base-path-with-default/src/Core/Client/RawClient.php
@@ -155,6 +155,16 @@ class RawClient
                 $request->headers,
                 $options['headers'] ?? [],
             ),
+            UrlEncodedApiRequest::class => array_merge(
+                [
+                    "Content-Type" => "application/x-www-form-urlencoded",
+                    "Accept" => "*/*",
+                ],
+                $this->headers,
+                $authHeaders,
+                $request->headers,
+                $options['headers'] ?? [],
+            ),
             MultipartApiRequest::class => array_merge(
                 $this->headers,
                 $authHeaders,
@@ -185,6 +195,24 @@ class RawClient
                     ),
                 )
             );
+        }
+
+        if ($request instanceof UrlEncodedApiRequest) {
+            if ($request->body === null) {
+                return null;
+            }
+            $body = $this->buildJsonBody($request->body, $options);
+            if ($body instanceof JsonSerializable) {
+                $body = $body->jsonSerialize();
+            }
+            if ($body instanceof \stdClass) {
+                $body = (array)$body;
+            }
+            if (!is_array($body)) {
+                throw new InvalidArgumentException('Form-urlencoded request body must serialize to an array');
+            }
+            $body = array_filter($body, static fn ($value) => $value !== null);
+            return $this->streamFactory->createStream(http_build_query($body));
         }
 
         if ($request instanceof MultipartApiRequest) {

--- a/seed/php-sdk/api-wide-base-path-with-default/src/Core/Client/UrlEncodedApiRequest.php
+++ b/seed/php-sdk/api-wide-base-path-with-default/src/Core/Client/UrlEncodedApiRequest.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Seed\Core\Client;
+
+class UrlEncodedApiRequest extends BaseApiRequest
+{
+    /**
+     * @param string $baseUrl The base URL for the request
+     * @param string $path The path for the request
+     * @param HttpMethod $method The HTTP method for the request
+     * @param array<string, string> $headers Additional headers for the request (optional)
+     * @param array<string, mixed> $query Query parameters for the request (optional)
+     * @param mixed|null $body The form-urlencoded request body (optional)
+     */
+    public function __construct(
+        string $baseUrl,
+        string $path,
+        HttpMethod $method,
+        array $headers = [],
+        array $query = [],
+        public readonly mixed $body = null
+    ) {
+        parent::__construct($baseUrl, $path, $method, $headers, $query);
+    }
+}

--- a/seed/php-sdk/api-wide-base-path/.fern/metadata.json
+++ b/seed/php-sdk/api-wide-base-path/.fern/metadata.json
@@ -3,8 +3,7 @@
   "generatorName": "fernapi/fern-php-sdk",
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/php-sdk/api-wide-base-path/src/Core/Client/RawClient.php
+++ b/seed/php-sdk/api-wide-base-path/src/Core/Client/RawClient.php
@@ -155,6 +155,16 @@ class RawClient
                 $request->headers,
                 $options['headers'] ?? [],
             ),
+            UrlEncodedApiRequest::class => array_merge(
+                [
+                    "Content-Type" => "application/x-www-form-urlencoded",
+                    "Accept" => "*/*",
+                ],
+                $this->headers,
+                $authHeaders,
+                $request->headers,
+                $options['headers'] ?? [],
+            ),
             MultipartApiRequest::class => array_merge(
                 $this->headers,
                 $authHeaders,
@@ -185,6 +195,24 @@ class RawClient
                     ),
                 )
             );
+        }
+
+        if ($request instanceof UrlEncodedApiRequest) {
+            if ($request->body === null) {
+                return null;
+            }
+            $body = $this->buildJsonBody($request->body, $options);
+            if ($body instanceof JsonSerializable) {
+                $body = $body->jsonSerialize();
+            }
+            if ($body instanceof \stdClass) {
+                $body = (array)$body;
+            }
+            if (!is_array($body)) {
+                throw new InvalidArgumentException('Form-urlencoded request body must serialize to an array');
+            }
+            $body = array_filter($body, static fn ($value) => $value !== null);
+            return $this->streamFactory->createStream(http_build_query($body));
         }
 
         if ($request instanceof MultipartApiRequest) {

--- a/seed/php-sdk/api-wide-base-path/src/Core/Client/UrlEncodedApiRequest.php
+++ b/seed/php-sdk/api-wide-base-path/src/Core/Client/UrlEncodedApiRequest.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Seed\Core\Client;
+
+class UrlEncodedApiRequest extends BaseApiRequest
+{
+    /**
+     * @param string $baseUrl The base URL for the request
+     * @param string $path The path for the request
+     * @param HttpMethod $method The HTTP method for the request
+     * @param array<string, string> $headers Additional headers for the request (optional)
+     * @param array<string, mixed> $query Query parameters for the request (optional)
+     * @param mixed|null $body The form-urlencoded request body (optional)
+     */
+    public function __construct(
+        string $baseUrl,
+        string $path,
+        HttpMethod $method,
+        array $headers = [],
+        array $query = [],
+        public readonly mixed $body = null
+    ) {
+        parent::__construct($baseUrl, $path, $method, $headers, $query);
+    }
+}

--- a/seed/php-sdk/audiences/.fern/metadata.json
+++ b/seed/php-sdk/audiences/.fern/metadata.json
@@ -3,8 +3,7 @@
   "generatorName": "fernapi/fern-php-sdk",
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/php-sdk/audiences/src/Core/Client/RawClient.php
+++ b/seed/php-sdk/audiences/src/Core/Client/RawClient.php
@@ -155,6 +155,16 @@ class RawClient
                 $request->headers,
                 $options['headers'] ?? [],
             ),
+            UrlEncodedApiRequest::class => array_merge(
+                [
+                    "Content-Type" => "application/x-www-form-urlencoded",
+                    "Accept" => "*/*",
+                ],
+                $this->headers,
+                $authHeaders,
+                $request->headers,
+                $options['headers'] ?? [],
+            ),
             MultipartApiRequest::class => array_merge(
                 $this->headers,
                 $authHeaders,
@@ -185,6 +195,24 @@ class RawClient
                     ),
                 )
             );
+        }
+
+        if ($request instanceof UrlEncodedApiRequest) {
+            if ($request->body === null) {
+                return null;
+            }
+            $body = $this->buildJsonBody($request->body, $options);
+            if ($body instanceof JsonSerializable) {
+                $body = $body->jsonSerialize();
+            }
+            if ($body instanceof \stdClass) {
+                $body = (array)$body;
+            }
+            if (!is_array($body)) {
+                throw new InvalidArgumentException('Form-urlencoded request body must serialize to an array');
+            }
+            $body = array_filter($body, static fn ($value) => $value !== null);
+            return $this->streamFactory->createStream(http_build_query($body));
         }
 
         if ($request instanceof MultipartApiRequest) {

--- a/seed/php-sdk/audiences/src/Core/Client/UrlEncodedApiRequest.php
+++ b/seed/php-sdk/audiences/src/Core/Client/UrlEncodedApiRequest.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Seed\Core\Client;
+
+class UrlEncodedApiRequest extends BaseApiRequest
+{
+    /**
+     * @param string $baseUrl The base URL for the request
+     * @param string $path The path for the request
+     * @param HttpMethod $method The HTTP method for the request
+     * @param array<string, string> $headers Additional headers for the request (optional)
+     * @param array<string, mixed> $query Query parameters for the request (optional)
+     * @param mixed|null $body The form-urlencoded request body (optional)
+     */
+    public function __construct(
+        string $baseUrl,
+        string $path,
+        HttpMethod $method,
+        array $headers = [],
+        array $query = [],
+        public readonly mixed $body = null
+    ) {
+        parent::__construct($baseUrl, $path, $method, $headers, $query);
+    }
+}

--- a/seed/php-sdk/basic-auth-environment-variables/.fern/metadata.json
+++ b/seed/php-sdk/basic-auth-environment-variables/.fern/metadata.json
@@ -3,8 +3,7 @@
   "generatorName": "fernapi/fern-php-sdk",
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/php-sdk/basic-auth-environment-variables/src/Core/Client/RawClient.php
+++ b/seed/php-sdk/basic-auth-environment-variables/src/Core/Client/RawClient.php
@@ -155,6 +155,16 @@ class RawClient
                 $request->headers,
                 $options['headers'] ?? [],
             ),
+            UrlEncodedApiRequest::class => array_merge(
+                [
+                    "Content-Type" => "application/x-www-form-urlencoded",
+                    "Accept" => "*/*",
+                ],
+                $this->headers,
+                $authHeaders,
+                $request->headers,
+                $options['headers'] ?? [],
+            ),
             MultipartApiRequest::class => array_merge(
                 $this->headers,
                 $authHeaders,
@@ -185,6 +195,24 @@ class RawClient
                     ),
                 )
             );
+        }
+
+        if ($request instanceof UrlEncodedApiRequest) {
+            if ($request->body === null) {
+                return null;
+            }
+            $body = $this->buildJsonBody($request->body, $options);
+            if ($body instanceof JsonSerializable) {
+                $body = $body->jsonSerialize();
+            }
+            if ($body instanceof \stdClass) {
+                $body = (array)$body;
+            }
+            if (!is_array($body)) {
+                throw new InvalidArgumentException('Form-urlencoded request body must serialize to an array');
+            }
+            $body = array_filter($body, static fn ($value) => $value !== null);
+            return $this->streamFactory->createStream(http_build_query($body));
         }
 
         if ($request instanceof MultipartApiRequest) {

--- a/seed/php-sdk/basic-auth-environment-variables/src/Core/Client/UrlEncodedApiRequest.php
+++ b/seed/php-sdk/basic-auth-environment-variables/src/Core/Client/UrlEncodedApiRequest.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Seed\Core\Client;
+
+class UrlEncodedApiRequest extends BaseApiRequest
+{
+    /**
+     * @param string $baseUrl The base URL for the request
+     * @param string $path The path for the request
+     * @param HttpMethod $method The HTTP method for the request
+     * @param array<string, string> $headers Additional headers for the request (optional)
+     * @param array<string, mixed> $query Query parameters for the request (optional)
+     * @param mixed|null $body The form-urlencoded request body (optional)
+     */
+    public function __construct(
+        string $baseUrl,
+        string $path,
+        HttpMethod $method,
+        array $headers = [],
+        array $query = [],
+        public readonly mixed $body = null
+    ) {
+        parent::__construct($baseUrl, $path, $method, $headers, $query);
+    }
+}

--- a/seed/php-sdk/basic-auth-pw-omitted/wire-tests/.fern/metadata.json
+++ b/seed/php-sdk/basic-auth-pw-omitted/wire-tests/.fern/metadata.json
@@ -6,8 +6,7 @@
     "enable-wire-tests": true
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/php-sdk/basic-auth-pw-omitted/wire-tests/src/Core/Client/RawClient.php
+++ b/seed/php-sdk/basic-auth-pw-omitted/wire-tests/src/Core/Client/RawClient.php
@@ -155,6 +155,16 @@ class RawClient
                 $request->headers,
                 $options['headers'] ?? [],
             ),
+            UrlEncodedApiRequest::class => array_merge(
+                [
+                    "Content-Type" => "application/x-www-form-urlencoded",
+                    "Accept" => "*/*",
+                ],
+                $this->headers,
+                $authHeaders,
+                $request->headers,
+                $options['headers'] ?? [],
+            ),
             MultipartApiRequest::class => array_merge(
                 $this->headers,
                 $authHeaders,
@@ -185,6 +195,24 @@ class RawClient
                     ),
                 )
             );
+        }
+
+        if ($request instanceof UrlEncodedApiRequest) {
+            if ($request->body === null) {
+                return null;
+            }
+            $body = $this->buildJsonBody($request->body, $options);
+            if ($body instanceof JsonSerializable) {
+                $body = $body->jsonSerialize();
+            }
+            if ($body instanceof \stdClass) {
+                $body = (array)$body;
+            }
+            if (!is_array($body)) {
+                throw new InvalidArgumentException('Form-urlencoded request body must serialize to an array');
+            }
+            $body = array_filter($body, static fn ($value) => $value !== null);
+            return $this->streamFactory->createStream(http_build_query($body));
         }
 
         if ($request instanceof MultipartApiRequest) {

--- a/seed/php-sdk/basic-auth-pw-omitted/wire-tests/src/Core/Client/UrlEncodedApiRequest.php
+++ b/seed/php-sdk/basic-auth-pw-omitted/wire-tests/src/Core/Client/UrlEncodedApiRequest.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Seed\Core\Client;
+
+class UrlEncodedApiRequest extends BaseApiRequest
+{
+    /**
+     * @param string $baseUrl The base URL for the request
+     * @param string $path The path for the request
+     * @param HttpMethod $method The HTTP method for the request
+     * @param array<string, string> $headers Additional headers for the request (optional)
+     * @param array<string, mixed> $query Query parameters for the request (optional)
+     * @param mixed|null $body The form-urlencoded request body (optional)
+     */
+    public function __construct(
+        string $baseUrl,
+        string $path,
+        HttpMethod $method,
+        array $headers = [],
+        array $query = [],
+        public readonly mixed $body = null
+    ) {
+        parent::__construct($baseUrl, $path, $method, $headers, $query);
+    }
+}

--- a/seed/php-sdk/basic-auth/wire-tests/.fern/metadata.json
+++ b/seed/php-sdk/basic-auth/wire-tests/.fern/metadata.json
@@ -6,8 +6,7 @@
     "enable-wire-tests": true
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/php-sdk/basic-auth/wire-tests/src/Core/Client/RawClient.php
+++ b/seed/php-sdk/basic-auth/wire-tests/src/Core/Client/RawClient.php
@@ -155,6 +155,16 @@ class RawClient
                 $request->headers,
                 $options['headers'] ?? [],
             ),
+            UrlEncodedApiRequest::class => array_merge(
+                [
+                    "Content-Type" => "application/x-www-form-urlencoded",
+                    "Accept" => "*/*",
+                ],
+                $this->headers,
+                $authHeaders,
+                $request->headers,
+                $options['headers'] ?? [],
+            ),
             MultipartApiRequest::class => array_merge(
                 $this->headers,
                 $authHeaders,
@@ -185,6 +195,24 @@ class RawClient
                     ),
                 )
             );
+        }
+
+        if ($request instanceof UrlEncodedApiRequest) {
+            if ($request->body === null) {
+                return null;
+            }
+            $body = $this->buildJsonBody($request->body, $options);
+            if ($body instanceof JsonSerializable) {
+                $body = $body->jsonSerialize();
+            }
+            if ($body instanceof \stdClass) {
+                $body = (array)$body;
+            }
+            if (!is_array($body)) {
+                throw new InvalidArgumentException('Form-urlencoded request body must serialize to an array');
+            }
+            $body = array_filter($body, static fn ($value) => $value !== null);
+            return $this->streamFactory->createStream(http_build_query($body));
         }
 
         if ($request instanceof MultipartApiRequest) {

--- a/seed/php-sdk/basic-auth/wire-tests/src/Core/Client/UrlEncodedApiRequest.php
+++ b/seed/php-sdk/basic-auth/wire-tests/src/Core/Client/UrlEncodedApiRequest.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Seed\Core\Client;
+
+class UrlEncodedApiRequest extends BaseApiRequest
+{
+    /**
+     * @param string $baseUrl The base URL for the request
+     * @param string $path The path for the request
+     * @param HttpMethod $method The HTTP method for the request
+     * @param array<string, string> $headers Additional headers for the request (optional)
+     * @param array<string, mixed> $query Query parameters for the request (optional)
+     * @param mixed|null $body The form-urlencoded request body (optional)
+     */
+    public function __construct(
+        string $baseUrl,
+        string $path,
+        HttpMethod $method,
+        array $headers = [],
+        array $query = [],
+        public readonly mixed $body = null
+    ) {
+        parent::__construct($baseUrl, $path, $method, $headers, $query);
+    }
+}

--- a/seed/php-sdk/bearer-token-environment-variable/.fern/metadata.json
+++ b/seed/php-sdk/bearer-token-environment-variable/.fern/metadata.json
@@ -3,8 +3,7 @@
   "generatorName": "fernapi/fern-php-sdk",
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/php-sdk/bearer-token-environment-variable/src/Core/Client/RawClient.php
+++ b/seed/php-sdk/bearer-token-environment-variable/src/Core/Client/RawClient.php
@@ -155,6 +155,16 @@ class RawClient
                 $request->headers,
                 $options['headers'] ?? [],
             ),
+            UrlEncodedApiRequest::class => array_merge(
+                [
+                    "Content-Type" => "application/x-www-form-urlencoded",
+                    "Accept" => "*/*",
+                ],
+                $this->headers,
+                $authHeaders,
+                $request->headers,
+                $options['headers'] ?? [],
+            ),
             MultipartApiRequest::class => array_merge(
                 $this->headers,
                 $authHeaders,
@@ -185,6 +195,24 @@ class RawClient
                     ),
                 )
             );
+        }
+
+        if ($request instanceof UrlEncodedApiRequest) {
+            if ($request->body === null) {
+                return null;
+            }
+            $body = $this->buildJsonBody($request->body, $options);
+            if ($body instanceof JsonSerializable) {
+                $body = $body->jsonSerialize();
+            }
+            if ($body instanceof \stdClass) {
+                $body = (array)$body;
+            }
+            if (!is_array($body)) {
+                throw new InvalidArgumentException('Form-urlencoded request body must serialize to an array');
+            }
+            $body = array_filter($body, static fn ($value) => $value !== null);
+            return $this->streamFactory->createStream(http_build_query($body));
         }
 
         if ($request instanceof MultipartApiRequest) {

--- a/seed/php-sdk/bearer-token-environment-variable/src/Core/Client/UrlEncodedApiRequest.php
+++ b/seed/php-sdk/bearer-token-environment-variable/src/Core/Client/UrlEncodedApiRequest.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Seed\Core\Client;
+
+class UrlEncodedApiRequest extends BaseApiRequest
+{
+    /**
+     * @param string $baseUrl The base URL for the request
+     * @param string $path The path for the request
+     * @param HttpMethod $method The HTTP method for the request
+     * @param array<string, string> $headers Additional headers for the request (optional)
+     * @param array<string, mixed> $query Query parameters for the request (optional)
+     * @param mixed|null $body The form-urlencoded request body (optional)
+     */
+    public function __construct(
+        string $baseUrl,
+        string $path,
+        HttpMethod $method,
+        array $headers = [],
+        array $query = [],
+        public readonly mixed $body = null
+    ) {
+        parent::__construct($baseUrl, $path, $method, $headers, $query);
+    }
+}

--- a/seed/php-sdk/bytes-download/.fern/metadata.json
+++ b/seed/php-sdk/bytes-download/.fern/metadata.json
@@ -3,8 +3,7 @@
   "generatorName": "fernapi/fern-php-sdk",
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/php-sdk/bytes-download/src/Core/Client/RawClient.php
+++ b/seed/php-sdk/bytes-download/src/Core/Client/RawClient.php
@@ -155,6 +155,16 @@ class RawClient
                 $request->headers,
                 $options['headers'] ?? [],
             ),
+            UrlEncodedApiRequest::class => array_merge(
+                [
+                    "Content-Type" => "application/x-www-form-urlencoded",
+                    "Accept" => "*/*",
+                ],
+                $this->headers,
+                $authHeaders,
+                $request->headers,
+                $options['headers'] ?? [],
+            ),
             MultipartApiRequest::class => array_merge(
                 $this->headers,
                 $authHeaders,
@@ -185,6 +195,24 @@ class RawClient
                     ),
                 )
             );
+        }
+
+        if ($request instanceof UrlEncodedApiRequest) {
+            if ($request->body === null) {
+                return null;
+            }
+            $body = $this->buildJsonBody($request->body, $options);
+            if ($body instanceof JsonSerializable) {
+                $body = $body->jsonSerialize();
+            }
+            if ($body instanceof \stdClass) {
+                $body = (array)$body;
+            }
+            if (!is_array($body)) {
+                throw new InvalidArgumentException('Form-urlencoded request body must serialize to an array');
+            }
+            $body = array_filter($body, static fn ($value) => $value !== null);
+            return $this->streamFactory->createStream(http_build_query($body));
         }
 
         if ($request instanceof MultipartApiRequest) {

--- a/seed/php-sdk/bytes-download/src/Core/Client/UrlEncodedApiRequest.php
+++ b/seed/php-sdk/bytes-download/src/Core/Client/UrlEncodedApiRequest.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Seed\Core\Client;
+
+class UrlEncodedApiRequest extends BaseApiRequest
+{
+    /**
+     * @param string $baseUrl The base URL for the request
+     * @param string $path The path for the request
+     * @param HttpMethod $method The HTTP method for the request
+     * @param array<string, string> $headers Additional headers for the request (optional)
+     * @param array<string, mixed> $query Query parameters for the request (optional)
+     * @param mixed|null $body The form-urlencoded request body (optional)
+     */
+    public function __construct(
+        string $baseUrl,
+        string $path,
+        HttpMethod $method,
+        array $headers = [],
+        array $query = [],
+        public readonly mixed $body = null
+    ) {
+        parent::__construct($baseUrl, $path, $method, $headers, $query);
+    }
+}

--- a/seed/php-sdk/bytes-upload/.fern/metadata.json
+++ b/seed/php-sdk/bytes-upload/.fern/metadata.json
@@ -3,8 +3,7 @@
   "generatorName": "fernapi/fern-php-sdk",
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/php-sdk/bytes-upload/src/Core/Client/RawClient.php
+++ b/seed/php-sdk/bytes-upload/src/Core/Client/RawClient.php
@@ -155,6 +155,16 @@ class RawClient
                 $request->headers,
                 $options['headers'] ?? [],
             ),
+            UrlEncodedApiRequest::class => array_merge(
+                [
+                    "Content-Type" => "application/x-www-form-urlencoded",
+                    "Accept" => "*/*",
+                ],
+                $this->headers,
+                $authHeaders,
+                $request->headers,
+                $options['headers'] ?? [],
+            ),
             MultipartApiRequest::class => array_merge(
                 $this->headers,
                 $authHeaders,
@@ -185,6 +195,24 @@ class RawClient
                     ),
                 )
             );
+        }
+
+        if ($request instanceof UrlEncodedApiRequest) {
+            if ($request->body === null) {
+                return null;
+            }
+            $body = $this->buildJsonBody($request->body, $options);
+            if ($body instanceof JsonSerializable) {
+                $body = $body->jsonSerialize();
+            }
+            if ($body instanceof \stdClass) {
+                $body = (array)$body;
+            }
+            if (!is_array($body)) {
+                throw new InvalidArgumentException('Form-urlencoded request body must serialize to an array');
+            }
+            $body = array_filter($body, static fn ($value) => $value !== null);
+            return $this->streamFactory->createStream(http_build_query($body));
         }
 
         if ($request instanceof MultipartApiRequest) {

--- a/seed/php-sdk/bytes-upload/src/Core/Client/UrlEncodedApiRequest.php
+++ b/seed/php-sdk/bytes-upload/src/Core/Client/UrlEncodedApiRequest.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Seed\Core\Client;
+
+class UrlEncodedApiRequest extends BaseApiRequest
+{
+    /**
+     * @param string $baseUrl The base URL for the request
+     * @param string $path The path for the request
+     * @param HttpMethod $method The HTTP method for the request
+     * @param array<string, string> $headers Additional headers for the request (optional)
+     * @param array<string, mixed> $query Query parameters for the request (optional)
+     * @param mixed|null $body The form-urlencoded request body (optional)
+     */
+    public function __construct(
+        string $baseUrl,
+        string $path,
+        HttpMethod $method,
+        array $headers = [],
+        array $query = [],
+        public readonly mixed $body = null
+    ) {
+        parent::__construct($baseUrl, $path, $method, $headers, $query);
+    }
+}

--- a/seed/php-sdk/circular-references-advanced/.fern/metadata.json
+++ b/seed/php-sdk/circular-references-advanced/.fern/metadata.json
@@ -3,8 +3,7 @@
   "generatorName": "fernapi/fern-php-sdk",
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/php-sdk/circular-references-advanced/src/Core/Client/RawClient.php
+++ b/seed/php-sdk/circular-references-advanced/src/Core/Client/RawClient.php
@@ -155,6 +155,16 @@ class RawClient
                 $request->headers,
                 $options['headers'] ?? [],
             ),
+            UrlEncodedApiRequest::class => array_merge(
+                [
+                    "Content-Type" => "application/x-www-form-urlencoded",
+                    "Accept" => "*/*",
+                ],
+                $this->headers,
+                $authHeaders,
+                $request->headers,
+                $options['headers'] ?? [],
+            ),
             MultipartApiRequest::class => array_merge(
                 $this->headers,
                 $authHeaders,
@@ -185,6 +195,24 @@ class RawClient
                     ),
                 )
             );
+        }
+
+        if ($request instanceof UrlEncodedApiRequest) {
+            if ($request->body === null) {
+                return null;
+            }
+            $body = $this->buildJsonBody($request->body, $options);
+            if ($body instanceof JsonSerializable) {
+                $body = $body->jsonSerialize();
+            }
+            if ($body instanceof \stdClass) {
+                $body = (array)$body;
+            }
+            if (!is_array($body)) {
+                throw new InvalidArgumentException('Form-urlencoded request body must serialize to an array');
+            }
+            $body = array_filter($body, static fn ($value) => $value !== null);
+            return $this->streamFactory->createStream(http_build_query($body));
         }
 
         if ($request instanceof MultipartApiRequest) {

--- a/seed/php-sdk/circular-references-advanced/src/Core/Client/UrlEncodedApiRequest.php
+++ b/seed/php-sdk/circular-references-advanced/src/Core/Client/UrlEncodedApiRequest.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Seed\Core\Client;
+
+class UrlEncodedApiRequest extends BaseApiRequest
+{
+    /**
+     * @param string $baseUrl The base URL for the request
+     * @param string $path The path for the request
+     * @param HttpMethod $method The HTTP method for the request
+     * @param array<string, string> $headers Additional headers for the request (optional)
+     * @param array<string, mixed> $query Query parameters for the request (optional)
+     * @param mixed|null $body The form-urlencoded request body (optional)
+     */
+    public function __construct(
+        string $baseUrl,
+        string $path,
+        HttpMethod $method,
+        array $headers = [],
+        array $query = [],
+        public readonly mixed $body = null
+    ) {
+        parent::__construct($baseUrl, $path, $method, $headers, $query);
+    }
+}

--- a/seed/php-sdk/circular-references-extends/.fern/metadata.json
+++ b/seed/php-sdk/circular-references-extends/.fern/metadata.json
@@ -3,8 +3,7 @@
   "generatorName": "fernapi/fern-php-sdk",
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/php-sdk/circular-references-extends/src/Core/Client/RawClient.php
+++ b/seed/php-sdk/circular-references-extends/src/Core/Client/RawClient.php
@@ -155,6 +155,16 @@ class RawClient
                 $request->headers,
                 $options['headers'] ?? [],
             ),
+            UrlEncodedApiRequest::class => array_merge(
+                [
+                    "Content-Type" => "application/x-www-form-urlencoded",
+                    "Accept" => "*/*",
+                ],
+                $this->headers,
+                $authHeaders,
+                $request->headers,
+                $options['headers'] ?? [],
+            ),
             MultipartApiRequest::class => array_merge(
                 $this->headers,
                 $authHeaders,
@@ -185,6 +195,24 @@ class RawClient
                     ),
                 )
             );
+        }
+
+        if ($request instanceof UrlEncodedApiRequest) {
+            if ($request->body === null) {
+                return null;
+            }
+            $body = $this->buildJsonBody($request->body, $options);
+            if ($body instanceof JsonSerializable) {
+                $body = $body->jsonSerialize();
+            }
+            if ($body instanceof \stdClass) {
+                $body = (array)$body;
+            }
+            if (!is_array($body)) {
+                throw new InvalidArgumentException('Form-urlencoded request body must serialize to an array');
+            }
+            $body = array_filter($body, static fn ($value) => $value !== null);
+            return $this->streamFactory->createStream(http_build_query($body));
         }
 
         if ($request instanceof MultipartApiRequest) {

--- a/seed/php-sdk/circular-references-extends/src/Core/Client/UrlEncodedApiRequest.php
+++ b/seed/php-sdk/circular-references-extends/src/Core/Client/UrlEncodedApiRequest.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Seed\Core\Client;
+
+class UrlEncodedApiRequest extends BaseApiRequest
+{
+    /**
+     * @param string $baseUrl The base URL for the request
+     * @param string $path The path for the request
+     * @param HttpMethod $method The HTTP method for the request
+     * @param array<string, string> $headers Additional headers for the request (optional)
+     * @param array<string, mixed> $query Query parameters for the request (optional)
+     * @param mixed|null $body The form-urlencoded request body (optional)
+     */
+    public function __construct(
+        string $baseUrl,
+        string $path,
+        HttpMethod $method,
+        array $headers = [],
+        array $query = [],
+        public readonly mixed $body = null
+    ) {
+        parent::__construct($baseUrl, $path, $method, $headers, $query);
+    }
+}

--- a/seed/php-sdk/circular-references/.fern/metadata.json
+++ b/seed/php-sdk/circular-references/.fern/metadata.json
@@ -3,8 +3,7 @@
   "generatorName": "fernapi/fern-php-sdk",
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/php-sdk/circular-references/src/Core/Client/RawClient.php
+++ b/seed/php-sdk/circular-references/src/Core/Client/RawClient.php
@@ -155,6 +155,16 @@ class RawClient
                 $request->headers,
                 $options['headers'] ?? [],
             ),
+            UrlEncodedApiRequest::class => array_merge(
+                [
+                    "Content-Type" => "application/x-www-form-urlencoded",
+                    "Accept" => "*/*",
+                ],
+                $this->headers,
+                $authHeaders,
+                $request->headers,
+                $options['headers'] ?? [],
+            ),
             MultipartApiRequest::class => array_merge(
                 $this->headers,
                 $authHeaders,
@@ -185,6 +195,24 @@ class RawClient
                     ),
                 )
             );
+        }
+
+        if ($request instanceof UrlEncodedApiRequest) {
+            if ($request->body === null) {
+                return null;
+            }
+            $body = $this->buildJsonBody($request->body, $options);
+            if ($body instanceof JsonSerializable) {
+                $body = $body->jsonSerialize();
+            }
+            if ($body instanceof \stdClass) {
+                $body = (array)$body;
+            }
+            if (!is_array($body)) {
+                throw new InvalidArgumentException('Form-urlencoded request body must serialize to an array');
+            }
+            $body = array_filter($body, static fn ($value) => $value !== null);
+            return $this->streamFactory->createStream(http_build_query($body));
         }
 
         if ($request instanceof MultipartApiRequest) {

--- a/seed/php-sdk/circular-references/src/Core/Client/UrlEncodedApiRequest.php
+++ b/seed/php-sdk/circular-references/src/Core/Client/UrlEncodedApiRequest.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Seed\Core\Client;
+
+class UrlEncodedApiRequest extends BaseApiRequest
+{
+    /**
+     * @param string $baseUrl The base URL for the request
+     * @param string $path The path for the request
+     * @param HttpMethod $method The HTTP method for the request
+     * @param array<string, string> $headers Additional headers for the request (optional)
+     * @param array<string, mixed> $query Query parameters for the request (optional)
+     * @param mixed|null $body The form-urlencoded request body (optional)
+     */
+    public function __construct(
+        string $baseUrl,
+        string $path,
+        HttpMethod $method,
+        array $headers = [],
+        array $query = [],
+        public readonly mixed $body = null
+    ) {
+        parent::__construct($baseUrl, $path, $method, $headers, $query);
+    }
+}

--- a/seed/php-sdk/cli-multi-spec-namespaced/.fern/metadata.json
+++ b/seed/php-sdk/cli-multi-spec-namespaced/.fern/metadata.json
@@ -3,8 +3,7 @@
   "generatorName": "fernapi/fern-php-sdk",
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/php-sdk/cli-multi-spec-namespaced/src/Core/Client/RawClient.php
+++ b/seed/php-sdk/cli-multi-spec-namespaced/src/Core/Client/RawClient.php
@@ -155,6 +155,16 @@ class RawClient
                 $request->headers,
                 $options['headers'] ?? [],
             ),
+            UrlEncodedApiRequest::class => array_merge(
+                [
+                    "Content-Type" => "application/x-www-form-urlencoded",
+                    "Accept" => "*/*",
+                ],
+                $this->headers,
+                $authHeaders,
+                $request->headers,
+                $options['headers'] ?? [],
+            ),
             MultipartApiRequest::class => array_merge(
                 $this->headers,
                 $authHeaders,
@@ -185,6 +195,24 @@ class RawClient
                     ),
                 )
             );
+        }
+
+        if ($request instanceof UrlEncodedApiRequest) {
+            if ($request->body === null) {
+                return null;
+            }
+            $body = $this->buildJsonBody($request->body, $options);
+            if ($body instanceof JsonSerializable) {
+                $body = $body->jsonSerialize();
+            }
+            if ($body instanceof \stdClass) {
+                $body = (array)$body;
+            }
+            if (!is_array($body)) {
+                throw new InvalidArgumentException('Form-urlencoded request body must serialize to an array');
+            }
+            $body = array_filter($body, static fn ($value) => $value !== null);
+            return $this->streamFactory->createStream(http_build_query($body));
         }
 
         if ($request instanceof MultipartApiRequest) {

--- a/seed/php-sdk/cli-multi-spec-namespaced/src/Core/Client/UrlEncodedApiRequest.php
+++ b/seed/php-sdk/cli-multi-spec-namespaced/src/Core/Client/UrlEncodedApiRequest.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Seed\Core\Client;
+
+class UrlEncodedApiRequest extends BaseApiRequest
+{
+    /**
+     * @param string $baseUrl The base URL for the request
+     * @param string $path The path for the request
+     * @param HttpMethod $method The HTTP method for the request
+     * @param array<string, string> $headers Additional headers for the request (optional)
+     * @param array<string, mixed> $query Query parameters for the request (optional)
+     * @param mixed|null $body The form-urlencoded request body (optional)
+     */
+    public function __construct(
+        string $baseUrl,
+        string $path,
+        HttpMethod $method,
+        array $headers = [],
+        array $query = [],
+        public readonly mixed $body = null
+    ) {
+        parent::__construct($baseUrl, $path, $method, $headers, $query);
+    }
+}

--- a/seed/php-sdk/cli-multi-spec/.fern/metadata.json
+++ b/seed/php-sdk/cli-multi-spec/.fern/metadata.json
@@ -3,8 +3,7 @@
   "generatorName": "fernapi/fern-php-sdk",
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/php-sdk/cli-multi-spec/src/Core/Client/RawClient.php
+++ b/seed/php-sdk/cli-multi-spec/src/Core/Client/RawClient.php
@@ -155,6 +155,16 @@ class RawClient
                 $request->headers,
                 $options['headers'] ?? [],
             ),
+            UrlEncodedApiRequest::class => array_merge(
+                [
+                    "Content-Type" => "application/x-www-form-urlencoded",
+                    "Accept" => "*/*",
+                ],
+                $this->headers,
+                $authHeaders,
+                $request->headers,
+                $options['headers'] ?? [],
+            ),
             MultipartApiRequest::class => array_merge(
                 $this->headers,
                 $authHeaders,
@@ -185,6 +195,24 @@ class RawClient
                     ),
                 )
             );
+        }
+
+        if ($request instanceof UrlEncodedApiRequest) {
+            if ($request->body === null) {
+                return null;
+            }
+            $body = $this->buildJsonBody($request->body, $options);
+            if ($body instanceof JsonSerializable) {
+                $body = $body->jsonSerialize();
+            }
+            if ($body instanceof \stdClass) {
+                $body = (array)$body;
+            }
+            if (!is_array($body)) {
+                throw new InvalidArgumentException('Form-urlencoded request body must serialize to an array');
+            }
+            $body = array_filter($body, static fn ($value) => $value !== null);
+            return $this->streamFactory->createStream(http_build_query($body));
         }
 
         if ($request instanceof MultipartApiRequest) {

--- a/seed/php-sdk/cli-multi-spec/src/Core/Client/UrlEncodedApiRequest.php
+++ b/seed/php-sdk/cli-multi-spec/src/Core/Client/UrlEncodedApiRequest.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Seed\Core\Client;
+
+class UrlEncodedApiRequest extends BaseApiRequest
+{
+    /**
+     * @param string $baseUrl The base URL for the request
+     * @param string $path The path for the request
+     * @param HttpMethod $method The HTTP method for the request
+     * @param array<string, string> $headers Additional headers for the request (optional)
+     * @param array<string, mixed> $query Query parameters for the request (optional)
+     * @param mixed|null $body The form-urlencoded request body (optional)
+     */
+    public function __construct(
+        string $baseUrl,
+        string $path,
+        HttpMethod $method,
+        array $headers = [],
+        array $query = [],
+        public readonly mixed $body = null
+    ) {
+        parent::__construct($baseUrl, $path, $method, $headers, $query);
+    }
+}

--- a/seed/php-sdk/client-side-params/.fern/metadata.json
+++ b/seed/php-sdk/client-side-params/.fern/metadata.json
@@ -3,8 +3,7 @@
   "generatorName": "fernapi/fern-php-sdk",
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/php-sdk/client-side-params/src/Core/Client/RawClient.php
+++ b/seed/php-sdk/client-side-params/src/Core/Client/RawClient.php
@@ -155,6 +155,16 @@ class RawClient
                 $request->headers,
                 $options['headers'] ?? [],
             ),
+            UrlEncodedApiRequest::class => array_merge(
+                [
+                    "Content-Type" => "application/x-www-form-urlencoded",
+                    "Accept" => "*/*",
+                ],
+                $this->headers,
+                $authHeaders,
+                $request->headers,
+                $options['headers'] ?? [],
+            ),
             MultipartApiRequest::class => array_merge(
                 $this->headers,
                 $authHeaders,
@@ -185,6 +195,24 @@ class RawClient
                     ),
                 )
             );
+        }
+
+        if ($request instanceof UrlEncodedApiRequest) {
+            if ($request->body === null) {
+                return null;
+            }
+            $body = $this->buildJsonBody($request->body, $options);
+            if ($body instanceof JsonSerializable) {
+                $body = $body->jsonSerialize();
+            }
+            if ($body instanceof \stdClass) {
+                $body = (array)$body;
+            }
+            if (!is_array($body)) {
+                throw new InvalidArgumentException('Form-urlencoded request body must serialize to an array');
+            }
+            $body = array_filter($body, static fn ($value) => $value !== null);
+            return $this->streamFactory->createStream(http_build_query($body));
         }
 
         if ($request instanceof MultipartApiRequest) {

--- a/seed/php-sdk/client-side-params/src/Core/Client/UrlEncodedApiRequest.php
+++ b/seed/php-sdk/client-side-params/src/Core/Client/UrlEncodedApiRequest.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Seed\Core\Client;
+
+class UrlEncodedApiRequest extends BaseApiRequest
+{
+    /**
+     * @param string $baseUrl The base URL for the request
+     * @param string $path The path for the request
+     * @param HttpMethod $method The HTTP method for the request
+     * @param array<string, string> $headers Additional headers for the request (optional)
+     * @param array<string, mixed> $query Query parameters for the request (optional)
+     * @param mixed|null $body The form-urlencoded request body (optional)
+     */
+    public function __construct(
+        string $baseUrl,
+        string $path,
+        HttpMethod $method,
+        array $headers = [],
+        array $query = [],
+        public readonly mixed $body = null
+    ) {
+        parent::__construct($baseUrl, $path, $method, $headers, $query);
+    }
+}

--- a/seed/php-sdk/content-type/.fern/metadata.json
+++ b/seed/php-sdk/content-type/.fern/metadata.json
@@ -3,8 +3,7 @@
   "generatorName": "fernapi/fern-php-sdk",
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/php-sdk/content-type/src/Core/Client/RawClient.php
+++ b/seed/php-sdk/content-type/src/Core/Client/RawClient.php
@@ -155,6 +155,16 @@ class RawClient
                 $request->headers,
                 $options['headers'] ?? [],
             ),
+            UrlEncodedApiRequest::class => array_merge(
+                [
+                    "Content-Type" => "application/x-www-form-urlencoded",
+                    "Accept" => "*/*",
+                ],
+                $this->headers,
+                $authHeaders,
+                $request->headers,
+                $options['headers'] ?? [],
+            ),
             MultipartApiRequest::class => array_merge(
                 $this->headers,
                 $authHeaders,
@@ -185,6 +195,24 @@ class RawClient
                     ),
                 )
             );
+        }
+
+        if ($request instanceof UrlEncodedApiRequest) {
+            if ($request->body === null) {
+                return null;
+            }
+            $body = $this->buildJsonBody($request->body, $options);
+            if ($body instanceof JsonSerializable) {
+                $body = $body->jsonSerialize();
+            }
+            if ($body instanceof \stdClass) {
+                $body = (array)$body;
+            }
+            if (!is_array($body)) {
+                throw new InvalidArgumentException('Form-urlencoded request body must serialize to an array');
+            }
+            $body = array_filter($body, static fn ($value) => $value !== null);
+            return $this->streamFactory->createStream(http_build_query($body));
         }
 
         if ($request instanceof MultipartApiRequest) {

--- a/seed/php-sdk/content-type/src/Core/Client/UrlEncodedApiRequest.php
+++ b/seed/php-sdk/content-type/src/Core/Client/UrlEncodedApiRequest.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Seed\Core\Client;
+
+class UrlEncodedApiRequest extends BaseApiRequest
+{
+    /**
+     * @param string $baseUrl The base URL for the request
+     * @param string $path The path for the request
+     * @param HttpMethod $method The HTTP method for the request
+     * @param array<string, string> $headers Additional headers for the request (optional)
+     * @param array<string, mixed> $query Query parameters for the request (optional)
+     * @param mixed|null $body The form-urlencoded request body (optional)
+     */
+    public function __construct(
+        string $baseUrl,
+        string $path,
+        HttpMethod $method,
+        array $headers = [],
+        array $query = [],
+        public readonly mixed $body = null
+    ) {
+        parent::__construct($baseUrl, $path, $method, $headers, $query);
+    }
+}

--- a/seed/php-sdk/cross-package-type-names/.fern/metadata.json
+++ b/seed/php-sdk/cross-package-type-names/.fern/metadata.json
@@ -3,8 +3,7 @@
   "generatorName": "fernapi/fern-php-sdk",
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/php-sdk/cross-package-type-names/src/Core/Client/RawClient.php
+++ b/seed/php-sdk/cross-package-type-names/src/Core/Client/RawClient.php
@@ -155,6 +155,16 @@ class RawClient
                 $request->headers,
                 $options['headers'] ?? [],
             ),
+            UrlEncodedApiRequest::class => array_merge(
+                [
+                    "Content-Type" => "application/x-www-form-urlencoded",
+                    "Accept" => "*/*",
+                ],
+                $this->headers,
+                $authHeaders,
+                $request->headers,
+                $options['headers'] ?? [],
+            ),
             MultipartApiRequest::class => array_merge(
                 $this->headers,
                 $authHeaders,
@@ -185,6 +195,24 @@ class RawClient
                     ),
                 )
             );
+        }
+
+        if ($request instanceof UrlEncodedApiRequest) {
+            if ($request->body === null) {
+                return null;
+            }
+            $body = $this->buildJsonBody($request->body, $options);
+            if ($body instanceof JsonSerializable) {
+                $body = $body->jsonSerialize();
+            }
+            if ($body instanceof \stdClass) {
+                $body = (array)$body;
+            }
+            if (!is_array($body)) {
+                throw new InvalidArgumentException('Form-urlencoded request body must serialize to an array');
+            }
+            $body = array_filter($body, static fn ($value) => $value !== null);
+            return $this->streamFactory->createStream(http_build_query($body));
         }
 
         if ($request instanceof MultipartApiRequest) {

--- a/seed/php-sdk/cross-package-type-names/src/Core/Client/UrlEncodedApiRequest.php
+++ b/seed/php-sdk/cross-package-type-names/src/Core/Client/UrlEncodedApiRequest.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Seed\Core\Client;
+
+class UrlEncodedApiRequest extends BaseApiRequest
+{
+    /**
+     * @param string $baseUrl The base URL for the request
+     * @param string $path The path for the request
+     * @param HttpMethod $method The HTTP method for the request
+     * @param array<string, string> $headers Additional headers for the request (optional)
+     * @param array<string, mixed> $query Query parameters for the request (optional)
+     * @param mixed|null $body The form-urlencoded request body (optional)
+     */
+    public function __construct(
+        string $baseUrl,
+        string $path,
+        HttpMethod $method,
+        array $headers = [],
+        array $query = [],
+        public readonly mixed $body = null
+    ) {
+        parent::__construct($baseUrl, $path, $method, $headers, $query);
+    }
+}

--- a/seed/php-sdk/dollar-string-examples/.fern/metadata.json
+++ b/seed/php-sdk/dollar-string-examples/.fern/metadata.json
@@ -3,8 +3,7 @@
   "generatorName": "fernapi/fern-php-sdk",
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/php-sdk/dollar-string-examples/src/Core/Client/RawClient.php
+++ b/seed/php-sdk/dollar-string-examples/src/Core/Client/RawClient.php
@@ -155,6 +155,16 @@ class RawClient
                 $request->headers,
                 $options['headers'] ?? [],
             ),
+            UrlEncodedApiRequest::class => array_merge(
+                [
+                    "Content-Type" => "application/x-www-form-urlencoded",
+                    "Accept" => "*/*",
+                ],
+                $this->headers,
+                $authHeaders,
+                $request->headers,
+                $options['headers'] ?? [],
+            ),
             MultipartApiRequest::class => array_merge(
                 $this->headers,
                 $authHeaders,
@@ -185,6 +195,24 @@ class RawClient
                     ),
                 )
             );
+        }
+
+        if ($request instanceof UrlEncodedApiRequest) {
+            if ($request->body === null) {
+                return null;
+            }
+            $body = $this->buildJsonBody($request->body, $options);
+            if ($body instanceof JsonSerializable) {
+                $body = $body->jsonSerialize();
+            }
+            if ($body instanceof \stdClass) {
+                $body = (array)$body;
+            }
+            if (!is_array($body)) {
+                throw new InvalidArgumentException('Form-urlencoded request body must serialize to an array');
+            }
+            $body = array_filter($body, static fn ($value) => $value !== null);
+            return $this->streamFactory->createStream(http_build_query($body));
         }
 
         if ($request instanceof MultipartApiRequest) {

--- a/seed/php-sdk/dollar-string-examples/src/Core/Client/UrlEncodedApiRequest.php
+++ b/seed/php-sdk/dollar-string-examples/src/Core/Client/UrlEncodedApiRequest.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Seed\Core\Client;
+
+class UrlEncodedApiRequest extends BaseApiRequest
+{
+    /**
+     * @param string $baseUrl The base URL for the request
+     * @param string $path The path for the request
+     * @param HttpMethod $method The HTTP method for the request
+     * @param array<string, string> $headers Additional headers for the request (optional)
+     * @param array<string, mixed> $query Query parameters for the request (optional)
+     * @param mixed|null $body The form-urlencoded request body (optional)
+     */
+    public function __construct(
+        string $baseUrl,
+        string $path,
+        HttpMethod $method,
+        array $headers = [],
+        array $query = [],
+        public readonly mixed $body = null
+    ) {
+        parent::__construct($baseUrl, $path, $method, $headers, $query);
+    }
+}

--- a/seed/php-sdk/empty-clients/.fern/metadata.json
+++ b/seed/php-sdk/empty-clients/.fern/metadata.json
@@ -3,8 +3,7 @@
   "generatorName": "fernapi/fern-php-sdk",
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/php-sdk/empty-clients/src/Core/Client/RawClient.php
+++ b/seed/php-sdk/empty-clients/src/Core/Client/RawClient.php
@@ -155,6 +155,16 @@ class RawClient
                 $request->headers,
                 $options['headers'] ?? [],
             ),
+            UrlEncodedApiRequest::class => array_merge(
+                [
+                    "Content-Type" => "application/x-www-form-urlencoded",
+                    "Accept" => "*/*",
+                ],
+                $this->headers,
+                $authHeaders,
+                $request->headers,
+                $options['headers'] ?? [],
+            ),
             MultipartApiRequest::class => array_merge(
                 $this->headers,
                 $authHeaders,
@@ -185,6 +195,24 @@ class RawClient
                     ),
                 )
             );
+        }
+
+        if ($request instanceof UrlEncodedApiRequest) {
+            if ($request->body === null) {
+                return null;
+            }
+            $body = $this->buildJsonBody($request->body, $options);
+            if ($body instanceof JsonSerializable) {
+                $body = $body->jsonSerialize();
+            }
+            if ($body instanceof \stdClass) {
+                $body = (array)$body;
+            }
+            if (!is_array($body)) {
+                throw new InvalidArgumentException('Form-urlencoded request body must serialize to an array');
+            }
+            $body = array_filter($body, static fn ($value) => $value !== null);
+            return $this->streamFactory->createStream(http_build_query($body));
         }
 
         if ($request instanceof MultipartApiRequest) {

--- a/seed/php-sdk/empty-clients/src/Core/Client/UrlEncodedApiRequest.php
+++ b/seed/php-sdk/empty-clients/src/Core/Client/UrlEncodedApiRequest.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Seed\Core\Client;
+
+class UrlEncodedApiRequest extends BaseApiRequest
+{
+    /**
+     * @param string $baseUrl The base URL for the request
+     * @param string $path The path for the request
+     * @param HttpMethod $method The HTTP method for the request
+     * @param array<string, string> $headers Additional headers for the request (optional)
+     * @param array<string, mixed> $query Query parameters for the request (optional)
+     * @param mixed|null $body The form-urlencoded request body (optional)
+     */
+    public function __construct(
+        string $baseUrl,
+        string $path,
+        HttpMethod $method,
+        array $headers = [],
+        array $query = [],
+        public readonly mixed $body = null
+    ) {
+        parent::__construct($baseUrl, $path, $method, $headers, $query);
+    }
+}

--- a/seed/php-sdk/endpoint-security-auth/.fern/metadata.json
+++ b/seed/php-sdk/endpoint-security-auth/.fern/metadata.json
@@ -3,8 +3,7 @@
   "generatorName": "fernapi/fern-php-sdk",
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/php-sdk/endpoint-security-auth/src/Core/Client/RawClient.php
+++ b/seed/php-sdk/endpoint-security-auth/src/Core/Client/RawClient.php
@@ -155,6 +155,16 @@ class RawClient
                 $request->headers,
                 $options['headers'] ?? [],
             ),
+            UrlEncodedApiRequest::class => array_merge(
+                [
+                    "Content-Type" => "application/x-www-form-urlencoded",
+                    "Accept" => "*/*",
+                ],
+                $this->headers,
+                $authHeaders,
+                $request->headers,
+                $options['headers'] ?? [],
+            ),
             MultipartApiRequest::class => array_merge(
                 $this->headers,
                 $authHeaders,
@@ -185,6 +195,24 @@ class RawClient
                     ),
                 )
             );
+        }
+
+        if ($request instanceof UrlEncodedApiRequest) {
+            if ($request->body === null) {
+                return null;
+            }
+            $body = $this->buildJsonBody($request->body, $options);
+            if ($body instanceof JsonSerializable) {
+                $body = $body->jsonSerialize();
+            }
+            if ($body instanceof \stdClass) {
+                $body = (array)$body;
+            }
+            if (!is_array($body)) {
+                throw new InvalidArgumentException('Form-urlencoded request body must serialize to an array');
+            }
+            $body = array_filter($body, static fn ($value) => $value !== null);
+            return $this->streamFactory->createStream(http_build_query($body));
         }
 
         if ($request instanceof MultipartApiRequest) {

--- a/seed/php-sdk/endpoint-security-auth/src/Core/Client/UrlEncodedApiRequest.php
+++ b/seed/php-sdk/endpoint-security-auth/src/Core/Client/UrlEncodedApiRequest.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Seed\Core\Client;
+
+class UrlEncodedApiRequest extends BaseApiRequest
+{
+    /**
+     * @param string $baseUrl The base URL for the request
+     * @param string $path The path for the request
+     * @param HttpMethod $method The HTTP method for the request
+     * @param array<string, string> $headers Additional headers for the request (optional)
+     * @param array<string, mixed> $query Query parameters for the request (optional)
+     * @param mixed|null $body The form-urlencoded request body (optional)
+     */
+    public function __construct(
+        string $baseUrl,
+        string $path,
+        HttpMethod $method,
+        array $headers = [],
+        array $query = [],
+        public readonly mixed $body = null
+    ) {
+        parent::__construct($baseUrl, $path, $method, $headers, $query);
+    }
+}

--- a/seed/php-sdk/enum/.fern/metadata.json
+++ b/seed/php-sdk/enum/.fern/metadata.json
@@ -3,8 +3,7 @@
   "generatorName": "fernapi/fern-php-sdk",
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/php-sdk/enum/src/Core/Client/RawClient.php
+++ b/seed/php-sdk/enum/src/Core/Client/RawClient.php
@@ -155,6 +155,16 @@ class RawClient
                 $request->headers,
                 $options['headers'] ?? [],
             ),
+            UrlEncodedApiRequest::class => array_merge(
+                [
+                    "Content-Type" => "application/x-www-form-urlencoded",
+                    "Accept" => "*/*",
+                ],
+                $this->headers,
+                $authHeaders,
+                $request->headers,
+                $options['headers'] ?? [],
+            ),
             MultipartApiRequest::class => array_merge(
                 $this->headers,
                 $authHeaders,
@@ -185,6 +195,24 @@ class RawClient
                     ),
                 )
             );
+        }
+
+        if ($request instanceof UrlEncodedApiRequest) {
+            if ($request->body === null) {
+                return null;
+            }
+            $body = $this->buildJsonBody($request->body, $options);
+            if ($body instanceof JsonSerializable) {
+                $body = $body->jsonSerialize();
+            }
+            if ($body instanceof \stdClass) {
+                $body = (array)$body;
+            }
+            if (!is_array($body)) {
+                throw new InvalidArgumentException('Form-urlencoded request body must serialize to an array');
+            }
+            $body = array_filter($body, static fn ($value) => $value !== null);
+            return $this->streamFactory->createStream(http_build_query($body));
         }
 
         if ($request instanceof MultipartApiRequest) {

--- a/seed/php-sdk/enum/src/Core/Client/UrlEncodedApiRequest.php
+++ b/seed/php-sdk/enum/src/Core/Client/UrlEncodedApiRequest.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Seed\Core\Client;
+
+class UrlEncodedApiRequest extends BaseApiRequest
+{
+    /**
+     * @param string $baseUrl The base URL for the request
+     * @param string $path The path for the request
+     * @param HttpMethod $method The HTTP method for the request
+     * @param array<string, string> $headers Additional headers for the request (optional)
+     * @param array<string, mixed> $query Query parameters for the request (optional)
+     * @param mixed|null $body The form-urlencoded request body (optional)
+     */
+    public function __construct(
+        string $baseUrl,
+        string $path,
+        HttpMethod $method,
+        array $headers = [],
+        array $query = [],
+        public readonly mixed $body = null
+    ) {
+        parent::__construct($baseUrl, $path, $method, $headers, $query);
+    }
+}

--- a/seed/php-sdk/error-property/.fern/metadata.json
+++ b/seed/php-sdk/error-property/.fern/metadata.json
@@ -3,8 +3,7 @@
   "generatorName": "fernapi/fern-php-sdk",
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/php-sdk/error-property/src/Core/Client/RawClient.php
+++ b/seed/php-sdk/error-property/src/Core/Client/RawClient.php
@@ -155,6 +155,16 @@ class RawClient
                 $request->headers,
                 $options['headers'] ?? [],
             ),
+            UrlEncodedApiRequest::class => array_merge(
+                [
+                    "Content-Type" => "application/x-www-form-urlencoded",
+                    "Accept" => "*/*",
+                ],
+                $this->headers,
+                $authHeaders,
+                $request->headers,
+                $options['headers'] ?? [],
+            ),
             MultipartApiRequest::class => array_merge(
                 $this->headers,
                 $authHeaders,
@@ -185,6 +195,24 @@ class RawClient
                     ),
                 )
             );
+        }
+
+        if ($request instanceof UrlEncodedApiRequest) {
+            if ($request->body === null) {
+                return null;
+            }
+            $body = $this->buildJsonBody($request->body, $options);
+            if ($body instanceof JsonSerializable) {
+                $body = $body->jsonSerialize();
+            }
+            if ($body instanceof \stdClass) {
+                $body = (array)$body;
+            }
+            if (!is_array($body)) {
+                throw new InvalidArgumentException('Form-urlencoded request body must serialize to an array');
+            }
+            $body = array_filter($body, static fn ($value) => $value !== null);
+            return $this->streamFactory->createStream(http_build_query($body));
         }
 
         if ($request instanceof MultipartApiRequest) {

--- a/seed/php-sdk/error-property/src/Core/Client/UrlEncodedApiRequest.php
+++ b/seed/php-sdk/error-property/src/Core/Client/UrlEncodedApiRequest.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Seed\Core\Client;
+
+class UrlEncodedApiRequest extends BaseApiRequest
+{
+    /**
+     * @param string $baseUrl The base URL for the request
+     * @param string $path The path for the request
+     * @param HttpMethod $method The HTTP method for the request
+     * @param array<string, string> $headers Additional headers for the request (optional)
+     * @param array<string, mixed> $query Query parameters for the request (optional)
+     * @param mixed|null $body The form-urlencoded request body (optional)
+     */
+    public function __construct(
+        string $baseUrl,
+        string $path,
+        HttpMethod $method,
+        array $headers = [],
+        array $query = [],
+        public readonly mixed $body = null
+    ) {
+        parent::__construct($baseUrl, $path, $method, $headers, $query);
+    }
+}

--- a/seed/php-sdk/errors/.fern/metadata.json
+++ b/seed/php-sdk/errors/.fern/metadata.json
@@ -3,8 +3,7 @@
   "generatorName": "fernapi/fern-php-sdk",
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/php-sdk/errors/src/Core/Client/RawClient.php
+++ b/seed/php-sdk/errors/src/Core/Client/RawClient.php
@@ -155,6 +155,16 @@ class RawClient
                 $request->headers,
                 $options['headers'] ?? [],
             ),
+            UrlEncodedApiRequest::class => array_merge(
+                [
+                    "Content-Type" => "application/x-www-form-urlencoded",
+                    "Accept" => "*/*",
+                ],
+                $this->headers,
+                $authHeaders,
+                $request->headers,
+                $options['headers'] ?? [],
+            ),
             MultipartApiRequest::class => array_merge(
                 $this->headers,
                 $authHeaders,
@@ -185,6 +195,24 @@ class RawClient
                     ),
                 )
             );
+        }
+
+        if ($request instanceof UrlEncodedApiRequest) {
+            if ($request->body === null) {
+                return null;
+            }
+            $body = $this->buildJsonBody($request->body, $options);
+            if ($body instanceof JsonSerializable) {
+                $body = $body->jsonSerialize();
+            }
+            if ($body instanceof \stdClass) {
+                $body = (array)$body;
+            }
+            if (!is_array($body)) {
+                throw new InvalidArgumentException('Form-urlencoded request body must serialize to an array');
+            }
+            $body = array_filter($body, static fn ($value) => $value !== null);
+            return $this->streamFactory->createStream(http_build_query($body));
         }
 
         if ($request instanceof MultipartApiRequest) {

--- a/seed/php-sdk/errors/src/Core/Client/UrlEncodedApiRequest.php
+++ b/seed/php-sdk/errors/src/Core/Client/UrlEncodedApiRequest.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Seed\Core\Client;
+
+class UrlEncodedApiRequest extends BaseApiRequest
+{
+    /**
+     * @param string $baseUrl The base URL for the request
+     * @param string $path The path for the request
+     * @param HttpMethod $method The HTTP method for the request
+     * @param array<string, string> $headers Additional headers for the request (optional)
+     * @param array<string, mixed> $query Query parameters for the request (optional)
+     * @param mixed|null $body The form-urlencoded request body (optional)
+     */
+    public function __construct(
+        string $baseUrl,
+        string $path,
+        HttpMethod $method,
+        array $headers = [],
+        array $query = [],
+        public readonly mixed $body = null
+    ) {
+        parent::__construct($baseUrl, $path, $method, $headers, $query);
+    }
+}

--- a/seed/php-sdk/examples/no-custom-config/.fern/metadata.json
+++ b/seed/php-sdk/examples/no-custom-config/.fern/metadata.json
@@ -3,8 +3,7 @@
   "generatorName": "fernapi/fern-php-sdk",
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/php-sdk/examples/no-custom-config/src/Core/Client/RawClient.php
+++ b/seed/php-sdk/examples/no-custom-config/src/Core/Client/RawClient.php
@@ -155,6 +155,16 @@ class RawClient
                 $request->headers,
                 $options['headers'] ?? [],
             ),
+            UrlEncodedApiRequest::class => array_merge(
+                [
+                    "Content-Type" => "application/x-www-form-urlencoded",
+                    "Accept" => "*/*",
+                ],
+                $this->headers,
+                $authHeaders,
+                $request->headers,
+                $options['headers'] ?? [],
+            ),
             MultipartApiRequest::class => array_merge(
                 $this->headers,
                 $authHeaders,
@@ -185,6 +195,24 @@ class RawClient
                     ),
                 )
             );
+        }
+
+        if ($request instanceof UrlEncodedApiRequest) {
+            if ($request->body === null) {
+                return null;
+            }
+            $body = $this->buildJsonBody($request->body, $options);
+            if ($body instanceof JsonSerializable) {
+                $body = $body->jsonSerialize();
+            }
+            if ($body instanceof \stdClass) {
+                $body = (array)$body;
+            }
+            if (!is_array($body)) {
+                throw new InvalidArgumentException('Form-urlencoded request body must serialize to an array');
+            }
+            $body = array_filter($body, static fn ($value) => $value !== null);
+            return $this->streamFactory->createStream(http_build_query($body));
         }
 
         if ($request instanceof MultipartApiRequest) {

--- a/seed/php-sdk/examples/no-custom-config/src/Core/Client/UrlEncodedApiRequest.php
+++ b/seed/php-sdk/examples/no-custom-config/src/Core/Client/UrlEncodedApiRequest.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Seed\Core\Client;
+
+class UrlEncodedApiRequest extends BaseApiRequest
+{
+    /**
+     * @param string $baseUrl The base URL for the request
+     * @param string $path The path for the request
+     * @param HttpMethod $method The HTTP method for the request
+     * @param array<string, string> $headers Additional headers for the request (optional)
+     * @param array<string, mixed> $query Query parameters for the request (optional)
+     * @param mixed|null $body The form-urlencoded request body (optional)
+     */
+    public function __construct(
+        string $baseUrl,
+        string $path,
+        HttpMethod $method,
+        array $headers = [],
+        array $query = [],
+        public readonly mixed $body = null
+    ) {
+        parent::__construct($baseUrl, $path, $method, $headers, $query);
+    }
+}

--- a/seed/php-sdk/examples/readme-config/.fern/metadata.json
+++ b/seed/php-sdk/examples/readme-config/.fern/metadata.json
@@ -15,8 +15,7 @@
     ]
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/php-sdk/examples/readme-config/src/Core/Client/RawClient.php
+++ b/seed/php-sdk/examples/readme-config/src/Core/Client/RawClient.php
@@ -155,6 +155,16 @@ class RawClient
                 $request->headers,
                 $options['headers'] ?? [],
             ),
+            UrlEncodedApiRequest::class => array_merge(
+                [
+                    "Content-Type" => "application/x-www-form-urlencoded",
+                    "Accept" => "*/*",
+                ],
+                $this->headers,
+                $authHeaders,
+                $request->headers,
+                $options['headers'] ?? [],
+            ),
             MultipartApiRequest::class => array_merge(
                 $this->headers,
                 $authHeaders,
@@ -185,6 +195,24 @@ class RawClient
                     ),
                 )
             );
+        }
+
+        if ($request instanceof UrlEncodedApiRequest) {
+            if ($request->body === null) {
+                return null;
+            }
+            $body = $this->buildJsonBody($request->body, $options);
+            if ($body instanceof JsonSerializable) {
+                $body = $body->jsonSerialize();
+            }
+            if ($body instanceof \stdClass) {
+                $body = (array)$body;
+            }
+            if (!is_array($body)) {
+                throw new InvalidArgumentException('Form-urlencoded request body must serialize to an array');
+            }
+            $body = array_filter($body, static fn ($value) => $value !== null);
+            return $this->streamFactory->createStream(http_build_query($body));
         }
 
         if ($request instanceof MultipartApiRequest) {

--- a/seed/php-sdk/examples/readme-config/src/Core/Client/UrlEncodedApiRequest.php
+++ b/seed/php-sdk/examples/readme-config/src/Core/Client/UrlEncodedApiRequest.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Seed\Core\Client;
+
+class UrlEncodedApiRequest extends BaseApiRequest
+{
+    /**
+     * @param string $baseUrl The base URL for the request
+     * @param string $path The path for the request
+     * @param HttpMethod $method The HTTP method for the request
+     * @param array<string, string> $headers Additional headers for the request (optional)
+     * @param array<string, mixed> $query Query parameters for the request (optional)
+     * @param mixed|null $body The form-urlencoded request body (optional)
+     */
+    public function __construct(
+        string $baseUrl,
+        string $path,
+        HttpMethod $method,
+        array $headers = [],
+        array $query = [],
+        public readonly mixed $body = null
+    ) {
+        parent::__construct($baseUrl, $path, $method, $headers, $query);
+    }
+}

--- a/seed/php-sdk/exhaustive/no-custom-config/.fern/metadata.json
+++ b/seed/php-sdk/exhaustive/no-custom-config/.fern/metadata.json
@@ -3,8 +3,7 @@
   "generatorName": "fernapi/fern-php-sdk",
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/php-sdk/exhaustive/no-custom-config/src/Core/Client/RawClient.php
+++ b/seed/php-sdk/exhaustive/no-custom-config/src/Core/Client/RawClient.php
@@ -155,6 +155,16 @@ class RawClient
                 $request->headers,
                 $options['headers'] ?? [],
             ),
+            UrlEncodedApiRequest::class => array_merge(
+                [
+                    "Content-Type" => "application/x-www-form-urlencoded",
+                    "Accept" => "*/*",
+                ],
+                $this->headers,
+                $authHeaders,
+                $request->headers,
+                $options['headers'] ?? [],
+            ),
             MultipartApiRequest::class => array_merge(
                 $this->headers,
                 $authHeaders,
@@ -185,6 +195,24 @@ class RawClient
                     ),
                 )
             );
+        }
+
+        if ($request instanceof UrlEncodedApiRequest) {
+            if ($request->body === null) {
+                return null;
+            }
+            $body = $this->buildJsonBody($request->body, $options);
+            if ($body instanceof JsonSerializable) {
+                $body = $body->jsonSerialize();
+            }
+            if ($body instanceof \stdClass) {
+                $body = (array)$body;
+            }
+            if (!is_array($body)) {
+                throw new InvalidArgumentException('Form-urlencoded request body must serialize to an array');
+            }
+            $body = array_filter($body, static fn ($value) => $value !== null);
+            return $this->streamFactory->createStream(http_build_query($body));
         }
 
         if ($request instanceof MultipartApiRequest) {

--- a/seed/php-sdk/exhaustive/no-custom-config/src/Core/Client/UrlEncodedApiRequest.php
+++ b/seed/php-sdk/exhaustive/no-custom-config/src/Core/Client/UrlEncodedApiRequest.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Seed\Core\Client;
+
+class UrlEncodedApiRequest extends BaseApiRequest
+{
+    /**
+     * @param string $baseUrl The base URL for the request
+     * @param string $path The path for the request
+     * @param HttpMethod $method The HTTP method for the request
+     * @param array<string, string> $headers Additional headers for the request (optional)
+     * @param array<string, mixed> $query Query parameters for the request (optional)
+     * @param mixed|null $body The form-urlencoded request body (optional)
+     */
+    public function __construct(
+        string $baseUrl,
+        string $path,
+        HttpMethod $method,
+        array $headers = [],
+        array $query = [],
+        public readonly mixed $body = null
+    ) {
+        parent::__construct($baseUrl, $path, $method, $headers, $query);
+    }
+}

--- a/seed/php-sdk/exhaustive/wire-tests/.fern/metadata.json
+++ b/seed/php-sdk/exhaustive/wire-tests/.fern/metadata.json
@@ -6,8 +6,7 @@
     "enable-wire-tests": true
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/php-sdk/exhaustive/wire-tests/src/Core/Client/RawClient.php
+++ b/seed/php-sdk/exhaustive/wire-tests/src/Core/Client/RawClient.php
@@ -155,6 +155,16 @@ class RawClient
                 $request->headers,
                 $options['headers'] ?? [],
             ),
+            UrlEncodedApiRequest::class => array_merge(
+                [
+                    "Content-Type" => "application/x-www-form-urlencoded",
+                    "Accept" => "*/*",
+                ],
+                $this->headers,
+                $authHeaders,
+                $request->headers,
+                $options['headers'] ?? [],
+            ),
             MultipartApiRequest::class => array_merge(
                 $this->headers,
                 $authHeaders,
@@ -185,6 +195,24 @@ class RawClient
                     ),
                 )
             );
+        }
+
+        if ($request instanceof UrlEncodedApiRequest) {
+            if ($request->body === null) {
+                return null;
+            }
+            $body = $this->buildJsonBody($request->body, $options);
+            if ($body instanceof JsonSerializable) {
+                $body = $body->jsonSerialize();
+            }
+            if ($body instanceof \stdClass) {
+                $body = (array)$body;
+            }
+            if (!is_array($body)) {
+                throw new InvalidArgumentException('Form-urlencoded request body must serialize to an array');
+            }
+            $body = array_filter($body, static fn ($value) => $value !== null);
+            return $this->streamFactory->createStream(http_build_query($body));
         }
 
         if ($request instanceof MultipartApiRequest) {

--- a/seed/php-sdk/exhaustive/wire-tests/src/Core/Client/UrlEncodedApiRequest.php
+++ b/seed/php-sdk/exhaustive/wire-tests/src/Core/Client/UrlEncodedApiRequest.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Seed\Core\Client;
+
+class UrlEncodedApiRequest extends BaseApiRequest
+{
+    /**
+     * @param string $baseUrl The base URL for the request
+     * @param string $path The path for the request
+     * @param HttpMethod $method The HTTP method for the request
+     * @param array<string, string> $headers Additional headers for the request (optional)
+     * @param array<string, mixed> $query Query parameters for the request (optional)
+     * @param mixed|null $body The form-urlencoded request body (optional)
+     */
+    public function __construct(
+        string $baseUrl,
+        string $path,
+        HttpMethod $method,
+        array $headers = [],
+        array $query = [],
+        public readonly mixed $body = null
+    ) {
+        parent::__construct($baseUrl, $path, $method, $headers, $query);
+    }
+}

--- a/seed/php-sdk/extends/no-custom-config/.fern/metadata.json
+++ b/seed/php-sdk/extends/no-custom-config/.fern/metadata.json
@@ -3,8 +3,7 @@
   "generatorName": "fernapi/fern-php-sdk",
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/php-sdk/extends/no-custom-config/src/Core/Client/RawClient.php
+++ b/seed/php-sdk/extends/no-custom-config/src/Core/Client/RawClient.php
@@ -155,6 +155,16 @@ class RawClient
                 $request->headers,
                 $options['headers'] ?? [],
             ),
+            UrlEncodedApiRequest::class => array_merge(
+                [
+                    "Content-Type" => "application/x-www-form-urlencoded",
+                    "Accept" => "*/*",
+                ],
+                $this->headers,
+                $authHeaders,
+                $request->headers,
+                $options['headers'] ?? [],
+            ),
             MultipartApiRequest::class => array_merge(
                 $this->headers,
                 $authHeaders,
@@ -185,6 +195,24 @@ class RawClient
                     ),
                 )
             );
+        }
+
+        if ($request instanceof UrlEncodedApiRequest) {
+            if ($request->body === null) {
+                return null;
+            }
+            $body = $this->buildJsonBody($request->body, $options);
+            if ($body instanceof JsonSerializable) {
+                $body = $body->jsonSerialize();
+            }
+            if ($body instanceof \stdClass) {
+                $body = (array)$body;
+            }
+            if (!is_array($body)) {
+                throw new InvalidArgumentException('Form-urlencoded request body must serialize to an array');
+            }
+            $body = array_filter($body, static fn ($value) => $value !== null);
+            return $this->streamFactory->createStream(http_build_query($body));
         }
 
         if ($request instanceof MultipartApiRequest) {

--- a/seed/php-sdk/extends/no-custom-config/src/Core/Client/UrlEncodedApiRequest.php
+++ b/seed/php-sdk/extends/no-custom-config/src/Core/Client/UrlEncodedApiRequest.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Seed\Core\Client;
+
+class UrlEncodedApiRequest extends BaseApiRequest
+{
+    /**
+     * @param string $baseUrl The base URL for the request
+     * @param string $path The path for the request
+     * @param HttpMethod $method The HTTP method for the request
+     * @param array<string, string> $headers Additional headers for the request (optional)
+     * @param array<string, mixed> $query Query parameters for the request (optional)
+     * @param mixed|null $body The form-urlencoded request body (optional)
+     */
+    public function __construct(
+        string $baseUrl,
+        string $path,
+        HttpMethod $method,
+        array $headers = [],
+        array $query = [],
+        public readonly mixed $body = null
+    ) {
+        parent::__construct($baseUrl, $path, $method, $headers, $query);
+    }
+}

--- a/seed/php-sdk/extends/private/.fern/metadata.json
+++ b/seed/php-sdk/extends/private/.fern/metadata.json
@@ -6,8 +6,7 @@
     "propertyAccess": "private"
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/php-sdk/extends/private/src/Core/Client/RawClient.php
+++ b/seed/php-sdk/extends/private/src/Core/Client/RawClient.php
@@ -155,6 +155,16 @@ class RawClient
                 $request->headers,
                 $options['headers'] ?? [],
             ),
+            UrlEncodedApiRequest::class => array_merge(
+                [
+                    "Content-Type" => "application/x-www-form-urlencoded",
+                    "Accept" => "*/*",
+                ],
+                $this->headers,
+                $authHeaders,
+                $request->headers,
+                $options['headers'] ?? [],
+            ),
             MultipartApiRequest::class => array_merge(
                 $this->headers,
                 $authHeaders,
@@ -185,6 +195,24 @@ class RawClient
                     ),
                 )
             );
+        }
+
+        if ($request instanceof UrlEncodedApiRequest) {
+            if ($request->body === null) {
+                return null;
+            }
+            $body = $this->buildJsonBody($request->body, $options);
+            if ($body instanceof JsonSerializable) {
+                $body = $body->jsonSerialize();
+            }
+            if ($body instanceof \stdClass) {
+                $body = (array)$body;
+            }
+            if (!is_array($body)) {
+                throw new InvalidArgumentException('Form-urlencoded request body must serialize to an array');
+            }
+            $body = array_filter($body, static fn ($value) => $value !== null);
+            return $this->streamFactory->createStream(http_build_query($body));
         }
 
         if ($request instanceof MultipartApiRequest) {

--- a/seed/php-sdk/extends/private/src/Core/Client/UrlEncodedApiRequest.php
+++ b/seed/php-sdk/extends/private/src/Core/Client/UrlEncodedApiRequest.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Seed\Core\Client;
+
+class UrlEncodedApiRequest extends BaseApiRequest
+{
+    /**
+     * @param string $baseUrl The base URL for the request
+     * @param string $path The path for the request
+     * @param HttpMethod $method The HTTP method for the request
+     * @param array<string, string> $headers Additional headers for the request (optional)
+     * @param array<string, mixed> $query Query parameters for the request (optional)
+     * @param mixed|null $body The form-urlencoded request body (optional)
+     */
+    public function __construct(
+        string $baseUrl,
+        string $path,
+        HttpMethod $method,
+        array $headers = [],
+        array $query = [],
+        public readonly mixed $body = null
+    ) {
+        parent::__construct($baseUrl, $path, $method, $headers, $query);
+    }
+}

--- a/seed/php-sdk/extra-properties/.fern/metadata.json
+++ b/seed/php-sdk/extra-properties/.fern/metadata.json
@@ -3,8 +3,7 @@
   "generatorName": "fernapi/fern-php-sdk",
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/php-sdk/extra-properties/src/Core/Client/RawClient.php
+++ b/seed/php-sdk/extra-properties/src/Core/Client/RawClient.php
@@ -155,6 +155,16 @@ class RawClient
                 $request->headers,
                 $options['headers'] ?? [],
             ),
+            UrlEncodedApiRequest::class => array_merge(
+                [
+                    "Content-Type" => "application/x-www-form-urlencoded",
+                    "Accept" => "*/*",
+                ],
+                $this->headers,
+                $authHeaders,
+                $request->headers,
+                $options['headers'] ?? [],
+            ),
             MultipartApiRequest::class => array_merge(
                 $this->headers,
                 $authHeaders,
@@ -185,6 +195,24 @@ class RawClient
                     ),
                 )
             );
+        }
+
+        if ($request instanceof UrlEncodedApiRequest) {
+            if ($request->body === null) {
+                return null;
+            }
+            $body = $this->buildJsonBody($request->body, $options);
+            if ($body instanceof JsonSerializable) {
+                $body = $body->jsonSerialize();
+            }
+            if ($body instanceof \stdClass) {
+                $body = (array)$body;
+            }
+            if (!is_array($body)) {
+                throw new InvalidArgumentException('Form-urlencoded request body must serialize to an array');
+            }
+            $body = array_filter($body, static fn ($value) => $value !== null);
+            return $this->streamFactory->createStream(http_build_query($body));
         }
 
         if ($request instanceof MultipartApiRequest) {

--- a/seed/php-sdk/extra-properties/src/Core/Client/UrlEncodedApiRequest.php
+++ b/seed/php-sdk/extra-properties/src/Core/Client/UrlEncodedApiRequest.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Seed\Core\Client;
+
+class UrlEncodedApiRequest extends BaseApiRequest
+{
+    /**
+     * @param string $baseUrl The base URL for the request
+     * @param string $path The path for the request
+     * @param HttpMethod $method The HTTP method for the request
+     * @param array<string, string> $headers Additional headers for the request (optional)
+     * @param array<string, mixed> $query Query parameters for the request (optional)
+     * @param mixed|null $body The form-urlencoded request body (optional)
+     */
+    public function __construct(
+        string $baseUrl,
+        string $path,
+        HttpMethod $method,
+        array $headers = [],
+        array $query = [],
+        public readonly mixed $body = null
+    ) {
+        parent::__construct($baseUrl, $path, $method, $headers, $query);
+    }
+}

--- a/seed/php-sdk/file-download/.fern/metadata.json
+++ b/seed/php-sdk/file-download/.fern/metadata.json
@@ -3,8 +3,7 @@
   "generatorName": "fernapi/fern-php-sdk",
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/php-sdk/file-download/src/Core/Client/RawClient.php
+++ b/seed/php-sdk/file-download/src/Core/Client/RawClient.php
@@ -155,6 +155,16 @@ class RawClient
                 $request->headers,
                 $options['headers'] ?? [],
             ),
+            UrlEncodedApiRequest::class => array_merge(
+                [
+                    "Content-Type" => "application/x-www-form-urlencoded",
+                    "Accept" => "*/*",
+                ],
+                $this->headers,
+                $authHeaders,
+                $request->headers,
+                $options['headers'] ?? [],
+            ),
             MultipartApiRequest::class => array_merge(
                 $this->headers,
                 $authHeaders,
@@ -185,6 +195,24 @@ class RawClient
                     ),
                 )
             );
+        }
+
+        if ($request instanceof UrlEncodedApiRequest) {
+            if ($request->body === null) {
+                return null;
+            }
+            $body = $this->buildJsonBody($request->body, $options);
+            if ($body instanceof JsonSerializable) {
+                $body = $body->jsonSerialize();
+            }
+            if ($body instanceof \stdClass) {
+                $body = (array)$body;
+            }
+            if (!is_array($body)) {
+                throw new InvalidArgumentException('Form-urlencoded request body must serialize to an array');
+            }
+            $body = array_filter($body, static fn ($value) => $value !== null);
+            return $this->streamFactory->createStream(http_build_query($body));
         }
 
         if ($request instanceof MultipartApiRequest) {

--- a/seed/php-sdk/file-download/src/Core/Client/UrlEncodedApiRequest.php
+++ b/seed/php-sdk/file-download/src/Core/Client/UrlEncodedApiRequest.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Seed\Core\Client;
+
+class UrlEncodedApiRequest extends BaseApiRequest
+{
+    /**
+     * @param string $baseUrl The base URL for the request
+     * @param string $path The path for the request
+     * @param HttpMethod $method The HTTP method for the request
+     * @param array<string, string> $headers Additional headers for the request (optional)
+     * @param array<string, mixed> $query Query parameters for the request (optional)
+     * @param mixed|null $body The form-urlencoded request body (optional)
+     */
+    public function __construct(
+        string $baseUrl,
+        string $path,
+        HttpMethod $method,
+        array $headers = [],
+        array $query = [],
+        public readonly mixed $body = null
+    ) {
+        parent::__construct($baseUrl, $path, $method, $headers, $query);
+    }
+}

--- a/seed/php-sdk/file-upload-openapi/.fern/metadata.json
+++ b/seed/php-sdk/file-upload-openapi/.fern/metadata.json
@@ -3,8 +3,7 @@
   "generatorName": "fernapi/fern-php-sdk",
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/php-sdk/file-upload-openapi/src/Core/Client/RawClient.php
+++ b/seed/php-sdk/file-upload-openapi/src/Core/Client/RawClient.php
@@ -155,6 +155,16 @@ class RawClient
                 $request->headers,
                 $options['headers'] ?? [],
             ),
+            UrlEncodedApiRequest::class => array_merge(
+                [
+                    "Content-Type" => "application/x-www-form-urlencoded",
+                    "Accept" => "*/*",
+                ],
+                $this->headers,
+                $authHeaders,
+                $request->headers,
+                $options['headers'] ?? [],
+            ),
             MultipartApiRequest::class => array_merge(
                 $this->headers,
                 $authHeaders,
@@ -185,6 +195,24 @@ class RawClient
                     ),
                 )
             );
+        }
+
+        if ($request instanceof UrlEncodedApiRequest) {
+            if ($request->body === null) {
+                return null;
+            }
+            $body = $this->buildJsonBody($request->body, $options);
+            if ($body instanceof JsonSerializable) {
+                $body = $body->jsonSerialize();
+            }
+            if ($body instanceof \stdClass) {
+                $body = (array)$body;
+            }
+            if (!is_array($body)) {
+                throw new InvalidArgumentException('Form-urlencoded request body must serialize to an array');
+            }
+            $body = array_filter($body, static fn ($value) => $value !== null);
+            return $this->streamFactory->createStream(http_build_query($body));
         }
 
         if ($request instanceof MultipartApiRequest) {

--- a/seed/php-sdk/file-upload-openapi/src/Core/Client/UrlEncodedApiRequest.php
+++ b/seed/php-sdk/file-upload-openapi/src/Core/Client/UrlEncodedApiRequest.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Seed\Core\Client;
+
+class UrlEncodedApiRequest extends BaseApiRequest
+{
+    /**
+     * @param string $baseUrl The base URL for the request
+     * @param string $path The path for the request
+     * @param HttpMethod $method The HTTP method for the request
+     * @param array<string, string> $headers Additional headers for the request (optional)
+     * @param array<string, mixed> $query Query parameters for the request (optional)
+     * @param mixed|null $body The form-urlencoded request body (optional)
+     */
+    public function __construct(
+        string $baseUrl,
+        string $path,
+        HttpMethod $method,
+        array $headers = [],
+        array $query = [],
+        public readonly mixed $body = null
+    ) {
+        parent::__construct($baseUrl, $path, $method, $headers, $query);
+    }
+}

--- a/seed/php-sdk/file-upload/.fern/metadata.json
+++ b/seed/php-sdk/file-upload/.fern/metadata.json
@@ -3,8 +3,7 @@
   "generatorName": "fernapi/fern-php-sdk",
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/php-sdk/file-upload/src/Core/Client/RawClient.php
+++ b/seed/php-sdk/file-upload/src/Core/Client/RawClient.php
@@ -155,6 +155,16 @@ class RawClient
                 $request->headers,
                 $options['headers'] ?? [],
             ),
+            UrlEncodedApiRequest::class => array_merge(
+                [
+                    "Content-Type" => "application/x-www-form-urlencoded",
+                    "Accept" => "*/*",
+                ],
+                $this->headers,
+                $authHeaders,
+                $request->headers,
+                $options['headers'] ?? [],
+            ),
             MultipartApiRequest::class => array_merge(
                 $this->headers,
                 $authHeaders,
@@ -185,6 +195,24 @@ class RawClient
                     ),
                 )
             );
+        }
+
+        if ($request instanceof UrlEncodedApiRequest) {
+            if ($request->body === null) {
+                return null;
+            }
+            $body = $this->buildJsonBody($request->body, $options);
+            if ($body instanceof JsonSerializable) {
+                $body = $body->jsonSerialize();
+            }
+            if ($body instanceof \stdClass) {
+                $body = (array)$body;
+            }
+            if (!is_array($body)) {
+                throw new InvalidArgumentException('Form-urlencoded request body must serialize to an array');
+            }
+            $body = array_filter($body, static fn ($value) => $value !== null);
+            return $this->streamFactory->createStream(http_build_query($body));
         }
 
         if ($request instanceof MultipartApiRequest) {

--- a/seed/php-sdk/file-upload/src/Core/Client/UrlEncodedApiRequest.php
+++ b/seed/php-sdk/file-upload/src/Core/Client/UrlEncodedApiRequest.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Seed\Core\Client;
+
+class UrlEncodedApiRequest extends BaseApiRequest
+{
+    /**
+     * @param string $baseUrl The base URL for the request
+     * @param string $path The path for the request
+     * @param HttpMethod $method The HTTP method for the request
+     * @param array<string, string> $headers Additional headers for the request (optional)
+     * @param array<string, mixed> $query Query parameters for the request (optional)
+     * @param mixed|null $body The form-urlencoded request body (optional)
+     */
+    public function __construct(
+        string $baseUrl,
+        string $path,
+        HttpMethod $method,
+        array $headers = [],
+        array $query = [],
+        public readonly mixed $body = null
+    ) {
+        parent::__construct($baseUrl, $path, $method, $headers, $query);
+    }
+}

--- a/seed/php-sdk/folders/no-custom-config/.fern/metadata.json
+++ b/seed/php-sdk/folders/no-custom-config/.fern/metadata.json
@@ -3,8 +3,7 @@
   "generatorName": "fernapi/fern-php-sdk",
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/php-sdk/folders/no-custom-config/src/Core/Client/RawClient.php
+++ b/seed/php-sdk/folders/no-custom-config/src/Core/Client/RawClient.php
@@ -155,6 +155,16 @@ class RawClient
                 $request->headers,
                 $options['headers'] ?? [],
             ),
+            UrlEncodedApiRequest::class => array_merge(
+                [
+                    "Content-Type" => "application/x-www-form-urlencoded",
+                    "Accept" => "*/*",
+                ],
+                $this->headers,
+                $authHeaders,
+                $request->headers,
+                $options['headers'] ?? [],
+            ),
             MultipartApiRequest::class => array_merge(
                 $this->headers,
                 $authHeaders,
@@ -185,6 +195,24 @@ class RawClient
                     ),
                 )
             );
+        }
+
+        if ($request instanceof UrlEncodedApiRequest) {
+            if ($request->body === null) {
+                return null;
+            }
+            $body = $this->buildJsonBody($request->body, $options);
+            if ($body instanceof JsonSerializable) {
+                $body = $body->jsonSerialize();
+            }
+            if ($body instanceof \stdClass) {
+                $body = (array)$body;
+            }
+            if (!is_array($body)) {
+                throw new InvalidArgumentException('Form-urlencoded request body must serialize to an array');
+            }
+            $body = array_filter($body, static fn ($value) => $value !== null);
+            return $this->streamFactory->createStream(http_build_query($body));
         }
 
         if ($request instanceof MultipartApiRequest) {

--- a/seed/php-sdk/folders/no-custom-config/src/Core/Client/UrlEncodedApiRequest.php
+++ b/seed/php-sdk/folders/no-custom-config/src/Core/Client/UrlEncodedApiRequest.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Seed\Core\Client;
+
+class UrlEncodedApiRequest extends BaseApiRequest
+{
+    /**
+     * @param string $baseUrl The base URL for the request
+     * @param string $path The path for the request
+     * @param HttpMethod $method The HTTP method for the request
+     * @param array<string, string> $headers Additional headers for the request (optional)
+     * @param array<string, mixed> $query Query parameters for the request (optional)
+     * @param mixed|null $body The form-urlencoded request body (optional)
+     */
+    public function __construct(
+        string $baseUrl,
+        string $path,
+        HttpMethod $method,
+        array $headers = [],
+        array $query = [],
+        public readonly mixed $body = null
+    ) {
+        parent::__construct($baseUrl, $path, $method, $headers, $query);
+    }
+}

--- a/seed/php-sdk/folders/with-interfaces/.fern/metadata.json
+++ b/seed/php-sdk/folders/with-interfaces/.fern/metadata.json
@@ -6,8 +6,7 @@
     "generateClientInterfaces": true
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/php-sdk/folders/with-interfaces/src/Core/Client/RawClient.php
+++ b/seed/php-sdk/folders/with-interfaces/src/Core/Client/RawClient.php
@@ -155,6 +155,16 @@ class RawClient
                 $request->headers,
                 $options['headers'] ?? [],
             ),
+            UrlEncodedApiRequest::class => array_merge(
+                [
+                    "Content-Type" => "application/x-www-form-urlencoded",
+                    "Accept" => "*/*",
+                ],
+                $this->headers,
+                $authHeaders,
+                $request->headers,
+                $options['headers'] ?? [],
+            ),
             MultipartApiRequest::class => array_merge(
                 $this->headers,
                 $authHeaders,
@@ -185,6 +195,24 @@ class RawClient
                     ),
                 )
             );
+        }
+
+        if ($request instanceof UrlEncodedApiRequest) {
+            if ($request->body === null) {
+                return null;
+            }
+            $body = $this->buildJsonBody($request->body, $options);
+            if ($body instanceof JsonSerializable) {
+                $body = $body->jsonSerialize();
+            }
+            if ($body instanceof \stdClass) {
+                $body = (array)$body;
+            }
+            if (!is_array($body)) {
+                throw new InvalidArgumentException('Form-urlencoded request body must serialize to an array');
+            }
+            $body = array_filter($body, static fn ($value) => $value !== null);
+            return $this->streamFactory->createStream(http_build_query($body));
         }
 
         if ($request instanceof MultipartApiRequest) {

--- a/seed/php-sdk/folders/with-interfaces/src/Core/Client/UrlEncodedApiRequest.php
+++ b/seed/php-sdk/folders/with-interfaces/src/Core/Client/UrlEncodedApiRequest.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Seed\Core\Client;
+
+class UrlEncodedApiRequest extends BaseApiRequest
+{
+    /**
+     * @param string $baseUrl The base URL for the request
+     * @param string $path The path for the request
+     * @param HttpMethod $method The HTTP method for the request
+     * @param array<string, string> $headers Additional headers for the request (optional)
+     * @param array<string, mixed> $query Query parameters for the request (optional)
+     * @param mixed|null $body The form-urlencoded request body (optional)
+     */
+    public function __construct(
+        string $baseUrl,
+        string $path,
+        HttpMethod $method,
+        array $headers = [],
+        array $query = [],
+        public readonly mixed $body = null
+    ) {
+        parent::__construct($baseUrl, $path, $method, $headers, $query);
+    }
+}

--- a/seed/php-sdk/header-auth-environment-variable/.fern/metadata.json
+++ b/seed/php-sdk/header-auth-environment-variable/.fern/metadata.json
@@ -3,8 +3,7 @@
   "generatorName": "fernapi/fern-php-sdk",
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/php-sdk/header-auth-environment-variable/src/Core/Client/RawClient.php
+++ b/seed/php-sdk/header-auth-environment-variable/src/Core/Client/RawClient.php
@@ -155,6 +155,16 @@ class RawClient
                 $request->headers,
                 $options['headers'] ?? [],
             ),
+            UrlEncodedApiRequest::class => array_merge(
+                [
+                    "Content-Type" => "application/x-www-form-urlencoded",
+                    "Accept" => "*/*",
+                ],
+                $this->headers,
+                $authHeaders,
+                $request->headers,
+                $options['headers'] ?? [],
+            ),
             MultipartApiRequest::class => array_merge(
                 $this->headers,
                 $authHeaders,
@@ -185,6 +195,24 @@ class RawClient
                     ),
                 )
             );
+        }
+
+        if ($request instanceof UrlEncodedApiRequest) {
+            if ($request->body === null) {
+                return null;
+            }
+            $body = $this->buildJsonBody($request->body, $options);
+            if ($body instanceof JsonSerializable) {
+                $body = $body->jsonSerialize();
+            }
+            if ($body instanceof \stdClass) {
+                $body = (array)$body;
+            }
+            if (!is_array($body)) {
+                throw new InvalidArgumentException('Form-urlencoded request body must serialize to an array');
+            }
+            $body = array_filter($body, static fn ($value) => $value !== null);
+            return $this->streamFactory->createStream(http_build_query($body));
         }
 
         if ($request instanceof MultipartApiRequest) {

--- a/seed/php-sdk/header-auth-environment-variable/src/Core/Client/UrlEncodedApiRequest.php
+++ b/seed/php-sdk/header-auth-environment-variable/src/Core/Client/UrlEncodedApiRequest.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Seed\Core\Client;
+
+class UrlEncodedApiRequest extends BaseApiRequest
+{
+    /**
+     * @param string $baseUrl The base URL for the request
+     * @param string $path The path for the request
+     * @param HttpMethod $method The HTTP method for the request
+     * @param array<string, string> $headers Additional headers for the request (optional)
+     * @param array<string, mixed> $query Query parameters for the request (optional)
+     * @param mixed|null $body The form-urlencoded request body (optional)
+     */
+    public function __construct(
+        string $baseUrl,
+        string $path,
+        HttpMethod $method,
+        array $headers = [],
+        array $query = [],
+        public readonly mixed $body = null
+    ) {
+        parent::__construct($baseUrl, $path, $method, $headers, $query);
+    }
+}

--- a/seed/php-sdk/header-auth/.fern/metadata.json
+++ b/seed/php-sdk/header-auth/.fern/metadata.json
@@ -3,8 +3,7 @@
   "generatorName": "fernapi/fern-php-sdk",
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/php-sdk/header-auth/src/Core/Client/RawClient.php
+++ b/seed/php-sdk/header-auth/src/Core/Client/RawClient.php
@@ -155,6 +155,16 @@ class RawClient
                 $request->headers,
                 $options['headers'] ?? [],
             ),
+            UrlEncodedApiRequest::class => array_merge(
+                [
+                    "Content-Type" => "application/x-www-form-urlencoded",
+                    "Accept" => "*/*",
+                ],
+                $this->headers,
+                $authHeaders,
+                $request->headers,
+                $options['headers'] ?? [],
+            ),
             MultipartApiRequest::class => array_merge(
                 $this->headers,
                 $authHeaders,
@@ -185,6 +195,24 @@ class RawClient
                     ),
                 )
             );
+        }
+
+        if ($request instanceof UrlEncodedApiRequest) {
+            if ($request->body === null) {
+                return null;
+            }
+            $body = $this->buildJsonBody($request->body, $options);
+            if ($body instanceof JsonSerializable) {
+                $body = $body->jsonSerialize();
+            }
+            if ($body instanceof \stdClass) {
+                $body = (array)$body;
+            }
+            if (!is_array($body)) {
+                throw new InvalidArgumentException('Form-urlencoded request body must serialize to an array');
+            }
+            $body = array_filter($body, static fn ($value) => $value !== null);
+            return $this->streamFactory->createStream(http_build_query($body));
         }
 
         if ($request instanceof MultipartApiRequest) {

--- a/seed/php-sdk/header-auth/src/Core/Client/UrlEncodedApiRequest.php
+++ b/seed/php-sdk/header-auth/src/Core/Client/UrlEncodedApiRequest.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Seed\Core\Client;
+
+class UrlEncodedApiRequest extends BaseApiRequest
+{
+    /**
+     * @param string $baseUrl The base URL for the request
+     * @param string $path The path for the request
+     * @param HttpMethod $method The HTTP method for the request
+     * @param array<string, string> $headers Additional headers for the request (optional)
+     * @param array<string, mixed> $query Query parameters for the request (optional)
+     * @param mixed|null $body The form-urlencoded request body (optional)
+     */
+    public function __construct(
+        string $baseUrl,
+        string $path,
+        HttpMethod $method,
+        array $headers = [],
+        array $query = [],
+        public readonly mixed $body = null
+    ) {
+        parent::__construct($baseUrl, $path, $method, $headers, $query);
+    }
+}

--- a/seed/php-sdk/http-head/.fern/metadata.json
+++ b/seed/php-sdk/http-head/.fern/metadata.json
@@ -3,8 +3,7 @@
   "generatorName": "fernapi/fern-php-sdk",
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/php-sdk/http-head/src/Core/Client/RawClient.php
+++ b/seed/php-sdk/http-head/src/Core/Client/RawClient.php
@@ -155,6 +155,16 @@ class RawClient
                 $request->headers,
                 $options['headers'] ?? [],
             ),
+            UrlEncodedApiRequest::class => array_merge(
+                [
+                    "Content-Type" => "application/x-www-form-urlencoded",
+                    "Accept" => "*/*",
+                ],
+                $this->headers,
+                $authHeaders,
+                $request->headers,
+                $options['headers'] ?? [],
+            ),
             MultipartApiRequest::class => array_merge(
                 $this->headers,
                 $authHeaders,
@@ -185,6 +195,24 @@ class RawClient
                     ),
                 )
             );
+        }
+
+        if ($request instanceof UrlEncodedApiRequest) {
+            if ($request->body === null) {
+                return null;
+            }
+            $body = $this->buildJsonBody($request->body, $options);
+            if ($body instanceof JsonSerializable) {
+                $body = $body->jsonSerialize();
+            }
+            if ($body instanceof \stdClass) {
+                $body = (array)$body;
+            }
+            if (!is_array($body)) {
+                throw new InvalidArgumentException('Form-urlencoded request body must serialize to an array');
+            }
+            $body = array_filter($body, static fn ($value) => $value !== null);
+            return $this->streamFactory->createStream(http_build_query($body));
         }
 
         if ($request instanceof MultipartApiRequest) {

--- a/seed/php-sdk/http-head/src/Core/Client/UrlEncodedApiRequest.php
+++ b/seed/php-sdk/http-head/src/Core/Client/UrlEncodedApiRequest.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Seed\Core\Client;
+
+class UrlEncodedApiRequest extends BaseApiRequest
+{
+    /**
+     * @param string $baseUrl The base URL for the request
+     * @param string $path The path for the request
+     * @param HttpMethod $method The HTTP method for the request
+     * @param array<string, string> $headers Additional headers for the request (optional)
+     * @param array<string, mixed> $query Query parameters for the request (optional)
+     * @param mixed|null $body The form-urlencoded request body (optional)
+     */
+    public function __construct(
+        string $baseUrl,
+        string $path,
+        HttpMethod $method,
+        array $headers = [],
+        array $query = [],
+        public readonly mixed $body = null
+    ) {
+        parent::__construct($baseUrl, $path, $method, $headers, $query);
+    }
+}

--- a/seed/php-sdk/idempotency-headers/auto-generate-idempotency-key/.fern/metadata.json
+++ b/seed/php-sdk/idempotency-headers/auto-generate-idempotency-key/.fern/metadata.json
@@ -6,8 +6,7 @@
     "auto-generate-idempotency-key": true
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/php-sdk/idempotency-headers/auto-generate-idempotency-key/src/Core/Client/RawClient.php
+++ b/seed/php-sdk/idempotency-headers/auto-generate-idempotency-key/src/Core/Client/RawClient.php
@@ -155,6 +155,16 @@ class RawClient
                 $request->headers,
                 $options['headers'] ?? [],
             ),
+            UrlEncodedApiRequest::class => array_merge(
+                [
+                    "Content-Type" => "application/x-www-form-urlencoded",
+                    "Accept" => "*/*",
+                ],
+                $this->headers,
+                $authHeaders,
+                $request->headers,
+                $options['headers'] ?? [],
+            ),
             MultipartApiRequest::class => array_merge(
                 $this->headers,
                 $authHeaders,
@@ -185,6 +195,24 @@ class RawClient
                     ),
                 )
             );
+        }
+
+        if ($request instanceof UrlEncodedApiRequest) {
+            if ($request->body === null) {
+                return null;
+            }
+            $body = $this->buildJsonBody($request->body, $options);
+            if ($body instanceof JsonSerializable) {
+                $body = $body->jsonSerialize();
+            }
+            if ($body instanceof \stdClass) {
+                $body = (array)$body;
+            }
+            if (!is_array($body)) {
+                throw new InvalidArgumentException('Form-urlencoded request body must serialize to an array');
+            }
+            $body = array_filter($body, static fn ($value) => $value !== null);
+            return $this->streamFactory->createStream(http_build_query($body));
         }
 
         if ($request instanceof MultipartApiRequest) {

--- a/seed/php-sdk/idempotency-headers/auto-generate-idempotency-key/src/Core/Client/UrlEncodedApiRequest.php
+++ b/seed/php-sdk/idempotency-headers/auto-generate-idempotency-key/src/Core/Client/UrlEncodedApiRequest.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Seed\Core\Client;
+
+class UrlEncodedApiRequest extends BaseApiRequest
+{
+    /**
+     * @param string $baseUrl The base URL for the request
+     * @param string $path The path for the request
+     * @param HttpMethod $method The HTTP method for the request
+     * @param array<string, string> $headers Additional headers for the request (optional)
+     * @param array<string, mixed> $query Query parameters for the request (optional)
+     * @param mixed|null $body The form-urlencoded request body (optional)
+     */
+    public function __construct(
+        string $baseUrl,
+        string $path,
+        HttpMethod $method,
+        array $headers = [],
+        array $query = [],
+        public readonly mixed $body = null
+    ) {
+        parent::__construct($baseUrl, $path, $method, $headers, $query);
+    }
+}

--- a/seed/php-sdk/idempotency-headers/no-custom-config/.fern/metadata.json
+++ b/seed/php-sdk/idempotency-headers/no-custom-config/.fern/metadata.json
@@ -3,8 +3,7 @@
   "generatorName": "fernapi/fern-php-sdk",
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/php-sdk/idempotency-headers/no-custom-config/src/Core/Client/RawClient.php
+++ b/seed/php-sdk/idempotency-headers/no-custom-config/src/Core/Client/RawClient.php
@@ -155,6 +155,16 @@ class RawClient
                 $request->headers,
                 $options['headers'] ?? [],
             ),
+            UrlEncodedApiRequest::class => array_merge(
+                [
+                    "Content-Type" => "application/x-www-form-urlencoded",
+                    "Accept" => "*/*",
+                ],
+                $this->headers,
+                $authHeaders,
+                $request->headers,
+                $options['headers'] ?? [],
+            ),
             MultipartApiRequest::class => array_merge(
                 $this->headers,
                 $authHeaders,
@@ -185,6 +195,24 @@ class RawClient
                     ),
                 )
             );
+        }
+
+        if ($request instanceof UrlEncodedApiRequest) {
+            if ($request->body === null) {
+                return null;
+            }
+            $body = $this->buildJsonBody($request->body, $options);
+            if ($body instanceof JsonSerializable) {
+                $body = $body->jsonSerialize();
+            }
+            if ($body instanceof \stdClass) {
+                $body = (array)$body;
+            }
+            if (!is_array($body)) {
+                throw new InvalidArgumentException('Form-urlencoded request body must serialize to an array');
+            }
+            $body = array_filter($body, static fn ($value) => $value !== null);
+            return $this->streamFactory->createStream(http_build_query($body));
         }
 
         if ($request instanceof MultipartApiRequest) {

--- a/seed/php-sdk/idempotency-headers/no-custom-config/src/Core/Client/UrlEncodedApiRequest.php
+++ b/seed/php-sdk/idempotency-headers/no-custom-config/src/Core/Client/UrlEncodedApiRequest.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Seed\Core\Client;
+
+class UrlEncodedApiRequest extends BaseApiRequest
+{
+    /**
+     * @param string $baseUrl The base URL for the request
+     * @param string $path The path for the request
+     * @param HttpMethod $method The HTTP method for the request
+     * @param array<string, string> $headers Additional headers for the request (optional)
+     * @param array<string, mixed> $query Query parameters for the request (optional)
+     * @param mixed|null $body The form-urlencoded request body (optional)
+     */
+    public function __construct(
+        string $baseUrl,
+        string $path,
+        HttpMethod $method,
+        array $headers = [],
+        array $query = [],
+        public readonly mixed $body = null
+    ) {
+        parent::__construct($baseUrl, $path, $method, $headers, $query);
+    }
+}

--- a/seed/php-sdk/imdb/clientName/.fern/metadata.json
+++ b/seed/php-sdk/imdb/clientName/.fern/metadata.json
@@ -7,8 +7,7 @@
     "maxRetries": 5
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/php-sdk/imdb/clientName/src/Core/Client/RawClient.php
+++ b/seed/php-sdk/imdb/clientName/src/Core/Client/RawClient.php
@@ -155,6 +155,16 @@ class RawClient
                 $request->headers,
                 $options['headers'] ?? [],
             ),
+            UrlEncodedApiRequest::class => array_merge(
+                [
+                    "Content-Type" => "application/x-www-form-urlencoded",
+                    "Accept" => "*/*",
+                ],
+                $this->headers,
+                $authHeaders,
+                $request->headers,
+                $options['headers'] ?? [],
+            ),
             MultipartApiRequest::class => array_merge(
                 $this->headers,
                 $authHeaders,
@@ -185,6 +195,24 @@ class RawClient
                     ),
                 )
             );
+        }
+
+        if ($request instanceof UrlEncodedApiRequest) {
+            if ($request->body === null) {
+                return null;
+            }
+            $body = $this->buildJsonBody($request->body, $options);
+            if ($body instanceof JsonSerializable) {
+                $body = $body->jsonSerialize();
+            }
+            if ($body instanceof \stdClass) {
+                $body = (array)$body;
+            }
+            if (!is_array($body)) {
+                throw new InvalidArgumentException('Form-urlencoded request body must serialize to an array');
+            }
+            $body = array_filter($body, static fn ($value) => $value !== null);
+            return $this->streamFactory->createStream(http_build_query($body));
         }
 
         if ($request instanceof MultipartApiRequest) {

--- a/seed/php-sdk/imdb/clientName/src/Core/Client/UrlEncodedApiRequest.php
+++ b/seed/php-sdk/imdb/clientName/src/Core/Client/UrlEncodedApiRequest.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Seed\Core\Client;
+
+class UrlEncodedApiRequest extends BaseApiRequest
+{
+    /**
+     * @param string $baseUrl The base URL for the request
+     * @param string $path The path for the request
+     * @param HttpMethod $method The HTTP method for the request
+     * @param array<string, string> $headers Additional headers for the request (optional)
+     * @param array<string, mixed> $query Query parameters for the request (optional)
+     * @param mixed|null $body The form-urlencoded request body (optional)
+     */
+    public function __construct(
+        string $baseUrl,
+        string $path,
+        HttpMethod $method,
+        array $headers = [],
+        array $query = [],
+        public readonly mixed $body = null
+    ) {
+        parent::__construct($baseUrl, $path, $method, $headers, $query);
+    }
+}

--- a/seed/php-sdk/imdb/include-platform-headers/.fern/metadata.json
+++ b/seed/php-sdk/imdb/include-platform-headers/.fern/metadata.json
@@ -6,8 +6,7 @@
     "includePlatformHeaders": true
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/php-sdk/imdb/include-platform-headers/src/Core/Client/RawClient.php
+++ b/seed/php-sdk/imdb/include-platform-headers/src/Core/Client/RawClient.php
@@ -155,6 +155,16 @@ class RawClient
                 $request->headers,
                 $options['headers'] ?? [],
             ),
+            UrlEncodedApiRequest::class => array_merge(
+                [
+                    "Content-Type" => "application/x-www-form-urlencoded",
+                    "Accept" => "*/*",
+                ],
+                $this->headers,
+                $authHeaders,
+                $request->headers,
+                $options['headers'] ?? [],
+            ),
             MultipartApiRequest::class => array_merge(
                 $this->headers,
                 $authHeaders,
@@ -185,6 +195,24 @@ class RawClient
                     ),
                 )
             );
+        }
+
+        if ($request instanceof UrlEncodedApiRequest) {
+            if ($request->body === null) {
+                return null;
+            }
+            $body = $this->buildJsonBody($request->body, $options);
+            if ($body instanceof JsonSerializable) {
+                $body = $body->jsonSerialize();
+            }
+            if ($body instanceof \stdClass) {
+                $body = (array)$body;
+            }
+            if (!is_array($body)) {
+                throw new InvalidArgumentException('Form-urlencoded request body must serialize to an array');
+            }
+            $body = array_filter($body, static fn ($value) => $value !== null);
+            return $this->streamFactory->createStream(http_build_query($body));
         }
 
         if ($request instanceof MultipartApiRequest) {

--- a/seed/php-sdk/imdb/include-platform-headers/src/Core/Client/UrlEncodedApiRequest.php
+++ b/seed/php-sdk/imdb/include-platform-headers/src/Core/Client/UrlEncodedApiRequest.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Seed\Core\Client;
+
+class UrlEncodedApiRequest extends BaseApiRequest
+{
+    /**
+     * @param string $baseUrl The base URL for the request
+     * @param string $path The path for the request
+     * @param HttpMethod $method The HTTP method for the request
+     * @param array<string, string> $headers Additional headers for the request (optional)
+     * @param array<string, mixed> $query Query parameters for the request (optional)
+     * @param mixed|null $body The form-urlencoded request body (optional)
+     */
+    public function __construct(
+        string $baseUrl,
+        string $path,
+        HttpMethod $method,
+        array $headers = [],
+        array $query = [],
+        public readonly mixed $body = null
+    ) {
+        parent::__construct($baseUrl, $path, $method, $headers, $query);
+    }
+}

--- a/seed/php-sdk/imdb/namespace/.fern/metadata.json
+++ b/seed/php-sdk/imdb/namespace/.fern/metadata.json
@@ -6,8 +6,7 @@
     "namespace": "Fern"
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/php-sdk/imdb/namespace/src/Core/Client/RawClient.php
+++ b/seed/php-sdk/imdb/namespace/src/Core/Client/RawClient.php
@@ -155,6 +155,16 @@ class RawClient
                 $request->headers,
                 $options['headers'] ?? [],
             ),
+            UrlEncodedApiRequest::class => array_merge(
+                [
+                    "Content-Type" => "application/x-www-form-urlencoded",
+                    "Accept" => "*/*",
+                ],
+                $this->headers,
+                $authHeaders,
+                $request->headers,
+                $options['headers'] ?? [],
+            ),
             MultipartApiRequest::class => array_merge(
                 $this->headers,
                 $authHeaders,
@@ -185,6 +195,24 @@ class RawClient
                     ),
                 )
             );
+        }
+
+        if ($request instanceof UrlEncodedApiRequest) {
+            if ($request->body === null) {
+                return null;
+            }
+            $body = $this->buildJsonBody($request->body, $options);
+            if ($body instanceof JsonSerializable) {
+                $body = $body->jsonSerialize();
+            }
+            if ($body instanceof \stdClass) {
+                $body = (array)$body;
+            }
+            if (!is_array($body)) {
+                throw new InvalidArgumentException('Form-urlencoded request body must serialize to an array');
+            }
+            $body = array_filter($body, static fn ($value) => $value !== null);
+            return $this->streamFactory->createStream(http_build_query($body));
         }
 
         if ($request instanceof MultipartApiRequest) {

--- a/seed/php-sdk/imdb/namespace/src/Core/Client/UrlEncodedApiRequest.php
+++ b/seed/php-sdk/imdb/namespace/src/Core/Client/UrlEncodedApiRequest.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Fern\Core\Client;
+
+class UrlEncodedApiRequest extends BaseApiRequest
+{
+    /**
+     * @param string $baseUrl The base URL for the request
+     * @param string $path The path for the request
+     * @param HttpMethod $method The HTTP method for the request
+     * @param array<string, string> $headers Additional headers for the request (optional)
+     * @param array<string, mixed> $query Query parameters for the request (optional)
+     * @param mixed|null $body The form-urlencoded request body (optional)
+     */
+    public function __construct(
+        string $baseUrl,
+        string $path,
+        HttpMethod $method,
+        array $headers = [],
+        array $query = [],
+        public readonly mixed $body = null
+    ) {
+        parent::__construct($baseUrl, $path, $method, $headers, $query);
+    }
+}

--- a/seed/php-sdk/imdb/no-custom-config/.fern/metadata.json
+++ b/seed/php-sdk/imdb/no-custom-config/.fern/metadata.json
@@ -3,8 +3,7 @@
   "generatorName": "fernapi/fern-php-sdk",
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/php-sdk/imdb/no-custom-config/src/Core/Client/RawClient.php
+++ b/seed/php-sdk/imdb/no-custom-config/src/Core/Client/RawClient.php
@@ -155,6 +155,16 @@ class RawClient
                 $request->headers,
                 $options['headers'] ?? [],
             ),
+            UrlEncodedApiRequest::class => array_merge(
+                [
+                    "Content-Type" => "application/x-www-form-urlencoded",
+                    "Accept" => "*/*",
+                ],
+                $this->headers,
+                $authHeaders,
+                $request->headers,
+                $options['headers'] ?? [],
+            ),
             MultipartApiRequest::class => array_merge(
                 $this->headers,
                 $authHeaders,
@@ -185,6 +195,24 @@ class RawClient
                     ),
                 )
             );
+        }
+
+        if ($request instanceof UrlEncodedApiRequest) {
+            if ($request->body === null) {
+                return null;
+            }
+            $body = $this->buildJsonBody($request->body, $options);
+            if ($body instanceof JsonSerializable) {
+                $body = $body->jsonSerialize();
+            }
+            if ($body instanceof \stdClass) {
+                $body = (array)$body;
+            }
+            if (!is_array($body)) {
+                throw new InvalidArgumentException('Form-urlencoded request body must serialize to an array');
+            }
+            $body = array_filter($body, static fn ($value) => $value !== null);
+            return $this->streamFactory->createStream(http_build_query($body));
         }
 
         if ($request instanceof MultipartApiRequest) {

--- a/seed/php-sdk/imdb/no-custom-config/src/Core/Client/UrlEncodedApiRequest.php
+++ b/seed/php-sdk/imdb/no-custom-config/src/Core/Client/UrlEncodedApiRequest.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Seed\Core\Client;
+
+class UrlEncodedApiRequest extends BaseApiRequest
+{
+    /**
+     * @param string $baseUrl The base URL for the request
+     * @param string $path The path for the request
+     * @param HttpMethod $method The HTTP method for the request
+     * @param array<string, string> $headers Additional headers for the request (optional)
+     * @param array<string, mixed> $query Query parameters for the request (optional)
+     * @param mixed|null $body The form-urlencoded request body (optional)
+     */
+    public function __construct(
+        string $baseUrl,
+        string $path,
+        HttpMethod $method,
+        array $headers = [],
+        array $query = [],
+        public readonly mixed $body = null
+    ) {
+        parent::__construct($baseUrl, $path, $method, $headers, $query);
+    }
+}

--- a/seed/php-sdk/imdb/omit-fern-headers/.fern/metadata.json
+++ b/seed/php-sdk/imdb/omit-fern-headers/.fern/metadata.json
@@ -6,8 +6,7 @@
     "omitFernHeaders": true
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/php-sdk/imdb/omit-fern-headers/src/Core/Client/RawClient.php
+++ b/seed/php-sdk/imdb/omit-fern-headers/src/Core/Client/RawClient.php
@@ -155,6 +155,16 @@ class RawClient
                 $request->headers,
                 $options['headers'] ?? [],
             ),
+            UrlEncodedApiRequest::class => array_merge(
+                [
+                    "Content-Type" => "application/x-www-form-urlencoded",
+                    "Accept" => "*/*",
+                ],
+                $this->headers,
+                $authHeaders,
+                $request->headers,
+                $options['headers'] ?? [],
+            ),
             MultipartApiRequest::class => array_merge(
                 $this->headers,
                 $authHeaders,
@@ -185,6 +195,24 @@ class RawClient
                     ),
                 )
             );
+        }
+
+        if ($request instanceof UrlEncodedApiRequest) {
+            if ($request->body === null) {
+                return null;
+            }
+            $body = $this->buildJsonBody($request->body, $options);
+            if ($body instanceof JsonSerializable) {
+                $body = $body->jsonSerialize();
+            }
+            if ($body instanceof \stdClass) {
+                $body = (array)$body;
+            }
+            if (!is_array($body)) {
+                throw new InvalidArgumentException('Form-urlencoded request body must serialize to an array');
+            }
+            $body = array_filter($body, static fn ($value) => $value !== null);
+            return $this->streamFactory->createStream(http_build_query($body));
         }
 
         if ($request instanceof MultipartApiRequest) {

--- a/seed/php-sdk/imdb/omit-fern-headers/src/Core/Client/UrlEncodedApiRequest.php
+++ b/seed/php-sdk/imdb/omit-fern-headers/src/Core/Client/UrlEncodedApiRequest.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Seed\Core\Client;
+
+class UrlEncodedApiRequest extends BaseApiRequest
+{
+    /**
+     * @param string $baseUrl The base URL for the request
+     * @param string $path The path for the request
+     * @param HttpMethod $method The HTTP method for the request
+     * @param array<string, string> $headers Additional headers for the request (optional)
+     * @param array<string, mixed> $query Query parameters for the request (optional)
+     * @param mixed|null $body The form-urlencoded request body (optional)
+     */
+    public function __construct(
+        string $baseUrl,
+        string $path,
+        HttpMethod $method,
+        array $headers = [],
+        array $query = [],
+        public readonly mixed $body = null
+    ) {
+        parent::__construct($baseUrl, $path, $method, $headers, $query);
+    }
+}

--- a/seed/php-sdk/imdb/package-path/.fern/metadata.json
+++ b/seed/php-sdk/imdb/package-path/.fern/metadata.json
@@ -7,8 +7,7 @@
     "namespace": "Custom\\Package\\Path"
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/php-sdk/imdb/package-path/src/Custom/Package/Path/Core/Client/RawClient.php
+++ b/seed/php-sdk/imdb/package-path/src/Custom/Package/Path/Core/Client/RawClient.php
@@ -155,6 +155,16 @@ class RawClient
                 $request->headers,
                 $options['headers'] ?? [],
             ),
+            UrlEncodedApiRequest::class => array_merge(
+                [
+                    "Content-Type" => "application/x-www-form-urlencoded",
+                    "Accept" => "*/*",
+                ],
+                $this->headers,
+                $authHeaders,
+                $request->headers,
+                $options['headers'] ?? [],
+            ),
             MultipartApiRequest::class => array_merge(
                 $this->headers,
                 $authHeaders,
@@ -185,6 +195,24 @@ class RawClient
                     ),
                 )
             );
+        }
+
+        if ($request instanceof UrlEncodedApiRequest) {
+            if ($request->body === null) {
+                return null;
+            }
+            $body = $this->buildJsonBody($request->body, $options);
+            if ($body instanceof JsonSerializable) {
+                $body = $body->jsonSerialize();
+            }
+            if ($body instanceof \stdClass) {
+                $body = (array)$body;
+            }
+            if (!is_array($body)) {
+                throw new InvalidArgumentException('Form-urlencoded request body must serialize to an array');
+            }
+            $body = array_filter($body, static fn ($value) => $value !== null);
+            return $this->streamFactory->createStream(http_build_query($body));
         }
 
         if ($request instanceof MultipartApiRequest) {

--- a/seed/php-sdk/imdb/package-path/src/Custom/Package/Path/Core/Client/UrlEncodedApiRequest.php
+++ b/seed/php-sdk/imdb/package-path/src/Custom/Package/Path/Core/Client/UrlEncodedApiRequest.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Custom\Package\Path\Core\Client;
+
+class UrlEncodedApiRequest extends BaseApiRequest
+{
+    /**
+     * @param string $baseUrl The base URL for the request
+     * @param string $path The path for the request
+     * @param HttpMethod $method The HTTP method for the request
+     * @param array<string, string> $headers Additional headers for the request (optional)
+     * @param array<string, mixed> $query Query parameters for the request (optional)
+     * @param mixed|null $body The form-urlencoded request body (optional)
+     */
+    public function __construct(
+        string $baseUrl,
+        string $path,
+        HttpMethod $method,
+        array $headers = [],
+        array $query = [],
+        public readonly mixed $body = null
+    ) {
+        parent::__construct($baseUrl, $path, $method, $headers, $query);
+    }
+}

--- a/seed/php-sdk/imdb/packageName/.fern/metadata.json
+++ b/seed/php-sdk/imdb/packageName/.fern/metadata.json
@@ -6,8 +6,7 @@
     "packageName": "fern-api/imdb-php"
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/php-sdk/imdb/packageName/src/Core/Client/RawClient.php
+++ b/seed/php-sdk/imdb/packageName/src/Core/Client/RawClient.php
@@ -155,6 +155,16 @@ class RawClient
                 $request->headers,
                 $options['headers'] ?? [],
             ),
+            UrlEncodedApiRequest::class => array_merge(
+                [
+                    "Content-Type" => "application/x-www-form-urlencoded",
+                    "Accept" => "*/*",
+                ],
+                $this->headers,
+                $authHeaders,
+                $request->headers,
+                $options['headers'] ?? [],
+            ),
             MultipartApiRequest::class => array_merge(
                 $this->headers,
                 $authHeaders,
@@ -185,6 +195,24 @@ class RawClient
                     ),
                 )
             );
+        }
+
+        if ($request instanceof UrlEncodedApiRequest) {
+            if ($request->body === null) {
+                return null;
+            }
+            $body = $this->buildJsonBody($request->body, $options);
+            if ($body instanceof JsonSerializable) {
+                $body = $body->jsonSerialize();
+            }
+            if ($body instanceof \stdClass) {
+                $body = (array)$body;
+            }
+            if (!is_array($body)) {
+                throw new InvalidArgumentException('Form-urlencoded request body must serialize to an array');
+            }
+            $body = array_filter($body, static fn ($value) => $value !== null);
+            return $this->streamFactory->createStream(http_build_query($body));
         }
 
         if ($request instanceof MultipartApiRequest) {

--- a/seed/php-sdk/imdb/packageName/src/Core/Client/UrlEncodedApiRequest.php
+++ b/seed/php-sdk/imdb/packageName/src/Core/Client/UrlEncodedApiRequest.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Seed\Core\Client;
+
+class UrlEncodedApiRequest extends BaseApiRequest
+{
+    /**
+     * @param string $baseUrl The base URL for the request
+     * @param string $path The path for the request
+     * @param HttpMethod $method The HTTP method for the request
+     * @param array<string, string> $headers Additional headers for the request (optional)
+     * @param array<string, mixed> $query Query parameters for the request (optional)
+     * @param mixed|null $body The form-urlencoded request body (optional)
+     */
+    public function __construct(
+        string $baseUrl,
+        string $path,
+        HttpMethod $method,
+        array $headers = [],
+        array $query = [],
+        public readonly mixed $body = null
+    ) {
+        parent::__construct($baseUrl, $path, $method, $headers, $query);
+    }
+}

--- a/seed/php-sdk/imdb/private/.fern/metadata.json
+++ b/seed/php-sdk/imdb/private/.fern/metadata.json
@@ -6,8 +6,7 @@
     "propertyAccess": "private"
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/php-sdk/imdb/private/src/Core/Client/RawClient.php
+++ b/seed/php-sdk/imdb/private/src/Core/Client/RawClient.php
@@ -155,6 +155,16 @@ class RawClient
                 $request->headers,
                 $options['headers'] ?? [],
             ),
+            UrlEncodedApiRequest::class => array_merge(
+                [
+                    "Content-Type" => "application/x-www-form-urlencoded",
+                    "Accept" => "*/*",
+                ],
+                $this->headers,
+                $authHeaders,
+                $request->headers,
+                $options['headers'] ?? [],
+            ),
             MultipartApiRequest::class => array_merge(
                 $this->headers,
                 $authHeaders,
@@ -185,6 +195,24 @@ class RawClient
                     ),
                 )
             );
+        }
+
+        if ($request instanceof UrlEncodedApiRequest) {
+            if ($request->body === null) {
+                return null;
+            }
+            $body = $this->buildJsonBody($request->body, $options);
+            if ($body instanceof JsonSerializable) {
+                $body = $body->jsonSerialize();
+            }
+            if ($body instanceof \stdClass) {
+                $body = (array)$body;
+            }
+            if (!is_array($body)) {
+                throw new InvalidArgumentException('Form-urlencoded request body must serialize to an array');
+            }
+            $body = array_filter($body, static fn ($value) => $value !== null);
+            return $this->streamFactory->createStream(http_build_query($body));
         }
 
         if ($request instanceof MultipartApiRequest) {

--- a/seed/php-sdk/imdb/private/src/Core/Client/UrlEncodedApiRequest.php
+++ b/seed/php-sdk/imdb/private/src/Core/Client/UrlEncodedApiRequest.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Seed\Core\Client;
+
+class UrlEncodedApiRequest extends BaseApiRequest
+{
+    /**
+     * @param string $baseUrl The base URL for the request
+     * @param string $path The path for the request
+     * @param HttpMethod $method The HTTP method for the request
+     * @param array<string, string> $headers Additional headers for the request (optional)
+     * @param array<string, mixed> $query Query parameters for the request (optional)
+     * @param mixed|null $body The form-urlencoded request body (optional)
+     */
+    public function __construct(
+        string $baseUrl,
+        string $path,
+        HttpMethod $method,
+        array $headers = [],
+        array $query = [],
+        public readonly mixed $body = null
+    ) {
+        parent::__construct($baseUrl, $path, $method, $headers, $query);
+    }
+}

--- a/seed/php-sdk/inferred-auth-explicit/.fern/metadata.json
+++ b/seed/php-sdk/inferred-auth-explicit/.fern/metadata.json
@@ -3,8 +3,7 @@
   "generatorName": "fernapi/fern-php-sdk",
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/php-sdk/inferred-auth-explicit/src/Core/Client/RawClient.php
+++ b/seed/php-sdk/inferred-auth-explicit/src/Core/Client/RawClient.php
@@ -155,6 +155,16 @@ class RawClient
                 $request->headers,
                 $options['headers'] ?? [],
             ),
+            UrlEncodedApiRequest::class => array_merge(
+                [
+                    "Content-Type" => "application/x-www-form-urlencoded",
+                    "Accept" => "*/*",
+                ],
+                $this->headers,
+                $authHeaders,
+                $request->headers,
+                $options['headers'] ?? [],
+            ),
             MultipartApiRequest::class => array_merge(
                 $this->headers,
                 $authHeaders,
@@ -185,6 +195,24 @@ class RawClient
                     ),
                 )
             );
+        }
+
+        if ($request instanceof UrlEncodedApiRequest) {
+            if ($request->body === null) {
+                return null;
+            }
+            $body = $this->buildJsonBody($request->body, $options);
+            if ($body instanceof JsonSerializable) {
+                $body = $body->jsonSerialize();
+            }
+            if ($body instanceof \stdClass) {
+                $body = (array)$body;
+            }
+            if (!is_array($body)) {
+                throw new InvalidArgumentException('Form-urlencoded request body must serialize to an array');
+            }
+            $body = array_filter($body, static fn ($value) => $value !== null);
+            return $this->streamFactory->createStream(http_build_query($body));
         }
 
         if ($request instanceof MultipartApiRequest) {

--- a/seed/php-sdk/inferred-auth-explicit/src/Core/Client/UrlEncodedApiRequest.php
+++ b/seed/php-sdk/inferred-auth-explicit/src/Core/Client/UrlEncodedApiRequest.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Seed\Core\Client;
+
+class UrlEncodedApiRequest extends BaseApiRequest
+{
+    /**
+     * @param string $baseUrl The base URL for the request
+     * @param string $path The path for the request
+     * @param HttpMethod $method The HTTP method for the request
+     * @param array<string, string> $headers Additional headers for the request (optional)
+     * @param array<string, mixed> $query Query parameters for the request (optional)
+     * @param mixed|null $body The form-urlencoded request body (optional)
+     */
+    public function __construct(
+        string $baseUrl,
+        string $path,
+        HttpMethod $method,
+        array $headers = [],
+        array $query = [],
+        public readonly mixed $body = null
+    ) {
+        parent::__construct($baseUrl, $path, $method, $headers, $query);
+    }
+}

--- a/seed/php-sdk/inferred-auth-implicit-api-key/.fern/metadata.json
+++ b/seed/php-sdk/inferred-auth-implicit-api-key/.fern/metadata.json
@@ -3,8 +3,7 @@
   "generatorName": "fernapi/fern-php-sdk",
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/php-sdk/inferred-auth-implicit-api-key/src/Core/Client/RawClient.php
+++ b/seed/php-sdk/inferred-auth-implicit-api-key/src/Core/Client/RawClient.php
@@ -155,6 +155,16 @@ class RawClient
                 $request->headers,
                 $options['headers'] ?? [],
             ),
+            UrlEncodedApiRequest::class => array_merge(
+                [
+                    "Content-Type" => "application/x-www-form-urlencoded",
+                    "Accept" => "*/*",
+                ],
+                $this->headers,
+                $authHeaders,
+                $request->headers,
+                $options['headers'] ?? [],
+            ),
             MultipartApiRequest::class => array_merge(
                 $this->headers,
                 $authHeaders,
@@ -185,6 +195,24 @@ class RawClient
                     ),
                 )
             );
+        }
+
+        if ($request instanceof UrlEncodedApiRequest) {
+            if ($request->body === null) {
+                return null;
+            }
+            $body = $this->buildJsonBody($request->body, $options);
+            if ($body instanceof JsonSerializable) {
+                $body = $body->jsonSerialize();
+            }
+            if ($body instanceof \stdClass) {
+                $body = (array)$body;
+            }
+            if (!is_array($body)) {
+                throw new InvalidArgumentException('Form-urlencoded request body must serialize to an array');
+            }
+            $body = array_filter($body, static fn ($value) => $value !== null);
+            return $this->streamFactory->createStream(http_build_query($body));
         }
 
         if ($request instanceof MultipartApiRequest) {

--- a/seed/php-sdk/inferred-auth-implicit-api-key/src/Core/Client/UrlEncodedApiRequest.php
+++ b/seed/php-sdk/inferred-auth-implicit-api-key/src/Core/Client/UrlEncodedApiRequest.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Seed\Core\Client;
+
+class UrlEncodedApiRequest extends BaseApiRequest
+{
+    /**
+     * @param string $baseUrl The base URL for the request
+     * @param string $path The path for the request
+     * @param HttpMethod $method The HTTP method for the request
+     * @param array<string, string> $headers Additional headers for the request (optional)
+     * @param array<string, mixed> $query Query parameters for the request (optional)
+     * @param mixed|null $body The form-urlencoded request body (optional)
+     */
+    public function __construct(
+        string $baseUrl,
+        string $path,
+        HttpMethod $method,
+        array $headers = [],
+        array $query = [],
+        public readonly mixed $body = null
+    ) {
+        parent::__construct($baseUrl, $path, $method, $headers, $query);
+    }
+}

--- a/seed/php-sdk/inferred-auth-implicit-no-expiry/.fern/metadata.json
+++ b/seed/php-sdk/inferred-auth-implicit-no-expiry/.fern/metadata.json
@@ -3,8 +3,7 @@
   "generatorName": "fernapi/fern-php-sdk",
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/php-sdk/inferred-auth-implicit-no-expiry/src/Core/Client/RawClient.php
+++ b/seed/php-sdk/inferred-auth-implicit-no-expiry/src/Core/Client/RawClient.php
@@ -155,6 +155,16 @@ class RawClient
                 $request->headers,
                 $options['headers'] ?? [],
             ),
+            UrlEncodedApiRequest::class => array_merge(
+                [
+                    "Content-Type" => "application/x-www-form-urlencoded",
+                    "Accept" => "*/*",
+                ],
+                $this->headers,
+                $authHeaders,
+                $request->headers,
+                $options['headers'] ?? [],
+            ),
             MultipartApiRequest::class => array_merge(
                 $this->headers,
                 $authHeaders,
@@ -185,6 +195,24 @@ class RawClient
                     ),
                 )
             );
+        }
+
+        if ($request instanceof UrlEncodedApiRequest) {
+            if ($request->body === null) {
+                return null;
+            }
+            $body = $this->buildJsonBody($request->body, $options);
+            if ($body instanceof JsonSerializable) {
+                $body = $body->jsonSerialize();
+            }
+            if ($body instanceof \stdClass) {
+                $body = (array)$body;
+            }
+            if (!is_array($body)) {
+                throw new InvalidArgumentException('Form-urlencoded request body must serialize to an array');
+            }
+            $body = array_filter($body, static fn ($value) => $value !== null);
+            return $this->streamFactory->createStream(http_build_query($body));
         }
 
         if ($request instanceof MultipartApiRequest) {

--- a/seed/php-sdk/inferred-auth-implicit-no-expiry/src/Core/Client/UrlEncodedApiRequest.php
+++ b/seed/php-sdk/inferred-auth-implicit-no-expiry/src/Core/Client/UrlEncodedApiRequest.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Seed\Core\Client;
+
+class UrlEncodedApiRequest extends BaseApiRequest
+{
+    /**
+     * @param string $baseUrl The base URL for the request
+     * @param string $path The path for the request
+     * @param HttpMethod $method The HTTP method for the request
+     * @param array<string, string> $headers Additional headers for the request (optional)
+     * @param array<string, mixed> $query Query parameters for the request (optional)
+     * @param mixed|null $body The form-urlencoded request body (optional)
+     */
+    public function __construct(
+        string $baseUrl,
+        string $path,
+        HttpMethod $method,
+        array $headers = [],
+        array $query = [],
+        public readonly mixed $body = null
+    ) {
+        parent::__construct($baseUrl, $path, $method, $headers, $query);
+    }
+}

--- a/seed/php-sdk/inferred-auth-implicit-reference/.fern/metadata.json
+++ b/seed/php-sdk/inferred-auth-implicit-reference/.fern/metadata.json
@@ -3,8 +3,7 @@
   "generatorName": "fernapi/fern-php-sdk",
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/php-sdk/inferred-auth-implicit-reference/src/Core/Client/RawClient.php
+++ b/seed/php-sdk/inferred-auth-implicit-reference/src/Core/Client/RawClient.php
@@ -155,6 +155,16 @@ class RawClient
                 $request->headers,
                 $options['headers'] ?? [],
             ),
+            UrlEncodedApiRequest::class => array_merge(
+                [
+                    "Content-Type" => "application/x-www-form-urlencoded",
+                    "Accept" => "*/*",
+                ],
+                $this->headers,
+                $authHeaders,
+                $request->headers,
+                $options['headers'] ?? [],
+            ),
             MultipartApiRequest::class => array_merge(
                 $this->headers,
                 $authHeaders,
@@ -185,6 +195,24 @@ class RawClient
                     ),
                 )
             );
+        }
+
+        if ($request instanceof UrlEncodedApiRequest) {
+            if ($request->body === null) {
+                return null;
+            }
+            $body = $this->buildJsonBody($request->body, $options);
+            if ($body instanceof JsonSerializable) {
+                $body = $body->jsonSerialize();
+            }
+            if ($body instanceof \stdClass) {
+                $body = (array)$body;
+            }
+            if (!is_array($body)) {
+                throw new InvalidArgumentException('Form-urlencoded request body must serialize to an array');
+            }
+            $body = array_filter($body, static fn ($value) => $value !== null);
+            return $this->streamFactory->createStream(http_build_query($body));
         }
 
         if ($request instanceof MultipartApiRequest) {

--- a/seed/php-sdk/inferred-auth-implicit-reference/src/Core/Client/UrlEncodedApiRequest.php
+++ b/seed/php-sdk/inferred-auth-implicit-reference/src/Core/Client/UrlEncodedApiRequest.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Seed\Core\Client;
+
+class UrlEncodedApiRequest extends BaseApiRequest
+{
+    /**
+     * @param string $baseUrl The base URL for the request
+     * @param string $path The path for the request
+     * @param HttpMethod $method The HTTP method for the request
+     * @param array<string, string> $headers Additional headers for the request (optional)
+     * @param array<string, mixed> $query Query parameters for the request (optional)
+     * @param mixed|null $body The form-urlencoded request body (optional)
+     */
+    public function __construct(
+        string $baseUrl,
+        string $path,
+        HttpMethod $method,
+        array $headers = [],
+        array $query = [],
+        public readonly mixed $body = null
+    ) {
+        parent::__construct($baseUrl, $path, $method, $headers, $query);
+    }
+}

--- a/seed/php-sdk/inferred-auth-implicit/.fern/metadata.json
+++ b/seed/php-sdk/inferred-auth-implicit/.fern/metadata.json
@@ -3,8 +3,7 @@
   "generatorName": "fernapi/fern-php-sdk",
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/php-sdk/inferred-auth-implicit/reference.md
+++ b/seed/php-sdk/inferred-auth-implicit/reference.md
@@ -53,7 +53,7 @@ $client->auth->getTokenWithClientCredentials(
 <dl>
 <dd>
 
-**$clientSecret:** `string` 
+**$clientSecret:** `?string` 
     
 </dd>
 </dl>

--- a/seed/php-sdk/inferred-auth-implicit/src/Auth/Requests/GetTokenRequest.php
+++ b/seed/php-sdk/inferred-auth-implicit/src/Auth/Requests/GetTokenRequest.php
@@ -19,10 +19,10 @@ class GetTokenRequest extends JsonSerializableType
     public string $clientId;
 
     /**
-     * @var string $clientSecret
+     * @var ?string $clientSecret
      */
     #[JsonProperty('client_secret')]
-    public string $clientSecret;
+    public ?string $clientSecret;
 
     /**
      * @var 'https://api.example.com' $audience
@@ -46,9 +46,9 @@ class GetTokenRequest extends JsonSerializableType
      * @param array{
      *   xApiKey: string,
      *   clientId: string,
-     *   clientSecret: string,
      *   audience: 'https://api.example.com',
      *   grantType: 'client_credentials',
+     *   clientSecret?: ?string,
      *   scope?: ?string,
      * } $values
      */
@@ -57,7 +57,7 @@ class GetTokenRequest extends JsonSerializableType
     ) {
         $this->xApiKey = $values['xApiKey'];
         $this->clientId = $values['clientId'];
-        $this->clientSecret = $values['clientSecret'];
+        $this->clientSecret = $values['clientSecret'] ?? null;
         $this->audience = $values['audience'];
         $this->grantType = $values['grantType'];
         $this->scope = $values['scope'] ?? null;

--- a/seed/php-sdk/inferred-auth-implicit/src/Core/Client/RawClient.php
+++ b/seed/php-sdk/inferred-auth-implicit/src/Core/Client/RawClient.php
@@ -155,6 +155,16 @@ class RawClient
                 $request->headers,
                 $options['headers'] ?? [],
             ),
+            UrlEncodedApiRequest::class => array_merge(
+                [
+                    "Content-Type" => "application/x-www-form-urlencoded",
+                    "Accept" => "*/*",
+                ],
+                $this->headers,
+                $authHeaders,
+                $request->headers,
+                $options['headers'] ?? [],
+            ),
             MultipartApiRequest::class => array_merge(
                 $this->headers,
                 $authHeaders,
@@ -185,6 +195,24 @@ class RawClient
                     ),
                 )
             );
+        }
+
+        if ($request instanceof UrlEncodedApiRequest) {
+            if ($request->body === null) {
+                return null;
+            }
+            $body = $this->buildJsonBody($request->body, $options);
+            if ($body instanceof JsonSerializable) {
+                $body = $body->jsonSerialize();
+            }
+            if ($body instanceof \stdClass) {
+                $body = (array)$body;
+            }
+            if (!is_array($body)) {
+                throw new InvalidArgumentException('Form-urlencoded request body must serialize to an array');
+            }
+            $body = array_filter($body, static fn ($value) => $value !== null);
+            return $this->streamFactory->createStream(http_build_query($body));
         }
 
         if ($request instanceof MultipartApiRequest) {

--- a/seed/php-sdk/inferred-auth-implicit/src/Core/Client/UrlEncodedApiRequest.php
+++ b/seed/php-sdk/inferred-auth-implicit/src/Core/Client/UrlEncodedApiRequest.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Seed\Core\Client;
+
+class UrlEncodedApiRequest extends BaseApiRequest
+{
+    /**
+     * @param string $baseUrl The base URL for the request
+     * @param string $path The path for the request
+     * @param HttpMethod $method The HTTP method for the request
+     * @param array<string, string> $headers Additional headers for the request (optional)
+     * @param array<string, mixed> $query Query parameters for the request (optional)
+     * @param mixed|null $body The form-urlencoded request body (optional)
+     */
+    public function __construct(
+        string $baseUrl,
+        string $path,
+        HttpMethod $method,
+        array $headers = [],
+        array $query = [],
+        public readonly mixed $body = null
+    ) {
+        parent::__construct($baseUrl, $path, $method, $headers, $query);
+    }
+}

--- a/seed/php-sdk/inline-enum-type-name-override/.fern/metadata.json
+++ b/seed/php-sdk/inline-enum-type-name-override/.fern/metadata.json
@@ -3,8 +3,7 @@
   "generatorName": "fernapi/fern-php-sdk",
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/php-sdk/inline-enum-type-name-override/src/Core/Client/RawClient.php
+++ b/seed/php-sdk/inline-enum-type-name-override/src/Core/Client/RawClient.php
@@ -155,6 +155,16 @@ class RawClient
                 $request->headers,
                 $options['headers'] ?? [],
             ),
+            UrlEncodedApiRequest::class => array_merge(
+                [
+                    "Content-Type" => "application/x-www-form-urlencoded",
+                    "Accept" => "*/*",
+                ],
+                $this->headers,
+                $authHeaders,
+                $request->headers,
+                $options['headers'] ?? [],
+            ),
             MultipartApiRequest::class => array_merge(
                 $this->headers,
                 $authHeaders,
@@ -185,6 +195,24 @@ class RawClient
                     ),
                 )
             );
+        }
+
+        if ($request instanceof UrlEncodedApiRequest) {
+            if ($request->body === null) {
+                return null;
+            }
+            $body = $this->buildJsonBody($request->body, $options);
+            if ($body instanceof JsonSerializable) {
+                $body = $body->jsonSerialize();
+            }
+            if ($body instanceof \stdClass) {
+                $body = (array)$body;
+            }
+            if (!is_array($body)) {
+                throw new InvalidArgumentException('Form-urlencoded request body must serialize to an array');
+            }
+            $body = array_filter($body, static fn ($value) => $value !== null);
+            return $this->streamFactory->createStream(http_build_query($body));
         }
 
         if ($request instanceof MultipartApiRequest) {

--- a/seed/php-sdk/inline-enum-type-name-override/src/Core/Client/UrlEncodedApiRequest.php
+++ b/seed/php-sdk/inline-enum-type-name-override/src/Core/Client/UrlEncodedApiRequest.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Seed\Core\Client;
+
+class UrlEncodedApiRequest extends BaseApiRequest
+{
+    /**
+     * @param string $baseUrl The base URL for the request
+     * @param string $path The path for the request
+     * @param HttpMethod $method The HTTP method for the request
+     * @param array<string, string> $headers Additional headers for the request (optional)
+     * @param array<string, mixed> $query Query parameters for the request (optional)
+     * @param mixed|null $body The form-urlencoded request body (optional)
+     */
+    public function __construct(
+        string $baseUrl,
+        string $path,
+        HttpMethod $method,
+        array $headers = [],
+        array $query = [],
+        public readonly mixed $body = null
+    ) {
+        parent::__construct($baseUrl, $path, $method, $headers, $query);
+    }
+}

--- a/seed/php-sdk/license/.fern/metadata.json
+++ b/seed/php-sdk/license/.fern/metadata.json
@@ -3,8 +3,7 @@
   "generatorName": "fernapi/fern-php-sdk",
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/php-sdk/license/src/Core/Client/RawClient.php
+++ b/seed/php-sdk/license/src/Core/Client/RawClient.php
@@ -155,6 +155,16 @@ class RawClient
                 $request->headers,
                 $options['headers'] ?? [],
             ),
+            UrlEncodedApiRequest::class => array_merge(
+                [
+                    "Content-Type" => "application/x-www-form-urlencoded",
+                    "Accept" => "*/*",
+                ],
+                $this->headers,
+                $authHeaders,
+                $request->headers,
+                $options['headers'] ?? [],
+            ),
             MultipartApiRequest::class => array_merge(
                 $this->headers,
                 $authHeaders,
@@ -185,6 +195,24 @@ class RawClient
                     ),
                 )
             );
+        }
+
+        if ($request instanceof UrlEncodedApiRequest) {
+            if ($request->body === null) {
+                return null;
+            }
+            $body = $this->buildJsonBody($request->body, $options);
+            if ($body instanceof JsonSerializable) {
+                $body = $body->jsonSerialize();
+            }
+            if ($body instanceof \stdClass) {
+                $body = (array)$body;
+            }
+            if (!is_array($body)) {
+                throw new InvalidArgumentException('Form-urlencoded request body must serialize to an array');
+            }
+            $body = array_filter($body, static fn ($value) => $value !== null);
+            return $this->streamFactory->createStream(http_build_query($body));
         }
 
         if ($request instanceof MultipartApiRequest) {

--- a/seed/php-sdk/license/src/Core/Client/UrlEncodedApiRequest.php
+++ b/seed/php-sdk/license/src/Core/Client/UrlEncodedApiRequest.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Seed\Core\Client;
+
+class UrlEncodedApiRequest extends BaseApiRequest
+{
+    /**
+     * @param string $baseUrl The base URL for the request
+     * @param string $path The path for the request
+     * @param HttpMethod $method The HTTP method for the request
+     * @param array<string, string> $headers Additional headers for the request (optional)
+     * @param array<string, mixed> $query Query parameters for the request (optional)
+     * @param mixed|null $body The form-urlencoded request body (optional)
+     */
+    public function __construct(
+        string $baseUrl,
+        string $path,
+        HttpMethod $method,
+        array $headers = [],
+        array $query = [],
+        public readonly mixed $body = null
+    ) {
+        parent::__construct($baseUrl, $path, $method, $headers, $query);
+    }
+}

--- a/seed/php-sdk/literal-user-agent/.fern/metadata.json
+++ b/seed/php-sdk/literal-user-agent/.fern/metadata.json
@@ -3,8 +3,7 @@
   "generatorName": "fernapi/fern-php-sdk",
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/php-sdk/literal-user-agent/src/Core/Client/RawClient.php
+++ b/seed/php-sdk/literal-user-agent/src/Core/Client/RawClient.php
@@ -155,6 +155,16 @@ class RawClient
                 $request->headers,
                 $options['headers'] ?? [],
             ),
+            UrlEncodedApiRequest::class => array_merge(
+                [
+                    "Content-Type" => "application/x-www-form-urlencoded",
+                    "Accept" => "*/*",
+                ],
+                $this->headers,
+                $authHeaders,
+                $request->headers,
+                $options['headers'] ?? [],
+            ),
             MultipartApiRequest::class => array_merge(
                 $this->headers,
                 $authHeaders,
@@ -185,6 +195,24 @@ class RawClient
                     ),
                 )
             );
+        }
+
+        if ($request instanceof UrlEncodedApiRequest) {
+            if ($request->body === null) {
+                return null;
+            }
+            $body = $this->buildJsonBody($request->body, $options);
+            if ($body instanceof JsonSerializable) {
+                $body = $body->jsonSerialize();
+            }
+            if ($body instanceof \stdClass) {
+                $body = (array)$body;
+            }
+            if (!is_array($body)) {
+                throw new InvalidArgumentException('Form-urlencoded request body must serialize to an array');
+            }
+            $body = array_filter($body, static fn ($value) => $value !== null);
+            return $this->streamFactory->createStream(http_build_query($body));
         }
 
         if ($request instanceof MultipartApiRequest) {

--- a/seed/php-sdk/literal-user-agent/src/Core/Client/UrlEncodedApiRequest.php
+++ b/seed/php-sdk/literal-user-agent/src/Core/Client/UrlEncodedApiRequest.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Seed\Core\Client;
+
+class UrlEncodedApiRequest extends BaseApiRequest
+{
+    /**
+     * @param string $baseUrl The base URL for the request
+     * @param string $path The path for the request
+     * @param HttpMethod $method The HTTP method for the request
+     * @param array<string, string> $headers Additional headers for the request (optional)
+     * @param array<string, mixed> $query Query parameters for the request (optional)
+     * @param mixed|null $body The form-urlencoded request body (optional)
+     */
+    public function __construct(
+        string $baseUrl,
+        string $path,
+        HttpMethod $method,
+        array $headers = [],
+        array $query = [],
+        public readonly mixed $body = null
+    ) {
+        parent::__construct($baseUrl, $path, $method, $headers, $query);
+    }
+}

--- a/seed/php-sdk/literal/.fern/metadata.json
+++ b/seed/php-sdk/literal/.fern/metadata.json
@@ -3,8 +3,7 @@
   "generatorName": "fernapi/fern-php-sdk",
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/php-sdk/literal/src/Core/Client/RawClient.php
+++ b/seed/php-sdk/literal/src/Core/Client/RawClient.php
@@ -155,6 +155,16 @@ class RawClient
                 $request->headers,
                 $options['headers'] ?? [],
             ),
+            UrlEncodedApiRequest::class => array_merge(
+                [
+                    "Content-Type" => "application/x-www-form-urlencoded",
+                    "Accept" => "*/*",
+                ],
+                $this->headers,
+                $authHeaders,
+                $request->headers,
+                $options['headers'] ?? [],
+            ),
             MultipartApiRequest::class => array_merge(
                 $this->headers,
                 $authHeaders,
@@ -185,6 +195,24 @@ class RawClient
                     ),
                 )
             );
+        }
+
+        if ($request instanceof UrlEncodedApiRequest) {
+            if ($request->body === null) {
+                return null;
+            }
+            $body = $this->buildJsonBody($request->body, $options);
+            if ($body instanceof JsonSerializable) {
+                $body = $body->jsonSerialize();
+            }
+            if ($body instanceof \stdClass) {
+                $body = (array)$body;
+            }
+            if (!is_array($body)) {
+                throw new InvalidArgumentException('Form-urlencoded request body must serialize to an array');
+            }
+            $body = array_filter($body, static fn ($value) => $value !== null);
+            return $this->streamFactory->createStream(http_build_query($body));
         }
 
         if ($request instanceof MultipartApiRequest) {

--- a/seed/php-sdk/literal/src/Core/Client/UrlEncodedApiRequest.php
+++ b/seed/php-sdk/literal/src/Core/Client/UrlEncodedApiRequest.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Seed\Core\Client;
+
+class UrlEncodedApiRequest extends BaseApiRequest
+{
+    /**
+     * @param string $baseUrl The base URL for the request
+     * @param string $path The path for the request
+     * @param HttpMethod $method The HTTP method for the request
+     * @param array<string, string> $headers Additional headers for the request (optional)
+     * @param array<string, mixed> $query Query parameters for the request (optional)
+     * @param mixed|null $body The form-urlencoded request body (optional)
+     */
+    public function __construct(
+        string $baseUrl,
+        string $path,
+        HttpMethod $method,
+        array $headers = [],
+        array $query = [],
+        public readonly mixed $body = null
+    ) {
+        parent::__construct($baseUrl, $path, $method, $headers, $query);
+    }
+}

--- a/seed/php-sdk/literals-unions/.fern/metadata.json
+++ b/seed/php-sdk/literals-unions/.fern/metadata.json
@@ -3,8 +3,7 @@
   "generatorName": "fernapi/fern-php-sdk",
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/php-sdk/literals-unions/src/Core/Client/RawClient.php
+++ b/seed/php-sdk/literals-unions/src/Core/Client/RawClient.php
@@ -155,6 +155,16 @@ class RawClient
                 $request->headers,
                 $options['headers'] ?? [],
             ),
+            UrlEncodedApiRequest::class => array_merge(
+                [
+                    "Content-Type" => "application/x-www-form-urlencoded",
+                    "Accept" => "*/*",
+                ],
+                $this->headers,
+                $authHeaders,
+                $request->headers,
+                $options['headers'] ?? [],
+            ),
             MultipartApiRequest::class => array_merge(
                 $this->headers,
                 $authHeaders,
@@ -185,6 +195,24 @@ class RawClient
                     ),
                 )
             );
+        }
+
+        if ($request instanceof UrlEncodedApiRequest) {
+            if ($request->body === null) {
+                return null;
+            }
+            $body = $this->buildJsonBody($request->body, $options);
+            if ($body instanceof JsonSerializable) {
+                $body = $body->jsonSerialize();
+            }
+            if ($body instanceof \stdClass) {
+                $body = (array)$body;
+            }
+            if (!is_array($body)) {
+                throw new InvalidArgumentException('Form-urlencoded request body must serialize to an array');
+            }
+            $body = array_filter($body, static fn ($value) => $value !== null);
+            return $this->streamFactory->createStream(http_build_query($body));
         }
 
         if ($request instanceof MultipartApiRequest) {

--- a/seed/php-sdk/literals-unions/src/Core/Client/UrlEncodedApiRequest.php
+++ b/seed/php-sdk/literals-unions/src/Core/Client/UrlEncodedApiRequest.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Seed\Core\Client;
+
+class UrlEncodedApiRequest extends BaseApiRequest
+{
+    /**
+     * @param string $baseUrl The base URL for the request
+     * @param string $path The path for the request
+     * @param HttpMethod $method The HTTP method for the request
+     * @param array<string, string> $headers Additional headers for the request (optional)
+     * @param array<string, mixed> $query Query parameters for the request (optional)
+     * @param mixed|null $body The form-urlencoded request body (optional)
+     */
+    public function __construct(
+        string $baseUrl,
+        string $path,
+        HttpMethod $method,
+        array $headers = [],
+        array $query = [],
+        public readonly mixed $body = null
+    ) {
+        parent::__construct($baseUrl, $path, $method, $headers, $query);
+    }
+}

--- a/seed/php-sdk/mixed-case/.fern/metadata.json
+++ b/seed/php-sdk/mixed-case/.fern/metadata.json
@@ -3,8 +3,7 @@
   "generatorName": "fernapi/fern-php-sdk",
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/php-sdk/mixed-case/src/Core/Client/RawClient.php
+++ b/seed/php-sdk/mixed-case/src/Core/Client/RawClient.php
@@ -155,6 +155,16 @@ class RawClient
                 $request->headers,
                 $options['headers'] ?? [],
             ),
+            UrlEncodedApiRequest::class => array_merge(
+                [
+                    "Content-Type" => "application/x-www-form-urlencoded",
+                    "Accept" => "*/*",
+                ],
+                $this->headers,
+                $authHeaders,
+                $request->headers,
+                $options['headers'] ?? [],
+            ),
             MultipartApiRequest::class => array_merge(
                 $this->headers,
                 $authHeaders,
@@ -185,6 +195,24 @@ class RawClient
                     ),
                 )
             );
+        }
+
+        if ($request instanceof UrlEncodedApiRequest) {
+            if ($request->body === null) {
+                return null;
+            }
+            $body = $this->buildJsonBody($request->body, $options);
+            if ($body instanceof JsonSerializable) {
+                $body = $body->jsonSerialize();
+            }
+            if ($body instanceof \stdClass) {
+                $body = (array)$body;
+            }
+            if (!is_array($body)) {
+                throw new InvalidArgumentException('Form-urlencoded request body must serialize to an array');
+            }
+            $body = array_filter($body, static fn ($value) => $value !== null);
+            return $this->streamFactory->createStream(http_build_query($body));
         }
 
         if ($request instanceof MultipartApiRequest) {

--- a/seed/php-sdk/mixed-case/src/Core/Client/UrlEncodedApiRequest.php
+++ b/seed/php-sdk/mixed-case/src/Core/Client/UrlEncodedApiRequest.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Seed\Core\Client;
+
+class UrlEncodedApiRequest extends BaseApiRequest
+{
+    /**
+     * @param string $baseUrl The base URL for the request
+     * @param string $path The path for the request
+     * @param HttpMethod $method The HTTP method for the request
+     * @param array<string, string> $headers Additional headers for the request (optional)
+     * @param array<string, mixed> $query Query parameters for the request (optional)
+     * @param mixed|null $body The form-urlencoded request body (optional)
+     */
+    public function __construct(
+        string $baseUrl,
+        string $path,
+        HttpMethod $method,
+        array $headers = [],
+        array $query = [],
+        public readonly mixed $body = null
+    ) {
+        parent::__construct($baseUrl, $path, $method, $headers, $query);
+    }
+}

--- a/seed/php-sdk/mixed-file-directory/.fern/metadata.json
+++ b/seed/php-sdk/mixed-file-directory/.fern/metadata.json
@@ -3,8 +3,7 @@
   "generatorName": "fernapi/fern-php-sdk",
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/php-sdk/mixed-file-directory/src/Core/Client/RawClient.php
+++ b/seed/php-sdk/mixed-file-directory/src/Core/Client/RawClient.php
@@ -155,6 +155,16 @@ class RawClient
                 $request->headers,
                 $options['headers'] ?? [],
             ),
+            UrlEncodedApiRequest::class => array_merge(
+                [
+                    "Content-Type" => "application/x-www-form-urlencoded",
+                    "Accept" => "*/*",
+                ],
+                $this->headers,
+                $authHeaders,
+                $request->headers,
+                $options['headers'] ?? [],
+            ),
             MultipartApiRequest::class => array_merge(
                 $this->headers,
                 $authHeaders,
@@ -185,6 +195,24 @@ class RawClient
                     ),
                 )
             );
+        }
+
+        if ($request instanceof UrlEncodedApiRequest) {
+            if ($request->body === null) {
+                return null;
+            }
+            $body = $this->buildJsonBody($request->body, $options);
+            if ($body instanceof JsonSerializable) {
+                $body = $body->jsonSerialize();
+            }
+            if ($body instanceof \stdClass) {
+                $body = (array)$body;
+            }
+            if (!is_array($body)) {
+                throw new InvalidArgumentException('Form-urlencoded request body must serialize to an array');
+            }
+            $body = array_filter($body, static fn ($value) => $value !== null);
+            return $this->streamFactory->createStream(http_build_query($body));
         }
 
         if ($request instanceof MultipartApiRequest) {

--- a/seed/php-sdk/mixed-file-directory/src/Core/Client/UrlEncodedApiRequest.php
+++ b/seed/php-sdk/mixed-file-directory/src/Core/Client/UrlEncodedApiRequest.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Seed\Core\Client;
+
+class UrlEncodedApiRequest extends BaseApiRequest
+{
+    /**
+     * @param string $baseUrl The base URL for the request
+     * @param string $path The path for the request
+     * @param HttpMethod $method The HTTP method for the request
+     * @param array<string, string> $headers Additional headers for the request (optional)
+     * @param array<string, mixed> $query Query parameters for the request (optional)
+     * @param mixed|null $body The form-urlencoded request body (optional)
+     */
+    public function __construct(
+        string $baseUrl,
+        string $path,
+        HttpMethod $method,
+        array $headers = [],
+        array $query = [],
+        public readonly mixed $body = null
+    ) {
+        parent::__construct($baseUrl, $path, $method, $headers, $query);
+    }
+}

--- a/seed/php-sdk/multi-content-type-examples/.fern/metadata.json
+++ b/seed/php-sdk/multi-content-type-examples/.fern/metadata.json
@@ -3,8 +3,7 @@
   "generatorName": "fernapi/fern-php-sdk",
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/php-sdk/multi-content-type-examples/src/Core/Client/RawClient.php
+++ b/seed/php-sdk/multi-content-type-examples/src/Core/Client/RawClient.php
@@ -155,6 +155,16 @@ class RawClient
                 $request->headers,
                 $options['headers'] ?? [],
             ),
+            UrlEncodedApiRequest::class => array_merge(
+                [
+                    "Content-Type" => "application/x-www-form-urlencoded",
+                    "Accept" => "*/*",
+                ],
+                $this->headers,
+                $authHeaders,
+                $request->headers,
+                $options['headers'] ?? [],
+            ),
             MultipartApiRequest::class => array_merge(
                 $this->headers,
                 $authHeaders,
@@ -185,6 +195,24 @@ class RawClient
                     ),
                 )
             );
+        }
+
+        if ($request instanceof UrlEncodedApiRequest) {
+            if ($request->body === null) {
+                return null;
+            }
+            $body = $this->buildJsonBody($request->body, $options);
+            if ($body instanceof JsonSerializable) {
+                $body = $body->jsonSerialize();
+            }
+            if ($body instanceof \stdClass) {
+                $body = (array)$body;
+            }
+            if (!is_array($body)) {
+                throw new InvalidArgumentException('Form-urlencoded request body must serialize to an array');
+            }
+            $body = array_filter($body, static fn ($value) => $value !== null);
+            return $this->streamFactory->createStream(http_build_query($body));
         }
 
         if ($request instanceof MultipartApiRequest) {

--- a/seed/php-sdk/multi-content-type-examples/src/Core/Client/UrlEncodedApiRequest.php
+++ b/seed/php-sdk/multi-content-type-examples/src/Core/Client/UrlEncodedApiRequest.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Seed\Core\Client;
+
+class UrlEncodedApiRequest extends BaseApiRequest
+{
+    /**
+     * @param string $baseUrl The base URL for the request
+     * @param string $path The path for the request
+     * @param HttpMethod $method The HTTP method for the request
+     * @param array<string, string> $headers Additional headers for the request (optional)
+     * @param array<string, mixed> $query Query parameters for the request (optional)
+     * @param mixed|null $body The form-urlencoded request body (optional)
+     */
+    public function __construct(
+        string $baseUrl,
+        string $path,
+        HttpMethod $method,
+        array $headers = [],
+        array $query = [],
+        public readonly mixed $body = null
+    ) {
+        parent::__construct($baseUrl, $path, $method, $headers, $query);
+    }
+}

--- a/seed/php-sdk/multi-line-docs/.fern/metadata.json
+++ b/seed/php-sdk/multi-line-docs/.fern/metadata.json
@@ -3,8 +3,7 @@
   "generatorName": "fernapi/fern-php-sdk",
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/php-sdk/multi-line-docs/src/Core/Client/RawClient.php
+++ b/seed/php-sdk/multi-line-docs/src/Core/Client/RawClient.php
@@ -155,6 +155,16 @@ class RawClient
                 $request->headers,
                 $options['headers'] ?? [],
             ),
+            UrlEncodedApiRequest::class => array_merge(
+                [
+                    "Content-Type" => "application/x-www-form-urlencoded",
+                    "Accept" => "*/*",
+                ],
+                $this->headers,
+                $authHeaders,
+                $request->headers,
+                $options['headers'] ?? [],
+            ),
             MultipartApiRequest::class => array_merge(
                 $this->headers,
                 $authHeaders,
@@ -185,6 +195,24 @@ class RawClient
                     ),
                 )
             );
+        }
+
+        if ($request instanceof UrlEncodedApiRequest) {
+            if ($request->body === null) {
+                return null;
+            }
+            $body = $this->buildJsonBody($request->body, $options);
+            if ($body instanceof JsonSerializable) {
+                $body = $body->jsonSerialize();
+            }
+            if ($body instanceof \stdClass) {
+                $body = (array)$body;
+            }
+            if (!is_array($body)) {
+                throw new InvalidArgumentException('Form-urlencoded request body must serialize to an array');
+            }
+            $body = array_filter($body, static fn ($value) => $value !== null);
+            return $this->streamFactory->createStream(http_build_query($body));
         }
 
         if ($request instanceof MultipartApiRequest) {

--- a/seed/php-sdk/multi-line-docs/src/Core/Client/UrlEncodedApiRequest.php
+++ b/seed/php-sdk/multi-line-docs/src/Core/Client/UrlEncodedApiRequest.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Seed\Core\Client;
+
+class UrlEncodedApiRequest extends BaseApiRequest
+{
+    /**
+     * @param string $baseUrl The base URL for the request
+     * @param string $path The path for the request
+     * @param HttpMethod $method The HTTP method for the request
+     * @param array<string, string> $headers Additional headers for the request (optional)
+     * @param array<string, mixed> $query Query parameters for the request (optional)
+     * @param mixed|null $body The form-urlencoded request body (optional)
+     */
+    public function __construct(
+        string $baseUrl,
+        string $path,
+        HttpMethod $method,
+        array $headers = [],
+        array $query = [],
+        public readonly mixed $body = null
+    ) {
+        parent::__construct($baseUrl, $path, $method, $headers, $query);
+    }
+}

--- a/seed/php-sdk/multi-url-environment-no-default/.fern/metadata.json
+++ b/seed/php-sdk/multi-url-environment-no-default/.fern/metadata.json
@@ -3,8 +3,7 @@
   "generatorName": "fernapi/fern-php-sdk",
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/php-sdk/multi-url-environment-no-default/src/Core/Client/RawClient.php
+++ b/seed/php-sdk/multi-url-environment-no-default/src/Core/Client/RawClient.php
@@ -155,6 +155,16 @@ class RawClient
                 $request->headers,
                 $options['headers'] ?? [],
             ),
+            UrlEncodedApiRequest::class => array_merge(
+                [
+                    "Content-Type" => "application/x-www-form-urlencoded",
+                    "Accept" => "*/*",
+                ],
+                $this->headers,
+                $authHeaders,
+                $request->headers,
+                $options['headers'] ?? [],
+            ),
             MultipartApiRequest::class => array_merge(
                 $this->headers,
                 $authHeaders,
@@ -185,6 +195,24 @@ class RawClient
                     ),
                 )
             );
+        }
+
+        if ($request instanceof UrlEncodedApiRequest) {
+            if ($request->body === null) {
+                return null;
+            }
+            $body = $this->buildJsonBody($request->body, $options);
+            if ($body instanceof JsonSerializable) {
+                $body = $body->jsonSerialize();
+            }
+            if ($body instanceof \stdClass) {
+                $body = (array)$body;
+            }
+            if (!is_array($body)) {
+                throw new InvalidArgumentException('Form-urlencoded request body must serialize to an array');
+            }
+            $body = array_filter($body, static fn ($value) => $value !== null);
+            return $this->streamFactory->createStream(http_build_query($body));
         }
 
         if ($request instanceof MultipartApiRequest) {

--- a/seed/php-sdk/multi-url-environment-no-default/src/Core/Client/UrlEncodedApiRequest.php
+++ b/seed/php-sdk/multi-url-environment-no-default/src/Core/Client/UrlEncodedApiRequest.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Seed\Core\Client;
+
+class UrlEncodedApiRequest extends BaseApiRequest
+{
+    /**
+     * @param string $baseUrl The base URL for the request
+     * @param string $path The path for the request
+     * @param HttpMethod $method The HTTP method for the request
+     * @param array<string, string> $headers Additional headers for the request (optional)
+     * @param array<string, mixed> $query Query parameters for the request (optional)
+     * @param mixed|null $body The form-urlencoded request body (optional)
+     */
+    public function __construct(
+        string $baseUrl,
+        string $path,
+        HttpMethod $method,
+        array $headers = [],
+        array $query = [],
+        public readonly mixed $body = null
+    ) {
+        parent::__construct($baseUrl, $path, $method, $headers, $query);
+    }
+}

--- a/seed/php-sdk/multi-url-environment-reference/.fern/metadata.json
+++ b/seed/php-sdk/multi-url-environment-reference/.fern/metadata.json
@@ -3,8 +3,7 @@
   "generatorName": "fernapi/fern-php-sdk",
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/php-sdk/multi-url-environment-reference/src/Core/Client/RawClient.php
+++ b/seed/php-sdk/multi-url-environment-reference/src/Core/Client/RawClient.php
@@ -155,6 +155,16 @@ class RawClient
                 $request->headers,
                 $options['headers'] ?? [],
             ),
+            UrlEncodedApiRequest::class => array_merge(
+                [
+                    "Content-Type" => "application/x-www-form-urlencoded",
+                    "Accept" => "*/*",
+                ],
+                $this->headers,
+                $authHeaders,
+                $request->headers,
+                $options['headers'] ?? [],
+            ),
             MultipartApiRequest::class => array_merge(
                 $this->headers,
                 $authHeaders,
@@ -185,6 +195,24 @@ class RawClient
                     ),
                 )
             );
+        }
+
+        if ($request instanceof UrlEncodedApiRequest) {
+            if ($request->body === null) {
+                return null;
+            }
+            $body = $this->buildJsonBody($request->body, $options);
+            if ($body instanceof JsonSerializable) {
+                $body = $body->jsonSerialize();
+            }
+            if ($body instanceof \stdClass) {
+                $body = (array)$body;
+            }
+            if (!is_array($body)) {
+                throw new InvalidArgumentException('Form-urlencoded request body must serialize to an array');
+            }
+            $body = array_filter($body, static fn ($value) => $value !== null);
+            return $this->streamFactory->createStream(http_build_query($body));
         }
 
         if ($request instanceof MultipartApiRequest) {

--- a/seed/php-sdk/multi-url-environment-reference/src/Core/Client/UrlEncodedApiRequest.php
+++ b/seed/php-sdk/multi-url-environment-reference/src/Core/Client/UrlEncodedApiRequest.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Seed\Core\Client;
+
+class UrlEncodedApiRequest extends BaseApiRequest
+{
+    /**
+     * @param string $baseUrl The base URL for the request
+     * @param string $path The path for the request
+     * @param HttpMethod $method The HTTP method for the request
+     * @param array<string, string> $headers Additional headers for the request (optional)
+     * @param array<string, mixed> $query Query parameters for the request (optional)
+     * @param mixed|null $body The form-urlencoded request body (optional)
+     */
+    public function __construct(
+        string $baseUrl,
+        string $path,
+        HttpMethod $method,
+        array $headers = [],
+        array $query = [],
+        public readonly mixed $body = null
+    ) {
+        parent::__construct($baseUrl, $path, $method, $headers, $query);
+    }
+}

--- a/seed/php-sdk/multi-url-environment/.fern/metadata.json
+++ b/seed/php-sdk/multi-url-environment/.fern/metadata.json
@@ -3,8 +3,7 @@
   "generatorName": "fernapi/fern-php-sdk",
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/php-sdk/multi-url-environment/src/Core/Client/RawClient.php
+++ b/seed/php-sdk/multi-url-environment/src/Core/Client/RawClient.php
@@ -155,6 +155,16 @@ class RawClient
                 $request->headers,
                 $options['headers'] ?? [],
             ),
+            UrlEncodedApiRequest::class => array_merge(
+                [
+                    "Content-Type" => "application/x-www-form-urlencoded",
+                    "Accept" => "*/*",
+                ],
+                $this->headers,
+                $authHeaders,
+                $request->headers,
+                $options['headers'] ?? [],
+            ),
             MultipartApiRequest::class => array_merge(
                 $this->headers,
                 $authHeaders,
@@ -185,6 +195,24 @@ class RawClient
                     ),
                 )
             );
+        }
+
+        if ($request instanceof UrlEncodedApiRequest) {
+            if ($request->body === null) {
+                return null;
+            }
+            $body = $this->buildJsonBody($request->body, $options);
+            if ($body instanceof JsonSerializable) {
+                $body = $body->jsonSerialize();
+            }
+            if ($body instanceof \stdClass) {
+                $body = (array)$body;
+            }
+            if (!is_array($body)) {
+                throw new InvalidArgumentException('Form-urlencoded request body must serialize to an array');
+            }
+            $body = array_filter($body, static fn ($value) => $value !== null);
+            return $this->streamFactory->createStream(http_build_query($body));
         }
 
         if ($request instanceof MultipartApiRequest) {

--- a/seed/php-sdk/multi-url-environment/src/Core/Client/UrlEncodedApiRequest.php
+++ b/seed/php-sdk/multi-url-environment/src/Core/Client/UrlEncodedApiRequest.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Seed\Core\Client;
+
+class UrlEncodedApiRequest extends BaseApiRequest
+{
+    /**
+     * @param string $baseUrl The base URL for the request
+     * @param string $path The path for the request
+     * @param HttpMethod $method The HTTP method for the request
+     * @param array<string, string> $headers Additional headers for the request (optional)
+     * @param array<string, mixed> $query Query parameters for the request (optional)
+     * @param mixed|null $body The form-urlencoded request body (optional)
+     */
+    public function __construct(
+        string $baseUrl,
+        string $path,
+        HttpMethod $method,
+        array $headers = [],
+        array $query = [],
+        public readonly mixed $body = null
+    ) {
+        parent::__construct($baseUrl, $path, $method, $headers, $query);
+    }
+}

--- a/seed/php-sdk/multiple-request-bodies/.fern/metadata.json
+++ b/seed/php-sdk/multiple-request-bodies/.fern/metadata.json
@@ -3,8 +3,7 @@
   "generatorName": "fernapi/fern-php-sdk",
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/php-sdk/multiple-request-bodies/src/Core/Client/RawClient.php
+++ b/seed/php-sdk/multiple-request-bodies/src/Core/Client/RawClient.php
@@ -155,6 +155,16 @@ class RawClient
                 $request->headers,
                 $options['headers'] ?? [],
             ),
+            UrlEncodedApiRequest::class => array_merge(
+                [
+                    "Content-Type" => "application/x-www-form-urlencoded",
+                    "Accept" => "*/*",
+                ],
+                $this->headers,
+                $authHeaders,
+                $request->headers,
+                $options['headers'] ?? [],
+            ),
             MultipartApiRequest::class => array_merge(
                 $this->headers,
                 $authHeaders,
@@ -185,6 +195,24 @@ class RawClient
                     ),
                 )
             );
+        }
+
+        if ($request instanceof UrlEncodedApiRequest) {
+            if ($request->body === null) {
+                return null;
+            }
+            $body = $this->buildJsonBody($request->body, $options);
+            if ($body instanceof JsonSerializable) {
+                $body = $body->jsonSerialize();
+            }
+            if ($body instanceof \stdClass) {
+                $body = (array)$body;
+            }
+            if (!is_array($body)) {
+                throw new InvalidArgumentException('Form-urlencoded request body must serialize to an array');
+            }
+            $body = array_filter($body, static fn ($value) => $value !== null);
+            return $this->streamFactory->createStream(http_build_query($body));
         }
 
         if ($request instanceof MultipartApiRequest) {

--- a/seed/php-sdk/multiple-request-bodies/src/Core/Client/UrlEncodedApiRequest.php
+++ b/seed/php-sdk/multiple-request-bodies/src/Core/Client/UrlEncodedApiRequest.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Seed\Core\Client;
+
+class UrlEncodedApiRequest extends BaseApiRequest
+{
+    /**
+     * @param string $baseUrl The base URL for the request
+     * @param string $path The path for the request
+     * @param HttpMethod $method The HTTP method for the request
+     * @param array<string, string> $headers Additional headers for the request (optional)
+     * @param array<string, mixed> $query Query parameters for the request (optional)
+     * @param mixed|null $body The form-urlencoded request body (optional)
+     */
+    public function __construct(
+        string $baseUrl,
+        string $path,
+        HttpMethod $method,
+        array $headers = [],
+        array $query = [],
+        public readonly mixed $body = null
+    ) {
+        parent::__construct($baseUrl, $path, $method, $headers, $query);
+    }
+}

--- a/seed/php-sdk/no-content-response/.fern/metadata.json
+++ b/seed/php-sdk/no-content-response/.fern/metadata.json
@@ -3,8 +3,7 @@
   "generatorName": "fernapi/fern-php-sdk",
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/php-sdk/no-content-response/src/Core/Client/RawClient.php
+++ b/seed/php-sdk/no-content-response/src/Core/Client/RawClient.php
@@ -155,6 +155,16 @@ class RawClient
                 $request->headers,
                 $options['headers'] ?? [],
             ),
+            UrlEncodedApiRequest::class => array_merge(
+                [
+                    "Content-Type" => "application/x-www-form-urlencoded",
+                    "Accept" => "*/*",
+                ],
+                $this->headers,
+                $authHeaders,
+                $request->headers,
+                $options['headers'] ?? [],
+            ),
             MultipartApiRequest::class => array_merge(
                 $this->headers,
                 $authHeaders,
@@ -185,6 +195,24 @@ class RawClient
                     ),
                 )
             );
+        }
+
+        if ($request instanceof UrlEncodedApiRequest) {
+            if ($request->body === null) {
+                return null;
+            }
+            $body = $this->buildJsonBody($request->body, $options);
+            if ($body instanceof JsonSerializable) {
+                $body = $body->jsonSerialize();
+            }
+            if ($body instanceof \stdClass) {
+                $body = (array)$body;
+            }
+            if (!is_array($body)) {
+                throw new InvalidArgumentException('Form-urlencoded request body must serialize to an array');
+            }
+            $body = array_filter($body, static fn ($value) => $value !== null);
+            return $this->streamFactory->createStream(http_build_query($body));
         }
 
         if ($request instanceof MultipartApiRequest) {

--- a/seed/php-sdk/no-content-response/src/Core/Client/UrlEncodedApiRequest.php
+++ b/seed/php-sdk/no-content-response/src/Core/Client/UrlEncodedApiRequest.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Seed\Core\Client;
+
+class UrlEncodedApiRequest extends BaseApiRequest
+{
+    /**
+     * @param string $baseUrl The base URL for the request
+     * @param string $path The path for the request
+     * @param HttpMethod $method The HTTP method for the request
+     * @param array<string, string> $headers Additional headers for the request (optional)
+     * @param array<string, mixed> $query Query parameters for the request (optional)
+     * @param mixed|null $body The form-urlencoded request body (optional)
+     */
+    public function __construct(
+        string $baseUrl,
+        string $path,
+        HttpMethod $method,
+        array $headers = [],
+        array $query = [],
+        public readonly mixed $body = null
+    ) {
+        parent::__construct($baseUrl, $path, $method, $headers, $query);
+    }
+}

--- a/seed/php-sdk/no-environment/.fern/metadata.json
+++ b/seed/php-sdk/no-environment/.fern/metadata.json
@@ -3,8 +3,7 @@
   "generatorName": "fernapi/fern-php-sdk",
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/php-sdk/no-environment/src/Core/Client/RawClient.php
+++ b/seed/php-sdk/no-environment/src/Core/Client/RawClient.php
@@ -155,6 +155,16 @@ class RawClient
                 $request->headers,
                 $options['headers'] ?? [],
             ),
+            UrlEncodedApiRequest::class => array_merge(
+                [
+                    "Content-Type" => "application/x-www-form-urlencoded",
+                    "Accept" => "*/*",
+                ],
+                $this->headers,
+                $authHeaders,
+                $request->headers,
+                $options['headers'] ?? [],
+            ),
             MultipartApiRequest::class => array_merge(
                 $this->headers,
                 $authHeaders,
@@ -185,6 +195,24 @@ class RawClient
                     ),
                 )
             );
+        }
+
+        if ($request instanceof UrlEncodedApiRequest) {
+            if ($request->body === null) {
+                return null;
+            }
+            $body = $this->buildJsonBody($request->body, $options);
+            if ($body instanceof JsonSerializable) {
+                $body = $body->jsonSerialize();
+            }
+            if ($body instanceof \stdClass) {
+                $body = (array)$body;
+            }
+            if (!is_array($body)) {
+                throw new InvalidArgumentException('Form-urlencoded request body must serialize to an array');
+            }
+            $body = array_filter($body, static fn ($value) => $value !== null);
+            return $this->streamFactory->createStream(http_build_query($body));
         }
 
         if ($request instanceof MultipartApiRequest) {

--- a/seed/php-sdk/no-environment/src/Core/Client/UrlEncodedApiRequest.php
+++ b/seed/php-sdk/no-environment/src/Core/Client/UrlEncodedApiRequest.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Seed\Core\Client;
+
+class UrlEncodedApiRequest extends BaseApiRequest
+{
+    /**
+     * @param string $baseUrl The base URL for the request
+     * @param string $path The path for the request
+     * @param HttpMethod $method The HTTP method for the request
+     * @param array<string, string> $headers Additional headers for the request (optional)
+     * @param array<string, mixed> $query Query parameters for the request (optional)
+     * @param mixed|null $body The form-urlencoded request body (optional)
+     */
+    public function __construct(
+        string $baseUrl,
+        string $path,
+        HttpMethod $method,
+        array $headers = [],
+        array $query = [],
+        public readonly mixed $body = null
+    ) {
+        parent::__construct($baseUrl, $path, $method, $headers, $query);
+    }
+}

--- a/seed/php-sdk/no-retries/.fern/metadata.json
+++ b/seed/php-sdk/no-retries/.fern/metadata.json
@@ -3,8 +3,7 @@
   "generatorName": "fernapi/fern-php-sdk",
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/php-sdk/no-retries/src/Core/Client/RawClient.php
+++ b/seed/php-sdk/no-retries/src/Core/Client/RawClient.php
@@ -155,6 +155,16 @@ class RawClient
                 $request->headers,
                 $options['headers'] ?? [],
             ),
+            UrlEncodedApiRequest::class => array_merge(
+                [
+                    "Content-Type" => "application/x-www-form-urlencoded",
+                    "Accept" => "*/*",
+                ],
+                $this->headers,
+                $authHeaders,
+                $request->headers,
+                $options['headers'] ?? [],
+            ),
             MultipartApiRequest::class => array_merge(
                 $this->headers,
                 $authHeaders,
@@ -185,6 +195,24 @@ class RawClient
                     ),
                 )
             );
+        }
+
+        if ($request instanceof UrlEncodedApiRequest) {
+            if ($request->body === null) {
+                return null;
+            }
+            $body = $this->buildJsonBody($request->body, $options);
+            if ($body instanceof JsonSerializable) {
+                $body = $body->jsonSerialize();
+            }
+            if ($body instanceof \stdClass) {
+                $body = (array)$body;
+            }
+            if (!is_array($body)) {
+                throw new InvalidArgumentException('Form-urlencoded request body must serialize to an array');
+            }
+            $body = array_filter($body, static fn ($value) => $value !== null);
+            return $this->streamFactory->createStream(http_build_query($body));
         }
 
         if ($request instanceof MultipartApiRequest) {

--- a/seed/php-sdk/no-retries/src/Core/Client/UrlEncodedApiRequest.php
+++ b/seed/php-sdk/no-retries/src/Core/Client/UrlEncodedApiRequest.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Seed\Core\Client;
+
+class UrlEncodedApiRequest extends BaseApiRequest
+{
+    /**
+     * @param string $baseUrl The base URL for the request
+     * @param string $path The path for the request
+     * @param HttpMethod $method The HTTP method for the request
+     * @param array<string, string> $headers Additional headers for the request (optional)
+     * @param array<string, mixed> $query Query parameters for the request (optional)
+     * @param mixed|null $body The form-urlencoded request body (optional)
+     */
+    public function __construct(
+        string $baseUrl,
+        string $path,
+        HttpMethod $method,
+        array $headers = [],
+        array $query = [],
+        public readonly mixed $body = null
+    ) {
+        parent::__construct($baseUrl, $path, $method, $headers, $query);
+    }
+}

--- a/seed/php-sdk/null-type/.fern/metadata.json
+++ b/seed/php-sdk/null-type/.fern/metadata.json
@@ -3,8 +3,7 @@
   "generatorName": "fernapi/fern-php-sdk",
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/php-sdk/null-type/src/Core/Client/RawClient.php
+++ b/seed/php-sdk/null-type/src/Core/Client/RawClient.php
@@ -155,6 +155,16 @@ class RawClient
                 $request->headers,
                 $options['headers'] ?? [],
             ),
+            UrlEncodedApiRequest::class => array_merge(
+                [
+                    "Content-Type" => "application/x-www-form-urlencoded",
+                    "Accept" => "*/*",
+                ],
+                $this->headers,
+                $authHeaders,
+                $request->headers,
+                $options['headers'] ?? [],
+            ),
             MultipartApiRequest::class => array_merge(
                 $this->headers,
                 $authHeaders,
@@ -185,6 +195,24 @@ class RawClient
                     ),
                 )
             );
+        }
+
+        if ($request instanceof UrlEncodedApiRequest) {
+            if ($request->body === null) {
+                return null;
+            }
+            $body = $this->buildJsonBody($request->body, $options);
+            if ($body instanceof JsonSerializable) {
+                $body = $body->jsonSerialize();
+            }
+            if ($body instanceof \stdClass) {
+                $body = (array)$body;
+            }
+            if (!is_array($body)) {
+                throw new InvalidArgumentException('Form-urlencoded request body must serialize to an array');
+            }
+            $body = array_filter($body, static fn ($value) => $value !== null);
+            return $this->streamFactory->createStream(http_build_query($body));
         }
 
         if ($request instanceof MultipartApiRequest) {

--- a/seed/php-sdk/null-type/src/Core/Client/UrlEncodedApiRequest.php
+++ b/seed/php-sdk/null-type/src/Core/Client/UrlEncodedApiRequest.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Seed\Core\Client;
+
+class UrlEncodedApiRequest extends BaseApiRequest
+{
+    /**
+     * @param string $baseUrl The base URL for the request
+     * @param string $path The path for the request
+     * @param HttpMethod $method The HTTP method for the request
+     * @param array<string, string> $headers Additional headers for the request (optional)
+     * @param array<string, mixed> $query Query parameters for the request (optional)
+     * @param mixed|null $body The form-urlencoded request body (optional)
+     */
+    public function __construct(
+        string $baseUrl,
+        string $path,
+        HttpMethod $method,
+        array $headers = [],
+        array $query = [],
+        public readonly mixed $body = null
+    ) {
+        parent::__construct($baseUrl, $path, $method, $headers, $query);
+    }
+}

--- a/seed/php-sdk/nullable-allof-extends/.fern/metadata.json
+++ b/seed/php-sdk/nullable-allof-extends/.fern/metadata.json
@@ -3,8 +3,7 @@
   "generatorName": "fernapi/fern-php-sdk",
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/php-sdk/nullable-allof-extends/src/Core/Client/RawClient.php
+++ b/seed/php-sdk/nullable-allof-extends/src/Core/Client/RawClient.php
@@ -155,6 +155,16 @@ class RawClient
                 $request->headers,
                 $options['headers'] ?? [],
             ),
+            UrlEncodedApiRequest::class => array_merge(
+                [
+                    "Content-Type" => "application/x-www-form-urlencoded",
+                    "Accept" => "*/*",
+                ],
+                $this->headers,
+                $authHeaders,
+                $request->headers,
+                $options['headers'] ?? [],
+            ),
             MultipartApiRequest::class => array_merge(
                 $this->headers,
                 $authHeaders,
@@ -185,6 +195,24 @@ class RawClient
                     ),
                 )
             );
+        }
+
+        if ($request instanceof UrlEncodedApiRequest) {
+            if ($request->body === null) {
+                return null;
+            }
+            $body = $this->buildJsonBody($request->body, $options);
+            if ($body instanceof JsonSerializable) {
+                $body = $body->jsonSerialize();
+            }
+            if ($body instanceof \stdClass) {
+                $body = (array)$body;
+            }
+            if (!is_array($body)) {
+                throw new InvalidArgumentException('Form-urlencoded request body must serialize to an array');
+            }
+            $body = array_filter($body, static fn ($value) => $value !== null);
+            return $this->streamFactory->createStream(http_build_query($body));
         }
 
         if ($request instanceof MultipartApiRequest) {

--- a/seed/php-sdk/nullable-allof-extends/src/Core/Client/UrlEncodedApiRequest.php
+++ b/seed/php-sdk/nullable-allof-extends/src/Core/Client/UrlEncodedApiRequest.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Seed\Core\Client;
+
+class UrlEncodedApiRequest extends BaseApiRequest
+{
+    /**
+     * @param string $baseUrl The base URL for the request
+     * @param string $path The path for the request
+     * @param HttpMethod $method The HTTP method for the request
+     * @param array<string, string> $headers Additional headers for the request (optional)
+     * @param array<string, mixed> $query Query parameters for the request (optional)
+     * @param mixed|null $body The form-urlencoded request body (optional)
+     */
+    public function __construct(
+        string $baseUrl,
+        string $path,
+        HttpMethod $method,
+        array $headers = [],
+        array $query = [],
+        public readonly mixed $body = null
+    ) {
+        parent::__construct($baseUrl, $path, $method, $headers, $query);
+    }
+}

--- a/seed/php-sdk/nullable-optional/.fern/metadata.json
+++ b/seed/php-sdk/nullable-optional/.fern/metadata.json
@@ -3,8 +3,7 @@
   "generatorName": "fernapi/fern-php-sdk",
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/php-sdk/nullable-optional/src/Core/Client/RawClient.php
+++ b/seed/php-sdk/nullable-optional/src/Core/Client/RawClient.php
@@ -155,6 +155,16 @@ class RawClient
                 $request->headers,
                 $options['headers'] ?? [],
             ),
+            UrlEncodedApiRequest::class => array_merge(
+                [
+                    "Content-Type" => "application/x-www-form-urlencoded",
+                    "Accept" => "*/*",
+                ],
+                $this->headers,
+                $authHeaders,
+                $request->headers,
+                $options['headers'] ?? [],
+            ),
             MultipartApiRequest::class => array_merge(
                 $this->headers,
                 $authHeaders,
@@ -185,6 +195,24 @@ class RawClient
                     ),
                 )
             );
+        }
+
+        if ($request instanceof UrlEncodedApiRequest) {
+            if ($request->body === null) {
+                return null;
+            }
+            $body = $this->buildJsonBody($request->body, $options);
+            if ($body instanceof JsonSerializable) {
+                $body = $body->jsonSerialize();
+            }
+            if ($body instanceof \stdClass) {
+                $body = (array)$body;
+            }
+            if (!is_array($body)) {
+                throw new InvalidArgumentException('Form-urlencoded request body must serialize to an array');
+            }
+            $body = array_filter($body, static fn ($value) => $value !== null);
+            return $this->streamFactory->createStream(http_build_query($body));
         }
 
         if ($request instanceof MultipartApiRequest) {

--- a/seed/php-sdk/nullable-optional/src/Core/Client/UrlEncodedApiRequest.php
+++ b/seed/php-sdk/nullable-optional/src/Core/Client/UrlEncodedApiRequest.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Seed\Core\Client;
+
+class UrlEncodedApiRequest extends BaseApiRequest
+{
+    /**
+     * @param string $baseUrl The base URL for the request
+     * @param string $path The path for the request
+     * @param HttpMethod $method The HTTP method for the request
+     * @param array<string, string> $headers Additional headers for the request (optional)
+     * @param array<string, mixed> $query Query parameters for the request (optional)
+     * @param mixed|null $body The form-urlencoded request body (optional)
+     */
+    public function __construct(
+        string $baseUrl,
+        string $path,
+        HttpMethod $method,
+        array $headers = [],
+        array $query = [],
+        public readonly mixed $body = null
+    ) {
+        parent::__construct($baseUrl, $path, $method, $headers, $query);
+    }
+}

--- a/seed/php-sdk/nullable-request-body/.fern/metadata.json
+++ b/seed/php-sdk/nullable-request-body/.fern/metadata.json
@@ -3,8 +3,7 @@
   "generatorName": "fernapi/fern-php-sdk",
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/php-sdk/nullable-request-body/src/Core/Client/RawClient.php
+++ b/seed/php-sdk/nullable-request-body/src/Core/Client/RawClient.php
@@ -155,6 +155,16 @@ class RawClient
                 $request->headers,
                 $options['headers'] ?? [],
             ),
+            UrlEncodedApiRequest::class => array_merge(
+                [
+                    "Content-Type" => "application/x-www-form-urlencoded",
+                    "Accept" => "*/*",
+                ],
+                $this->headers,
+                $authHeaders,
+                $request->headers,
+                $options['headers'] ?? [],
+            ),
             MultipartApiRequest::class => array_merge(
                 $this->headers,
                 $authHeaders,
@@ -185,6 +195,24 @@ class RawClient
                     ),
                 )
             );
+        }
+
+        if ($request instanceof UrlEncodedApiRequest) {
+            if ($request->body === null) {
+                return null;
+            }
+            $body = $this->buildJsonBody($request->body, $options);
+            if ($body instanceof JsonSerializable) {
+                $body = $body->jsonSerialize();
+            }
+            if ($body instanceof \stdClass) {
+                $body = (array)$body;
+            }
+            if (!is_array($body)) {
+                throw new InvalidArgumentException('Form-urlencoded request body must serialize to an array');
+            }
+            $body = array_filter($body, static fn ($value) => $value !== null);
+            return $this->streamFactory->createStream(http_build_query($body));
         }
 
         if ($request instanceof MultipartApiRequest) {

--- a/seed/php-sdk/nullable-request-body/src/Core/Client/UrlEncodedApiRequest.php
+++ b/seed/php-sdk/nullable-request-body/src/Core/Client/UrlEncodedApiRequest.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Seed\Core\Client;
+
+class UrlEncodedApiRequest extends BaseApiRequest
+{
+    /**
+     * @param string $baseUrl The base URL for the request
+     * @param string $path The path for the request
+     * @param HttpMethod $method The HTTP method for the request
+     * @param array<string, string> $headers Additional headers for the request (optional)
+     * @param array<string, mixed> $query Query parameters for the request (optional)
+     * @param mixed|null $body The form-urlencoded request body (optional)
+     */
+    public function __construct(
+        string $baseUrl,
+        string $path,
+        HttpMethod $method,
+        array $headers = [],
+        array $query = [],
+        public readonly mixed $body = null
+    ) {
+        parent::__construct($baseUrl, $path, $method, $headers, $query);
+    }
+}

--- a/seed/php-sdk/nullable/.fern/metadata.json
+++ b/seed/php-sdk/nullable/.fern/metadata.json
@@ -3,8 +3,7 @@
   "generatorName": "fernapi/fern-php-sdk",
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/php-sdk/nullable/src/Core/Client/RawClient.php
+++ b/seed/php-sdk/nullable/src/Core/Client/RawClient.php
@@ -155,6 +155,16 @@ class RawClient
                 $request->headers,
                 $options['headers'] ?? [],
             ),
+            UrlEncodedApiRequest::class => array_merge(
+                [
+                    "Content-Type" => "application/x-www-form-urlencoded",
+                    "Accept" => "*/*",
+                ],
+                $this->headers,
+                $authHeaders,
+                $request->headers,
+                $options['headers'] ?? [],
+            ),
             MultipartApiRequest::class => array_merge(
                 $this->headers,
                 $authHeaders,
@@ -185,6 +195,24 @@ class RawClient
                     ),
                 )
             );
+        }
+
+        if ($request instanceof UrlEncodedApiRequest) {
+            if ($request->body === null) {
+                return null;
+            }
+            $body = $this->buildJsonBody($request->body, $options);
+            if ($body instanceof JsonSerializable) {
+                $body = $body->jsonSerialize();
+            }
+            if ($body instanceof \stdClass) {
+                $body = (array)$body;
+            }
+            if (!is_array($body)) {
+                throw new InvalidArgumentException('Form-urlencoded request body must serialize to an array');
+            }
+            $body = array_filter($body, static fn ($value) => $value !== null);
+            return $this->streamFactory->createStream(http_build_query($body));
         }
 
         if ($request instanceof MultipartApiRequest) {

--- a/seed/php-sdk/nullable/src/Core/Client/UrlEncodedApiRequest.php
+++ b/seed/php-sdk/nullable/src/Core/Client/UrlEncodedApiRequest.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Seed\Core\Client;
+
+class UrlEncodedApiRequest extends BaseApiRequest
+{
+    /**
+     * @param string $baseUrl The base URL for the request
+     * @param string $path The path for the request
+     * @param HttpMethod $method The HTTP method for the request
+     * @param array<string, string> $headers Additional headers for the request (optional)
+     * @param array<string, mixed> $query Query parameters for the request (optional)
+     * @param mixed|null $body The form-urlencoded request body (optional)
+     */
+    public function __construct(
+        string $baseUrl,
+        string $path,
+        HttpMethod $method,
+        array $headers = [],
+        array $query = [],
+        public readonly mixed $body = null
+    ) {
+        parent::__construct($baseUrl, $path, $method, $headers, $query);
+    }
+}

--- a/seed/php-sdk/oauth-client-credentials-custom/.fern/metadata.json
+++ b/seed/php-sdk/oauth-client-credentials-custom/.fern/metadata.json
@@ -3,8 +3,7 @@
   "generatorName": "fernapi/fern-php-sdk",
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/php-sdk/oauth-client-credentials-custom/src/Core/Client/RawClient.php
+++ b/seed/php-sdk/oauth-client-credentials-custom/src/Core/Client/RawClient.php
@@ -155,6 +155,16 @@ class RawClient
                 $request->headers,
                 $options['headers'] ?? [],
             ),
+            UrlEncodedApiRequest::class => array_merge(
+                [
+                    "Content-Type" => "application/x-www-form-urlencoded",
+                    "Accept" => "*/*",
+                ],
+                $this->headers,
+                $authHeaders,
+                $request->headers,
+                $options['headers'] ?? [],
+            ),
             MultipartApiRequest::class => array_merge(
                 $this->headers,
                 $authHeaders,
@@ -185,6 +195,24 @@ class RawClient
                     ),
                 )
             );
+        }
+
+        if ($request instanceof UrlEncodedApiRequest) {
+            if ($request->body === null) {
+                return null;
+            }
+            $body = $this->buildJsonBody($request->body, $options);
+            if ($body instanceof JsonSerializable) {
+                $body = $body->jsonSerialize();
+            }
+            if ($body instanceof \stdClass) {
+                $body = (array)$body;
+            }
+            if (!is_array($body)) {
+                throw new InvalidArgumentException('Form-urlencoded request body must serialize to an array');
+            }
+            $body = array_filter($body, static fn ($value) => $value !== null);
+            return $this->streamFactory->createStream(http_build_query($body));
         }
 
         if ($request instanceof MultipartApiRequest) {

--- a/seed/php-sdk/oauth-client-credentials-custom/src/Core/Client/UrlEncodedApiRequest.php
+++ b/seed/php-sdk/oauth-client-credentials-custom/src/Core/Client/UrlEncodedApiRequest.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Seed\Core\Client;
+
+class UrlEncodedApiRequest extends BaseApiRequest
+{
+    /**
+     * @param string $baseUrl The base URL for the request
+     * @param string $path The path for the request
+     * @param HttpMethod $method The HTTP method for the request
+     * @param array<string, string> $headers Additional headers for the request (optional)
+     * @param array<string, mixed> $query Query parameters for the request (optional)
+     * @param mixed|null $body The form-urlencoded request body (optional)
+     */
+    public function __construct(
+        string $baseUrl,
+        string $path,
+        HttpMethod $method,
+        array $headers = [],
+        array $query = [],
+        public readonly mixed $body = null
+    ) {
+        parent::__construct($baseUrl, $path, $method, $headers, $query);
+    }
+}

--- a/seed/php-sdk/oauth-client-credentials-default/.fern/metadata.json
+++ b/seed/php-sdk/oauth-client-credentials-default/.fern/metadata.json
@@ -3,8 +3,7 @@
   "generatorName": "fernapi/fern-php-sdk",
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/php-sdk/oauth-client-credentials-default/src/Core/Client/RawClient.php
+++ b/seed/php-sdk/oauth-client-credentials-default/src/Core/Client/RawClient.php
@@ -155,6 +155,16 @@ class RawClient
                 $request->headers,
                 $options['headers'] ?? [],
             ),
+            UrlEncodedApiRequest::class => array_merge(
+                [
+                    "Content-Type" => "application/x-www-form-urlencoded",
+                    "Accept" => "*/*",
+                ],
+                $this->headers,
+                $authHeaders,
+                $request->headers,
+                $options['headers'] ?? [],
+            ),
             MultipartApiRequest::class => array_merge(
                 $this->headers,
                 $authHeaders,
@@ -185,6 +195,24 @@ class RawClient
                     ),
                 )
             );
+        }
+
+        if ($request instanceof UrlEncodedApiRequest) {
+            if ($request->body === null) {
+                return null;
+            }
+            $body = $this->buildJsonBody($request->body, $options);
+            if ($body instanceof JsonSerializable) {
+                $body = $body->jsonSerialize();
+            }
+            if ($body instanceof \stdClass) {
+                $body = (array)$body;
+            }
+            if (!is_array($body)) {
+                throw new InvalidArgumentException('Form-urlencoded request body must serialize to an array');
+            }
+            $body = array_filter($body, static fn ($value) => $value !== null);
+            return $this->streamFactory->createStream(http_build_query($body));
         }
 
         if ($request instanceof MultipartApiRequest) {

--- a/seed/php-sdk/oauth-client-credentials-default/src/Core/Client/UrlEncodedApiRequest.php
+++ b/seed/php-sdk/oauth-client-credentials-default/src/Core/Client/UrlEncodedApiRequest.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Seed\Core\Client;
+
+class UrlEncodedApiRequest extends BaseApiRequest
+{
+    /**
+     * @param string $baseUrl The base URL for the request
+     * @param string $path The path for the request
+     * @param HttpMethod $method The HTTP method for the request
+     * @param array<string, string> $headers Additional headers for the request (optional)
+     * @param array<string, mixed> $query Query parameters for the request (optional)
+     * @param mixed|null $body The form-urlencoded request body (optional)
+     */
+    public function __construct(
+        string $baseUrl,
+        string $path,
+        HttpMethod $method,
+        array $headers = [],
+        array $query = [],
+        public readonly mixed $body = null
+    ) {
+        parent::__construct($baseUrl, $path, $method, $headers, $query);
+    }
+}

--- a/seed/php-sdk/oauth-client-credentials-environment-variables/.fern/metadata.json
+++ b/seed/php-sdk/oauth-client-credentials-environment-variables/.fern/metadata.json
@@ -3,8 +3,7 @@
   "generatorName": "fernapi/fern-php-sdk",
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/php-sdk/oauth-client-credentials-environment-variables/src/Core/Client/RawClient.php
+++ b/seed/php-sdk/oauth-client-credentials-environment-variables/src/Core/Client/RawClient.php
@@ -155,6 +155,16 @@ class RawClient
                 $request->headers,
                 $options['headers'] ?? [],
             ),
+            UrlEncodedApiRequest::class => array_merge(
+                [
+                    "Content-Type" => "application/x-www-form-urlencoded",
+                    "Accept" => "*/*",
+                ],
+                $this->headers,
+                $authHeaders,
+                $request->headers,
+                $options['headers'] ?? [],
+            ),
             MultipartApiRequest::class => array_merge(
                 $this->headers,
                 $authHeaders,
@@ -185,6 +195,24 @@ class RawClient
                     ),
                 )
             );
+        }
+
+        if ($request instanceof UrlEncodedApiRequest) {
+            if ($request->body === null) {
+                return null;
+            }
+            $body = $this->buildJsonBody($request->body, $options);
+            if ($body instanceof JsonSerializable) {
+                $body = $body->jsonSerialize();
+            }
+            if ($body instanceof \stdClass) {
+                $body = (array)$body;
+            }
+            if (!is_array($body)) {
+                throw new InvalidArgumentException('Form-urlencoded request body must serialize to an array');
+            }
+            $body = array_filter($body, static fn ($value) => $value !== null);
+            return $this->streamFactory->createStream(http_build_query($body));
         }
 
         if ($request instanceof MultipartApiRequest) {

--- a/seed/php-sdk/oauth-client-credentials-environment-variables/src/Core/Client/UrlEncodedApiRequest.php
+++ b/seed/php-sdk/oauth-client-credentials-environment-variables/src/Core/Client/UrlEncodedApiRequest.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Seed\Core\Client;
+
+class UrlEncodedApiRequest extends BaseApiRequest
+{
+    /**
+     * @param string $baseUrl The base URL for the request
+     * @param string $path The path for the request
+     * @param HttpMethod $method The HTTP method for the request
+     * @param array<string, string> $headers Additional headers for the request (optional)
+     * @param array<string, mixed> $query Query parameters for the request (optional)
+     * @param mixed|null $body The form-urlencoded request body (optional)
+     */
+    public function __construct(
+        string $baseUrl,
+        string $path,
+        HttpMethod $method,
+        array $headers = [],
+        array $query = [],
+        public readonly mixed $body = null
+    ) {
+        parent::__construct($baseUrl, $path, $method, $headers, $query);
+    }
+}

--- a/seed/php-sdk/oauth-client-credentials-mandatory-auth/.fern/metadata.json
+++ b/seed/php-sdk/oauth-client-credentials-mandatory-auth/.fern/metadata.json
@@ -3,8 +3,7 @@
   "generatorName": "fernapi/fern-php-sdk",
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/php-sdk/oauth-client-credentials-mandatory-auth/src/Core/Client/RawClient.php
+++ b/seed/php-sdk/oauth-client-credentials-mandatory-auth/src/Core/Client/RawClient.php
@@ -155,6 +155,16 @@ class RawClient
                 $request->headers,
                 $options['headers'] ?? [],
             ),
+            UrlEncodedApiRequest::class => array_merge(
+                [
+                    "Content-Type" => "application/x-www-form-urlencoded",
+                    "Accept" => "*/*",
+                ],
+                $this->headers,
+                $authHeaders,
+                $request->headers,
+                $options['headers'] ?? [],
+            ),
             MultipartApiRequest::class => array_merge(
                 $this->headers,
                 $authHeaders,
@@ -185,6 +195,24 @@ class RawClient
                     ),
                 )
             );
+        }
+
+        if ($request instanceof UrlEncodedApiRequest) {
+            if ($request->body === null) {
+                return null;
+            }
+            $body = $this->buildJsonBody($request->body, $options);
+            if ($body instanceof JsonSerializable) {
+                $body = $body->jsonSerialize();
+            }
+            if ($body instanceof \stdClass) {
+                $body = (array)$body;
+            }
+            if (!is_array($body)) {
+                throw new InvalidArgumentException('Form-urlencoded request body must serialize to an array');
+            }
+            $body = array_filter($body, static fn ($value) => $value !== null);
+            return $this->streamFactory->createStream(http_build_query($body));
         }
 
         if ($request instanceof MultipartApiRequest) {

--- a/seed/php-sdk/oauth-client-credentials-mandatory-auth/src/Core/Client/UrlEncodedApiRequest.php
+++ b/seed/php-sdk/oauth-client-credentials-mandatory-auth/src/Core/Client/UrlEncodedApiRequest.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Seed\Core\Client;
+
+class UrlEncodedApiRequest extends BaseApiRequest
+{
+    /**
+     * @param string $baseUrl The base URL for the request
+     * @param string $path The path for the request
+     * @param HttpMethod $method The HTTP method for the request
+     * @param array<string, string> $headers Additional headers for the request (optional)
+     * @param array<string, mixed> $query Query parameters for the request (optional)
+     * @param mixed|null $body The form-urlencoded request body (optional)
+     */
+    public function __construct(
+        string $baseUrl,
+        string $path,
+        HttpMethod $method,
+        array $headers = [],
+        array $query = [],
+        public readonly mixed $body = null
+    ) {
+        parent::__construct($baseUrl, $path, $method, $headers, $query);
+    }
+}

--- a/seed/php-sdk/oauth-client-credentials-nested-root/.fern/metadata.json
+++ b/seed/php-sdk/oauth-client-credentials-nested-root/.fern/metadata.json
@@ -3,8 +3,7 @@
   "generatorName": "fernapi/fern-php-sdk",
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/php-sdk/oauth-client-credentials-nested-root/src/Core/Client/RawClient.php
+++ b/seed/php-sdk/oauth-client-credentials-nested-root/src/Core/Client/RawClient.php
@@ -155,6 +155,16 @@ class RawClient
                 $request->headers,
                 $options['headers'] ?? [],
             ),
+            UrlEncodedApiRequest::class => array_merge(
+                [
+                    "Content-Type" => "application/x-www-form-urlencoded",
+                    "Accept" => "*/*",
+                ],
+                $this->headers,
+                $authHeaders,
+                $request->headers,
+                $options['headers'] ?? [],
+            ),
             MultipartApiRequest::class => array_merge(
                 $this->headers,
                 $authHeaders,
@@ -185,6 +195,24 @@ class RawClient
                     ),
                 )
             );
+        }
+
+        if ($request instanceof UrlEncodedApiRequest) {
+            if ($request->body === null) {
+                return null;
+            }
+            $body = $this->buildJsonBody($request->body, $options);
+            if ($body instanceof JsonSerializable) {
+                $body = $body->jsonSerialize();
+            }
+            if ($body instanceof \stdClass) {
+                $body = (array)$body;
+            }
+            if (!is_array($body)) {
+                throw new InvalidArgumentException('Form-urlencoded request body must serialize to an array');
+            }
+            $body = array_filter($body, static fn ($value) => $value !== null);
+            return $this->streamFactory->createStream(http_build_query($body));
         }
 
         if ($request instanceof MultipartApiRequest) {

--- a/seed/php-sdk/oauth-client-credentials-nested-root/src/Core/Client/UrlEncodedApiRequest.php
+++ b/seed/php-sdk/oauth-client-credentials-nested-root/src/Core/Client/UrlEncodedApiRequest.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Seed\Core\Client;
+
+class UrlEncodedApiRequest extends BaseApiRequest
+{
+    /**
+     * @param string $baseUrl The base URL for the request
+     * @param string $path The path for the request
+     * @param HttpMethod $method The HTTP method for the request
+     * @param array<string, string> $headers Additional headers for the request (optional)
+     * @param array<string, mixed> $query Query parameters for the request (optional)
+     * @param mixed|null $body The form-urlencoded request body (optional)
+     */
+    public function __construct(
+        string $baseUrl,
+        string $path,
+        HttpMethod $method,
+        array $headers = [],
+        array $query = [],
+        public readonly mixed $body = null
+    ) {
+        parent::__construct($baseUrl, $path, $method, $headers, $query);
+    }
+}

--- a/seed/php-sdk/oauth-client-credentials-openapi/.fern/metadata.json
+++ b/seed/php-sdk/oauth-client-credentials-openapi/.fern/metadata.json
@@ -3,8 +3,7 @@
   "generatorName": "fernapi/fern-php-sdk",
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/php-sdk/oauth-client-credentials-openapi/src/Core/Client/RawClient.php
+++ b/seed/php-sdk/oauth-client-credentials-openapi/src/Core/Client/RawClient.php
@@ -155,6 +155,16 @@ class RawClient
                 $request->headers,
                 $options['headers'] ?? [],
             ),
+            UrlEncodedApiRequest::class => array_merge(
+                [
+                    "Content-Type" => "application/x-www-form-urlencoded",
+                    "Accept" => "*/*",
+                ],
+                $this->headers,
+                $authHeaders,
+                $request->headers,
+                $options['headers'] ?? [],
+            ),
             MultipartApiRequest::class => array_merge(
                 $this->headers,
                 $authHeaders,
@@ -185,6 +195,24 @@ class RawClient
                     ),
                 )
             );
+        }
+
+        if ($request instanceof UrlEncodedApiRequest) {
+            if ($request->body === null) {
+                return null;
+            }
+            $body = $this->buildJsonBody($request->body, $options);
+            if ($body instanceof JsonSerializable) {
+                $body = $body->jsonSerialize();
+            }
+            if ($body instanceof \stdClass) {
+                $body = (array)$body;
+            }
+            if (!is_array($body)) {
+                throw new InvalidArgumentException('Form-urlencoded request body must serialize to an array');
+            }
+            $body = array_filter($body, static fn ($value) => $value !== null);
+            return $this->streamFactory->createStream(http_build_query($body));
         }
 
         if ($request instanceof MultipartApiRequest) {

--- a/seed/php-sdk/oauth-client-credentials-openapi/src/Core/Client/UrlEncodedApiRequest.php
+++ b/seed/php-sdk/oauth-client-credentials-openapi/src/Core/Client/UrlEncodedApiRequest.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Seed\Core\Client;
+
+class UrlEncodedApiRequest extends BaseApiRequest
+{
+    /**
+     * @param string $baseUrl The base URL for the request
+     * @param string $path The path for the request
+     * @param HttpMethod $method The HTTP method for the request
+     * @param array<string, string> $headers Additional headers for the request (optional)
+     * @param array<string, mixed> $query Query parameters for the request (optional)
+     * @param mixed|null $body The form-urlencoded request body (optional)
+     */
+    public function __construct(
+        string $baseUrl,
+        string $path,
+        HttpMethod $method,
+        array $headers = [],
+        array $query = [],
+        public readonly mixed $body = null
+    ) {
+        parent::__construct($baseUrl, $path, $method, $headers, $query);
+    }
+}

--- a/seed/php-sdk/oauth-client-credentials-reference/.fern/metadata.json
+++ b/seed/php-sdk/oauth-client-credentials-reference/.fern/metadata.json
@@ -3,8 +3,7 @@
   "generatorName": "fernapi/fern-php-sdk",
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/php-sdk/oauth-client-credentials-reference/src/Core/Client/RawClient.php
+++ b/seed/php-sdk/oauth-client-credentials-reference/src/Core/Client/RawClient.php
@@ -155,6 +155,16 @@ class RawClient
                 $request->headers,
                 $options['headers'] ?? [],
             ),
+            UrlEncodedApiRequest::class => array_merge(
+                [
+                    "Content-Type" => "application/x-www-form-urlencoded",
+                    "Accept" => "*/*",
+                ],
+                $this->headers,
+                $authHeaders,
+                $request->headers,
+                $options['headers'] ?? [],
+            ),
             MultipartApiRequest::class => array_merge(
                 $this->headers,
                 $authHeaders,
@@ -185,6 +195,24 @@ class RawClient
                     ),
                 )
             );
+        }
+
+        if ($request instanceof UrlEncodedApiRequest) {
+            if ($request->body === null) {
+                return null;
+            }
+            $body = $this->buildJsonBody($request->body, $options);
+            if ($body instanceof JsonSerializable) {
+                $body = $body->jsonSerialize();
+            }
+            if ($body instanceof \stdClass) {
+                $body = (array)$body;
+            }
+            if (!is_array($body)) {
+                throw new InvalidArgumentException('Form-urlencoded request body must serialize to an array');
+            }
+            $body = array_filter($body, static fn ($value) => $value !== null);
+            return $this->streamFactory->createStream(http_build_query($body));
         }
 
         if ($request instanceof MultipartApiRequest) {

--- a/seed/php-sdk/oauth-client-credentials-reference/src/Core/Client/UrlEncodedApiRequest.php
+++ b/seed/php-sdk/oauth-client-credentials-reference/src/Core/Client/UrlEncodedApiRequest.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Seed\Core\Client;
+
+class UrlEncodedApiRequest extends BaseApiRequest
+{
+    /**
+     * @param string $baseUrl The base URL for the request
+     * @param string $path The path for the request
+     * @param HttpMethod $method The HTTP method for the request
+     * @param array<string, string> $headers Additional headers for the request (optional)
+     * @param array<string, mixed> $query Query parameters for the request (optional)
+     * @param mixed|null $body The form-urlencoded request body (optional)
+     */
+    public function __construct(
+        string $baseUrl,
+        string $path,
+        HttpMethod $method,
+        array $headers = [],
+        array $query = [],
+        public readonly mixed $body = null
+    ) {
+        parent::__construct($baseUrl, $path, $method, $headers, $query);
+    }
+}

--- a/seed/php-sdk/oauth-client-credentials-with-variables/.fern/metadata.json
+++ b/seed/php-sdk/oauth-client-credentials-with-variables/.fern/metadata.json
@@ -3,8 +3,7 @@
   "generatorName": "fernapi/fern-php-sdk",
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/php-sdk/oauth-client-credentials-with-variables/src/Core/Client/RawClient.php
+++ b/seed/php-sdk/oauth-client-credentials-with-variables/src/Core/Client/RawClient.php
@@ -155,6 +155,16 @@ class RawClient
                 $request->headers,
                 $options['headers'] ?? [],
             ),
+            UrlEncodedApiRequest::class => array_merge(
+                [
+                    "Content-Type" => "application/x-www-form-urlencoded",
+                    "Accept" => "*/*",
+                ],
+                $this->headers,
+                $authHeaders,
+                $request->headers,
+                $options['headers'] ?? [],
+            ),
             MultipartApiRequest::class => array_merge(
                 $this->headers,
                 $authHeaders,
@@ -185,6 +195,24 @@ class RawClient
                     ),
                 )
             );
+        }
+
+        if ($request instanceof UrlEncodedApiRequest) {
+            if ($request->body === null) {
+                return null;
+            }
+            $body = $this->buildJsonBody($request->body, $options);
+            if ($body instanceof JsonSerializable) {
+                $body = $body->jsonSerialize();
+            }
+            if ($body instanceof \stdClass) {
+                $body = (array)$body;
+            }
+            if (!is_array($body)) {
+                throw new InvalidArgumentException('Form-urlencoded request body must serialize to an array');
+            }
+            $body = array_filter($body, static fn ($value) => $value !== null);
+            return $this->streamFactory->createStream(http_build_query($body));
         }
 
         if ($request instanceof MultipartApiRequest) {

--- a/seed/php-sdk/oauth-client-credentials-with-variables/src/Core/Client/UrlEncodedApiRequest.php
+++ b/seed/php-sdk/oauth-client-credentials-with-variables/src/Core/Client/UrlEncodedApiRequest.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Seed\Core\Client;
+
+class UrlEncodedApiRequest extends BaseApiRequest
+{
+    /**
+     * @param string $baseUrl The base URL for the request
+     * @param string $path The path for the request
+     * @param HttpMethod $method The HTTP method for the request
+     * @param array<string, string> $headers Additional headers for the request (optional)
+     * @param array<string, mixed> $query Query parameters for the request (optional)
+     * @param mixed|null $body The form-urlencoded request body (optional)
+     */
+    public function __construct(
+        string $baseUrl,
+        string $path,
+        HttpMethod $method,
+        array $headers = [],
+        array $query = [],
+        public readonly mixed $body = null
+    ) {
+        parent::__construct($baseUrl, $path, $method, $headers, $query);
+    }
+}

--- a/seed/php-sdk/oauth-client-credentials/.fern/metadata.json
+++ b/seed/php-sdk/oauth-client-credentials/.fern/metadata.json
@@ -3,8 +3,7 @@
   "generatorName": "fernapi/fern-php-sdk",
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/php-sdk/oauth-client-credentials/src/Auth/AuthClient.php
+++ b/seed/php-sdk/oauth-client-credentials/src/Auth/AuthClient.php
@@ -8,7 +8,7 @@ use Seed\Auth\Requests\GetTokenRequest;
 use Seed\Auth\Types\TokenResponse;
 use Seed\Exceptions\SeedException;
 use Seed\Exceptions\SeedApiException;
-use Seed\Core\Json\JsonApiRequest;
+use Seed\Core\Client\UrlEncodedApiRequest;
 use Seed\Core\Client\HttpMethod;
 use JsonException;
 use Psr\Http\Client\ClientExceptionInterface;
@@ -69,7 +69,7 @@ class AuthClient
         $options = array_merge($this->options, $options ?? []);
         try {
             $response = $this->client->sendRequest(
-                new JsonApiRequest(
+                new UrlEncodedApiRequest(
                     baseUrl: $options['baseUrl'] ?? $this->client->options['baseUrl'] ?? '',
                     path: "/token",
                     method: HttpMethod::POST,
@@ -116,7 +116,7 @@ class AuthClient
         $options = array_merge($this->options, $options ?? []);
         try {
             $response = $this->client->sendRequest(
-                new JsonApiRequest(
+                new UrlEncodedApiRequest(
                     baseUrl: $options['baseUrl'] ?? $this->client->options['baseUrl'] ?? '',
                     path: "/token",
                     method: HttpMethod::POST,

--- a/seed/php-sdk/oauth-client-credentials/src/Core/Client/RawClient.php
+++ b/seed/php-sdk/oauth-client-credentials/src/Core/Client/RawClient.php
@@ -155,6 +155,16 @@ class RawClient
                 $request->headers,
                 $options['headers'] ?? [],
             ),
+            UrlEncodedApiRequest::class => array_merge(
+                [
+                    "Content-Type" => "application/x-www-form-urlencoded",
+                    "Accept" => "*/*",
+                ],
+                $this->headers,
+                $authHeaders,
+                $request->headers,
+                $options['headers'] ?? [],
+            ),
             MultipartApiRequest::class => array_merge(
                 $this->headers,
                 $authHeaders,
@@ -185,6 +195,24 @@ class RawClient
                     ),
                 )
             );
+        }
+
+        if ($request instanceof UrlEncodedApiRequest) {
+            if ($request->body === null) {
+                return null;
+            }
+            $body = $this->buildJsonBody($request->body, $options);
+            if ($body instanceof JsonSerializable) {
+                $body = $body->jsonSerialize();
+            }
+            if ($body instanceof \stdClass) {
+                $body = (array)$body;
+            }
+            if (!is_array($body)) {
+                throw new InvalidArgumentException('Form-urlencoded request body must serialize to an array');
+            }
+            $body = array_filter($body, static fn ($value) => $value !== null);
+            return $this->streamFactory->createStream(http_build_query($body));
         }
 
         if ($request instanceof MultipartApiRequest) {

--- a/seed/php-sdk/oauth-client-credentials/src/Core/Client/UrlEncodedApiRequest.php
+++ b/seed/php-sdk/oauth-client-credentials/src/Core/Client/UrlEncodedApiRequest.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Seed\Core\Client;
+
+class UrlEncodedApiRequest extends BaseApiRequest
+{
+    /**
+     * @param string $baseUrl The base URL for the request
+     * @param string $path The path for the request
+     * @param HttpMethod $method The HTTP method for the request
+     * @param array<string, string> $headers Additional headers for the request (optional)
+     * @param array<string, mixed> $query Query parameters for the request (optional)
+     * @param mixed|null $body The form-urlencoded request body (optional)
+     */
+    public function __construct(
+        string $baseUrl,
+        string $path,
+        HttpMethod $method,
+        array $headers = [],
+        array $query = [],
+        public readonly mixed $body = null
+    ) {
+        parent::__construct($baseUrl, $path, $method, $headers, $query);
+    }
+}

--- a/seed/php-sdk/object/.fern/metadata.json
+++ b/seed/php-sdk/object/.fern/metadata.json
@@ -3,8 +3,7 @@
   "generatorName": "fernapi/fern-php-sdk",
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/php-sdk/object/src/Core/Client/RawClient.php
+++ b/seed/php-sdk/object/src/Core/Client/RawClient.php
@@ -155,6 +155,16 @@ class RawClient
                 $request->headers,
                 $options['headers'] ?? [],
             ),
+            UrlEncodedApiRequest::class => array_merge(
+                [
+                    "Content-Type" => "application/x-www-form-urlencoded",
+                    "Accept" => "*/*",
+                ],
+                $this->headers,
+                $authHeaders,
+                $request->headers,
+                $options['headers'] ?? [],
+            ),
             MultipartApiRequest::class => array_merge(
                 $this->headers,
                 $authHeaders,
@@ -185,6 +195,24 @@ class RawClient
                     ),
                 )
             );
+        }
+
+        if ($request instanceof UrlEncodedApiRequest) {
+            if ($request->body === null) {
+                return null;
+            }
+            $body = $this->buildJsonBody($request->body, $options);
+            if ($body instanceof JsonSerializable) {
+                $body = $body->jsonSerialize();
+            }
+            if ($body instanceof \stdClass) {
+                $body = (array)$body;
+            }
+            if (!is_array($body)) {
+                throw new InvalidArgumentException('Form-urlencoded request body must serialize to an array');
+            }
+            $body = array_filter($body, static fn ($value) => $value !== null);
+            return $this->streamFactory->createStream(http_build_query($body));
         }
 
         if ($request instanceof MultipartApiRequest) {

--- a/seed/php-sdk/object/src/Core/Client/UrlEncodedApiRequest.php
+++ b/seed/php-sdk/object/src/Core/Client/UrlEncodedApiRequest.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Seed\Core\Client;
+
+class UrlEncodedApiRequest extends BaseApiRequest
+{
+    /**
+     * @param string $baseUrl The base URL for the request
+     * @param string $path The path for the request
+     * @param HttpMethod $method The HTTP method for the request
+     * @param array<string, string> $headers Additional headers for the request (optional)
+     * @param array<string, mixed> $query Query parameters for the request (optional)
+     * @param mixed|null $body The form-urlencoded request body (optional)
+     */
+    public function __construct(
+        string $baseUrl,
+        string $path,
+        HttpMethod $method,
+        array $headers = [],
+        array $query = [],
+        public readonly mixed $body = null
+    ) {
+        parent::__construct($baseUrl, $path, $method, $headers, $query);
+    }
+}

--- a/seed/php-sdk/objects-with-imports/.fern/metadata.json
+++ b/seed/php-sdk/objects-with-imports/.fern/metadata.json
@@ -3,8 +3,7 @@
   "generatorName": "fernapi/fern-php-sdk",
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/php-sdk/objects-with-imports/src/Core/Client/RawClient.php
+++ b/seed/php-sdk/objects-with-imports/src/Core/Client/RawClient.php
@@ -155,6 +155,16 @@ class RawClient
                 $request->headers,
                 $options['headers'] ?? [],
             ),
+            UrlEncodedApiRequest::class => array_merge(
+                [
+                    "Content-Type" => "application/x-www-form-urlencoded",
+                    "Accept" => "*/*",
+                ],
+                $this->headers,
+                $authHeaders,
+                $request->headers,
+                $options['headers'] ?? [],
+            ),
             MultipartApiRequest::class => array_merge(
                 $this->headers,
                 $authHeaders,
@@ -185,6 +195,24 @@ class RawClient
                     ),
                 )
             );
+        }
+
+        if ($request instanceof UrlEncodedApiRequest) {
+            if ($request->body === null) {
+                return null;
+            }
+            $body = $this->buildJsonBody($request->body, $options);
+            if ($body instanceof JsonSerializable) {
+                $body = $body->jsonSerialize();
+            }
+            if ($body instanceof \stdClass) {
+                $body = (array)$body;
+            }
+            if (!is_array($body)) {
+                throw new InvalidArgumentException('Form-urlencoded request body must serialize to an array');
+            }
+            $body = array_filter($body, static fn ($value) => $value !== null);
+            return $this->streamFactory->createStream(http_build_query($body));
         }
 
         if ($request instanceof MultipartApiRequest) {

--- a/seed/php-sdk/objects-with-imports/src/Core/Client/UrlEncodedApiRequest.php
+++ b/seed/php-sdk/objects-with-imports/src/Core/Client/UrlEncodedApiRequest.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Seed\Core\Client;
+
+class UrlEncodedApiRequest extends BaseApiRequest
+{
+    /**
+     * @param string $baseUrl The base URL for the request
+     * @param string $path The path for the request
+     * @param HttpMethod $method The HTTP method for the request
+     * @param array<string, string> $headers Additional headers for the request (optional)
+     * @param array<string, mixed> $query Query parameters for the request (optional)
+     * @param mixed|null $body The form-urlencoded request body (optional)
+     */
+    public function __construct(
+        string $baseUrl,
+        string $path,
+        HttpMethod $method,
+        array $headers = [],
+        array $query = [],
+        public readonly mixed $body = null
+    ) {
+        parent::__construct($baseUrl, $path, $method, $headers, $query);
+    }
+}

--- a/seed/php-sdk/openapi-request-body-ref/.fern/metadata.json
+++ b/seed/php-sdk/openapi-request-body-ref/.fern/metadata.json
@@ -3,8 +3,7 @@
   "generatorName": "fernapi/fern-php-sdk",
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/php-sdk/openapi-request-body-ref/src/Core/Client/RawClient.php
+++ b/seed/php-sdk/openapi-request-body-ref/src/Core/Client/RawClient.php
@@ -155,6 +155,16 @@ class RawClient
                 $request->headers,
                 $options['headers'] ?? [],
             ),
+            UrlEncodedApiRequest::class => array_merge(
+                [
+                    "Content-Type" => "application/x-www-form-urlencoded",
+                    "Accept" => "*/*",
+                ],
+                $this->headers,
+                $authHeaders,
+                $request->headers,
+                $options['headers'] ?? [],
+            ),
             MultipartApiRequest::class => array_merge(
                 $this->headers,
                 $authHeaders,
@@ -185,6 +195,24 @@ class RawClient
                     ),
                 )
             );
+        }
+
+        if ($request instanceof UrlEncodedApiRequest) {
+            if ($request->body === null) {
+                return null;
+            }
+            $body = $this->buildJsonBody($request->body, $options);
+            if ($body instanceof JsonSerializable) {
+                $body = $body->jsonSerialize();
+            }
+            if ($body instanceof \stdClass) {
+                $body = (array)$body;
+            }
+            if (!is_array($body)) {
+                throw new InvalidArgumentException('Form-urlencoded request body must serialize to an array');
+            }
+            $body = array_filter($body, static fn ($value) => $value !== null);
+            return $this->streamFactory->createStream(http_build_query($body));
         }
 
         if ($request instanceof MultipartApiRequest) {

--- a/seed/php-sdk/openapi-request-body-ref/src/Core/Client/UrlEncodedApiRequest.php
+++ b/seed/php-sdk/openapi-request-body-ref/src/Core/Client/UrlEncodedApiRequest.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Seed\Core\Client;
+
+class UrlEncodedApiRequest extends BaseApiRequest
+{
+    /**
+     * @param string $baseUrl The base URL for the request
+     * @param string $path The path for the request
+     * @param HttpMethod $method The HTTP method for the request
+     * @param array<string, string> $headers Additional headers for the request (optional)
+     * @param array<string, mixed> $query Query parameters for the request (optional)
+     * @param mixed|null $body The form-urlencoded request body (optional)
+     */
+    public function __construct(
+        string $baseUrl,
+        string $path,
+        HttpMethod $method,
+        array $headers = [],
+        array $query = [],
+        public readonly mixed $body = null
+    ) {
+        parent::__construct($baseUrl, $path, $method, $headers, $query);
+    }
+}

--- a/seed/php-sdk/openapi-subtitle/.fern/metadata.json
+++ b/seed/php-sdk/openapi-subtitle/.fern/metadata.json
@@ -3,8 +3,7 @@
   "generatorName": "fernapi/fern-php-sdk",
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/php-sdk/openapi-subtitle/src/Core/Client/RawClient.php
+++ b/seed/php-sdk/openapi-subtitle/src/Core/Client/RawClient.php
@@ -155,6 +155,16 @@ class RawClient
                 $request->headers,
                 $options['headers'] ?? [],
             ),
+            UrlEncodedApiRequest::class => array_merge(
+                [
+                    "Content-Type" => "application/x-www-form-urlencoded",
+                    "Accept" => "*/*",
+                ],
+                $this->headers,
+                $authHeaders,
+                $request->headers,
+                $options['headers'] ?? [],
+            ),
             MultipartApiRequest::class => array_merge(
                 $this->headers,
                 $authHeaders,
@@ -185,6 +195,24 @@ class RawClient
                     ),
                 )
             );
+        }
+
+        if ($request instanceof UrlEncodedApiRequest) {
+            if ($request->body === null) {
+                return null;
+            }
+            $body = $this->buildJsonBody($request->body, $options);
+            if ($body instanceof JsonSerializable) {
+                $body = $body->jsonSerialize();
+            }
+            if ($body instanceof \stdClass) {
+                $body = (array)$body;
+            }
+            if (!is_array($body)) {
+                throw new InvalidArgumentException('Form-urlencoded request body must serialize to an array');
+            }
+            $body = array_filter($body, static fn ($value) => $value !== null);
+            return $this->streamFactory->createStream(http_build_query($body));
         }
 
         if ($request instanceof MultipartApiRequest) {

--- a/seed/php-sdk/openapi-subtitle/src/Core/Client/UrlEncodedApiRequest.php
+++ b/seed/php-sdk/openapi-subtitle/src/Core/Client/UrlEncodedApiRequest.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Seed\Core\Client;
+
+class UrlEncodedApiRequest extends BaseApiRequest
+{
+    /**
+     * @param string $baseUrl The base URL for the request
+     * @param string $path The path for the request
+     * @param HttpMethod $method The HTTP method for the request
+     * @param array<string, string> $headers Additional headers for the request (optional)
+     * @param array<string, mixed> $query Query parameters for the request (optional)
+     * @param mixed|null $body The form-urlencoded request body (optional)
+     */
+    public function __construct(
+        string $baseUrl,
+        string $path,
+        HttpMethod $method,
+        array $headers = [],
+        array $query = [],
+        public readonly mixed $body = null
+    ) {
+        parent::__construct($baseUrl, $path, $method, $headers, $query);
+    }
+}

--- a/seed/php-sdk/optional/.fern/metadata.json
+++ b/seed/php-sdk/optional/.fern/metadata.json
@@ -3,8 +3,7 @@
   "generatorName": "fernapi/fern-php-sdk",
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/php-sdk/optional/src/Core/Client/RawClient.php
+++ b/seed/php-sdk/optional/src/Core/Client/RawClient.php
@@ -155,6 +155,16 @@ class RawClient
                 $request->headers,
                 $options['headers'] ?? [],
             ),
+            UrlEncodedApiRequest::class => array_merge(
+                [
+                    "Content-Type" => "application/x-www-form-urlencoded",
+                    "Accept" => "*/*",
+                ],
+                $this->headers,
+                $authHeaders,
+                $request->headers,
+                $options['headers'] ?? [],
+            ),
             MultipartApiRequest::class => array_merge(
                 $this->headers,
                 $authHeaders,
@@ -185,6 +195,24 @@ class RawClient
                     ),
                 )
             );
+        }
+
+        if ($request instanceof UrlEncodedApiRequest) {
+            if ($request->body === null) {
+                return null;
+            }
+            $body = $this->buildJsonBody($request->body, $options);
+            if ($body instanceof JsonSerializable) {
+                $body = $body->jsonSerialize();
+            }
+            if ($body instanceof \stdClass) {
+                $body = (array)$body;
+            }
+            if (!is_array($body)) {
+                throw new InvalidArgumentException('Form-urlencoded request body must serialize to an array');
+            }
+            $body = array_filter($body, static fn ($value) => $value !== null);
+            return $this->streamFactory->createStream(http_build_query($body));
         }
 
         if ($request instanceof MultipartApiRequest) {

--- a/seed/php-sdk/optional/src/Core/Client/UrlEncodedApiRequest.php
+++ b/seed/php-sdk/optional/src/Core/Client/UrlEncodedApiRequest.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Seed\Core\Client;
+
+class UrlEncodedApiRequest extends BaseApiRequest
+{
+    /**
+     * @param string $baseUrl The base URL for the request
+     * @param string $path The path for the request
+     * @param HttpMethod $method The HTTP method for the request
+     * @param array<string, string> $headers Additional headers for the request (optional)
+     * @param array<string, mixed> $query Query parameters for the request (optional)
+     * @param mixed|null $body The form-urlencoded request body (optional)
+     */
+    public function __construct(
+        string $baseUrl,
+        string $path,
+        HttpMethod $method,
+        array $headers = [],
+        array $query = [],
+        public readonly mixed $body = null
+    ) {
+        parent::__construct($baseUrl, $path, $method, $headers, $query);
+    }
+}

--- a/seed/php-sdk/package-yml/no-custom-config/.fern/metadata.json
+++ b/seed/php-sdk/package-yml/no-custom-config/.fern/metadata.json
@@ -3,8 +3,7 @@
   "generatorName": "fernapi/fern-php-sdk",
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/php-sdk/package-yml/no-custom-config/src/Core/Client/RawClient.php
+++ b/seed/php-sdk/package-yml/no-custom-config/src/Core/Client/RawClient.php
@@ -155,6 +155,16 @@ class RawClient
                 $request->headers,
                 $options['headers'] ?? [],
             ),
+            UrlEncodedApiRequest::class => array_merge(
+                [
+                    "Content-Type" => "application/x-www-form-urlencoded",
+                    "Accept" => "*/*",
+                ],
+                $this->headers,
+                $authHeaders,
+                $request->headers,
+                $options['headers'] ?? [],
+            ),
             MultipartApiRequest::class => array_merge(
                 $this->headers,
                 $authHeaders,
@@ -185,6 +195,24 @@ class RawClient
                     ),
                 )
             );
+        }
+
+        if ($request instanceof UrlEncodedApiRequest) {
+            if ($request->body === null) {
+                return null;
+            }
+            $body = $this->buildJsonBody($request->body, $options);
+            if ($body instanceof JsonSerializable) {
+                $body = $body->jsonSerialize();
+            }
+            if ($body instanceof \stdClass) {
+                $body = (array)$body;
+            }
+            if (!is_array($body)) {
+                throw new InvalidArgumentException('Form-urlencoded request body must serialize to an array');
+            }
+            $body = array_filter($body, static fn ($value) => $value !== null);
+            return $this->streamFactory->createStream(http_build_query($body));
         }
 
         if ($request instanceof MultipartApiRequest) {

--- a/seed/php-sdk/package-yml/no-custom-config/src/Core/Client/UrlEncodedApiRequest.php
+++ b/seed/php-sdk/package-yml/no-custom-config/src/Core/Client/UrlEncodedApiRequest.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Seed\Core\Client;
+
+class UrlEncodedApiRequest extends BaseApiRequest
+{
+    /**
+     * @param string $baseUrl The base URL for the request
+     * @param string $path The path for the request
+     * @param HttpMethod $method The HTTP method for the request
+     * @param array<string, string> $headers Additional headers for the request (optional)
+     * @param array<string, mixed> $query Query parameters for the request (optional)
+     * @param mixed|null $body The form-urlencoded request body (optional)
+     */
+    public function __construct(
+        string $baseUrl,
+        string $path,
+        HttpMethod $method,
+        array $headers = [],
+        array $query = [],
+        public readonly mixed $body = null
+    ) {
+        parent::__construct($baseUrl, $path, $method, $headers, $query);
+    }
+}

--- a/seed/php-sdk/package-yml/private/.fern/metadata.json
+++ b/seed/php-sdk/package-yml/private/.fern/metadata.json
@@ -6,8 +6,7 @@
     "propertyAccess": "private"
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/php-sdk/package-yml/private/src/Core/Client/RawClient.php
+++ b/seed/php-sdk/package-yml/private/src/Core/Client/RawClient.php
@@ -155,6 +155,16 @@ class RawClient
                 $request->headers,
                 $options['headers'] ?? [],
             ),
+            UrlEncodedApiRequest::class => array_merge(
+                [
+                    "Content-Type" => "application/x-www-form-urlencoded",
+                    "Accept" => "*/*",
+                ],
+                $this->headers,
+                $authHeaders,
+                $request->headers,
+                $options['headers'] ?? [],
+            ),
             MultipartApiRequest::class => array_merge(
                 $this->headers,
                 $authHeaders,
@@ -185,6 +195,24 @@ class RawClient
                     ),
                 )
             );
+        }
+
+        if ($request instanceof UrlEncodedApiRequest) {
+            if ($request->body === null) {
+                return null;
+            }
+            $body = $this->buildJsonBody($request->body, $options);
+            if ($body instanceof JsonSerializable) {
+                $body = $body->jsonSerialize();
+            }
+            if ($body instanceof \stdClass) {
+                $body = (array)$body;
+            }
+            if (!is_array($body)) {
+                throw new InvalidArgumentException('Form-urlencoded request body must serialize to an array');
+            }
+            $body = array_filter($body, static fn ($value) => $value !== null);
+            return $this->streamFactory->createStream(http_build_query($body));
         }
 
         if ($request instanceof MultipartApiRequest) {

--- a/seed/php-sdk/package-yml/private/src/Core/Client/UrlEncodedApiRequest.php
+++ b/seed/php-sdk/package-yml/private/src/Core/Client/UrlEncodedApiRequest.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Seed\Core\Client;
+
+class UrlEncodedApiRequest extends BaseApiRequest
+{
+    /**
+     * @param string $baseUrl The base URL for the request
+     * @param string $path The path for the request
+     * @param HttpMethod $method The HTTP method for the request
+     * @param array<string, string> $headers Additional headers for the request (optional)
+     * @param array<string, mixed> $query Query parameters for the request (optional)
+     * @param mixed|null $body The form-urlencoded request body (optional)
+     */
+    public function __construct(
+        string $baseUrl,
+        string $path,
+        HttpMethod $method,
+        array $headers = [],
+        array $query = [],
+        public readonly mixed $body = null
+    ) {
+        parent::__construct($baseUrl, $path, $method, $headers, $query);
+    }
+}

--- a/seed/php-sdk/pagination-custom/.fern/metadata.json
+++ b/seed/php-sdk/pagination-custom/.fern/metadata.json
@@ -3,8 +3,7 @@
   "generatorName": "fernapi/fern-php-sdk",
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/php-sdk/pagination-custom/src/Core/Client/RawClient.php
+++ b/seed/php-sdk/pagination-custom/src/Core/Client/RawClient.php
@@ -155,6 +155,16 @@ class RawClient
                 $request->headers,
                 $options['headers'] ?? [],
             ),
+            UrlEncodedApiRequest::class => array_merge(
+                [
+                    "Content-Type" => "application/x-www-form-urlencoded",
+                    "Accept" => "*/*",
+                ],
+                $this->headers,
+                $authHeaders,
+                $request->headers,
+                $options['headers'] ?? [],
+            ),
             MultipartApiRequest::class => array_merge(
                 $this->headers,
                 $authHeaders,
@@ -185,6 +195,24 @@ class RawClient
                     ),
                 )
             );
+        }
+
+        if ($request instanceof UrlEncodedApiRequest) {
+            if ($request->body === null) {
+                return null;
+            }
+            $body = $this->buildJsonBody($request->body, $options);
+            if ($body instanceof JsonSerializable) {
+                $body = $body->jsonSerialize();
+            }
+            if ($body instanceof \stdClass) {
+                $body = (array)$body;
+            }
+            if (!is_array($body)) {
+                throw new InvalidArgumentException('Form-urlencoded request body must serialize to an array');
+            }
+            $body = array_filter($body, static fn ($value) => $value !== null);
+            return $this->streamFactory->createStream(http_build_query($body));
         }
 
         if ($request instanceof MultipartApiRequest) {

--- a/seed/php-sdk/pagination-custom/src/Core/Client/UrlEncodedApiRequest.php
+++ b/seed/php-sdk/pagination-custom/src/Core/Client/UrlEncodedApiRequest.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Seed\Core\Client;
+
+class UrlEncodedApiRequest extends BaseApiRequest
+{
+    /**
+     * @param string $baseUrl The base URL for the request
+     * @param string $path The path for the request
+     * @param HttpMethod $method The HTTP method for the request
+     * @param array<string, string> $headers Additional headers for the request (optional)
+     * @param array<string, mixed> $query Query parameters for the request (optional)
+     * @param mixed|null $body The form-urlencoded request body (optional)
+     */
+    public function __construct(
+        string $baseUrl,
+        string $path,
+        HttpMethod $method,
+        array $headers = [],
+        array $query = [],
+        public readonly mixed $body = null
+    ) {
+        parent::__construct($baseUrl, $path, $method, $headers, $query);
+    }
+}

--- a/seed/php-sdk/pagination-uri-path/.fern/metadata.json
+++ b/seed/php-sdk/pagination-uri-path/.fern/metadata.json
@@ -3,8 +3,7 @@
   "generatorName": "fernapi/fern-php-sdk",
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/php-sdk/pagination-uri-path/src/Core/Client/RawClient.php
+++ b/seed/php-sdk/pagination-uri-path/src/Core/Client/RawClient.php
@@ -155,6 +155,16 @@ class RawClient
                 $request->headers,
                 $options['headers'] ?? [],
             ),
+            UrlEncodedApiRequest::class => array_merge(
+                [
+                    "Content-Type" => "application/x-www-form-urlencoded",
+                    "Accept" => "*/*",
+                ],
+                $this->headers,
+                $authHeaders,
+                $request->headers,
+                $options['headers'] ?? [],
+            ),
             MultipartApiRequest::class => array_merge(
                 $this->headers,
                 $authHeaders,
@@ -185,6 +195,24 @@ class RawClient
                     ),
                 )
             );
+        }
+
+        if ($request instanceof UrlEncodedApiRequest) {
+            if ($request->body === null) {
+                return null;
+            }
+            $body = $this->buildJsonBody($request->body, $options);
+            if ($body instanceof JsonSerializable) {
+                $body = $body->jsonSerialize();
+            }
+            if ($body instanceof \stdClass) {
+                $body = (array)$body;
+            }
+            if (!is_array($body)) {
+                throw new InvalidArgumentException('Form-urlencoded request body must serialize to an array');
+            }
+            $body = array_filter($body, static fn ($value) => $value !== null);
+            return $this->streamFactory->createStream(http_build_query($body));
         }
 
         if ($request instanceof MultipartApiRequest) {

--- a/seed/php-sdk/pagination-uri-path/src/Core/Client/UrlEncodedApiRequest.php
+++ b/seed/php-sdk/pagination-uri-path/src/Core/Client/UrlEncodedApiRequest.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Seed\Core\Client;
+
+class UrlEncodedApiRequest extends BaseApiRequest
+{
+    /**
+     * @param string $baseUrl The base URL for the request
+     * @param string $path The path for the request
+     * @param HttpMethod $method The HTTP method for the request
+     * @param array<string, string> $headers Additional headers for the request (optional)
+     * @param array<string, mixed> $query Query parameters for the request (optional)
+     * @param mixed|null $body The form-urlencoded request body (optional)
+     */
+    public function __construct(
+        string $baseUrl,
+        string $path,
+        HttpMethod $method,
+        array $headers = [],
+        array $query = [],
+        public readonly mixed $body = null
+    ) {
+        parent::__construct($baseUrl, $path, $method, $headers, $query);
+    }
+}

--- a/seed/php-sdk/pagination/no-custom-config/.fern/metadata.json
+++ b/seed/php-sdk/pagination/no-custom-config/.fern/metadata.json
@@ -3,8 +3,7 @@
   "generatorName": "fernapi/fern-php-sdk",
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/php-sdk/pagination/no-custom-config/src/Core/Client/RawClient.php
+++ b/seed/php-sdk/pagination/no-custom-config/src/Core/Client/RawClient.php
@@ -155,6 +155,16 @@ class RawClient
                 $request->headers,
                 $options['headers'] ?? [],
             ),
+            UrlEncodedApiRequest::class => array_merge(
+                [
+                    "Content-Type" => "application/x-www-form-urlencoded",
+                    "Accept" => "*/*",
+                ],
+                $this->headers,
+                $authHeaders,
+                $request->headers,
+                $options['headers'] ?? [],
+            ),
             MultipartApiRequest::class => array_merge(
                 $this->headers,
                 $authHeaders,
@@ -185,6 +195,24 @@ class RawClient
                     ),
                 )
             );
+        }
+
+        if ($request instanceof UrlEncodedApiRequest) {
+            if ($request->body === null) {
+                return null;
+            }
+            $body = $this->buildJsonBody($request->body, $options);
+            if ($body instanceof JsonSerializable) {
+                $body = $body->jsonSerialize();
+            }
+            if ($body instanceof \stdClass) {
+                $body = (array)$body;
+            }
+            if (!is_array($body)) {
+                throw new InvalidArgumentException('Form-urlencoded request body must serialize to an array');
+            }
+            $body = array_filter($body, static fn ($value) => $value !== null);
+            return $this->streamFactory->createStream(http_build_query($body));
         }
 
         if ($request instanceof MultipartApiRequest) {

--- a/seed/php-sdk/pagination/no-custom-config/src/Core/Client/UrlEncodedApiRequest.php
+++ b/seed/php-sdk/pagination/no-custom-config/src/Core/Client/UrlEncodedApiRequest.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Seed\Core\Client;
+
+class UrlEncodedApiRequest extends BaseApiRequest
+{
+    /**
+     * @param string $baseUrl The base URL for the request
+     * @param string $path The path for the request
+     * @param HttpMethod $method The HTTP method for the request
+     * @param array<string, string> $headers Additional headers for the request (optional)
+     * @param array<string, mixed> $query Query parameters for the request (optional)
+     * @param mixed|null $body The form-urlencoded request body (optional)
+     */
+    public function __construct(
+        string $baseUrl,
+        string $path,
+        HttpMethod $method,
+        array $headers = [],
+        array $query = [],
+        public readonly mixed $body = null
+    ) {
+        parent::__construct($baseUrl, $path, $method, $headers, $query);
+    }
+}

--- a/seed/php-sdk/pagination/page-index-semantics/.fern/metadata.json
+++ b/seed/php-sdk/pagination/page-index-semantics/.fern/metadata.json
@@ -6,8 +6,7 @@
     "offsetSemantics": "page-index"
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/php-sdk/pagination/page-index-semantics/src/Core/Client/RawClient.php
+++ b/seed/php-sdk/pagination/page-index-semantics/src/Core/Client/RawClient.php
@@ -155,6 +155,16 @@ class RawClient
                 $request->headers,
                 $options['headers'] ?? [],
             ),
+            UrlEncodedApiRequest::class => array_merge(
+                [
+                    "Content-Type" => "application/x-www-form-urlencoded",
+                    "Accept" => "*/*",
+                ],
+                $this->headers,
+                $authHeaders,
+                $request->headers,
+                $options['headers'] ?? [],
+            ),
             MultipartApiRequest::class => array_merge(
                 $this->headers,
                 $authHeaders,
@@ -185,6 +195,24 @@ class RawClient
                     ),
                 )
             );
+        }
+
+        if ($request instanceof UrlEncodedApiRequest) {
+            if ($request->body === null) {
+                return null;
+            }
+            $body = $this->buildJsonBody($request->body, $options);
+            if ($body instanceof JsonSerializable) {
+                $body = $body->jsonSerialize();
+            }
+            if ($body instanceof \stdClass) {
+                $body = (array)$body;
+            }
+            if (!is_array($body)) {
+                throw new InvalidArgumentException('Form-urlencoded request body must serialize to an array');
+            }
+            $body = array_filter($body, static fn ($value) => $value !== null);
+            return $this->streamFactory->createStream(http_build_query($body));
         }
 
         if ($request instanceof MultipartApiRequest) {

--- a/seed/php-sdk/pagination/page-index-semantics/src/Core/Client/UrlEncodedApiRequest.php
+++ b/seed/php-sdk/pagination/page-index-semantics/src/Core/Client/UrlEncodedApiRequest.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Seed\Core\Client;
+
+class UrlEncodedApiRequest extends BaseApiRequest
+{
+    /**
+     * @param string $baseUrl The base URL for the request
+     * @param string $path The path for the request
+     * @param HttpMethod $method The HTTP method for the request
+     * @param array<string, string> $headers Additional headers for the request (optional)
+     * @param array<string, mixed> $query Query parameters for the request (optional)
+     * @param mixed|null $body The form-urlencoded request body (optional)
+     */
+    public function __construct(
+        string $baseUrl,
+        string $path,
+        HttpMethod $method,
+        array $headers = [],
+        array $query = [],
+        public readonly mixed $body = null
+    ) {
+        parent::__construct($baseUrl, $path, $method, $headers, $query);
+    }
+}

--- a/seed/php-sdk/pagination/property-accessors/.fern/metadata.json
+++ b/seed/php-sdk/pagination/property-accessors/.fern/metadata.json
@@ -6,8 +6,7 @@
     "propertyAccess": "private"
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/php-sdk/pagination/property-accessors/src/Core/Client/RawClient.php
+++ b/seed/php-sdk/pagination/property-accessors/src/Core/Client/RawClient.php
@@ -155,6 +155,16 @@ class RawClient
                 $request->headers,
                 $options['headers'] ?? [],
             ),
+            UrlEncodedApiRequest::class => array_merge(
+                [
+                    "Content-Type" => "application/x-www-form-urlencoded",
+                    "Accept" => "*/*",
+                ],
+                $this->headers,
+                $authHeaders,
+                $request->headers,
+                $options['headers'] ?? [],
+            ),
             MultipartApiRequest::class => array_merge(
                 $this->headers,
                 $authHeaders,
@@ -185,6 +195,24 @@ class RawClient
                     ),
                 )
             );
+        }
+
+        if ($request instanceof UrlEncodedApiRequest) {
+            if ($request->body === null) {
+                return null;
+            }
+            $body = $this->buildJsonBody($request->body, $options);
+            if ($body instanceof JsonSerializable) {
+                $body = $body->jsonSerialize();
+            }
+            if ($body instanceof \stdClass) {
+                $body = (array)$body;
+            }
+            if (!is_array($body)) {
+                throw new InvalidArgumentException('Form-urlencoded request body must serialize to an array');
+            }
+            $body = array_filter($body, static fn ($value) => $value !== null);
+            return $this->streamFactory->createStream(http_build_query($body));
         }
 
         if ($request instanceof MultipartApiRequest) {

--- a/seed/php-sdk/pagination/property-accessors/src/Core/Client/UrlEncodedApiRequest.php
+++ b/seed/php-sdk/pagination/property-accessors/src/Core/Client/UrlEncodedApiRequest.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Seed\Core\Client;
+
+class UrlEncodedApiRequest extends BaseApiRequest
+{
+    /**
+     * @param string $baseUrl The base URL for the request
+     * @param string $path The path for the request
+     * @param HttpMethod $method The HTTP method for the request
+     * @param array<string, string> $headers Additional headers for the request (optional)
+     * @param array<string, mixed> $query Query parameters for the request (optional)
+     * @param mixed|null $body The form-urlencoded request body (optional)
+     */
+    public function __construct(
+        string $baseUrl,
+        string $path,
+        HttpMethod $method,
+        array $headers = [],
+        array $query = [],
+        public readonly mixed $body = null
+    ) {
+        parent::__construct($baseUrl, $path, $method, $headers, $query);
+    }
+}

--- a/seed/php-sdk/path-parameters/inline-path-parameters-private/.fern/metadata.json
+++ b/seed/php-sdk/path-parameters/inline-path-parameters-private/.fern/metadata.json
@@ -7,8 +7,7 @@
     "propertyAccess": "private"
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/php-sdk/path-parameters/inline-path-parameters-private/src/Core/Client/RawClient.php
+++ b/seed/php-sdk/path-parameters/inline-path-parameters-private/src/Core/Client/RawClient.php
@@ -155,6 +155,16 @@ class RawClient
                 $request->headers,
                 $options['headers'] ?? [],
             ),
+            UrlEncodedApiRequest::class => array_merge(
+                [
+                    "Content-Type" => "application/x-www-form-urlencoded",
+                    "Accept" => "*/*",
+                ],
+                $this->headers,
+                $authHeaders,
+                $request->headers,
+                $options['headers'] ?? [],
+            ),
             MultipartApiRequest::class => array_merge(
                 $this->headers,
                 $authHeaders,
@@ -185,6 +195,24 @@ class RawClient
                     ),
                 )
             );
+        }
+
+        if ($request instanceof UrlEncodedApiRequest) {
+            if ($request->body === null) {
+                return null;
+            }
+            $body = $this->buildJsonBody($request->body, $options);
+            if ($body instanceof JsonSerializable) {
+                $body = $body->jsonSerialize();
+            }
+            if ($body instanceof \stdClass) {
+                $body = (array)$body;
+            }
+            if (!is_array($body)) {
+                throw new InvalidArgumentException('Form-urlencoded request body must serialize to an array');
+            }
+            $body = array_filter($body, static fn ($value) => $value !== null);
+            return $this->streamFactory->createStream(http_build_query($body));
         }
 
         if ($request instanceof MultipartApiRequest) {

--- a/seed/php-sdk/path-parameters/inline-path-parameters-private/src/Core/Client/UrlEncodedApiRequest.php
+++ b/seed/php-sdk/path-parameters/inline-path-parameters-private/src/Core/Client/UrlEncodedApiRequest.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Seed\Core\Client;
+
+class UrlEncodedApiRequest extends BaseApiRequest
+{
+    /**
+     * @param string $baseUrl The base URL for the request
+     * @param string $path The path for the request
+     * @param HttpMethod $method The HTTP method for the request
+     * @param array<string, string> $headers Additional headers for the request (optional)
+     * @param array<string, mixed> $query Query parameters for the request (optional)
+     * @param mixed|null $body The form-urlencoded request body (optional)
+     */
+    public function __construct(
+        string $baseUrl,
+        string $path,
+        HttpMethod $method,
+        array $headers = [],
+        array $query = [],
+        public readonly mixed $body = null
+    ) {
+        parent::__construct($baseUrl, $path, $method, $headers, $query);
+    }
+}

--- a/seed/php-sdk/path-parameters/inline-path-parameters/.fern/metadata.json
+++ b/seed/php-sdk/path-parameters/inline-path-parameters/.fern/metadata.json
@@ -6,8 +6,7 @@
     "inlinePathParameters": true
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/php-sdk/path-parameters/inline-path-parameters/src/Core/Client/RawClient.php
+++ b/seed/php-sdk/path-parameters/inline-path-parameters/src/Core/Client/RawClient.php
@@ -155,6 +155,16 @@ class RawClient
                 $request->headers,
                 $options['headers'] ?? [],
             ),
+            UrlEncodedApiRequest::class => array_merge(
+                [
+                    "Content-Type" => "application/x-www-form-urlencoded",
+                    "Accept" => "*/*",
+                ],
+                $this->headers,
+                $authHeaders,
+                $request->headers,
+                $options['headers'] ?? [],
+            ),
             MultipartApiRequest::class => array_merge(
                 $this->headers,
                 $authHeaders,
@@ -185,6 +195,24 @@ class RawClient
                     ),
                 )
             );
+        }
+
+        if ($request instanceof UrlEncodedApiRequest) {
+            if ($request->body === null) {
+                return null;
+            }
+            $body = $this->buildJsonBody($request->body, $options);
+            if ($body instanceof JsonSerializable) {
+                $body = $body->jsonSerialize();
+            }
+            if ($body instanceof \stdClass) {
+                $body = (array)$body;
+            }
+            if (!is_array($body)) {
+                throw new InvalidArgumentException('Form-urlencoded request body must serialize to an array');
+            }
+            $body = array_filter($body, static fn ($value) => $value !== null);
+            return $this->streamFactory->createStream(http_build_query($body));
         }
 
         if ($request instanceof MultipartApiRequest) {

--- a/seed/php-sdk/path-parameters/inline-path-parameters/src/Core/Client/UrlEncodedApiRequest.php
+++ b/seed/php-sdk/path-parameters/inline-path-parameters/src/Core/Client/UrlEncodedApiRequest.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Seed\Core\Client;
+
+class UrlEncodedApiRequest extends BaseApiRequest
+{
+    /**
+     * @param string $baseUrl The base URL for the request
+     * @param string $path The path for the request
+     * @param HttpMethod $method The HTTP method for the request
+     * @param array<string, string> $headers Additional headers for the request (optional)
+     * @param array<string, mixed> $query Query parameters for the request (optional)
+     * @param mixed|null $body The form-urlencoded request body (optional)
+     */
+    public function __construct(
+        string $baseUrl,
+        string $path,
+        HttpMethod $method,
+        array $headers = [],
+        array $query = [],
+        public readonly mixed $body = null
+    ) {
+        parent::__construct($baseUrl, $path, $method, $headers, $query);
+    }
+}

--- a/seed/php-sdk/path-parameters/no-custom-config/.fern/metadata.json
+++ b/seed/php-sdk/path-parameters/no-custom-config/.fern/metadata.json
@@ -3,8 +3,7 @@
   "generatorName": "fernapi/fern-php-sdk",
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/php-sdk/path-parameters/no-custom-config/src/Core/Client/RawClient.php
+++ b/seed/php-sdk/path-parameters/no-custom-config/src/Core/Client/RawClient.php
@@ -155,6 +155,16 @@ class RawClient
                 $request->headers,
                 $options['headers'] ?? [],
             ),
+            UrlEncodedApiRequest::class => array_merge(
+                [
+                    "Content-Type" => "application/x-www-form-urlencoded",
+                    "Accept" => "*/*",
+                ],
+                $this->headers,
+                $authHeaders,
+                $request->headers,
+                $options['headers'] ?? [],
+            ),
             MultipartApiRequest::class => array_merge(
                 $this->headers,
                 $authHeaders,
@@ -185,6 +195,24 @@ class RawClient
                     ),
                 )
             );
+        }
+
+        if ($request instanceof UrlEncodedApiRequest) {
+            if ($request->body === null) {
+                return null;
+            }
+            $body = $this->buildJsonBody($request->body, $options);
+            if ($body instanceof JsonSerializable) {
+                $body = $body->jsonSerialize();
+            }
+            if ($body instanceof \stdClass) {
+                $body = (array)$body;
+            }
+            if (!is_array($body)) {
+                throw new InvalidArgumentException('Form-urlencoded request body must serialize to an array');
+            }
+            $body = array_filter($body, static fn ($value) => $value !== null);
+            return $this->streamFactory->createStream(http_build_query($body));
         }
 
         if ($request instanceof MultipartApiRequest) {

--- a/seed/php-sdk/path-parameters/no-custom-config/src/Core/Client/UrlEncodedApiRequest.php
+++ b/seed/php-sdk/path-parameters/no-custom-config/src/Core/Client/UrlEncodedApiRequest.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Seed\Core\Client;
+
+class UrlEncodedApiRequest extends BaseApiRequest
+{
+    /**
+     * @param string $baseUrl The base URL for the request
+     * @param string $path The path for the request
+     * @param HttpMethod $method The HTTP method for the request
+     * @param array<string, string> $headers Additional headers for the request (optional)
+     * @param array<string, mixed> $query Query parameters for the request (optional)
+     * @param mixed|null $body The form-urlencoded request body (optional)
+     */
+    public function __construct(
+        string $baseUrl,
+        string $path,
+        HttpMethod $method,
+        array $headers = [],
+        array $query = [],
+        public readonly mixed $body = null
+    ) {
+        parent::__construct($baseUrl, $path, $method, $headers, $query);
+    }
+}

--- a/seed/php-sdk/plain-text/.fern/metadata.json
+++ b/seed/php-sdk/plain-text/.fern/metadata.json
@@ -3,8 +3,7 @@
   "generatorName": "fernapi/fern-php-sdk",
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/php-sdk/plain-text/src/Core/Client/RawClient.php
+++ b/seed/php-sdk/plain-text/src/Core/Client/RawClient.php
@@ -155,6 +155,16 @@ class RawClient
                 $request->headers,
                 $options['headers'] ?? [],
             ),
+            UrlEncodedApiRequest::class => array_merge(
+                [
+                    "Content-Type" => "application/x-www-form-urlencoded",
+                    "Accept" => "*/*",
+                ],
+                $this->headers,
+                $authHeaders,
+                $request->headers,
+                $options['headers'] ?? [],
+            ),
             MultipartApiRequest::class => array_merge(
                 $this->headers,
                 $authHeaders,
@@ -185,6 +195,24 @@ class RawClient
                     ),
                 )
             );
+        }
+
+        if ($request instanceof UrlEncodedApiRequest) {
+            if ($request->body === null) {
+                return null;
+            }
+            $body = $this->buildJsonBody($request->body, $options);
+            if ($body instanceof JsonSerializable) {
+                $body = $body->jsonSerialize();
+            }
+            if ($body instanceof \stdClass) {
+                $body = (array)$body;
+            }
+            if (!is_array($body)) {
+                throw new InvalidArgumentException('Form-urlencoded request body must serialize to an array');
+            }
+            $body = array_filter($body, static fn ($value) => $value !== null);
+            return $this->streamFactory->createStream(http_build_query($body));
         }
 
         if ($request instanceof MultipartApiRequest) {

--- a/seed/php-sdk/plain-text/src/Core/Client/UrlEncodedApiRequest.php
+++ b/seed/php-sdk/plain-text/src/Core/Client/UrlEncodedApiRequest.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Seed\Core\Client;
+
+class UrlEncodedApiRequest extends BaseApiRequest
+{
+    /**
+     * @param string $baseUrl The base URL for the request
+     * @param string $path The path for the request
+     * @param HttpMethod $method The HTTP method for the request
+     * @param array<string, string> $headers Additional headers for the request (optional)
+     * @param array<string, mixed> $query Query parameters for the request (optional)
+     * @param mixed|null $body The form-urlencoded request body (optional)
+     */
+    public function __construct(
+        string $baseUrl,
+        string $path,
+        HttpMethod $method,
+        array $headers = [],
+        array $query = [],
+        public readonly mixed $body = null
+    ) {
+        parent::__construct($baseUrl, $path, $method, $headers, $query);
+    }
+}

--- a/seed/php-sdk/property-access/.fern/metadata.json
+++ b/seed/php-sdk/property-access/.fern/metadata.json
@@ -3,8 +3,7 @@
   "generatorName": "fernapi/fern-php-sdk",
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/php-sdk/property-access/src/Core/Client/RawClient.php
+++ b/seed/php-sdk/property-access/src/Core/Client/RawClient.php
@@ -155,6 +155,16 @@ class RawClient
                 $request->headers,
                 $options['headers'] ?? [],
             ),
+            UrlEncodedApiRequest::class => array_merge(
+                [
+                    "Content-Type" => "application/x-www-form-urlencoded",
+                    "Accept" => "*/*",
+                ],
+                $this->headers,
+                $authHeaders,
+                $request->headers,
+                $options['headers'] ?? [],
+            ),
             MultipartApiRequest::class => array_merge(
                 $this->headers,
                 $authHeaders,
@@ -185,6 +195,24 @@ class RawClient
                     ),
                 )
             );
+        }
+
+        if ($request instanceof UrlEncodedApiRequest) {
+            if ($request->body === null) {
+                return null;
+            }
+            $body = $this->buildJsonBody($request->body, $options);
+            if ($body instanceof JsonSerializable) {
+                $body = $body->jsonSerialize();
+            }
+            if ($body instanceof \stdClass) {
+                $body = (array)$body;
+            }
+            if (!is_array($body)) {
+                throw new InvalidArgumentException('Form-urlencoded request body must serialize to an array');
+            }
+            $body = array_filter($body, static fn ($value) => $value !== null);
+            return $this->streamFactory->createStream(http_build_query($body));
         }
 
         if ($request instanceof MultipartApiRequest) {

--- a/seed/php-sdk/property-access/src/Core/Client/UrlEncodedApiRequest.php
+++ b/seed/php-sdk/property-access/src/Core/Client/UrlEncodedApiRequest.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Seed\Core\Client;
+
+class UrlEncodedApiRequest extends BaseApiRequest
+{
+    /**
+     * @param string $baseUrl The base URL for the request
+     * @param string $path The path for the request
+     * @param HttpMethod $method The HTTP method for the request
+     * @param array<string, string> $headers Additional headers for the request (optional)
+     * @param array<string, mixed> $query Query parameters for the request (optional)
+     * @param mixed|null $body The form-urlencoded request body (optional)
+     */
+    public function __construct(
+        string $baseUrl,
+        string $path,
+        HttpMethod $method,
+        array $headers = [],
+        array $query = [],
+        public readonly mixed $body = null
+    ) {
+        parent::__construct($baseUrl, $path, $method, $headers, $query);
+    }
+}

--- a/seed/php-sdk/public-object/.fern/metadata.json
+++ b/seed/php-sdk/public-object/.fern/metadata.json
@@ -3,8 +3,7 @@
   "generatorName": "fernapi/fern-php-sdk",
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/php-sdk/public-object/src/Core/Client/RawClient.php
+++ b/seed/php-sdk/public-object/src/Core/Client/RawClient.php
@@ -155,6 +155,16 @@ class RawClient
                 $request->headers,
                 $options['headers'] ?? [],
             ),
+            UrlEncodedApiRequest::class => array_merge(
+                [
+                    "Content-Type" => "application/x-www-form-urlencoded",
+                    "Accept" => "*/*",
+                ],
+                $this->headers,
+                $authHeaders,
+                $request->headers,
+                $options['headers'] ?? [],
+            ),
             MultipartApiRequest::class => array_merge(
                 $this->headers,
                 $authHeaders,
@@ -185,6 +195,24 @@ class RawClient
                     ),
                 )
             );
+        }
+
+        if ($request instanceof UrlEncodedApiRequest) {
+            if ($request->body === null) {
+                return null;
+            }
+            $body = $this->buildJsonBody($request->body, $options);
+            if ($body instanceof JsonSerializable) {
+                $body = $body->jsonSerialize();
+            }
+            if ($body instanceof \stdClass) {
+                $body = (array)$body;
+            }
+            if (!is_array($body)) {
+                throw new InvalidArgumentException('Form-urlencoded request body must serialize to an array');
+            }
+            $body = array_filter($body, static fn ($value) => $value !== null);
+            return $this->streamFactory->createStream(http_build_query($body));
         }
 
         if ($request instanceof MultipartApiRequest) {

--- a/seed/php-sdk/public-object/src/Core/Client/UrlEncodedApiRequest.php
+++ b/seed/php-sdk/public-object/src/Core/Client/UrlEncodedApiRequest.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Seed\Core\Client;
+
+class UrlEncodedApiRequest extends BaseApiRequest
+{
+    /**
+     * @param string $baseUrl The base URL for the request
+     * @param string $path The path for the request
+     * @param HttpMethod $method The HTTP method for the request
+     * @param array<string, string> $headers Additional headers for the request (optional)
+     * @param array<string, mixed> $query Query parameters for the request (optional)
+     * @param mixed|null $body The form-urlencoded request body (optional)
+     */
+    public function __construct(
+        string $baseUrl,
+        string $path,
+        HttpMethod $method,
+        array $headers = [],
+        array $query = [],
+        public readonly mixed $body = null
+    ) {
+        parent::__construct($baseUrl, $path, $method, $headers, $query);
+    }
+}

--- a/seed/php-sdk/query-param-name-conflict/.fern/metadata.json
+++ b/seed/php-sdk/query-param-name-conflict/.fern/metadata.json
@@ -3,8 +3,7 @@
   "generatorName": "fernapi/fern-php-sdk",
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/php-sdk/query-param-name-conflict/src/Core/Client/RawClient.php
+++ b/seed/php-sdk/query-param-name-conflict/src/Core/Client/RawClient.php
@@ -155,6 +155,16 @@ class RawClient
                 $request->headers,
                 $options['headers'] ?? [],
             ),
+            UrlEncodedApiRequest::class => array_merge(
+                [
+                    "Content-Type" => "application/x-www-form-urlencoded",
+                    "Accept" => "*/*",
+                ],
+                $this->headers,
+                $authHeaders,
+                $request->headers,
+                $options['headers'] ?? [],
+            ),
             MultipartApiRequest::class => array_merge(
                 $this->headers,
                 $authHeaders,
@@ -185,6 +195,24 @@ class RawClient
                     ),
                 )
             );
+        }
+
+        if ($request instanceof UrlEncodedApiRequest) {
+            if ($request->body === null) {
+                return null;
+            }
+            $body = $this->buildJsonBody($request->body, $options);
+            if ($body instanceof JsonSerializable) {
+                $body = $body->jsonSerialize();
+            }
+            if ($body instanceof \stdClass) {
+                $body = (array)$body;
+            }
+            if (!is_array($body)) {
+                throw new InvalidArgumentException('Form-urlencoded request body must serialize to an array');
+            }
+            $body = array_filter($body, static fn ($value) => $value !== null);
+            return $this->streamFactory->createStream(http_build_query($body));
         }
 
         if ($request instanceof MultipartApiRequest) {

--- a/seed/php-sdk/query-param-name-conflict/src/Core/Client/UrlEncodedApiRequest.php
+++ b/seed/php-sdk/query-param-name-conflict/src/Core/Client/UrlEncodedApiRequest.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Seed\Core\Client;
+
+class UrlEncodedApiRequest extends BaseApiRequest
+{
+    /**
+     * @param string $baseUrl The base URL for the request
+     * @param string $path The path for the request
+     * @param HttpMethod $method The HTTP method for the request
+     * @param array<string, string> $headers Additional headers for the request (optional)
+     * @param array<string, mixed> $query Query parameters for the request (optional)
+     * @param mixed|null $body The form-urlencoded request body (optional)
+     */
+    public function __construct(
+        string $baseUrl,
+        string $path,
+        HttpMethod $method,
+        array $headers = [],
+        array $query = [],
+        public readonly mixed $body = null
+    ) {
+        parent::__construct($baseUrl, $path, $method, $headers, $query);
+    }
+}

--- a/seed/php-sdk/query-parameters-openapi-as-objects/.fern/metadata.json
+++ b/seed/php-sdk/query-parameters-openapi-as-objects/.fern/metadata.json
@@ -3,8 +3,7 @@
   "generatorName": "fernapi/fern-php-sdk",
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/php-sdk/query-parameters-openapi-as-objects/src/Core/Client/RawClient.php
+++ b/seed/php-sdk/query-parameters-openapi-as-objects/src/Core/Client/RawClient.php
@@ -155,6 +155,16 @@ class RawClient
                 $request->headers,
                 $options['headers'] ?? [],
             ),
+            UrlEncodedApiRequest::class => array_merge(
+                [
+                    "Content-Type" => "application/x-www-form-urlencoded",
+                    "Accept" => "*/*",
+                ],
+                $this->headers,
+                $authHeaders,
+                $request->headers,
+                $options['headers'] ?? [],
+            ),
             MultipartApiRequest::class => array_merge(
                 $this->headers,
                 $authHeaders,
@@ -185,6 +195,24 @@ class RawClient
                     ),
                 )
             );
+        }
+
+        if ($request instanceof UrlEncodedApiRequest) {
+            if ($request->body === null) {
+                return null;
+            }
+            $body = $this->buildJsonBody($request->body, $options);
+            if ($body instanceof JsonSerializable) {
+                $body = $body->jsonSerialize();
+            }
+            if ($body instanceof \stdClass) {
+                $body = (array)$body;
+            }
+            if (!is_array($body)) {
+                throw new InvalidArgumentException('Form-urlencoded request body must serialize to an array');
+            }
+            $body = array_filter($body, static fn ($value) => $value !== null);
+            return $this->streamFactory->createStream(http_build_query($body));
         }
 
         if ($request instanceof MultipartApiRequest) {

--- a/seed/php-sdk/query-parameters-openapi-as-objects/src/Core/Client/UrlEncodedApiRequest.php
+++ b/seed/php-sdk/query-parameters-openapi-as-objects/src/Core/Client/UrlEncodedApiRequest.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Seed\Core\Client;
+
+class UrlEncodedApiRequest extends BaseApiRequest
+{
+    /**
+     * @param string $baseUrl The base URL for the request
+     * @param string $path The path for the request
+     * @param HttpMethod $method The HTTP method for the request
+     * @param array<string, string> $headers Additional headers for the request (optional)
+     * @param array<string, mixed> $query Query parameters for the request (optional)
+     * @param mixed|null $body The form-urlencoded request body (optional)
+     */
+    public function __construct(
+        string $baseUrl,
+        string $path,
+        HttpMethod $method,
+        array $headers = [],
+        array $query = [],
+        public readonly mixed $body = null
+    ) {
+        parent::__construct($baseUrl, $path, $method, $headers, $query);
+    }
+}

--- a/seed/php-sdk/query-parameters-openapi/.fern/metadata.json
+++ b/seed/php-sdk/query-parameters-openapi/.fern/metadata.json
@@ -3,8 +3,7 @@
   "generatorName": "fernapi/fern-php-sdk",
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/php-sdk/query-parameters-openapi/src/Core/Client/RawClient.php
+++ b/seed/php-sdk/query-parameters-openapi/src/Core/Client/RawClient.php
@@ -155,6 +155,16 @@ class RawClient
                 $request->headers,
                 $options['headers'] ?? [],
             ),
+            UrlEncodedApiRequest::class => array_merge(
+                [
+                    "Content-Type" => "application/x-www-form-urlencoded",
+                    "Accept" => "*/*",
+                ],
+                $this->headers,
+                $authHeaders,
+                $request->headers,
+                $options['headers'] ?? [],
+            ),
             MultipartApiRequest::class => array_merge(
                 $this->headers,
                 $authHeaders,
@@ -185,6 +195,24 @@ class RawClient
                     ),
                 )
             );
+        }
+
+        if ($request instanceof UrlEncodedApiRequest) {
+            if ($request->body === null) {
+                return null;
+            }
+            $body = $this->buildJsonBody($request->body, $options);
+            if ($body instanceof JsonSerializable) {
+                $body = $body->jsonSerialize();
+            }
+            if ($body instanceof \stdClass) {
+                $body = (array)$body;
+            }
+            if (!is_array($body)) {
+                throw new InvalidArgumentException('Form-urlencoded request body must serialize to an array');
+            }
+            $body = array_filter($body, static fn ($value) => $value !== null);
+            return $this->streamFactory->createStream(http_build_query($body));
         }
 
         if ($request instanceof MultipartApiRequest) {

--- a/seed/php-sdk/query-parameters-openapi/src/Core/Client/UrlEncodedApiRequest.php
+++ b/seed/php-sdk/query-parameters-openapi/src/Core/Client/UrlEncodedApiRequest.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Seed\Core\Client;
+
+class UrlEncodedApiRequest extends BaseApiRequest
+{
+    /**
+     * @param string $baseUrl The base URL for the request
+     * @param string $path The path for the request
+     * @param HttpMethod $method The HTTP method for the request
+     * @param array<string, string> $headers Additional headers for the request (optional)
+     * @param array<string, mixed> $query Query parameters for the request (optional)
+     * @param mixed|null $body The form-urlencoded request body (optional)
+     */
+    public function __construct(
+        string $baseUrl,
+        string $path,
+        HttpMethod $method,
+        array $headers = [],
+        array $query = [],
+        public readonly mixed $body = null
+    ) {
+        parent::__construct($baseUrl, $path, $method, $headers, $query);
+    }
+}

--- a/seed/php-sdk/query-parameters/no-custom-config/.fern/metadata.json
+++ b/seed/php-sdk/query-parameters/no-custom-config/.fern/metadata.json
@@ -3,8 +3,7 @@
   "generatorName": "fernapi/fern-php-sdk",
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/php-sdk/query-parameters/no-custom-config/src/Core/Client/RawClient.php
+++ b/seed/php-sdk/query-parameters/no-custom-config/src/Core/Client/RawClient.php
@@ -155,6 +155,16 @@ class RawClient
                 $request->headers,
                 $options['headers'] ?? [],
             ),
+            UrlEncodedApiRequest::class => array_merge(
+                [
+                    "Content-Type" => "application/x-www-form-urlencoded",
+                    "Accept" => "*/*",
+                ],
+                $this->headers,
+                $authHeaders,
+                $request->headers,
+                $options['headers'] ?? [],
+            ),
             MultipartApiRequest::class => array_merge(
                 $this->headers,
                 $authHeaders,
@@ -185,6 +195,24 @@ class RawClient
                     ),
                 )
             );
+        }
+
+        if ($request instanceof UrlEncodedApiRequest) {
+            if ($request->body === null) {
+                return null;
+            }
+            $body = $this->buildJsonBody($request->body, $options);
+            if ($body instanceof JsonSerializable) {
+                $body = $body->jsonSerialize();
+            }
+            if ($body instanceof \stdClass) {
+                $body = (array)$body;
+            }
+            if (!is_array($body)) {
+                throw new InvalidArgumentException('Form-urlencoded request body must serialize to an array');
+            }
+            $body = array_filter($body, static fn ($value) => $value !== null);
+            return $this->streamFactory->createStream(http_build_query($body));
         }
 
         if ($request instanceof MultipartApiRequest) {

--- a/seed/php-sdk/query-parameters/no-custom-config/src/Core/Client/UrlEncodedApiRequest.php
+++ b/seed/php-sdk/query-parameters/no-custom-config/src/Core/Client/UrlEncodedApiRequest.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Seed\Core\Client;
+
+class UrlEncodedApiRequest extends BaseApiRequest
+{
+    /**
+     * @param string $baseUrl The base URL for the request
+     * @param string $path The path for the request
+     * @param HttpMethod $method The HTTP method for the request
+     * @param array<string, string> $headers Additional headers for the request (optional)
+     * @param array<string, mixed> $query Query parameters for the request (optional)
+     * @param mixed|null $body The form-urlencoded request body (optional)
+     */
+    public function __construct(
+        string $baseUrl,
+        string $path,
+        HttpMethod $method,
+        array $headers = [],
+        array $query = [],
+        public readonly mixed $body = null
+    ) {
+        parent::__construct($baseUrl, $path, $method, $headers, $query);
+    }
+}

--- a/seed/php-sdk/query-parameters/private/.fern/metadata.json
+++ b/seed/php-sdk/query-parameters/private/.fern/metadata.json
@@ -6,8 +6,7 @@
     "propertyAccess": "private"
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/php-sdk/query-parameters/private/src/Core/Client/RawClient.php
+++ b/seed/php-sdk/query-parameters/private/src/Core/Client/RawClient.php
@@ -155,6 +155,16 @@ class RawClient
                 $request->headers,
                 $options['headers'] ?? [],
             ),
+            UrlEncodedApiRequest::class => array_merge(
+                [
+                    "Content-Type" => "application/x-www-form-urlencoded",
+                    "Accept" => "*/*",
+                ],
+                $this->headers,
+                $authHeaders,
+                $request->headers,
+                $options['headers'] ?? [],
+            ),
             MultipartApiRequest::class => array_merge(
                 $this->headers,
                 $authHeaders,
@@ -185,6 +195,24 @@ class RawClient
                     ),
                 )
             );
+        }
+
+        if ($request instanceof UrlEncodedApiRequest) {
+            if ($request->body === null) {
+                return null;
+            }
+            $body = $this->buildJsonBody($request->body, $options);
+            if ($body instanceof JsonSerializable) {
+                $body = $body->jsonSerialize();
+            }
+            if ($body instanceof \stdClass) {
+                $body = (array)$body;
+            }
+            if (!is_array($body)) {
+                throw new InvalidArgumentException('Form-urlencoded request body must serialize to an array');
+            }
+            $body = array_filter($body, static fn ($value) => $value !== null);
+            return $this->streamFactory->createStream(http_build_query($body));
         }
 
         if ($request instanceof MultipartApiRequest) {

--- a/seed/php-sdk/query-parameters/private/src/Core/Client/UrlEncodedApiRequest.php
+++ b/seed/php-sdk/query-parameters/private/src/Core/Client/UrlEncodedApiRequest.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Seed\Core\Client;
+
+class UrlEncodedApiRequest extends BaseApiRequest
+{
+    /**
+     * @param string $baseUrl The base URL for the request
+     * @param string $path The path for the request
+     * @param HttpMethod $method The HTTP method for the request
+     * @param array<string, string> $headers Additional headers for the request (optional)
+     * @param array<string, mixed> $query Query parameters for the request (optional)
+     * @param mixed|null $body The form-urlencoded request body (optional)
+     */
+    public function __construct(
+        string $baseUrl,
+        string $path,
+        HttpMethod $method,
+        array $headers = [],
+        array $query = [],
+        public readonly mixed $body = null
+    ) {
+        parent::__construct($baseUrl, $path, $method, $headers, $query);
+    }
+}

--- a/seed/php-sdk/request-parameters/no-custom-config/.fern/metadata.json
+++ b/seed/php-sdk/request-parameters/no-custom-config/.fern/metadata.json
@@ -3,8 +3,7 @@
   "generatorName": "fernapi/fern-php-sdk",
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/php-sdk/request-parameters/no-custom-config/src/Core/Client/RawClient.php
+++ b/seed/php-sdk/request-parameters/no-custom-config/src/Core/Client/RawClient.php
@@ -155,6 +155,16 @@ class RawClient
                 $request->headers,
                 $options['headers'] ?? [],
             ),
+            UrlEncodedApiRequest::class => array_merge(
+                [
+                    "Content-Type" => "application/x-www-form-urlencoded",
+                    "Accept" => "*/*",
+                ],
+                $this->headers,
+                $authHeaders,
+                $request->headers,
+                $options['headers'] ?? [],
+            ),
             MultipartApiRequest::class => array_merge(
                 $this->headers,
                 $authHeaders,
@@ -185,6 +195,24 @@ class RawClient
                     ),
                 )
             );
+        }
+
+        if ($request instanceof UrlEncodedApiRequest) {
+            if ($request->body === null) {
+                return null;
+            }
+            $body = $this->buildJsonBody($request->body, $options);
+            if ($body instanceof JsonSerializable) {
+                $body = $body->jsonSerialize();
+            }
+            if ($body instanceof \stdClass) {
+                $body = (array)$body;
+            }
+            if (!is_array($body)) {
+                throw new InvalidArgumentException('Form-urlencoded request body must serialize to an array');
+            }
+            $body = array_filter($body, static fn ($value) => $value !== null);
+            return $this->streamFactory->createStream(http_build_query($body));
         }
 
         if ($request instanceof MultipartApiRequest) {

--- a/seed/php-sdk/request-parameters/no-custom-config/src/Core/Client/UrlEncodedApiRequest.php
+++ b/seed/php-sdk/request-parameters/no-custom-config/src/Core/Client/UrlEncodedApiRequest.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Seed\Core\Client;
+
+class UrlEncodedApiRequest extends BaseApiRequest
+{
+    /**
+     * @param string $baseUrl The base URL for the request
+     * @param string $path The path for the request
+     * @param HttpMethod $method The HTTP method for the request
+     * @param array<string, string> $headers Additional headers for the request (optional)
+     * @param array<string, mixed> $query Query parameters for the request (optional)
+     * @param mixed|null $body The form-urlencoded request body (optional)
+     */
+    public function __construct(
+        string $baseUrl,
+        string $path,
+        HttpMethod $method,
+        array $headers = [],
+        array $query = [],
+        public readonly mixed $body = null
+    ) {
+        parent::__construct($baseUrl, $path, $method, $headers, $query);
+    }
+}

--- a/seed/php-sdk/request-parameters/with-defaults/.fern/metadata.json
+++ b/seed/php-sdk/request-parameters/with-defaults/.fern/metadata.json
@@ -6,8 +6,7 @@
     "useDefaultRequestParameterValues": true
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/php-sdk/request-parameters/with-defaults/src/Core/Client/RawClient.php
+++ b/seed/php-sdk/request-parameters/with-defaults/src/Core/Client/RawClient.php
@@ -155,6 +155,16 @@ class RawClient
                 $request->headers,
                 $options['headers'] ?? [],
             ),
+            UrlEncodedApiRequest::class => array_merge(
+                [
+                    "Content-Type" => "application/x-www-form-urlencoded",
+                    "Accept" => "*/*",
+                ],
+                $this->headers,
+                $authHeaders,
+                $request->headers,
+                $options['headers'] ?? [],
+            ),
             MultipartApiRequest::class => array_merge(
                 $this->headers,
                 $authHeaders,
@@ -185,6 +195,24 @@ class RawClient
                     ),
                 )
             );
+        }
+
+        if ($request instanceof UrlEncodedApiRequest) {
+            if ($request->body === null) {
+                return null;
+            }
+            $body = $this->buildJsonBody($request->body, $options);
+            if ($body instanceof JsonSerializable) {
+                $body = $body->jsonSerialize();
+            }
+            if ($body instanceof \stdClass) {
+                $body = (array)$body;
+            }
+            if (!is_array($body)) {
+                throw new InvalidArgumentException('Form-urlencoded request body must serialize to an array');
+            }
+            $body = array_filter($body, static fn ($value) => $value !== null);
+            return $this->streamFactory->createStream(http_build_query($body));
         }
 
         if ($request instanceof MultipartApiRequest) {

--- a/seed/php-sdk/request-parameters/with-defaults/src/Core/Client/UrlEncodedApiRequest.php
+++ b/seed/php-sdk/request-parameters/with-defaults/src/Core/Client/UrlEncodedApiRequest.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Seed\Core\Client;
+
+class UrlEncodedApiRequest extends BaseApiRequest
+{
+    /**
+     * @param string $baseUrl The base URL for the request
+     * @param string $path The path for the request
+     * @param HttpMethod $method The HTTP method for the request
+     * @param array<string, string> $headers Additional headers for the request (optional)
+     * @param array<string, mixed> $query Query parameters for the request (optional)
+     * @param mixed|null $body The form-urlencoded request body (optional)
+     */
+    public function __construct(
+        string $baseUrl,
+        string $path,
+        HttpMethod $method,
+        array $headers = [],
+        array $query = [],
+        public readonly mixed $body = null
+    ) {
+        parent::__construct($baseUrl, $path, $method, $headers, $query);
+    }
+}

--- a/seed/php-sdk/required-nullable/.fern/metadata.json
+++ b/seed/php-sdk/required-nullable/.fern/metadata.json
@@ -3,8 +3,7 @@
   "generatorName": "fernapi/fern-php-sdk",
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/php-sdk/required-nullable/src/Core/Client/RawClient.php
+++ b/seed/php-sdk/required-nullable/src/Core/Client/RawClient.php
@@ -155,6 +155,16 @@ class RawClient
                 $request->headers,
                 $options['headers'] ?? [],
             ),
+            UrlEncodedApiRequest::class => array_merge(
+                [
+                    "Content-Type" => "application/x-www-form-urlencoded",
+                    "Accept" => "*/*",
+                ],
+                $this->headers,
+                $authHeaders,
+                $request->headers,
+                $options['headers'] ?? [],
+            ),
             MultipartApiRequest::class => array_merge(
                 $this->headers,
                 $authHeaders,
@@ -185,6 +195,24 @@ class RawClient
                     ),
                 )
             );
+        }
+
+        if ($request instanceof UrlEncodedApiRequest) {
+            if ($request->body === null) {
+                return null;
+            }
+            $body = $this->buildJsonBody($request->body, $options);
+            if ($body instanceof JsonSerializable) {
+                $body = $body->jsonSerialize();
+            }
+            if ($body instanceof \stdClass) {
+                $body = (array)$body;
+            }
+            if (!is_array($body)) {
+                throw new InvalidArgumentException('Form-urlencoded request body must serialize to an array');
+            }
+            $body = array_filter($body, static fn ($value) => $value !== null);
+            return $this->streamFactory->createStream(http_build_query($body));
         }
 
         if ($request instanceof MultipartApiRequest) {

--- a/seed/php-sdk/required-nullable/src/Core/Client/UrlEncodedApiRequest.php
+++ b/seed/php-sdk/required-nullable/src/Core/Client/UrlEncodedApiRequest.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Seed\Core\Client;
+
+class UrlEncodedApiRequest extends BaseApiRequest
+{
+    /**
+     * @param string $baseUrl The base URL for the request
+     * @param string $path The path for the request
+     * @param HttpMethod $method The HTTP method for the request
+     * @param array<string, string> $headers Additional headers for the request (optional)
+     * @param array<string, mixed> $query Query parameters for the request (optional)
+     * @param mixed|null $body The form-urlencoded request body (optional)
+     */
+    public function __construct(
+        string $baseUrl,
+        string $path,
+        HttpMethod $method,
+        array $headers = [],
+        array $query = [],
+        public readonly mixed $body = null
+    ) {
+        parent::__construct($baseUrl, $path, $method, $headers, $query);
+    }
+}

--- a/seed/php-sdk/reserved-keywords/.fern/metadata.json
+++ b/seed/php-sdk/reserved-keywords/.fern/metadata.json
@@ -3,8 +3,7 @@
   "generatorName": "fernapi/fern-php-sdk",
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/php-sdk/reserved-keywords/src/Core/Client/RawClient.php
+++ b/seed/php-sdk/reserved-keywords/src/Core/Client/RawClient.php
@@ -155,6 +155,16 @@ class RawClient
                 $request->headers,
                 $options['headers'] ?? [],
             ),
+            UrlEncodedApiRequest::class => array_merge(
+                [
+                    "Content-Type" => "application/x-www-form-urlencoded",
+                    "Accept" => "*/*",
+                ],
+                $this->headers,
+                $authHeaders,
+                $request->headers,
+                $options['headers'] ?? [],
+            ),
             MultipartApiRequest::class => array_merge(
                 $this->headers,
                 $authHeaders,
@@ -185,6 +195,24 @@ class RawClient
                     ),
                 )
             );
+        }
+
+        if ($request instanceof UrlEncodedApiRequest) {
+            if ($request->body === null) {
+                return null;
+            }
+            $body = $this->buildJsonBody($request->body, $options);
+            if ($body instanceof JsonSerializable) {
+                $body = $body->jsonSerialize();
+            }
+            if ($body instanceof \stdClass) {
+                $body = (array)$body;
+            }
+            if (!is_array($body)) {
+                throw new InvalidArgumentException('Form-urlencoded request body must serialize to an array');
+            }
+            $body = array_filter($body, static fn ($value) => $value !== null);
+            return $this->streamFactory->createStream(http_build_query($body));
         }
 
         if ($request instanceof MultipartApiRequest) {

--- a/seed/php-sdk/reserved-keywords/src/Core/Client/UrlEncodedApiRequest.php
+++ b/seed/php-sdk/reserved-keywords/src/Core/Client/UrlEncodedApiRequest.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Seed\Core\Client;
+
+class UrlEncodedApiRequest extends BaseApiRequest
+{
+    /**
+     * @param string $baseUrl The base URL for the request
+     * @param string $path The path for the request
+     * @param HttpMethod $method The HTTP method for the request
+     * @param array<string, string> $headers Additional headers for the request (optional)
+     * @param array<string, mixed> $query Query parameters for the request (optional)
+     * @param mixed|null $body The form-urlencoded request body (optional)
+     */
+    public function __construct(
+        string $baseUrl,
+        string $path,
+        HttpMethod $method,
+        array $headers = [],
+        array $query = [],
+        public readonly mixed $body = null
+    ) {
+        parent::__construct($baseUrl, $path, $method, $headers, $query);
+    }
+}

--- a/seed/php-sdk/response-property/.fern/metadata.json
+++ b/seed/php-sdk/response-property/.fern/metadata.json
@@ -3,8 +3,7 @@
   "generatorName": "fernapi/fern-php-sdk",
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/php-sdk/response-property/src/Core/Client/RawClient.php
+++ b/seed/php-sdk/response-property/src/Core/Client/RawClient.php
@@ -155,6 +155,16 @@ class RawClient
                 $request->headers,
                 $options['headers'] ?? [],
             ),
+            UrlEncodedApiRequest::class => array_merge(
+                [
+                    "Content-Type" => "application/x-www-form-urlencoded",
+                    "Accept" => "*/*",
+                ],
+                $this->headers,
+                $authHeaders,
+                $request->headers,
+                $options['headers'] ?? [],
+            ),
             MultipartApiRequest::class => array_merge(
                 $this->headers,
                 $authHeaders,
@@ -185,6 +195,24 @@ class RawClient
                     ),
                 )
             );
+        }
+
+        if ($request instanceof UrlEncodedApiRequest) {
+            if ($request->body === null) {
+                return null;
+            }
+            $body = $this->buildJsonBody($request->body, $options);
+            if ($body instanceof JsonSerializable) {
+                $body = $body->jsonSerialize();
+            }
+            if ($body instanceof \stdClass) {
+                $body = (array)$body;
+            }
+            if (!is_array($body)) {
+                throw new InvalidArgumentException('Form-urlencoded request body must serialize to an array');
+            }
+            $body = array_filter($body, static fn ($value) => $value !== null);
+            return $this->streamFactory->createStream(http_build_query($body));
         }
 
         if ($request instanceof MultipartApiRequest) {

--- a/seed/php-sdk/response-property/src/Core/Client/UrlEncodedApiRequest.php
+++ b/seed/php-sdk/response-property/src/Core/Client/UrlEncodedApiRequest.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Seed\Core\Client;
+
+class UrlEncodedApiRequest extends BaseApiRequest
+{
+    /**
+     * @param string $baseUrl The base URL for the request
+     * @param string $path The path for the request
+     * @param HttpMethod $method The HTTP method for the request
+     * @param array<string, string> $headers Additional headers for the request (optional)
+     * @param array<string, mixed> $query Query parameters for the request (optional)
+     * @param mixed|null $body The form-urlencoded request body (optional)
+     */
+    public function __construct(
+        string $baseUrl,
+        string $path,
+        HttpMethod $method,
+        array $headers = [],
+        array $query = [],
+        public readonly mixed $body = null
+    ) {
+        parent::__construct($baseUrl, $path, $method, $headers, $query);
+    }
+}

--- a/seed/php-sdk/schemaless-request-body-examples/.fern/metadata.json
+++ b/seed/php-sdk/schemaless-request-body-examples/.fern/metadata.json
@@ -3,8 +3,7 @@
   "generatorName": "fernapi/fern-php-sdk",
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/php-sdk/schemaless-request-body-examples/src/Core/Client/RawClient.php
+++ b/seed/php-sdk/schemaless-request-body-examples/src/Core/Client/RawClient.php
@@ -155,6 +155,16 @@ class RawClient
                 $request->headers,
                 $options['headers'] ?? [],
             ),
+            UrlEncodedApiRequest::class => array_merge(
+                [
+                    "Content-Type" => "application/x-www-form-urlencoded",
+                    "Accept" => "*/*",
+                ],
+                $this->headers,
+                $authHeaders,
+                $request->headers,
+                $options['headers'] ?? [],
+            ),
             MultipartApiRequest::class => array_merge(
                 $this->headers,
                 $authHeaders,
@@ -185,6 +195,24 @@ class RawClient
                     ),
                 )
             );
+        }
+
+        if ($request instanceof UrlEncodedApiRequest) {
+            if ($request->body === null) {
+                return null;
+            }
+            $body = $this->buildJsonBody($request->body, $options);
+            if ($body instanceof JsonSerializable) {
+                $body = $body->jsonSerialize();
+            }
+            if ($body instanceof \stdClass) {
+                $body = (array)$body;
+            }
+            if (!is_array($body)) {
+                throw new InvalidArgumentException('Form-urlencoded request body must serialize to an array');
+            }
+            $body = array_filter($body, static fn ($value) => $value !== null);
+            return $this->streamFactory->createStream(http_build_query($body));
         }
 
         if ($request instanceof MultipartApiRequest) {

--- a/seed/php-sdk/schemaless-request-body-examples/src/Core/Client/UrlEncodedApiRequest.php
+++ b/seed/php-sdk/schemaless-request-body-examples/src/Core/Client/UrlEncodedApiRequest.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Seed\Core\Client;
+
+class UrlEncodedApiRequest extends BaseApiRequest
+{
+    /**
+     * @param string $baseUrl The base URL for the request
+     * @param string $path The path for the request
+     * @param HttpMethod $method The HTTP method for the request
+     * @param array<string, string> $headers Additional headers for the request (optional)
+     * @param array<string, mixed> $query Query parameters for the request (optional)
+     * @param mixed|null $body The form-urlencoded request body (optional)
+     */
+    public function __construct(
+        string $baseUrl,
+        string $path,
+        HttpMethod $method,
+        array $headers = [],
+        array $query = [],
+        public readonly mixed $body = null
+    ) {
+        parent::__construct($baseUrl, $path, $method, $headers, $query);
+    }
+}

--- a/seed/php-sdk/server-sent-event-examples/.fern/metadata.json
+++ b/seed/php-sdk/server-sent-event-examples/.fern/metadata.json
@@ -3,8 +3,7 @@
   "generatorName": "fernapi/fern-php-sdk",
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/php-sdk/server-sent-event-examples/src/Core/Client/RawClient.php
+++ b/seed/php-sdk/server-sent-event-examples/src/Core/Client/RawClient.php
@@ -155,6 +155,16 @@ class RawClient
                 $request->headers,
                 $options['headers'] ?? [],
             ),
+            UrlEncodedApiRequest::class => array_merge(
+                [
+                    "Content-Type" => "application/x-www-form-urlencoded",
+                    "Accept" => "*/*",
+                ],
+                $this->headers,
+                $authHeaders,
+                $request->headers,
+                $options['headers'] ?? [],
+            ),
             MultipartApiRequest::class => array_merge(
                 $this->headers,
                 $authHeaders,
@@ -185,6 +195,24 @@ class RawClient
                     ),
                 )
             );
+        }
+
+        if ($request instanceof UrlEncodedApiRequest) {
+            if ($request->body === null) {
+                return null;
+            }
+            $body = $this->buildJsonBody($request->body, $options);
+            if ($body instanceof JsonSerializable) {
+                $body = $body->jsonSerialize();
+            }
+            if ($body instanceof \stdClass) {
+                $body = (array)$body;
+            }
+            if (!is_array($body)) {
+                throw new InvalidArgumentException('Form-urlencoded request body must serialize to an array');
+            }
+            $body = array_filter($body, static fn ($value) => $value !== null);
+            return $this->streamFactory->createStream(http_build_query($body));
         }
 
         if ($request instanceof MultipartApiRequest) {

--- a/seed/php-sdk/server-sent-event-examples/src/Core/Client/UrlEncodedApiRequest.php
+++ b/seed/php-sdk/server-sent-event-examples/src/Core/Client/UrlEncodedApiRequest.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Seed\Core\Client;
+
+class UrlEncodedApiRequest extends BaseApiRequest
+{
+    /**
+     * @param string $baseUrl The base URL for the request
+     * @param string $path The path for the request
+     * @param HttpMethod $method The HTTP method for the request
+     * @param array<string, string> $headers Additional headers for the request (optional)
+     * @param array<string, mixed> $query Query parameters for the request (optional)
+     * @param mixed|null $body The form-urlencoded request body (optional)
+     */
+    public function __construct(
+        string $baseUrl,
+        string $path,
+        HttpMethod $method,
+        array $headers = [],
+        array $query = [],
+        public readonly mixed $body = null
+    ) {
+        parent::__construct($baseUrl, $path, $method, $headers, $query);
+    }
+}

--- a/seed/php-sdk/server-sent-events-openapi/.fern/metadata.json
+++ b/seed/php-sdk/server-sent-events-openapi/.fern/metadata.json
@@ -3,8 +3,7 @@
   "generatorName": "fernapi/fern-php-sdk",
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/php-sdk/server-sent-events-openapi/src/Core/Client/RawClient.php
+++ b/seed/php-sdk/server-sent-events-openapi/src/Core/Client/RawClient.php
@@ -155,6 +155,16 @@ class RawClient
                 $request->headers,
                 $options['headers'] ?? [],
             ),
+            UrlEncodedApiRequest::class => array_merge(
+                [
+                    "Content-Type" => "application/x-www-form-urlencoded",
+                    "Accept" => "*/*",
+                ],
+                $this->headers,
+                $authHeaders,
+                $request->headers,
+                $options['headers'] ?? [],
+            ),
             MultipartApiRequest::class => array_merge(
                 $this->headers,
                 $authHeaders,
@@ -185,6 +195,24 @@ class RawClient
                     ),
                 )
             );
+        }
+
+        if ($request instanceof UrlEncodedApiRequest) {
+            if ($request->body === null) {
+                return null;
+            }
+            $body = $this->buildJsonBody($request->body, $options);
+            if ($body instanceof JsonSerializable) {
+                $body = $body->jsonSerialize();
+            }
+            if ($body instanceof \stdClass) {
+                $body = (array)$body;
+            }
+            if (!is_array($body)) {
+                throw new InvalidArgumentException('Form-urlencoded request body must serialize to an array');
+            }
+            $body = array_filter($body, static fn ($value) => $value !== null);
+            return $this->streamFactory->createStream(http_build_query($body));
         }
 
         if ($request instanceof MultipartApiRequest) {

--- a/seed/php-sdk/server-sent-events-openapi/src/Core/Client/UrlEncodedApiRequest.php
+++ b/seed/php-sdk/server-sent-events-openapi/src/Core/Client/UrlEncodedApiRequest.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Seed\Core\Client;
+
+class UrlEncodedApiRequest extends BaseApiRequest
+{
+    /**
+     * @param string $baseUrl The base URL for the request
+     * @param string $path The path for the request
+     * @param HttpMethod $method The HTTP method for the request
+     * @param array<string, string> $headers Additional headers for the request (optional)
+     * @param array<string, mixed> $query Query parameters for the request (optional)
+     * @param mixed|null $body The form-urlencoded request body (optional)
+     */
+    public function __construct(
+        string $baseUrl,
+        string $path,
+        HttpMethod $method,
+        array $headers = [],
+        array $query = [],
+        public readonly mixed $body = null
+    ) {
+        parent::__construct($baseUrl, $path, $method, $headers, $query);
+    }
+}

--- a/seed/php-sdk/server-sent-events-resumable/.fern/metadata.json
+++ b/seed/php-sdk/server-sent-events-resumable/.fern/metadata.json
@@ -3,8 +3,7 @@
   "generatorName": "fernapi/fern-php-sdk",
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/php-sdk/server-sent-events-resumable/src/Core/Client/RawClient.php
+++ b/seed/php-sdk/server-sent-events-resumable/src/Core/Client/RawClient.php
@@ -155,6 +155,16 @@ class RawClient
                 $request->headers,
                 $options['headers'] ?? [],
             ),
+            UrlEncodedApiRequest::class => array_merge(
+                [
+                    "Content-Type" => "application/x-www-form-urlencoded",
+                    "Accept" => "*/*",
+                ],
+                $this->headers,
+                $authHeaders,
+                $request->headers,
+                $options['headers'] ?? [],
+            ),
             MultipartApiRequest::class => array_merge(
                 $this->headers,
                 $authHeaders,
@@ -185,6 +195,24 @@ class RawClient
                     ),
                 )
             );
+        }
+
+        if ($request instanceof UrlEncodedApiRequest) {
+            if ($request->body === null) {
+                return null;
+            }
+            $body = $this->buildJsonBody($request->body, $options);
+            if ($body instanceof JsonSerializable) {
+                $body = $body->jsonSerialize();
+            }
+            if ($body instanceof \stdClass) {
+                $body = (array)$body;
+            }
+            if (!is_array($body)) {
+                throw new InvalidArgumentException('Form-urlencoded request body must serialize to an array');
+            }
+            $body = array_filter($body, static fn ($value) => $value !== null);
+            return $this->streamFactory->createStream(http_build_query($body));
         }
 
         if ($request instanceof MultipartApiRequest) {

--- a/seed/php-sdk/server-sent-events-resumable/src/Core/Client/UrlEncodedApiRequest.php
+++ b/seed/php-sdk/server-sent-events-resumable/src/Core/Client/UrlEncodedApiRequest.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Seed\Core\Client;
+
+class UrlEncodedApiRequest extends BaseApiRequest
+{
+    /**
+     * @param string $baseUrl The base URL for the request
+     * @param string $path The path for the request
+     * @param HttpMethod $method The HTTP method for the request
+     * @param array<string, string> $headers Additional headers for the request (optional)
+     * @param array<string, mixed> $query Query parameters for the request (optional)
+     * @param mixed|null $body The form-urlencoded request body (optional)
+     */
+    public function __construct(
+        string $baseUrl,
+        string $path,
+        HttpMethod $method,
+        array $headers = [],
+        array $query = [],
+        public readonly mixed $body = null
+    ) {
+        parent::__construct($baseUrl, $path, $method, $headers, $query);
+    }
+}

--- a/seed/php-sdk/server-sent-events/.fern/metadata.json
+++ b/seed/php-sdk/server-sent-events/.fern/metadata.json
@@ -3,8 +3,7 @@
   "generatorName": "fernapi/fern-php-sdk",
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/php-sdk/server-sent-events/src/Core/Client/RawClient.php
+++ b/seed/php-sdk/server-sent-events/src/Core/Client/RawClient.php
@@ -155,6 +155,16 @@ class RawClient
                 $request->headers,
                 $options['headers'] ?? [],
             ),
+            UrlEncodedApiRequest::class => array_merge(
+                [
+                    "Content-Type" => "application/x-www-form-urlencoded",
+                    "Accept" => "*/*",
+                ],
+                $this->headers,
+                $authHeaders,
+                $request->headers,
+                $options['headers'] ?? [],
+            ),
             MultipartApiRequest::class => array_merge(
                 $this->headers,
                 $authHeaders,
@@ -185,6 +195,24 @@ class RawClient
                     ),
                 )
             );
+        }
+
+        if ($request instanceof UrlEncodedApiRequest) {
+            if ($request->body === null) {
+                return null;
+            }
+            $body = $this->buildJsonBody($request->body, $options);
+            if ($body instanceof JsonSerializable) {
+                $body = $body->jsonSerialize();
+            }
+            if ($body instanceof \stdClass) {
+                $body = (array)$body;
+            }
+            if (!is_array($body)) {
+                throw new InvalidArgumentException('Form-urlencoded request body must serialize to an array');
+            }
+            $body = array_filter($body, static fn ($value) => $value !== null);
+            return $this->streamFactory->createStream(http_build_query($body));
         }
 
         if ($request instanceof MultipartApiRequest) {

--- a/seed/php-sdk/server-sent-events/src/Core/Client/UrlEncodedApiRequest.php
+++ b/seed/php-sdk/server-sent-events/src/Core/Client/UrlEncodedApiRequest.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Seed\Core\Client;
+
+class UrlEncodedApiRequest extends BaseApiRequest
+{
+    /**
+     * @param string $baseUrl The base URL for the request
+     * @param string $path The path for the request
+     * @param HttpMethod $method The HTTP method for the request
+     * @param array<string, string> $headers Additional headers for the request (optional)
+     * @param array<string, mixed> $query Query parameters for the request (optional)
+     * @param mixed|null $body The form-urlencoded request body (optional)
+     */
+    public function __construct(
+        string $baseUrl,
+        string $path,
+        HttpMethod $method,
+        array $headers = [],
+        array $query = [],
+        public readonly mixed $body = null
+    ) {
+        parent::__construct($baseUrl, $path, $method, $headers, $query);
+    }
+}

--- a/seed/php-sdk/server-url-templating-single-url/no-custom-config/.fern/metadata.json
+++ b/seed/php-sdk/server-url-templating-single-url/no-custom-config/.fern/metadata.json
@@ -3,8 +3,7 @@
   "generatorName": "fernapi/fern-php-sdk",
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/php-sdk/server-url-templating-single-url/no-custom-config/src/Core/Client/RawClient.php
+++ b/seed/php-sdk/server-url-templating-single-url/no-custom-config/src/Core/Client/RawClient.php
@@ -155,6 +155,16 @@ class RawClient
                 $request->headers,
                 $options['headers'] ?? [],
             ),
+            UrlEncodedApiRequest::class => array_merge(
+                [
+                    "Content-Type" => "application/x-www-form-urlencoded",
+                    "Accept" => "*/*",
+                ],
+                $this->headers,
+                $authHeaders,
+                $request->headers,
+                $options['headers'] ?? [],
+            ),
             MultipartApiRequest::class => array_merge(
                 $this->headers,
                 $authHeaders,
@@ -185,6 +195,24 @@ class RawClient
                     ),
                 )
             );
+        }
+
+        if ($request instanceof UrlEncodedApiRequest) {
+            if ($request->body === null) {
+                return null;
+            }
+            $body = $this->buildJsonBody($request->body, $options);
+            if ($body instanceof JsonSerializable) {
+                $body = $body->jsonSerialize();
+            }
+            if ($body instanceof \stdClass) {
+                $body = (array)$body;
+            }
+            if (!is_array($body)) {
+                throw new InvalidArgumentException('Form-urlencoded request body must serialize to an array');
+            }
+            $body = array_filter($body, static fn ($value) => $value !== null);
+            return $this->streamFactory->createStream(http_build_query($body));
         }
 
         if ($request instanceof MultipartApiRequest) {

--- a/seed/php-sdk/server-url-templating-single-url/no-custom-config/src/Core/Client/UrlEncodedApiRequest.php
+++ b/seed/php-sdk/server-url-templating-single-url/no-custom-config/src/Core/Client/UrlEncodedApiRequest.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Seed\Core\Client;
+
+class UrlEncodedApiRequest extends BaseApiRequest
+{
+    /**
+     * @param string $baseUrl The base URL for the request
+     * @param string $path The path for the request
+     * @param HttpMethod $method The HTTP method for the request
+     * @param array<string, string> $headers Additional headers for the request (optional)
+     * @param array<string, mixed> $query Query parameters for the request (optional)
+     * @param mixed|null $body The form-urlencoded request body (optional)
+     */
+    public function __construct(
+        string $baseUrl,
+        string $path,
+        HttpMethod $method,
+        array $headers = [],
+        array $query = [],
+        public readonly mixed $body = null
+    ) {
+        parent::__construct($baseUrl, $path, $method, $headers, $query);
+    }
+}

--- a/seed/php-sdk/server-url-templating/no-custom-config/.fern/metadata.json
+++ b/seed/php-sdk/server-url-templating/no-custom-config/.fern/metadata.json
@@ -3,8 +3,7 @@
   "generatorName": "fernapi/fern-php-sdk",
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/php-sdk/server-url-templating/no-custom-config/src/Core/Client/RawClient.php
+++ b/seed/php-sdk/server-url-templating/no-custom-config/src/Core/Client/RawClient.php
@@ -155,6 +155,16 @@ class RawClient
                 $request->headers,
                 $options['headers'] ?? [],
             ),
+            UrlEncodedApiRequest::class => array_merge(
+                [
+                    "Content-Type" => "application/x-www-form-urlencoded",
+                    "Accept" => "*/*",
+                ],
+                $this->headers,
+                $authHeaders,
+                $request->headers,
+                $options['headers'] ?? [],
+            ),
             MultipartApiRequest::class => array_merge(
                 $this->headers,
                 $authHeaders,
@@ -185,6 +195,24 @@ class RawClient
                     ),
                 )
             );
+        }
+
+        if ($request instanceof UrlEncodedApiRequest) {
+            if ($request->body === null) {
+                return null;
+            }
+            $body = $this->buildJsonBody($request->body, $options);
+            if ($body instanceof JsonSerializable) {
+                $body = $body->jsonSerialize();
+            }
+            if ($body instanceof \stdClass) {
+                $body = (array)$body;
+            }
+            if (!is_array($body)) {
+                throw new InvalidArgumentException('Form-urlencoded request body must serialize to an array');
+            }
+            $body = array_filter($body, static fn ($value) => $value !== null);
+            return $this->streamFactory->createStream(http_build_query($body));
         }
 
         if ($request instanceof MultipartApiRequest) {

--- a/seed/php-sdk/server-url-templating/no-custom-config/src/Core/Client/UrlEncodedApiRequest.php
+++ b/seed/php-sdk/server-url-templating/no-custom-config/src/Core/Client/UrlEncodedApiRequest.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Seed\Core\Client;
+
+class UrlEncodedApiRequest extends BaseApiRequest
+{
+    /**
+     * @param string $baseUrl The base URL for the request
+     * @param string $path The path for the request
+     * @param HttpMethod $method The HTTP method for the request
+     * @param array<string, string> $headers Additional headers for the request (optional)
+     * @param array<string, mixed> $query Query parameters for the request (optional)
+     * @param mixed|null $body The form-urlencoded request body (optional)
+     */
+    public function __construct(
+        string $baseUrl,
+        string $path,
+        HttpMethod $method,
+        array $headers = [],
+        array $query = [],
+        public readonly mixed $body = null
+    ) {
+        parent::__construct($baseUrl, $path, $method, $headers, $query);
+    }
+}

--- a/seed/php-sdk/simple-api/.fern/metadata.json
+++ b/seed/php-sdk/simple-api/.fern/metadata.json
@@ -3,8 +3,7 @@
   "generatorName": "fernapi/fern-php-sdk",
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/php-sdk/simple-api/src/Core/Client/RawClient.php
+++ b/seed/php-sdk/simple-api/src/Core/Client/RawClient.php
@@ -155,6 +155,16 @@ class RawClient
                 $request->headers,
                 $options['headers'] ?? [],
             ),
+            UrlEncodedApiRequest::class => array_merge(
+                [
+                    "Content-Type" => "application/x-www-form-urlencoded",
+                    "Accept" => "*/*",
+                ],
+                $this->headers,
+                $authHeaders,
+                $request->headers,
+                $options['headers'] ?? [],
+            ),
             MultipartApiRequest::class => array_merge(
                 $this->headers,
                 $authHeaders,
@@ -185,6 +195,24 @@ class RawClient
                     ),
                 )
             );
+        }
+
+        if ($request instanceof UrlEncodedApiRequest) {
+            if ($request->body === null) {
+                return null;
+            }
+            $body = $this->buildJsonBody($request->body, $options);
+            if ($body instanceof JsonSerializable) {
+                $body = $body->jsonSerialize();
+            }
+            if ($body instanceof \stdClass) {
+                $body = (array)$body;
+            }
+            if (!is_array($body)) {
+                throw new InvalidArgumentException('Form-urlencoded request body must serialize to an array');
+            }
+            $body = array_filter($body, static fn ($value) => $value !== null);
+            return $this->streamFactory->createStream(http_build_query($body));
         }
 
         if ($request instanceof MultipartApiRequest) {

--- a/seed/php-sdk/simple-api/src/Core/Client/UrlEncodedApiRequest.php
+++ b/seed/php-sdk/simple-api/src/Core/Client/UrlEncodedApiRequest.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Seed\Core\Client;
+
+class UrlEncodedApiRequest extends BaseApiRequest
+{
+    /**
+     * @param string $baseUrl The base URL for the request
+     * @param string $path The path for the request
+     * @param HttpMethod $method The HTTP method for the request
+     * @param array<string, string> $headers Additional headers for the request (optional)
+     * @param array<string, mixed> $query Query parameters for the request (optional)
+     * @param mixed|null $body The form-urlencoded request body (optional)
+     */
+    public function __construct(
+        string $baseUrl,
+        string $path,
+        HttpMethod $method,
+        array $headers = [],
+        array $query = [],
+        public readonly mixed $body = null
+    ) {
+        parent::__construct($baseUrl, $path, $method, $headers, $query);
+    }
+}

--- a/seed/php-sdk/simple-fhir/.fern/metadata.json
+++ b/seed/php-sdk/simple-fhir/.fern/metadata.json
@@ -3,8 +3,7 @@
   "generatorName": "fernapi/fern-php-sdk",
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/php-sdk/simple-fhir/src/Core/Client/RawClient.php
+++ b/seed/php-sdk/simple-fhir/src/Core/Client/RawClient.php
@@ -155,6 +155,16 @@ class RawClient
                 $request->headers,
                 $options['headers'] ?? [],
             ),
+            UrlEncodedApiRequest::class => array_merge(
+                [
+                    "Content-Type" => "application/x-www-form-urlencoded",
+                    "Accept" => "*/*",
+                ],
+                $this->headers,
+                $authHeaders,
+                $request->headers,
+                $options['headers'] ?? [],
+            ),
             MultipartApiRequest::class => array_merge(
                 $this->headers,
                 $authHeaders,
@@ -185,6 +195,24 @@ class RawClient
                     ),
                 )
             );
+        }
+
+        if ($request instanceof UrlEncodedApiRequest) {
+            if ($request->body === null) {
+                return null;
+            }
+            $body = $this->buildJsonBody($request->body, $options);
+            if ($body instanceof JsonSerializable) {
+                $body = $body->jsonSerialize();
+            }
+            if ($body instanceof \stdClass) {
+                $body = (array)$body;
+            }
+            if (!is_array($body)) {
+                throw new InvalidArgumentException('Form-urlencoded request body must serialize to an array');
+            }
+            $body = array_filter($body, static fn ($value) => $value !== null);
+            return $this->streamFactory->createStream(http_build_query($body));
         }
 
         if ($request instanceof MultipartApiRequest) {

--- a/seed/php-sdk/simple-fhir/src/Core/Client/UrlEncodedApiRequest.php
+++ b/seed/php-sdk/simple-fhir/src/Core/Client/UrlEncodedApiRequest.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Seed\Core\Client;
+
+class UrlEncodedApiRequest extends BaseApiRequest
+{
+    /**
+     * @param string $baseUrl The base URL for the request
+     * @param string $path The path for the request
+     * @param HttpMethod $method The HTTP method for the request
+     * @param array<string, string> $headers Additional headers for the request (optional)
+     * @param array<string, mixed> $query Query parameters for the request (optional)
+     * @param mixed|null $body The form-urlencoded request body (optional)
+     */
+    public function __construct(
+        string $baseUrl,
+        string $path,
+        HttpMethod $method,
+        array $headers = [],
+        array $query = [],
+        public readonly mixed $body = null
+    ) {
+        parent::__construct($baseUrl, $path, $method, $headers, $query);
+    }
+}

--- a/seed/php-sdk/single-url-environment-default/.fern/metadata.json
+++ b/seed/php-sdk/single-url-environment-default/.fern/metadata.json
@@ -3,8 +3,7 @@
   "generatorName": "fernapi/fern-php-sdk",
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/php-sdk/single-url-environment-default/src/Core/Client/RawClient.php
+++ b/seed/php-sdk/single-url-environment-default/src/Core/Client/RawClient.php
@@ -155,6 +155,16 @@ class RawClient
                 $request->headers,
                 $options['headers'] ?? [],
             ),
+            UrlEncodedApiRequest::class => array_merge(
+                [
+                    "Content-Type" => "application/x-www-form-urlencoded",
+                    "Accept" => "*/*",
+                ],
+                $this->headers,
+                $authHeaders,
+                $request->headers,
+                $options['headers'] ?? [],
+            ),
             MultipartApiRequest::class => array_merge(
                 $this->headers,
                 $authHeaders,
@@ -185,6 +195,24 @@ class RawClient
                     ),
                 )
             );
+        }
+
+        if ($request instanceof UrlEncodedApiRequest) {
+            if ($request->body === null) {
+                return null;
+            }
+            $body = $this->buildJsonBody($request->body, $options);
+            if ($body instanceof JsonSerializable) {
+                $body = $body->jsonSerialize();
+            }
+            if ($body instanceof \stdClass) {
+                $body = (array)$body;
+            }
+            if (!is_array($body)) {
+                throw new InvalidArgumentException('Form-urlencoded request body must serialize to an array');
+            }
+            $body = array_filter($body, static fn ($value) => $value !== null);
+            return $this->streamFactory->createStream(http_build_query($body));
         }
 
         if ($request instanceof MultipartApiRequest) {

--- a/seed/php-sdk/single-url-environment-default/src/Core/Client/UrlEncodedApiRequest.php
+++ b/seed/php-sdk/single-url-environment-default/src/Core/Client/UrlEncodedApiRequest.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Seed\Core\Client;
+
+class UrlEncodedApiRequest extends BaseApiRequest
+{
+    /**
+     * @param string $baseUrl The base URL for the request
+     * @param string $path The path for the request
+     * @param HttpMethod $method The HTTP method for the request
+     * @param array<string, string> $headers Additional headers for the request (optional)
+     * @param array<string, mixed> $query Query parameters for the request (optional)
+     * @param mixed|null $body The form-urlencoded request body (optional)
+     */
+    public function __construct(
+        string $baseUrl,
+        string $path,
+        HttpMethod $method,
+        array $headers = [],
+        array $query = [],
+        public readonly mixed $body = null
+    ) {
+        parent::__construct($baseUrl, $path, $method, $headers, $query);
+    }
+}

--- a/seed/php-sdk/single-url-environment-no-default/.fern/metadata.json
+++ b/seed/php-sdk/single-url-environment-no-default/.fern/metadata.json
@@ -3,8 +3,7 @@
   "generatorName": "fernapi/fern-php-sdk",
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/php-sdk/single-url-environment-no-default/src/Core/Client/RawClient.php
+++ b/seed/php-sdk/single-url-environment-no-default/src/Core/Client/RawClient.php
@@ -155,6 +155,16 @@ class RawClient
                 $request->headers,
                 $options['headers'] ?? [],
             ),
+            UrlEncodedApiRequest::class => array_merge(
+                [
+                    "Content-Type" => "application/x-www-form-urlencoded",
+                    "Accept" => "*/*",
+                ],
+                $this->headers,
+                $authHeaders,
+                $request->headers,
+                $options['headers'] ?? [],
+            ),
             MultipartApiRequest::class => array_merge(
                 $this->headers,
                 $authHeaders,
@@ -185,6 +195,24 @@ class RawClient
                     ),
                 )
             );
+        }
+
+        if ($request instanceof UrlEncodedApiRequest) {
+            if ($request->body === null) {
+                return null;
+            }
+            $body = $this->buildJsonBody($request->body, $options);
+            if ($body instanceof JsonSerializable) {
+                $body = $body->jsonSerialize();
+            }
+            if ($body instanceof \stdClass) {
+                $body = (array)$body;
+            }
+            if (!is_array($body)) {
+                throw new InvalidArgumentException('Form-urlencoded request body must serialize to an array');
+            }
+            $body = array_filter($body, static fn ($value) => $value !== null);
+            return $this->streamFactory->createStream(http_build_query($body));
         }
 
         if ($request instanceof MultipartApiRequest) {

--- a/seed/php-sdk/single-url-environment-no-default/src/Core/Client/UrlEncodedApiRequest.php
+++ b/seed/php-sdk/single-url-environment-no-default/src/Core/Client/UrlEncodedApiRequest.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Seed\Core\Client;
+
+class UrlEncodedApiRequest extends BaseApiRequest
+{
+    /**
+     * @param string $baseUrl The base URL for the request
+     * @param string $path The path for the request
+     * @param HttpMethod $method The HTTP method for the request
+     * @param array<string, string> $headers Additional headers for the request (optional)
+     * @param array<string, mixed> $query Query parameters for the request (optional)
+     * @param mixed|null $body The form-urlencoded request body (optional)
+     */
+    public function __construct(
+        string $baseUrl,
+        string $path,
+        HttpMethod $method,
+        array $headers = [],
+        array $query = [],
+        public readonly mixed $body = null
+    ) {
+        parent::__construct($baseUrl, $path, $method, $headers, $query);
+    }
+}

--- a/seed/php-sdk/streaming-parameter/.fern/metadata.json
+++ b/seed/php-sdk/streaming-parameter/.fern/metadata.json
@@ -3,8 +3,7 @@
   "generatorName": "fernapi/fern-php-sdk",
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/php-sdk/streaming-parameter/src/Core/Client/RawClient.php
+++ b/seed/php-sdk/streaming-parameter/src/Core/Client/RawClient.php
@@ -155,6 +155,16 @@ class RawClient
                 $request->headers,
                 $options['headers'] ?? [],
             ),
+            UrlEncodedApiRequest::class => array_merge(
+                [
+                    "Content-Type" => "application/x-www-form-urlencoded",
+                    "Accept" => "*/*",
+                ],
+                $this->headers,
+                $authHeaders,
+                $request->headers,
+                $options['headers'] ?? [],
+            ),
             MultipartApiRequest::class => array_merge(
                 $this->headers,
                 $authHeaders,
@@ -185,6 +195,24 @@ class RawClient
                     ),
                 )
             );
+        }
+
+        if ($request instanceof UrlEncodedApiRequest) {
+            if ($request->body === null) {
+                return null;
+            }
+            $body = $this->buildJsonBody($request->body, $options);
+            if ($body instanceof JsonSerializable) {
+                $body = $body->jsonSerialize();
+            }
+            if ($body instanceof \stdClass) {
+                $body = (array)$body;
+            }
+            if (!is_array($body)) {
+                throw new InvalidArgumentException('Form-urlencoded request body must serialize to an array');
+            }
+            $body = array_filter($body, static fn ($value) => $value !== null);
+            return $this->streamFactory->createStream(http_build_query($body));
         }
 
         if ($request instanceof MultipartApiRequest) {

--- a/seed/php-sdk/streaming-parameter/src/Core/Client/UrlEncodedApiRequest.php
+++ b/seed/php-sdk/streaming-parameter/src/Core/Client/UrlEncodedApiRequest.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Seed\Core\Client;
+
+class UrlEncodedApiRequest extends BaseApiRequest
+{
+    /**
+     * @param string $baseUrl The base URL for the request
+     * @param string $path The path for the request
+     * @param HttpMethod $method The HTTP method for the request
+     * @param array<string, string> $headers Additional headers for the request (optional)
+     * @param array<string, mixed> $query Query parameters for the request (optional)
+     * @param mixed|null $body The form-urlencoded request body (optional)
+     */
+    public function __construct(
+        string $baseUrl,
+        string $path,
+        HttpMethod $method,
+        array $headers = [],
+        array $query = [],
+        public readonly mixed $body = null
+    ) {
+        parent::__construct($baseUrl, $path, $method, $headers, $query);
+    }
+}

--- a/seed/php-sdk/streaming/.fern/metadata.json
+++ b/seed/php-sdk/streaming/.fern/metadata.json
@@ -3,8 +3,7 @@
   "generatorName": "fernapi/fern-php-sdk",
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/php-sdk/streaming/src/Core/Client/RawClient.php
+++ b/seed/php-sdk/streaming/src/Core/Client/RawClient.php
@@ -155,6 +155,16 @@ class RawClient
                 $request->headers,
                 $options['headers'] ?? [],
             ),
+            UrlEncodedApiRequest::class => array_merge(
+                [
+                    "Content-Type" => "application/x-www-form-urlencoded",
+                    "Accept" => "*/*",
+                ],
+                $this->headers,
+                $authHeaders,
+                $request->headers,
+                $options['headers'] ?? [],
+            ),
             MultipartApiRequest::class => array_merge(
                 $this->headers,
                 $authHeaders,
@@ -185,6 +195,24 @@ class RawClient
                     ),
                 )
             );
+        }
+
+        if ($request instanceof UrlEncodedApiRequest) {
+            if ($request->body === null) {
+                return null;
+            }
+            $body = $this->buildJsonBody($request->body, $options);
+            if ($body instanceof JsonSerializable) {
+                $body = $body->jsonSerialize();
+            }
+            if ($body instanceof \stdClass) {
+                $body = (array)$body;
+            }
+            if (!is_array($body)) {
+                throw new InvalidArgumentException('Form-urlencoded request body must serialize to an array');
+            }
+            $body = array_filter($body, static fn ($value) => $value !== null);
+            return $this->streamFactory->createStream(http_build_query($body));
         }
 
         if ($request instanceof MultipartApiRequest) {

--- a/seed/php-sdk/streaming/src/Core/Client/UrlEncodedApiRequest.php
+++ b/seed/php-sdk/streaming/src/Core/Client/UrlEncodedApiRequest.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Seed\Core\Client;
+
+class UrlEncodedApiRequest extends BaseApiRequest
+{
+    /**
+     * @param string $baseUrl The base URL for the request
+     * @param string $path The path for the request
+     * @param HttpMethod $method The HTTP method for the request
+     * @param array<string, string> $headers Additional headers for the request (optional)
+     * @param array<string, mixed> $query Query parameters for the request (optional)
+     * @param mixed|null $body The form-urlencoded request body (optional)
+     */
+    public function __construct(
+        string $baseUrl,
+        string $path,
+        HttpMethod $method,
+        array $headers = [],
+        array $query = [],
+        public readonly mixed $body = null
+    ) {
+        parent::__construct($baseUrl, $path, $method, $headers, $query);
+    }
+}

--- a/seed/php-sdk/trace/.fern/metadata.json
+++ b/seed/php-sdk/trace/.fern/metadata.json
@@ -3,8 +3,7 @@
   "generatorName": "fernapi/fern-php-sdk",
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/php-sdk/trace/src/Core/Client/RawClient.php
+++ b/seed/php-sdk/trace/src/Core/Client/RawClient.php
@@ -155,6 +155,16 @@ class RawClient
                 $request->headers,
                 $options['headers'] ?? [],
             ),
+            UrlEncodedApiRequest::class => array_merge(
+                [
+                    "Content-Type" => "application/x-www-form-urlencoded",
+                    "Accept" => "*/*",
+                ],
+                $this->headers,
+                $authHeaders,
+                $request->headers,
+                $options['headers'] ?? [],
+            ),
             MultipartApiRequest::class => array_merge(
                 $this->headers,
                 $authHeaders,
@@ -185,6 +195,24 @@ class RawClient
                     ),
                 )
             );
+        }
+
+        if ($request instanceof UrlEncodedApiRequest) {
+            if ($request->body === null) {
+                return null;
+            }
+            $body = $this->buildJsonBody($request->body, $options);
+            if ($body instanceof JsonSerializable) {
+                $body = $body->jsonSerialize();
+            }
+            if ($body instanceof \stdClass) {
+                $body = (array)$body;
+            }
+            if (!is_array($body)) {
+                throw new InvalidArgumentException('Form-urlencoded request body must serialize to an array');
+            }
+            $body = array_filter($body, static fn ($value) => $value !== null);
+            return $this->streamFactory->createStream(http_build_query($body));
         }
 
         if ($request instanceof MultipartApiRequest) {

--- a/seed/php-sdk/trace/src/Core/Client/UrlEncodedApiRequest.php
+++ b/seed/php-sdk/trace/src/Core/Client/UrlEncodedApiRequest.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Seed\Core\Client;
+
+class UrlEncodedApiRequest extends BaseApiRequest
+{
+    /**
+     * @param string $baseUrl The base URL for the request
+     * @param string $path The path for the request
+     * @param HttpMethod $method The HTTP method for the request
+     * @param array<string, string> $headers Additional headers for the request (optional)
+     * @param array<string, mixed> $query Query parameters for the request (optional)
+     * @param mixed|null $body The form-urlencoded request body (optional)
+     */
+    public function __construct(
+        string $baseUrl,
+        string $path,
+        HttpMethod $method,
+        array $headers = [],
+        array $query = [],
+        public readonly mixed $body = null
+    ) {
+        parent::__construct($baseUrl, $path, $method, $headers, $query);
+    }
+}

--- a/seed/php-sdk/undiscriminated-union-with-response-property/.fern/metadata.json
+++ b/seed/php-sdk/undiscriminated-union-with-response-property/.fern/metadata.json
@@ -3,8 +3,7 @@
   "generatorName": "fernapi/fern-php-sdk",
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/php-sdk/undiscriminated-union-with-response-property/src/Core/Client/RawClient.php
+++ b/seed/php-sdk/undiscriminated-union-with-response-property/src/Core/Client/RawClient.php
@@ -155,6 +155,16 @@ class RawClient
                 $request->headers,
                 $options['headers'] ?? [],
             ),
+            UrlEncodedApiRequest::class => array_merge(
+                [
+                    "Content-Type" => "application/x-www-form-urlencoded",
+                    "Accept" => "*/*",
+                ],
+                $this->headers,
+                $authHeaders,
+                $request->headers,
+                $options['headers'] ?? [],
+            ),
             MultipartApiRequest::class => array_merge(
                 $this->headers,
                 $authHeaders,
@@ -185,6 +195,24 @@ class RawClient
                     ),
                 )
             );
+        }
+
+        if ($request instanceof UrlEncodedApiRequest) {
+            if ($request->body === null) {
+                return null;
+            }
+            $body = $this->buildJsonBody($request->body, $options);
+            if ($body instanceof JsonSerializable) {
+                $body = $body->jsonSerialize();
+            }
+            if ($body instanceof \stdClass) {
+                $body = (array)$body;
+            }
+            if (!is_array($body)) {
+                throw new InvalidArgumentException('Form-urlencoded request body must serialize to an array');
+            }
+            $body = array_filter($body, static fn ($value) => $value !== null);
+            return $this->streamFactory->createStream(http_build_query($body));
         }
 
         if ($request instanceof MultipartApiRequest) {

--- a/seed/php-sdk/undiscriminated-union-with-response-property/src/Core/Client/UrlEncodedApiRequest.php
+++ b/seed/php-sdk/undiscriminated-union-with-response-property/src/Core/Client/UrlEncodedApiRequest.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Seed\Core\Client;
+
+class UrlEncodedApiRequest extends BaseApiRequest
+{
+    /**
+     * @param string $baseUrl The base URL for the request
+     * @param string $path The path for the request
+     * @param HttpMethod $method The HTTP method for the request
+     * @param array<string, string> $headers Additional headers for the request (optional)
+     * @param array<string, mixed> $query Query parameters for the request (optional)
+     * @param mixed|null $body The form-urlencoded request body (optional)
+     */
+    public function __construct(
+        string $baseUrl,
+        string $path,
+        HttpMethod $method,
+        array $headers = [],
+        array $query = [],
+        public readonly mixed $body = null
+    ) {
+        parent::__construct($baseUrl, $path, $method, $headers, $query);
+    }
+}

--- a/seed/php-sdk/undiscriminated-unions/.fern/metadata.json
+++ b/seed/php-sdk/undiscriminated-unions/.fern/metadata.json
@@ -3,8 +3,7 @@
   "generatorName": "fernapi/fern-php-sdk",
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/php-sdk/undiscriminated-unions/src/Core/Client/RawClient.php
+++ b/seed/php-sdk/undiscriminated-unions/src/Core/Client/RawClient.php
@@ -155,6 +155,16 @@ class RawClient
                 $request->headers,
                 $options['headers'] ?? [],
             ),
+            UrlEncodedApiRequest::class => array_merge(
+                [
+                    "Content-Type" => "application/x-www-form-urlencoded",
+                    "Accept" => "*/*",
+                ],
+                $this->headers,
+                $authHeaders,
+                $request->headers,
+                $options['headers'] ?? [],
+            ),
             MultipartApiRequest::class => array_merge(
                 $this->headers,
                 $authHeaders,
@@ -185,6 +195,24 @@ class RawClient
                     ),
                 )
             );
+        }
+
+        if ($request instanceof UrlEncodedApiRequest) {
+            if ($request->body === null) {
+                return null;
+            }
+            $body = $this->buildJsonBody($request->body, $options);
+            if ($body instanceof JsonSerializable) {
+                $body = $body->jsonSerialize();
+            }
+            if ($body instanceof \stdClass) {
+                $body = (array)$body;
+            }
+            if (!is_array($body)) {
+                throw new InvalidArgumentException('Form-urlencoded request body must serialize to an array');
+            }
+            $body = array_filter($body, static fn ($value) => $value !== null);
+            return $this->streamFactory->createStream(http_build_query($body));
         }
 
         if ($request instanceof MultipartApiRequest) {

--- a/seed/php-sdk/undiscriminated-unions/src/Core/Client/UrlEncodedApiRequest.php
+++ b/seed/php-sdk/undiscriminated-unions/src/Core/Client/UrlEncodedApiRequest.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Seed\Core\Client;
+
+class UrlEncodedApiRequest extends BaseApiRequest
+{
+    /**
+     * @param string $baseUrl The base URL for the request
+     * @param string $path The path for the request
+     * @param HttpMethod $method The HTTP method for the request
+     * @param array<string, string> $headers Additional headers for the request (optional)
+     * @param array<string, mixed> $query Query parameters for the request (optional)
+     * @param mixed|null $body The form-urlencoded request body (optional)
+     */
+    public function __construct(
+        string $baseUrl,
+        string $path,
+        HttpMethod $method,
+        array $headers = [],
+        array $query = [],
+        public readonly mixed $body = null
+    ) {
+        parent::__construct($baseUrl, $path, $method, $headers, $query);
+    }
+}

--- a/seed/php-sdk/union-query-parameters/.fern/metadata.json
+++ b/seed/php-sdk/union-query-parameters/.fern/metadata.json
@@ -3,8 +3,7 @@
   "generatorName": "fernapi/fern-php-sdk",
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/php-sdk/union-query-parameters/src/Core/Client/RawClient.php
+++ b/seed/php-sdk/union-query-parameters/src/Core/Client/RawClient.php
@@ -155,6 +155,16 @@ class RawClient
                 $request->headers,
                 $options['headers'] ?? [],
             ),
+            UrlEncodedApiRequest::class => array_merge(
+                [
+                    "Content-Type" => "application/x-www-form-urlencoded",
+                    "Accept" => "*/*",
+                ],
+                $this->headers,
+                $authHeaders,
+                $request->headers,
+                $options['headers'] ?? [],
+            ),
             MultipartApiRequest::class => array_merge(
                 $this->headers,
                 $authHeaders,
@@ -185,6 +195,24 @@ class RawClient
                     ),
                 )
             );
+        }
+
+        if ($request instanceof UrlEncodedApiRequest) {
+            if ($request->body === null) {
+                return null;
+            }
+            $body = $this->buildJsonBody($request->body, $options);
+            if ($body instanceof JsonSerializable) {
+                $body = $body->jsonSerialize();
+            }
+            if ($body instanceof \stdClass) {
+                $body = (array)$body;
+            }
+            if (!is_array($body)) {
+                throw new InvalidArgumentException('Form-urlencoded request body must serialize to an array');
+            }
+            $body = array_filter($body, static fn ($value) => $value !== null);
+            return $this->streamFactory->createStream(http_build_query($body));
         }
 
         if ($request instanceof MultipartApiRequest) {

--- a/seed/php-sdk/union-query-parameters/src/Core/Client/UrlEncodedApiRequest.php
+++ b/seed/php-sdk/union-query-parameters/src/Core/Client/UrlEncodedApiRequest.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Seed\Core\Client;
+
+class UrlEncodedApiRequest extends BaseApiRequest
+{
+    /**
+     * @param string $baseUrl The base URL for the request
+     * @param string $path The path for the request
+     * @param HttpMethod $method The HTTP method for the request
+     * @param array<string, string> $headers Additional headers for the request (optional)
+     * @param array<string, mixed> $query Query parameters for the request (optional)
+     * @param mixed|null $body The form-urlencoded request body (optional)
+     */
+    public function __construct(
+        string $baseUrl,
+        string $path,
+        HttpMethod $method,
+        array $headers = [],
+        array $query = [],
+        public readonly mixed $body = null
+    ) {
+        parent::__construct($baseUrl, $path, $method, $headers, $query);
+    }
+}

--- a/seed/php-sdk/unions-with-local-date/.fern/metadata.json
+++ b/seed/php-sdk/unions-with-local-date/.fern/metadata.json
@@ -3,8 +3,7 @@
   "generatorName": "fernapi/fern-php-sdk",
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/php-sdk/unions-with-local-date/src/Core/Client/RawClient.php
+++ b/seed/php-sdk/unions-with-local-date/src/Core/Client/RawClient.php
@@ -155,6 +155,16 @@ class RawClient
                 $request->headers,
                 $options['headers'] ?? [],
             ),
+            UrlEncodedApiRequest::class => array_merge(
+                [
+                    "Content-Type" => "application/x-www-form-urlencoded",
+                    "Accept" => "*/*",
+                ],
+                $this->headers,
+                $authHeaders,
+                $request->headers,
+                $options['headers'] ?? [],
+            ),
             MultipartApiRequest::class => array_merge(
                 $this->headers,
                 $authHeaders,
@@ -185,6 +195,24 @@ class RawClient
                     ),
                 )
             );
+        }
+
+        if ($request instanceof UrlEncodedApiRequest) {
+            if ($request->body === null) {
+                return null;
+            }
+            $body = $this->buildJsonBody($request->body, $options);
+            if ($body instanceof JsonSerializable) {
+                $body = $body->jsonSerialize();
+            }
+            if ($body instanceof \stdClass) {
+                $body = (array)$body;
+            }
+            if (!is_array($body)) {
+                throw new InvalidArgumentException('Form-urlencoded request body must serialize to an array');
+            }
+            $body = array_filter($body, static fn ($value) => $value !== null);
+            return $this->streamFactory->createStream(http_build_query($body));
         }
 
         if ($request instanceof MultipartApiRequest) {

--- a/seed/php-sdk/unions-with-local-date/src/Core/Client/UrlEncodedApiRequest.php
+++ b/seed/php-sdk/unions-with-local-date/src/Core/Client/UrlEncodedApiRequest.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Seed\Core\Client;
+
+class UrlEncodedApiRequest extends BaseApiRequest
+{
+    /**
+     * @param string $baseUrl The base URL for the request
+     * @param string $path The path for the request
+     * @param HttpMethod $method The HTTP method for the request
+     * @param array<string, string> $headers Additional headers for the request (optional)
+     * @param array<string, mixed> $query Query parameters for the request (optional)
+     * @param mixed|null $body The form-urlencoded request body (optional)
+     */
+    public function __construct(
+        string $baseUrl,
+        string $path,
+        HttpMethod $method,
+        array $headers = [],
+        array $query = [],
+        public readonly mixed $body = null
+    ) {
+        parent::__construct($baseUrl, $path, $method, $headers, $query);
+    }
+}

--- a/seed/php-sdk/unions/no-custom-config/.fern/metadata.json
+++ b/seed/php-sdk/unions/no-custom-config/.fern/metadata.json
@@ -3,8 +3,7 @@
   "generatorName": "fernapi/fern-php-sdk",
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/php-sdk/unions/no-custom-config/src/Core/Client/RawClient.php
+++ b/seed/php-sdk/unions/no-custom-config/src/Core/Client/RawClient.php
@@ -155,6 +155,16 @@ class RawClient
                 $request->headers,
                 $options['headers'] ?? [],
             ),
+            UrlEncodedApiRequest::class => array_merge(
+                [
+                    "Content-Type" => "application/x-www-form-urlencoded",
+                    "Accept" => "*/*",
+                ],
+                $this->headers,
+                $authHeaders,
+                $request->headers,
+                $options['headers'] ?? [],
+            ),
             MultipartApiRequest::class => array_merge(
                 $this->headers,
                 $authHeaders,
@@ -185,6 +195,24 @@ class RawClient
                     ),
                 )
             );
+        }
+
+        if ($request instanceof UrlEncodedApiRequest) {
+            if ($request->body === null) {
+                return null;
+            }
+            $body = $this->buildJsonBody($request->body, $options);
+            if ($body instanceof JsonSerializable) {
+                $body = $body->jsonSerialize();
+            }
+            if ($body instanceof \stdClass) {
+                $body = (array)$body;
+            }
+            if (!is_array($body)) {
+                throw new InvalidArgumentException('Form-urlencoded request body must serialize to an array');
+            }
+            $body = array_filter($body, static fn ($value) => $value !== null);
+            return $this->streamFactory->createStream(http_build_query($body));
         }
 
         if ($request instanceof MultipartApiRequest) {

--- a/seed/php-sdk/unions/no-custom-config/src/Core/Client/UrlEncodedApiRequest.php
+++ b/seed/php-sdk/unions/no-custom-config/src/Core/Client/UrlEncodedApiRequest.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Seed\Core\Client;
+
+class UrlEncodedApiRequest extends BaseApiRequest
+{
+    /**
+     * @param string $baseUrl The base URL for the request
+     * @param string $path The path for the request
+     * @param HttpMethod $method The HTTP method for the request
+     * @param array<string, string> $headers Additional headers for the request (optional)
+     * @param array<string, mixed> $query Query parameters for the request (optional)
+     * @param mixed|null $body The form-urlencoded request body (optional)
+     */
+    public function __construct(
+        string $baseUrl,
+        string $path,
+        HttpMethod $method,
+        array $headers = [],
+        array $query = [],
+        public readonly mixed $body = null
+    ) {
+        parent::__construct($baseUrl, $path, $method, $headers, $query);
+    }
+}

--- a/seed/php-sdk/unions/property-accessors/.fern/metadata.json
+++ b/seed/php-sdk/unions/property-accessors/.fern/metadata.json
@@ -6,8 +6,7 @@
     "propertyAccess": "private"
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/php-sdk/unions/property-accessors/src/Core/Client/RawClient.php
+++ b/seed/php-sdk/unions/property-accessors/src/Core/Client/RawClient.php
@@ -155,6 +155,16 @@ class RawClient
                 $request->headers,
                 $options['headers'] ?? [],
             ),
+            UrlEncodedApiRequest::class => array_merge(
+                [
+                    "Content-Type" => "application/x-www-form-urlencoded",
+                    "Accept" => "*/*",
+                ],
+                $this->headers,
+                $authHeaders,
+                $request->headers,
+                $options['headers'] ?? [],
+            ),
             MultipartApiRequest::class => array_merge(
                 $this->headers,
                 $authHeaders,
@@ -185,6 +195,24 @@ class RawClient
                     ),
                 )
             );
+        }
+
+        if ($request instanceof UrlEncodedApiRequest) {
+            if ($request->body === null) {
+                return null;
+            }
+            $body = $this->buildJsonBody($request->body, $options);
+            if ($body instanceof JsonSerializable) {
+                $body = $body->jsonSerialize();
+            }
+            if ($body instanceof \stdClass) {
+                $body = (array)$body;
+            }
+            if (!is_array($body)) {
+                throw new InvalidArgumentException('Form-urlencoded request body must serialize to an array');
+            }
+            $body = array_filter($body, static fn ($value) => $value !== null);
+            return $this->streamFactory->createStream(http_build_query($body));
         }
 
         if ($request instanceof MultipartApiRequest) {

--- a/seed/php-sdk/unions/property-accessors/src/Core/Client/UrlEncodedApiRequest.php
+++ b/seed/php-sdk/unions/property-accessors/src/Core/Client/UrlEncodedApiRequest.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Seed\Core\Client;
+
+class UrlEncodedApiRequest extends BaseApiRequest
+{
+    /**
+     * @param string $baseUrl The base URL for the request
+     * @param string $path The path for the request
+     * @param HttpMethod $method The HTTP method for the request
+     * @param array<string, string> $headers Additional headers for the request (optional)
+     * @param array<string, mixed> $query Query parameters for the request (optional)
+     * @param mixed|null $body The form-urlencoded request body (optional)
+     */
+    public function __construct(
+        string $baseUrl,
+        string $path,
+        HttpMethod $method,
+        array $headers = [],
+        array $query = [],
+        public readonly mixed $body = null
+    ) {
+        parent::__construct($baseUrl, $path, $method, $headers, $query);
+    }
+}

--- a/seed/php-sdk/unknown/.fern/metadata.json
+++ b/seed/php-sdk/unknown/.fern/metadata.json
@@ -3,8 +3,7 @@
   "generatorName": "fernapi/fern-php-sdk",
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/php-sdk/unknown/src/Core/Client/RawClient.php
+++ b/seed/php-sdk/unknown/src/Core/Client/RawClient.php
@@ -155,6 +155,16 @@ class RawClient
                 $request->headers,
                 $options['headers'] ?? [],
             ),
+            UrlEncodedApiRequest::class => array_merge(
+                [
+                    "Content-Type" => "application/x-www-form-urlencoded",
+                    "Accept" => "*/*",
+                ],
+                $this->headers,
+                $authHeaders,
+                $request->headers,
+                $options['headers'] ?? [],
+            ),
             MultipartApiRequest::class => array_merge(
                 $this->headers,
                 $authHeaders,
@@ -185,6 +195,24 @@ class RawClient
                     ),
                 )
             );
+        }
+
+        if ($request instanceof UrlEncodedApiRequest) {
+            if ($request->body === null) {
+                return null;
+            }
+            $body = $this->buildJsonBody($request->body, $options);
+            if ($body instanceof JsonSerializable) {
+                $body = $body->jsonSerialize();
+            }
+            if ($body instanceof \stdClass) {
+                $body = (array)$body;
+            }
+            if (!is_array($body)) {
+                throw new InvalidArgumentException('Form-urlencoded request body must serialize to an array');
+            }
+            $body = array_filter($body, static fn ($value) => $value !== null);
+            return $this->streamFactory->createStream(http_build_query($body));
         }
 
         if ($request instanceof MultipartApiRequest) {

--- a/seed/php-sdk/unknown/src/Core/Client/UrlEncodedApiRequest.php
+++ b/seed/php-sdk/unknown/src/Core/Client/UrlEncodedApiRequest.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Seed\Core\Client;
+
+class UrlEncodedApiRequest extends BaseApiRequest
+{
+    /**
+     * @param string $baseUrl The base URL for the request
+     * @param string $path The path for the request
+     * @param HttpMethod $method The HTTP method for the request
+     * @param array<string, string> $headers Additional headers for the request (optional)
+     * @param array<string, mixed> $query Query parameters for the request (optional)
+     * @param mixed|null $body The form-urlencoded request body (optional)
+     */
+    public function __construct(
+        string $baseUrl,
+        string $path,
+        HttpMethod $method,
+        array $headers = [],
+        array $query = [],
+        public readonly mixed $body = null
+    ) {
+        parent::__construct($baseUrl, $path, $method, $headers, $query);
+    }
+}

--- a/seed/php-sdk/url-form-encoded/.fern/metadata.json
+++ b/seed/php-sdk/url-form-encoded/.fern/metadata.json
@@ -3,8 +3,7 @@
   "generatorName": "fernapi/fern-php-sdk",
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/php-sdk/url-form-encoded/src/Core/Client/RawClient.php
+++ b/seed/php-sdk/url-form-encoded/src/Core/Client/RawClient.php
@@ -155,6 +155,16 @@ class RawClient
                 $request->headers,
                 $options['headers'] ?? [],
             ),
+            UrlEncodedApiRequest::class => array_merge(
+                [
+                    "Content-Type" => "application/x-www-form-urlencoded",
+                    "Accept" => "*/*",
+                ],
+                $this->headers,
+                $authHeaders,
+                $request->headers,
+                $options['headers'] ?? [],
+            ),
             MultipartApiRequest::class => array_merge(
                 $this->headers,
                 $authHeaders,
@@ -185,6 +195,24 @@ class RawClient
                     ),
                 )
             );
+        }
+
+        if ($request instanceof UrlEncodedApiRequest) {
+            if ($request->body === null) {
+                return null;
+            }
+            $body = $this->buildJsonBody($request->body, $options);
+            if ($body instanceof JsonSerializable) {
+                $body = $body->jsonSerialize();
+            }
+            if ($body instanceof \stdClass) {
+                $body = (array)$body;
+            }
+            if (!is_array($body)) {
+                throw new InvalidArgumentException('Form-urlencoded request body must serialize to an array');
+            }
+            $body = array_filter($body, static fn ($value) => $value !== null);
+            return $this->streamFactory->createStream(http_build_query($body));
         }
 
         if ($request instanceof MultipartApiRequest) {

--- a/seed/php-sdk/url-form-encoded/src/Core/Client/UrlEncodedApiRequest.php
+++ b/seed/php-sdk/url-form-encoded/src/Core/Client/UrlEncodedApiRequest.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Seed\Core\Client;
+
+class UrlEncodedApiRequest extends BaseApiRequest
+{
+    /**
+     * @param string $baseUrl The base URL for the request
+     * @param string $path The path for the request
+     * @param HttpMethod $method The HTTP method for the request
+     * @param array<string, string> $headers Additional headers for the request (optional)
+     * @param array<string, mixed> $query Query parameters for the request (optional)
+     * @param mixed|null $body The form-urlencoded request body (optional)
+     */
+    public function __construct(
+        string $baseUrl,
+        string $path,
+        HttpMethod $method,
+        array $headers = [],
+        array $query = [],
+        public readonly mixed $body = null
+    ) {
+        parent::__construct($baseUrl, $path, $method, $headers, $query);
+    }
+}

--- a/seed/php-sdk/url-form-encoded/src/SeedClient.php
+++ b/seed/php-sdk/url-form-encoded/src/SeedClient.php
@@ -8,7 +8,7 @@ use Seed\Requests\PostSubmitRequest;
 use Seed\Types\PostSubmitResponse;
 use Seed\Exceptions\SeedException;
 use Seed\Exceptions\SeedApiException;
-use Seed\Core\Json\JsonApiRequest;
+use Seed\Core\Client\UrlEncodedApiRequest;
 use Seed\Core\Client\HttpMethod;
 use JsonException;
 use Psr\Http\Client\ClientExceptionInterface;
@@ -83,7 +83,7 @@ class SeedClient
         $options = array_merge($this->options, $options ?? []);
         try {
             $response = $this->client->sendRequest(
-                new JsonApiRequest(
+                new UrlEncodedApiRequest(
                     baseUrl: $options['baseUrl'] ?? $this->client->options['baseUrl'] ?? '',
                     path: "submit",
                     method: HttpMethod::POST,
@@ -130,7 +130,7 @@ class SeedClient
         $options = array_merge($this->options, $options ?? []);
         try {
             $response = $this->client->sendRequest(
-                new JsonApiRequest(
+                new UrlEncodedApiRequest(
                     baseUrl: $options['baseUrl'] ?? $this->client->options['baseUrl'] ?? '',
                     path: "token",
                     method: HttpMethod::POST,

--- a/seed/php-sdk/validation/.fern/metadata.json
+++ b/seed/php-sdk/validation/.fern/metadata.json
@@ -3,8 +3,7 @@
   "generatorName": "fernapi/fern-php-sdk",
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/php-sdk/validation/src/Core/Client/RawClient.php
+++ b/seed/php-sdk/validation/src/Core/Client/RawClient.php
@@ -155,6 +155,16 @@ class RawClient
                 $request->headers,
                 $options['headers'] ?? [],
             ),
+            UrlEncodedApiRequest::class => array_merge(
+                [
+                    "Content-Type" => "application/x-www-form-urlencoded",
+                    "Accept" => "*/*",
+                ],
+                $this->headers,
+                $authHeaders,
+                $request->headers,
+                $options['headers'] ?? [],
+            ),
             MultipartApiRequest::class => array_merge(
                 $this->headers,
                 $authHeaders,
@@ -185,6 +195,24 @@ class RawClient
                     ),
                 )
             );
+        }
+
+        if ($request instanceof UrlEncodedApiRequest) {
+            if ($request->body === null) {
+                return null;
+            }
+            $body = $this->buildJsonBody($request->body, $options);
+            if ($body instanceof JsonSerializable) {
+                $body = $body->jsonSerialize();
+            }
+            if ($body instanceof \stdClass) {
+                $body = (array)$body;
+            }
+            if (!is_array($body)) {
+                throw new InvalidArgumentException('Form-urlencoded request body must serialize to an array');
+            }
+            $body = array_filter($body, static fn ($value) => $value !== null);
+            return $this->streamFactory->createStream(http_build_query($body));
         }
 
         if ($request instanceof MultipartApiRequest) {

--- a/seed/php-sdk/validation/src/Core/Client/UrlEncodedApiRequest.php
+++ b/seed/php-sdk/validation/src/Core/Client/UrlEncodedApiRequest.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Seed\Core\Client;
+
+class UrlEncodedApiRequest extends BaseApiRequest
+{
+    /**
+     * @param string $baseUrl The base URL for the request
+     * @param string $path The path for the request
+     * @param HttpMethod $method The HTTP method for the request
+     * @param array<string, string> $headers Additional headers for the request (optional)
+     * @param array<string, mixed> $query Query parameters for the request (optional)
+     * @param mixed|null $body The form-urlencoded request body (optional)
+     */
+    public function __construct(
+        string $baseUrl,
+        string $path,
+        HttpMethod $method,
+        array $headers = [],
+        array $query = [],
+        public readonly mixed $body = null
+    ) {
+        parent::__construct($baseUrl, $path, $method, $headers, $query);
+    }
+}

--- a/seed/php-sdk/variables/.fern/metadata.json
+++ b/seed/php-sdk/variables/.fern/metadata.json
@@ -3,8 +3,7 @@
   "generatorName": "fernapi/fern-php-sdk",
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/php-sdk/variables/src/Core/Client/RawClient.php
+++ b/seed/php-sdk/variables/src/Core/Client/RawClient.php
@@ -155,6 +155,16 @@ class RawClient
                 $request->headers,
                 $options['headers'] ?? [],
             ),
+            UrlEncodedApiRequest::class => array_merge(
+                [
+                    "Content-Type" => "application/x-www-form-urlencoded",
+                    "Accept" => "*/*",
+                ],
+                $this->headers,
+                $authHeaders,
+                $request->headers,
+                $options['headers'] ?? [],
+            ),
             MultipartApiRequest::class => array_merge(
                 $this->headers,
                 $authHeaders,
@@ -185,6 +195,24 @@ class RawClient
                     ),
                 )
             );
+        }
+
+        if ($request instanceof UrlEncodedApiRequest) {
+            if ($request->body === null) {
+                return null;
+            }
+            $body = $this->buildJsonBody($request->body, $options);
+            if ($body instanceof JsonSerializable) {
+                $body = $body->jsonSerialize();
+            }
+            if ($body instanceof \stdClass) {
+                $body = (array)$body;
+            }
+            if (!is_array($body)) {
+                throw new InvalidArgumentException('Form-urlencoded request body must serialize to an array');
+            }
+            $body = array_filter($body, static fn ($value) => $value !== null);
+            return $this->streamFactory->createStream(http_build_query($body));
         }
 
         if ($request instanceof MultipartApiRequest) {

--- a/seed/php-sdk/variables/src/Core/Client/UrlEncodedApiRequest.php
+++ b/seed/php-sdk/variables/src/Core/Client/UrlEncodedApiRequest.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Seed\Core\Client;
+
+class UrlEncodedApiRequest extends BaseApiRequest
+{
+    /**
+     * @param string $baseUrl The base URL for the request
+     * @param string $path The path for the request
+     * @param HttpMethod $method The HTTP method for the request
+     * @param array<string, string> $headers Additional headers for the request (optional)
+     * @param array<string, mixed> $query Query parameters for the request (optional)
+     * @param mixed|null $body The form-urlencoded request body (optional)
+     */
+    public function __construct(
+        string $baseUrl,
+        string $path,
+        HttpMethod $method,
+        array $headers = [],
+        array $query = [],
+        public readonly mixed $body = null
+    ) {
+        parent::__construct($baseUrl, $path, $method, $headers, $query);
+    }
+}

--- a/seed/php-sdk/version-no-default/.fern/metadata.json
+++ b/seed/php-sdk/version-no-default/.fern/metadata.json
@@ -3,8 +3,7 @@
   "generatorName": "fernapi/fern-php-sdk",
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/php-sdk/version-no-default/src/Core/Client/RawClient.php
+++ b/seed/php-sdk/version-no-default/src/Core/Client/RawClient.php
@@ -155,6 +155,16 @@ class RawClient
                 $request->headers,
                 $options['headers'] ?? [],
             ),
+            UrlEncodedApiRequest::class => array_merge(
+                [
+                    "Content-Type" => "application/x-www-form-urlencoded",
+                    "Accept" => "*/*",
+                ],
+                $this->headers,
+                $authHeaders,
+                $request->headers,
+                $options['headers'] ?? [],
+            ),
             MultipartApiRequest::class => array_merge(
                 $this->headers,
                 $authHeaders,
@@ -185,6 +195,24 @@ class RawClient
                     ),
                 )
             );
+        }
+
+        if ($request instanceof UrlEncodedApiRequest) {
+            if ($request->body === null) {
+                return null;
+            }
+            $body = $this->buildJsonBody($request->body, $options);
+            if ($body instanceof JsonSerializable) {
+                $body = $body->jsonSerialize();
+            }
+            if ($body instanceof \stdClass) {
+                $body = (array)$body;
+            }
+            if (!is_array($body)) {
+                throw new InvalidArgumentException('Form-urlencoded request body must serialize to an array');
+            }
+            $body = array_filter($body, static fn ($value) => $value !== null);
+            return $this->streamFactory->createStream(http_build_query($body));
         }
 
         if ($request instanceof MultipartApiRequest) {

--- a/seed/php-sdk/version-no-default/src/Core/Client/UrlEncodedApiRequest.php
+++ b/seed/php-sdk/version-no-default/src/Core/Client/UrlEncodedApiRequest.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Seed\Core\Client;
+
+class UrlEncodedApiRequest extends BaseApiRequest
+{
+    /**
+     * @param string $baseUrl The base URL for the request
+     * @param string $path The path for the request
+     * @param HttpMethod $method The HTTP method for the request
+     * @param array<string, string> $headers Additional headers for the request (optional)
+     * @param array<string, mixed> $query Query parameters for the request (optional)
+     * @param mixed|null $body The form-urlencoded request body (optional)
+     */
+    public function __construct(
+        string $baseUrl,
+        string $path,
+        HttpMethod $method,
+        array $headers = [],
+        array $query = [],
+        public readonly mixed $body = null
+    ) {
+        parent::__construct($baseUrl, $path, $method, $headers, $query);
+    }
+}

--- a/seed/php-sdk/version/.fern/metadata.json
+++ b/seed/php-sdk/version/.fern/metadata.json
@@ -3,8 +3,7 @@
   "generatorName": "fernapi/fern-php-sdk",
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/php-sdk/version/src/Core/Client/RawClient.php
+++ b/seed/php-sdk/version/src/Core/Client/RawClient.php
@@ -155,6 +155,16 @@ class RawClient
                 $request->headers,
                 $options['headers'] ?? [],
             ),
+            UrlEncodedApiRequest::class => array_merge(
+                [
+                    "Content-Type" => "application/x-www-form-urlencoded",
+                    "Accept" => "*/*",
+                ],
+                $this->headers,
+                $authHeaders,
+                $request->headers,
+                $options['headers'] ?? [],
+            ),
             MultipartApiRequest::class => array_merge(
                 $this->headers,
                 $authHeaders,
@@ -185,6 +195,24 @@ class RawClient
                     ),
                 )
             );
+        }
+
+        if ($request instanceof UrlEncodedApiRequest) {
+            if ($request->body === null) {
+                return null;
+            }
+            $body = $this->buildJsonBody($request->body, $options);
+            if ($body instanceof JsonSerializable) {
+                $body = $body->jsonSerialize();
+            }
+            if ($body instanceof \stdClass) {
+                $body = (array)$body;
+            }
+            if (!is_array($body)) {
+                throw new InvalidArgumentException('Form-urlencoded request body must serialize to an array');
+            }
+            $body = array_filter($body, static fn ($value) => $value !== null);
+            return $this->streamFactory->createStream(http_build_query($body));
         }
 
         if ($request instanceof MultipartApiRequest) {

--- a/seed/php-sdk/version/src/Core/Client/UrlEncodedApiRequest.php
+++ b/seed/php-sdk/version/src/Core/Client/UrlEncodedApiRequest.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Seed\Core\Client;
+
+class UrlEncodedApiRequest extends BaseApiRequest
+{
+    /**
+     * @param string $baseUrl The base URL for the request
+     * @param string $path The path for the request
+     * @param HttpMethod $method The HTTP method for the request
+     * @param array<string, string> $headers Additional headers for the request (optional)
+     * @param array<string, mixed> $query Query parameters for the request (optional)
+     * @param mixed|null $body The form-urlencoded request body (optional)
+     */
+    public function __construct(
+        string $baseUrl,
+        string $path,
+        HttpMethod $method,
+        array $headers = [],
+        array $query = [],
+        public readonly mixed $body = null
+    ) {
+        parent::__construct($baseUrl, $path, $method, $headers, $query);
+    }
+}

--- a/seed/php-sdk/webhook-audience/.fern/metadata.json
+++ b/seed/php-sdk/webhook-audience/.fern/metadata.json
@@ -3,8 +3,7 @@
   "generatorName": "fernapi/fern-php-sdk",
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/php-sdk/webhook-audience/src/Core/Client/RawClient.php
+++ b/seed/php-sdk/webhook-audience/src/Core/Client/RawClient.php
@@ -155,6 +155,16 @@ class RawClient
                 $request->headers,
                 $options['headers'] ?? [],
             ),
+            UrlEncodedApiRequest::class => array_merge(
+                [
+                    "Content-Type" => "application/x-www-form-urlencoded",
+                    "Accept" => "*/*",
+                ],
+                $this->headers,
+                $authHeaders,
+                $request->headers,
+                $options['headers'] ?? [],
+            ),
             MultipartApiRequest::class => array_merge(
                 $this->headers,
                 $authHeaders,
@@ -185,6 +195,24 @@ class RawClient
                     ),
                 )
             );
+        }
+
+        if ($request instanceof UrlEncodedApiRequest) {
+            if ($request->body === null) {
+                return null;
+            }
+            $body = $this->buildJsonBody($request->body, $options);
+            if ($body instanceof JsonSerializable) {
+                $body = $body->jsonSerialize();
+            }
+            if ($body instanceof \stdClass) {
+                $body = (array)$body;
+            }
+            if (!is_array($body)) {
+                throw new InvalidArgumentException('Form-urlencoded request body must serialize to an array');
+            }
+            $body = array_filter($body, static fn ($value) => $value !== null);
+            return $this->streamFactory->createStream(http_build_query($body));
         }
 
         if ($request instanceof MultipartApiRequest) {

--- a/seed/php-sdk/webhook-audience/src/Core/Client/UrlEncodedApiRequest.php
+++ b/seed/php-sdk/webhook-audience/src/Core/Client/UrlEncodedApiRequest.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Seed\Core\Client;
+
+class UrlEncodedApiRequest extends BaseApiRequest
+{
+    /**
+     * @param string $baseUrl The base URL for the request
+     * @param string $path The path for the request
+     * @param HttpMethod $method The HTTP method for the request
+     * @param array<string, string> $headers Additional headers for the request (optional)
+     * @param array<string, mixed> $query Query parameters for the request (optional)
+     * @param mixed|null $body The form-urlencoded request body (optional)
+     */
+    public function __construct(
+        string $baseUrl,
+        string $path,
+        HttpMethod $method,
+        array $headers = [],
+        array $query = [],
+        public readonly mixed $body = null
+    ) {
+        parent::__construct($baseUrl, $path, $method, $headers, $query);
+    }
+}

--- a/seed/php-sdk/webhooks/.fern/metadata.json
+++ b/seed/php-sdk/webhooks/.fern/metadata.json
@@ -3,8 +3,7 @@
   "generatorName": "fernapi/fern-php-sdk",
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/php-sdk/webhooks/src/Core/Client/RawClient.php
+++ b/seed/php-sdk/webhooks/src/Core/Client/RawClient.php
@@ -155,6 +155,16 @@ class RawClient
                 $request->headers,
                 $options['headers'] ?? [],
             ),
+            UrlEncodedApiRequest::class => array_merge(
+                [
+                    "Content-Type" => "application/x-www-form-urlencoded",
+                    "Accept" => "*/*",
+                ],
+                $this->headers,
+                $authHeaders,
+                $request->headers,
+                $options['headers'] ?? [],
+            ),
             MultipartApiRequest::class => array_merge(
                 $this->headers,
                 $authHeaders,
@@ -185,6 +195,24 @@ class RawClient
                     ),
                 )
             );
+        }
+
+        if ($request instanceof UrlEncodedApiRequest) {
+            if ($request->body === null) {
+                return null;
+            }
+            $body = $this->buildJsonBody($request->body, $options);
+            if ($body instanceof JsonSerializable) {
+                $body = $body->jsonSerialize();
+            }
+            if ($body instanceof \stdClass) {
+                $body = (array)$body;
+            }
+            if (!is_array($body)) {
+                throw new InvalidArgumentException('Form-urlencoded request body must serialize to an array');
+            }
+            $body = array_filter($body, static fn ($value) => $value !== null);
+            return $this->streamFactory->createStream(http_build_query($body));
         }
 
         if ($request instanceof MultipartApiRequest) {

--- a/seed/php-sdk/webhooks/src/Core/Client/UrlEncodedApiRequest.php
+++ b/seed/php-sdk/webhooks/src/Core/Client/UrlEncodedApiRequest.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Seed\Core\Client;
+
+class UrlEncodedApiRequest extends BaseApiRequest
+{
+    /**
+     * @param string $baseUrl The base URL for the request
+     * @param string $path The path for the request
+     * @param HttpMethod $method The HTTP method for the request
+     * @param array<string, string> $headers Additional headers for the request (optional)
+     * @param array<string, mixed> $query Query parameters for the request (optional)
+     * @param mixed|null $body The form-urlencoded request body (optional)
+     */
+    public function __construct(
+        string $baseUrl,
+        string $path,
+        HttpMethod $method,
+        array $headers = [],
+        array $query = [],
+        public readonly mixed $body = null
+    ) {
+        parent::__construct($baseUrl, $path, $method, $headers, $query);
+    }
+}

--- a/seed/php-sdk/websocket-bearer-auth/.fern/metadata.json
+++ b/seed/php-sdk/websocket-bearer-auth/.fern/metadata.json
@@ -3,8 +3,7 @@
   "generatorName": "fernapi/fern-php-sdk",
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/php-sdk/websocket-bearer-auth/src/Core/Client/RawClient.php
+++ b/seed/php-sdk/websocket-bearer-auth/src/Core/Client/RawClient.php
@@ -155,6 +155,16 @@ class RawClient
                 $request->headers,
                 $options['headers'] ?? [],
             ),
+            UrlEncodedApiRequest::class => array_merge(
+                [
+                    "Content-Type" => "application/x-www-form-urlencoded",
+                    "Accept" => "*/*",
+                ],
+                $this->headers,
+                $authHeaders,
+                $request->headers,
+                $options['headers'] ?? [],
+            ),
             MultipartApiRequest::class => array_merge(
                 $this->headers,
                 $authHeaders,
@@ -185,6 +195,24 @@ class RawClient
                     ),
                 )
             );
+        }
+
+        if ($request instanceof UrlEncodedApiRequest) {
+            if ($request->body === null) {
+                return null;
+            }
+            $body = $this->buildJsonBody($request->body, $options);
+            if ($body instanceof JsonSerializable) {
+                $body = $body->jsonSerialize();
+            }
+            if ($body instanceof \stdClass) {
+                $body = (array)$body;
+            }
+            if (!is_array($body)) {
+                throw new InvalidArgumentException('Form-urlencoded request body must serialize to an array');
+            }
+            $body = array_filter($body, static fn ($value) => $value !== null);
+            return $this->streamFactory->createStream(http_build_query($body));
         }
 
         if ($request instanceof MultipartApiRequest) {

--- a/seed/php-sdk/websocket-bearer-auth/src/Core/Client/UrlEncodedApiRequest.php
+++ b/seed/php-sdk/websocket-bearer-auth/src/Core/Client/UrlEncodedApiRequest.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Seed\Core\Client;
+
+class UrlEncodedApiRequest extends BaseApiRequest
+{
+    /**
+     * @param string $baseUrl The base URL for the request
+     * @param string $path The path for the request
+     * @param HttpMethod $method The HTTP method for the request
+     * @param array<string, string> $headers Additional headers for the request (optional)
+     * @param array<string, mixed> $query Query parameters for the request (optional)
+     * @param mixed|null $body The form-urlencoded request body (optional)
+     */
+    public function __construct(
+        string $baseUrl,
+        string $path,
+        HttpMethod $method,
+        array $headers = [],
+        array $query = [],
+        public readonly mixed $body = null
+    ) {
+        parent::__construct($baseUrl, $path, $method, $headers, $query);
+    }
+}

--- a/seed/php-sdk/websocket-inferred-auth/.fern/metadata.json
+++ b/seed/php-sdk/websocket-inferred-auth/.fern/metadata.json
@@ -3,8 +3,7 @@
   "generatorName": "fernapi/fern-php-sdk",
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/php-sdk/websocket-inferred-auth/src/Core/Client/RawClient.php
+++ b/seed/php-sdk/websocket-inferred-auth/src/Core/Client/RawClient.php
@@ -155,6 +155,16 @@ class RawClient
                 $request->headers,
                 $options['headers'] ?? [],
             ),
+            UrlEncodedApiRequest::class => array_merge(
+                [
+                    "Content-Type" => "application/x-www-form-urlencoded",
+                    "Accept" => "*/*",
+                ],
+                $this->headers,
+                $authHeaders,
+                $request->headers,
+                $options['headers'] ?? [],
+            ),
             MultipartApiRequest::class => array_merge(
                 $this->headers,
                 $authHeaders,
@@ -185,6 +195,24 @@ class RawClient
                     ),
                 )
             );
+        }
+
+        if ($request instanceof UrlEncodedApiRequest) {
+            if ($request->body === null) {
+                return null;
+            }
+            $body = $this->buildJsonBody($request->body, $options);
+            if ($body instanceof JsonSerializable) {
+                $body = $body->jsonSerialize();
+            }
+            if ($body instanceof \stdClass) {
+                $body = (array)$body;
+            }
+            if (!is_array($body)) {
+                throw new InvalidArgumentException('Form-urlencoded request body must serialize to an array');
+            }
+            $body = array_filter($body, static fn ($value) => $value !== null);
+            return $this->streamFactory->createStream(http_build_query($body));
         }
 
         if ($request instanceof MultipartApiRequest) {

--- a/seed/php-sdk/websocket-inferred-auth/src/Core/Client/UrlEncodedApiRequest.php
+++ b/seed/php-sdk/websocket-inferred-auth/src/Core/Client/UrlEncodedApiRequest.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Seed\Core\Client;
+
+class UrlEncodedApiRequest extends BaseApiRequest
+{
+    /**
+     * @param string $baseUrl The base URL for the request
+     * @param string $path The path for the request
+     * @param HttpMethod $method The HTTP method for the request
+     * @param array<string, string> $headers Additional headers for the request (optional)
+     * @param array<string, mixed> $query Query parameters for the request (optional)
+     * @param mixed|null $body The form-urlencoded request body (optional)
+     */
+    public function __construct(
+        string $baseUrl,
+        string $path,
+        HttpMethod $method,
+        array $headers = [],
+        array $query = [],
+        public readonly mixed $body = null
+    ) {
+        parent::__construct($baseUrl, $path, $method, $headers, $query);
+    }
+}

--- a/seed/php-sdk/websocket-multi-url/.fern/metadata.json
+++ b/seed/php-sdk/websocket-multi-url/.fern/metadata.json
@@ -3,8 +3,7 @@
   "generatorName": "fernapi/fern-php-sdk",
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/php-sdk/websocket-multi-url/src/Core/Client/RawClient.php
+++ b/seed/php-sdk/websocket-multi-url/src/Core/Client/RawClient.php
@@ -155,6 +155,16 @@ class RawClient
                 $request->headers,
                 $options['headers'] ?? [],
             ),
+            UrlEncodedApiRequest::class => array_merge(
+                [
+                    "Content-Type" => "application/x-www-form-urlencoded",
+                    "Accept" => "*/*",
+                ],
+                $this->headers,
+                $authHeaders,
+                $request->headers,
+                $options['headers'] ?? [],
+            ),
             MultipartApiRequest::class => array_merge(
                 $this->headers,
                 $authHeaders,
@@ -185,6 +195,24 @@ class RawClient
                     ),
                 )
             );
+        }
+
+        if ($request instanceof UrlEncodedApiRequest) {
+            if ($request->body === null) {
+                return null;
+            }
+            $body = $this->buildJsonBody($request->body, $options);
+            if ($body instanceof JsonSerializable) {
+                $body = $body->jsonSerialize();
+            }
+            if ($body instanceof \stdClass) {
+                $body = (array)$body;
+            }
+            if (!is_array($body)) {
+                throw new InvalidArgumentException('Form-urlencoded request body must serialize to an array');
+            }
+            $body = array_filter($body, static fn ($value) => $value !== null);
+            return $this->streamFactory->createStream(http_build_query($body));
         }
 
         if ($request instanceof MultipartApiRequest) {

--- a/seed/php-sdk/websocket-multi-url/src/Core/Client/UrlEncodedApiRequest.php
+++ b/seed/php-sdk/websocket-multi-url/src/Core/Client/UrlEncodedApiRequest.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Seed\Core\Client;
+
+class UrlEncodedApiRequest extends BaseApiRequest
+{
+    /**
+     * @param string $baseUrl The base URL for the request
+     * @param string $path The path for the request
+     * @param HttpMethod $method The HTTP method for the request
+     * @param array<string, string> $headers Additional headers for the request (optional)
+     * @param array<string, mixed> $query Query parameters for the request (optional)
+     * @param mixed|null $body The form-urlencoded request body (optional)
+     */
+    public function __construct(
+        string $baseUrl,
+        string $path,
+        HttpMethod $method,
+        array $headers = [],
+        array $query = [],
+        public readonly mixed $body = null
+    ) {
+        parent::__construct($baseUrl, $path, $method, $headers, $query);
+    }
+}

--- a/seed/php-sdk/websocket/.fern/metadata.json
+++ b/seed/php-sdk/websocket/.fern/metadata.json
@@ -3,8 +3,7 @@
   "generatorName": "fernapi/fern-php-sdk",
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/php-sdk/websocket/src/Core/Client/RawClient.php
+++ b/seed/php-sdk/websocket/src/Core/Client/RawClient.php
@@ -155,6 +155,16 @@ class RawClient
                 $request->headers,
                 $options['headers'] ?? [],
             ),
+            UrlEncodedApiRequest::class => array_merge(
+                [
+                    "Content-Type" => "application/x-www-form-urlencoded",
+                    "Accept" => "*/*",
+                ],
+                $this->headers,
+                $authHeaders,
+                $request->headers,
+                $options['headers'] ?? [],
+            ),
             MultipartApiRequest::class => array_merge(
                 $this->headers,
                 $authHeaders,
@@ -185,6 +195,24 @@ class RawClient
                     ),
                 )
             );
+        }
+
+        if ($request instanceof UrlEncodedApiRequest) {
+            if ($request->body === null) {
+                return null;
+            }
+            $body = $this->buildJsonBody($request->body, $options);
+            if ($body instanceof JsonSerializable) {
+                $body = $body->jsonSerialize();
+            }
+            if ($body instanceof \stdClass) {
+                $body = (array)$body;
+            }
+            if (!is_array($body)) {
+                throw new InvalidArgumentException('Form-urlencoded request body must serialize to an array');
+            }
+            $body = array_filter($body, static fn ($value) => $value !== null);
+            return $this->streamFactory->createStream(http_build_query($body));
         }
 
         if ($request instanceof MultipartApiRequest) {

--- a/seed/php-sdk/websocket/src/Core/Client/UrlEncodedApiRequest.php
+++ b/seed/php-sdk/websocket/src/Core/Client/UrlEncodedApiRequest.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Seed\Core\Client;
+
+class UrlEncodedApiRequest extends BaseApiRequest
+{
+    /**
+     * @param string $baseUrl The base URL for the request
+     * @param string $path The path for the request
+     * @param HttpMethod $method The HTTP method for the request
+     * @param array<string, string> $headers Additional headers for the request (optional)
+     * @param array<string, mixed> $query Query parameters for the request (optional)
+     * @param mixed|null $body The form-urlencoded request body (optional)
+     */
+    public function __construct(
+        string $baseUrl,
+        string $path,
+        HttpMethod $method,
+        array $headers = [],
+        array $query = [],
+        public readonly mixed $body = null
+    ) {
+        parent::__construct($baseUrl, $path, $method, $headers, $query);
+    }
+}

--- a/seed/php-sdk/x-fern-default/.fern/metadata.json
+++ b/seed/php-sdk/x-fern-default/.fern/metadata.json
@@ -3,8 +3,7 @@
   "generatorName": "fernapi/fern-php-sdk",
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/php-sdk/x-fern-default/src/Core/Client/RawClient.php
+++ b/seed/php-sdk/x-fern-default/src/Core/Client/RawClient.php
@@ -155,6 +155,16 @@ class RawClient
                 $request->headers,
                 $options['headers'] ?? [],
             ),
+            UrlEncodedApiRequest::class => array_merge(
+                [
+                    "Content-Type" => "application/x-www-form-urlencoded",
+                    "Accept" => "*/*",
+                ],
+                $this->headers,
+                $authHeaders,
+                $request->headers,
+                $options['headers'] ?? [],
+            ),
             MultipartApiRequest::class => array_merge(
                 $this->headers,
                 $authHeaders,
@@ -185,6 +195,24 @@ class RawClient
                     ),
                 )
             );
+        }
+
+        if ($request instanceof UrlEncodedApiRequest) {
+            if ($request->body === null) {
+                return null;
+            }
+            $body = $this->buildJsonBody($request->body, $options);
+            if ($body instanceof JsonSerializable) {
+                $body = $body->jsonSerialize();
+            }
+            if ($body instanceof \stdClass) {
+                $body = (array)$body;
+            }
+            if (!is_array($body)) {
+                throw new InvalidArgumentException('Form-urlencoded request body must serialize to an array');
+            }
+            $body = array_filter($body, static fn ($value) => $value !== null);
+            return $this->streamFactory->createStream(http_build_query($body));
         }
 
         if ($request instanceof MultipartApiRequest) {

--- a/seed/php-sdk/x-fern-default/src/Core/Client/UrlEncodedApiRequest.php
+++ b/seed/php-sdk/x-fern-default/src/Core/Client/UrlEncodedApiRequest.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Seed\Core\Client;
+
+class UrlEncodedApiRequest extends BaseApiRequest
+{
+    /**
+     * @param string $baseUrl The base URL for the request
+     * @param string $path The path for the request
+     * @param HttpMethod $method The HTTP method for the request
+     * @param array<string, string> $headers Additional headers for the request (optional)
+     * @param array<string, mixed> $query Query parameters for the request (optional)
+     * @param mixed|null $body The form-urlencoded request body (optional)
+     */
+    public function __construct(
+        string $baseUrl,
+        string $path,
+        HttpMethod $method,
+        array $headers = [],
+        array $query = [],
+        public readonly mixed $body = null
+    ) {
+        parent::__construct($baseUrl, $path, $method, $headers, $query);
+    }
+}

--- a/seed/php-sdk/x-fern-global-parameters/.fern/metadata.json
+++ b/seed/php-sdk/x-fern-global-parameters/.fern/metadata.json
@@ -3,8 +3,7 @@
   "generatorName": "fernapi/fern-php-sdk",
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/php-sdk/x-fern-global-parameters/src/Core/Client/RawClient.php
+++ b/seed/php-sdk/x-fern-global-parameters/src/Core/Client/RawClient.php
@@ -155,6 +155,16 @@ class RawClient
                 $request->headers,
                 $options['headers'] ?? [],
             ),
+            UrlEncodedApiRequest::class => array_merge(
+                [
+                    "Content-Type" => "application/x-www-form-urlencoded",
+                    "Accept" => "*/*",
+                ],
+                $this->headers,
+                $authHeaders,
+                $request->headers,
+                $options['headers'] ?? [],
+            ),
             MultipartApiRequest::class => array_merge(
                 $this->headers,
                 $authHeaders,
@@ -185,6 +195,24 @@ class RawClient
                     ),
                 )
             );
+        }
+
+        if ($request instanceof UrlEncodedApiRequest) {
+            if ($request->body === null) {
+                return null;
+            }
+            $body = $this->buildJsonBody($request->body, $options);
+            if ($body instanceof JsonSerializable) {
+                $body = $body->jsonSerialize();
+            }
+            if ($body instanceof \stdClass) {
+                $body = (array)$body;
+            }
+            if (!is_array($body)) {
+                throw new InvalidArgumentException('Form-urlencoded request body must serialize to an array');
+            }
+            $body = array_filter($body, static fn ($value) => $value !== null);
+            return $this->streamFactory->createStream(http_build_query($body));
         }
 
         if ($request instanceof MultipartApiRequest) {

--- a/seed/php-sdk/x-fern-global-parameters/src/Core/Client/UrlEncodedApiRequest.php
+++ b/seed/php-sdk/x-fern-global-parameters/src/Core/Client/UrlEncodedApiRequest.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Seed\Core\Client;
+
+class UrlEncodedApiRequest extends BaseApiRequest
+{
+    /**
+     * @param string $baseUrl The base URL for the request
+     * @param string $path The path for the request
+     * @param HttpMethod $method The HTTP method for the request
+     * @param array<string, string> $headers Additional headers for the request (optional)
+     * @param array<string, mixed> $query Query parameters for the request (optional)
+     * @param mixed|null $body The form-urlencoded request body (optional)
+     */
+    public function __construct(
+        string $baseUrl,
+        string $path,
+        HttpMethod $method,
+        array $headers = [],
+        array $query = [],
+        public readonly mixed $body = null
+    ) {
+        parent::__construct($baseUrl, $path, $method, $headers, $query);
+    }
+}


### PR DESCRIPTION
## Description
Linear ticket: N/A

Endpoints declared with `content-type: application/x-www-form-urlencoded` (most commonly OAuth `get-token` endpoints) were generated as `JsonApiRequest`, so the body was serialized as JSON with `Content-Type: application/json`. OAuth token servers reject this (e.g. Twilio staging returns 415 / error 20422 "The requested resource /v2/token does not support this payload format").

## Changes Made
- New as-is core file `Client/UrlEncodedApiRequest.Template.php` (`UrlEncodedApiRequest extends BaseApiRequest`), shipped in the core client namespace for every generated SDK
- `RawClient.Template.php`:
  - `encodeHeaders` sets `Content-Type: application/x-www-form-urlencoded` for `UrlEncodedApiRequest`
  - `encodeRequestBody` serializes the body through the existing `buildJsonBody` (applying wire names / `bodyProperties` overrides), then encodes it with `http_build_query` (nulls dropped)
- `HttpEndpointGenerator.getRequestTypeClassReference` chooses `UrlEncodedApiRequest` when the `reference`/`inlinedRequestBody` contentType is `application/x-www-form-urlencoded`
- `SdkGeneratorContext.getUrlEncodedApiRequestClassReference()` + core as-is registration
- Changelog entry under `generators/php/sdk/changes/unreleased/`
- Regenerated php-sdk seed snapshots (`url-form-encoded` and `oauth-client-credentials` fixtures now use `UrlEncodedApiRequest`)

## Testing
- [ ] Unit tests added/updated
- [x] Manual testing completed
- `pnpm seed test --generator php-sdk` — 152/152 fixtures pass
- End-to-end: regenerated the Twilio Core PHP SDK with this generator and ran an OAuth client-credentials request against Twilio staging — the token request now succeeds (previously 415 / 20422) and the authenticated API call returns 200

Link to Devin session: https://app.devin.ai/sessions/48336a69f3844e1f90ee4fd24666390b
Requested by: @iamnamananand996