### PR TITLE
fix(cli): re-export HashMap/HashSet from embedded SDK crate prelude

### DIFF
--- a/generators/cli/changes/unreleased/fix-embedded-sdk-prelude-hashmap.yml
+++ b/generators/cli/changes/unreleased/fix-embedded-sdk-prelude-hashmap.yml
@@ -1,0 +1,11 @@
+- summary: |
+    Re-export `std::collections::{HashMap, HashSet}` from the embedded SDK
+    crate's `prelude`. The Rust SDK generator emits `use crate::prelude::*;`
+    in files that reference `HashMap`/`HashSet` by bare name — most notably
+    `error.rs`, whose error-body fields can resolve to
+    `Vec<HashMap<String, serde_json::Value>>`. The CLI generator previously
+    overwrote the standalone SDK prelude with only the types-crate re-export,
+    dropping the std re-export, so the generated `<binary>-sdk` crate failed
+    to compile with `cannot find type HashMap in this scope`. The embedded
+    prelude now mirrors the standalone SDK prelude for std collections.
+  type: fix

--- a/generators/cli/src/__test__/generateEmbeddedSdk.test.ts
+++ b/generators/cli/src/__test__/generateEmbeddedSdk.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vitest";
+import { buildEmbeddedSdkPrelude } from "../generateEmbeddedSdk.js";
+
+/**
+ * The embedded SDK crate's prelude must re-export both the co-generated
+ * types crate (for single type identity) and `std::collections`. The Rust
+ * SDK generator emits `use crate::prelude::*;` in `error.rs` and expects
+ * `HashMap`/`HashSet` to resolve through the prelude (error-body fields can
+ * be `Vec<HashMap<String, serde_json::Value>>`). Dropping the std re-export
+ * makes the generated crate fail to compile with `cannot find type HashMap`.
+ */
+describe("buildEmbeddedSdkPrelude", () => {
+    it("re-exports the types crate for single type identity", () => {
+        expect(buildEmbeddedSdkPrelude("my_api_types")).toContain("pub use my_api_types::*;");
+    });
+
+    it("re-exports std::collections so error.rs's HashMap fields resolve", () => {
+        expect(buildEmbeddedSdkPrelude("my_api_types")).toContain("pub use std::collections::{HashMap, HashSet};");
+    });
+
+    it("ends with a trailing newline", () => {
+        expect(buildEmbeddedSdkPrelude("my_api_types").endsWith("\n")).toBe(true);
+    });
+});

--- a/generators/cli/src/generateEmbeddedSdk.ts
+++ b/generators/cli/src/generateEmbeddedSdk.ts
@@ -212,8 +212,7 @@ async function patchSdkCrate(args: {
     //    type identity (`<sdk>::Pet` == `<types>::Pet`).
     const srcDir = path.join(sdkOutputDir, "src");
     await mkdir(srcDir, { recursive: true });
-    const preludeContent = `pub use ${typesSnakeName}::*;\n`;
-    await writeFile(path.join(srcDir, "prelude.rs"), preludeContent);
+    await writeFile(path.join(srcDir, "prelude.rs"), buildEmbeddedSdkPrelude(typesSnakeName));
 
     // 2b. Patch src/api/mod.rs — re-export the types crate so that
     //     service resource files (`use crate::api::*;`) can resolve
@@ -252,4 +251,28 @@ async function patchSdkCrate(args: {
     // 4. Remove the .fern/ metadata directory written by the base
     //    generator framework — not needed inside a workspace member.
     await rm(path.join(sdkOutputDir, ".fern"), { recursive: true, force: true });
+}
+
+/**
+ * Build the embedded SDK crate's `src/prelude.rs`.
+ *
+ * Re-exports:
+ *   1. The co-generated types crate, for single type identity
+ *      (`<sdk>::Pet` == `<types>::Pet`).
+ *   2. `std::collections::{HashMap, HashSet}`, mirroring the standalone
+ *      Rust SDK prelude (`generators/rust/base/src/asIs/prelude.rs`).
+ *
+ * The Rust SDK generator emits `use crate::prelude::*;` in files that
+ * reference `HashMap`/`HashSet` by bare name and rely on the prelude to
+ * bring `std::collections` into scope — most notably `error.rs`, whose
+ * error-body fields can resolve to `Vec<HashMap<String, serde_json::Value>>`.
+ * When the CLI generator overwrites the standalone prelude with only the
+ * types re-export, those files fail to compile with `cannot find type
+ * HashMap in this scope`. Keeping the std re-export here restores parity
+ * with the standalone SDK. It's dependency-free (std is always available),
+ * and explicit `use std::collections::HashMap;` in sibling files simply
+ * shadows this glob, so there is no ambiguity.
+ */
+export function buildEmbeddedSdkPrelude(typesSnakeName: string): string {
+    return [`pub use ${typesSnakeName}::*;`, "pub use std::collections::{HashMap, HashSet};", ""].join("\n");
 }


### PR DESCRIPTION
## Description
Fixes a compilation failure in CLIs generated by `fern-cli-generator`: the generated `<binary>-sdk` crate fails to build with `error[E0425]: cannot find type HashMap in this scope` whenever an error-body field resolves to a type using `HashMap` (e.g. `Vec<HashMap<String, serde_json::Value>>`).

### Root cause
The Rust SDK generator's `ErrorGenerator` emits `use crate::prelude::*;` in `error.rs` and relies on the prelude to bring `HashMap`/`HashSet` into scope. In the **standalone** Rust SDK this works because `generators/rust/base/src/asIs/prelude.rs` re-exports `pub use std::collections::{HashMap, HashSet};`.

However, the CLI generator's `patchSdkCrate` (`generators/cli/src/generateEmbeddedSdk.ts`) **overwrites** the embedded SDK crate's `src/prelude.rs` with only `pub use <types>::*;`, dropping the std re-export. So `error.rs`'s `use crate::prelude::*;` no longer resolves `HashMap` — the file references it by bare name and fails to compile. (The sibling embedded *types* crate prelude already re-exports std collections; only the SDK crate prelude was missing it.)

## Changes Made
- Restore `pub use std::collections::{HashMap, HashSet};` in the embedded SDK crate's prelude, mirroring the standalone SDK prelude and the embedded types crate.
- Extract the prelude construction into a testable `buildEmbeddedSdkPrelude` helper.
- Add a changelog entry (`fix`, patch bump).

The std re-export is dependency-free (always available) and safe: sibling files that `use std::collections::HashMap;` explicitly simply shadow the glob, so there is no ambiguity — the same pattern already compiles in the standalone SDK.

## Testing
- [x] Unit tests added/updated — new `generateEmbeddedSdk.test.ts` asserts the prelude re-exports both the types crate and `std::collections::{HashMap, HashSet}`.
- [x] `pnpm turbo run compile --filter @fern-api/cli-generator` passes.
- [x] Full CLI generator test suite passes (183 tests).

Reported against `fernapi/fern-cli-generator:0.23.2` (ir-version v67).

Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/17105" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->