### PR TITLE
chore(go): bump seed.yml irVersion to v67

### DIFF
--- a/seed/go-sdk/seed.yml
+++ b/seed/go-sdk/seed.yml
@@ -1,4 +1,4 @@
-irVersion: v66
+irVersion: v67
 displayName: Go SDK
 image: fernapi/fern-go-sdk
 changelogLocation: ../../generators/go/sdk/versions.yml


### PR DESCRIPTION
## What

Updates `seed/go-sdk/seed.yml` `irVersion` from `v66` to `v67`.

## Why

The [`Validate IR Version Consistency`](https://github.com/fern-api/fern/actions/runs/29474173749) check on `main` is failing:

```
go-sdk: seed.yml has irVersion 66 but latest release (1.49.6) has irVersion 67
```

go-sdk release `1.49.6` (#17042 / commit 7baa176) bumped `irVersion` to `67` in `generators/go/sdk/versions.yml`, but the corresponding `seed/go-sdk/seed.yml` was left at `v66`. The consistency check requires these to match.

## Verification

`./scripts/validate-ir-version-consistency.sh` now prints `All IR versions are consistent`.

Generated with [Claude Code](https://claude.com/claude-code)