### PR TITLE
fix(php): emit standalone LICENSE file for custom licenses

### DIFF
--- a/generators/php/base/src/project/PhpProject.ts
+++ b/generators/php/base/src/project/PhpProject.ts
@@ -1,9 +1,10 @@
 import { AbstractProject, File } from "@fern-api/base-generator";
+import { extractErrorMessage } from "@fern-api/core-utils";
 import { AbsoluteFilePath, join, RelativeFilePath } from "@fern-api/fs-utils";
 import { loggingExeca } from "@fern-api/logging-execa";
 import { BasePhpCustomConfigSchema } from "@fern-api/php-codegen";
 import { Eta } from "eta";
-import { mkdir, readFile, writeFile } from "fs/promises";
+import { copyFile, mkdir, readFile, writeFile } from "fs/promises";
 import { cloneDeep, isArray, mergeWith } from "lodash-es";
 import path from "path";
 
@@ -23,6 +24,10 @@ const TESTS_DIRECTORY_NAME = "tests";
 const CUSTOM_LICENSE_NAME = "LicenseRef-LICENSE";
 
 const COMPOSER_JSON_FILENAME = "composer.json";
+
+// In the Docker execution environment (local generation), the license file is mounted here.
+// For remote generation, Fiddle handles writing the LICENSE file after generation.
+const DOCKER_LICENSE_PATH = "/tmp/LICENSE";
 
 /**
  * In memory representation of a PHP project.
@@ -71,6 +76,34 @@ export class PhpProject extends AbstractProject<AbstractPhpGeneratorContext<Base
         await this.createUtilsDirectory();
         await this.createGitHubWorkflowsDirectory();
         await this.createComposerJson();
+        await this.writeLicenseFile();
+    }
+
+    private async writeLicenseFile(): Promise<void> {
+        const licenseConfig = this.context.config.license;
+        if (licenseConfig?.type !== "custom") {
+            return;
+        }
+
+        const licenseFileName = licenseConfig.filename ?? "LICENSE";
+        const destinationPath = join(this.absolutePathToOutputDirectory, RelativeFilePath.of(licenseFileName));
+
+        try {
+            await copyFile(DOCKER_LICENSE_PATH, destinationPath);
+            this.context.logger.debug(`Successfully copied LICENSE file to ${destinationPath}`);
+        } catch (error) {
+            // File not found is expected for remote generation where Fiddle handles it.
+            if (error instanceof Error && "code" in error && error.code === "ENOENT") {
+                this.context.logger.debug(
+                    `Custom license file not found at ${DOCKER_LICENSE_PATH}. This is expected for remote generation.`
+                );
+            } else {
+                // Log other errors for debugging while maintaining backwards compatibility.
+                this.context.logger.warn(
+                    `Failed to copy custom license file from ${DOCKER_LICENSE_PATH} to ${destinationPath}: ${extractErrorMessage(error)}`
+                );
+            }
+        }
     }
 
     private static getPackagePathPrefix(packagePath?: string): string {

--- a/generators/php/sdk/versions.yml
+++ b/generators/php/sdk/versions.yml
@@ -1,4 +1,16 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+- version: 2.13.3
+  changelogEntry:
+    - summary: |
+        Emit a standalone `LICENSE` file at the repo root when a custom license is
+        configured (`license: { custom: ./LICENSE }` in the generator's `github` block).
+        Previously the PHP generator only set the `license` field in `composer.json` and
+        never wrote the license file itself, so GitHub license detection and compliance
+        scanners reported no license. This brings the PHP generator to parity with the
+        TypeScript, Python, Java, and Go generators.
+      type: fix
+  createdAt: "2026-07-16"
+  irVersion: 67
 - version: 2.13.2
   changelogEntry:
     - summary: |


### PR DESCRIPTION
## Description
Linear ticket: Closes SE-82

Fern PHP SDKs never got a standalone `LICENSE` file at the repo root. The PHP generator only wrote the `license` field into `composer.json`, but GitHub's license detection and most compliance scanners look for the actual `LICENSE` file — so PHP SDKs (e.g. Brevo's `getbrevo/brevo-php`, [issue #143](https://github.com/getbrevo/brevo-php/issues/143)) showed up as having no license.

Every other SDK generator already emits the file. PHP was simply missing it — an unimplemented feature, not a deliberate choice.

## How LICENSE emission works (and how the other generators do it)
1. When you configure a custom license, the Fern CLI mounts that file inside the generator at a fixed path: `/tmp/LICENSE`.
2. The generator copies `/tmp/LICENSE` into the output repo root (as `LICENSE`).
3. Only **custom** licenses get a file. Standard SPDX licenses (like `MIT`) just get named in the package manifest (`composer.json`), no file needed.

Each generator has its own small method that does step 2. They're all nearly identical — for a custom license, copy `/tmp/LICENSE` into the repo root and quietly skip if the file isn't there:

| Generator | Method |
|---|---|
| Go | `GoProject.writeLicenseFile()` — `generators/go-v2/base/src/project/GoProject.ts` |
| TypeScript | `SdkGeneratorCli.writeLicenseFile()` → `copyLicenseFile()` — `generators/typescript/sdk/cli/src/SdkGeneratorCli.ts` |
| Python | `Project._copy_license_file()` — `generators/python/src/fern_python/codegen/project.py` |
| Java | `AbstractGeneratorCli.copyLicenseFile()` — `generators/java/generator-utils/.../AbstractGeneratorCli.java` |
| **PHP** | `PhpProject.writeLicenseFile()` — **added in this PR** |

(C# and Rust are slightly different: C# references the file in the `.csproj` via `<PackageLicenseFile>` rather than copying it, and Rust exposes explicit `packageLicense` / `packageLicenseFile` config flags.)

This PR adds the same step to PHP, modeled on Go's implementation (the closest architectural match).

## Changes Made
- Added `writeLicenseFile()` to `PhpProject` (modeled on Go's `GoProject.writeLicenseFile`): for a custom license, copy `/tmp/LICENSE` → `LICENSE` in the repo root. If the file isn't there (which is normal for remote/Fiddle generation), it quietly skips — so nothing breaks for existing users.
- Added a `2.13.3` changelog entry for the PHP SDK generator.
- [ ] Updated README.md generator (if applicable) — N/A

After this, getting a `LICENSE` file is a **config-only change** for any PHP customer: add `license: { custom: ./LICENSE }` to the PHP `github:` block, exactly like the other languages.

## Testing
- [ ] Unit tests added/updated — N/A. None of the other generators unit-test this either: seed never mounts `/tmp/LICENSE`, so the copy is a no-op in seed and there's nothing to snapshot (even C#'s `custom-license` fixture has no `LICENSE` file). A test here would only give false coverage.
- [x] Manual testing completed — `pnpm turbo run compile --filter @fern-api/php-base` passes (13/13 tasks).

Generated with [Claude Code](https://claude.com/claude-code)