### PR TITLE
fix(csharp): scope nested-type namespace shadow global:: to the enclosing type

### DIFF
--- a/generators/csharp/codegen/src/ast/core/Writer.ts
+++ b/generators/csharp/codegen/src/ast/core/Writer.ts
@@ -41,6 +41,11 @@ export class Writer extends AbstractWriter {
     /* Whether or not to skip adding global:: qualifier to System namespaces */
     public readonly skipGlobalQualifier: boolean;
 
+    /* Fully qualified names of the enclosing types currently being written, outermost first.
+       Used to detect nested-type namespace shadows that are only visible within a type's body
+       (see NameRegistry.hasNestedTypeShadowInScope). */
+    public readonly typeScopeStack: string[] = [];
+
     constructor({
         namespace,
         allNamespaceSegments,
@@ -68,6 +73,16 @@ export class Writer extends AbstractWriter {
         } else {
             this.references[reference.namespace] = [reference];
         }
+    }
+
+    /* Records that we are now writing inside the body of the given type. Paired with
+       popTypeScope() and called by Class.write around a type body. */
+    public pushTypeScope(fullyQualifiedName: string): void {
+        this.typeScopeStack.push(fullyQualifiedName);
+    }
+
+    public popTypeScope(): void {
+        this.typeScopeStack.pop();
     }
 
     public addNamespace(namespace: string): void {

--- a/generators/csharp/codegen/src/ast/types/Class.ts
+++ b/generators/csharp/codegen/src/ast/types/Class.ts
@@ -225,6 +225,9 @@ export class Class extends DefinedType {
 
         writer.writeNewLineIfLastLineNot();
         writer.pushScope();
+        // Track the enclosing-type scope so references written inside the body can detect a
+        // nested type that shadows the root namespace segment (CS0426) and qualify only here.
+        writer.pushTypeScope(this.reference.fullyQualifiedName);
 
         this.writeConsts(writer);
         this.writeFieldFields(writer);
@@ -236,6 +239,7 @@ export class Class extends DefinedType {
         this.writeNestedClasses(writer);
         this.writeNestedInterfaces(writer);
 
+        writer.popTypeScope();
         writer.popScope();
     }
 

--- a/generators/csharp/codegen/src/ast/types/ClassReference.ts
+++ b/generators/csharp/codegen/src/ast/types/ClassReference.ts
@@ -174,6 +174,9 @@ export class ClassReference extends Node implements Type {
                 // if the first namespace segment is both a type name and a namespace root,
                 // the C# compiler will resolve it to the type instead of the namespace (CS0426)
                 this.registry.hasTypeNamespaceConflict(this.namespaceSegments[0]) ||
+                // a nested type can also shadow the root namespace segment, but only within its
+                // enclosing type's body — qualify only when we are writing inside that scope
+                this.registry.hasNestedTypeShadowInScope(this.namespaceSegments[0], writer.typeScopeStack) ||
                 // or we always are going to be using fully qualified namespaces
                 writer.generation.settings.useFullyQualifiedNamespaces);
 

--- a/generators/csharp/codegen/src/context/__test__/name-registry.test.ts
+++ b/generators/csharp/codegen/src/context/__test__/name-registry.test.ts
@@ -593,40 +593,47 @@ describe("NameRegistry", () => {
         });
     });
 
-    describe("hasTypeNamespaceConflict", () => {
-        it("should detect a nested type whose name equals the root namespace segment", () => {
+    describe("hasNestedTypeShadowInScope", () => {
+        const enclosingFqn = "Auth0.ManagementApi.ConnectionResponseContent";
+
+        it("should detect a nested type whose name equals the root namespace segment only within its enclosing scope", () => {
             // Reproduces the CS0426 case: a union variant "auth0" generates a nested struct
             // `Auth0` inside `ConnectionResponseContent`, which lives in namespace
             // `Auth0.ManagementApi`. Within the enclosing type's body, the unqualified `Auth0`
             // resolves to the nested struct instead of the namespace root.
             const enclosing = createClassRef("ConnectionResponseContent", "Auth0.ManagementApi");
             nameRegistry.trackType(enclosing);
-
-            // The enclosing type alone makes "Auth0" a root namespace segment, but it is not
-            // yet a tracked type name, so there is no conflict.
-            expect(nameRegistry.hasTypeNamespaceConflict("Auth0")).toBe(false);
-
-            // The nested type named "Auth0" shadows the root namespace segment.
             const nestedAuth0 = createClassRef("Auth0", "Auth0.ManagementApi", enclosing);
             nameRegistry.trackType(nestedAuth0);
 
-            expect(nameRegistry.hasTypeNamespaceConflict("Auth0")).toBe(true);
+            // The nested type is NOT tracked as a global type name: unlike a top-level type that
+            // shadows the namespace everywhere, this shadow is confined to the enclosing scope.
+            expect(nameRegistry.hasTypeNamespaceConflict("Auth0")).toBe(false);
+
+            // Inside the enclosing type's body the shadow is visible, so the reference must be
+            // qualified.
+            expect(nameRegistry.hasNestedTypeShadowInScope("Auth0", [enclosingFqn])).toBe(true);
+            // ...as it is inside a further-nested type within that enclosing type.
+            expect(nameRegistry.hasNestedTypeShadowInScope("Auth0", [enclosingFqn, `${enclosingFqn}+Auth0`])).toBe(
+                true
+            );
+
+            // Outside the enclosing type (a different type / file), there is no shadow, so no
+            // qualification is needed.
+            expect(nameRegistry.hasNestedTypeShadowInScope("Auth0", [])).toBe(false);
+            expect(nameRegistry.hasNestedTypeShadowInScope("Auth0", ["Auth0.ManagementApi.SomeOtherType"])).toBe(false);
         });
 
-        it("should not create a spurious conflict for a nested type whose name does not match the root segment", () => {
-            // "Foo" is a root-level namespace segment (via a type in "Foo.Bar").
-            const rootNsType = createClassRef("Widget", "Foo.Bar");
-            nameRegistry.trackType(rootNsType);
-
-            // A nested type named "Foo" lives in an unrelated namespace whose root is "Auth0".
+        it("should not record a shadow for a nested type whose name does not match the root segment", () => {
+            // A nested type named "Foo" lives in a namespace whose root is "Auth0".
             const enclosing = createClassRef("ConnectionResponseContent", "Auth0.ManagementApi");
             nameRegistry.trackType(enclosing);
             const nestedFoo = createClassRef("Foo", "Auth0.ManagementApi", enclosing);
             nameRegistry.trackType(nestedFoo);
 
-            // "Foo" does not match its own root segment ("Auth0"), so it must not be tracked as
-            // a type name; otherwise it would spuriously conflict with the "Foo" namespace root.
-            expect(nameRegistry.hasTypeNamespaceConflict("Foo")).toBe(false);
+            // "Foo" does not match its own root segment ("Auth0"), so it does not shadow anything
+            // and must never be qualified on that basis.
+            expect(nameRegistry.hasNestedTypeShadowInScope("Foo", [enclosingFqn])).toBe(false);
         });
     });
 

--- a/generators/csharp/codegen/src/context/name-registry.ts
+++ b/generators/csharp/codegen/src/context/name-registry.ts
@@ -648,6 +648,20 @@ export class NameRegistry {
     private readonly namespaceNames = new Map<string, Set<string>>();
 
     /**
+     * Registry tracking nested types whose name equals the root segment of their own
+     * namespace, which shadows that namespace inside the enclosing type's body (CS0426).
+     *
+     * Unlike a top-level type/namespace conflict (which shadows everywhere and is recorded
+     * as a tracked type name), a nested type only shadows the namespace root within its
+     * enclosing type's lexical scope. We therefore record the enclosing types rather than
+     * the name globally, so references are qualified only when written inside that scope.
+     *
+     * Key: Nested type name that shadows its root namespace segment (e.g. "Auth0")
+     * Value: Set of enclosing-type fully qualified names the shadow is visible in
+     */
+    private readonly nestedTypeShadows = new Map<string, Set<string>>();
+
+    /**
      * Set of namespaces that are implicitly imported/available.
      * Types in nested namespaces under these prefixes are tracked for ambiguity detection.
      */
@@ -888,6 +902,29 @@ export class NameRegistry {
     }
 
     /**
+     * Checks whether `name` is a nested type that shadows its own root namespace segment
+     * (see {@link nestedTypeShadows}) AND whether we are currently writing inside one of the
+     * enclosing types where that shadow is visible. This is the scoped counterpart to
+     * {@link hasTypeNamespaceConflict}: it lets reference sites emit a `global::` qualifier
+     * only within the shadow's lexical scope, rather than everywhere the root segment appears.
+     *
+     * @param name - The first namespace segment of the reference being written (optional)
+     * @param typeScopeStack - Fully qualified names of the enclosing types currently open,
+     *                         outermost first (see `Writer.typeScopeStack`)
+     * @returns `true` if a matching nested-type shadow is in scope, `false` otherwise
+     */
+    public hasNestedTypeShadowInScope(name: string | undefined, typeScopeStack: readonly string[]): boolean {
+        if (!name || this.knownBuiltInIdentifiers.has(name)) {
+            return false;
+        }
+        const enclosers = this.nestedTypeShadows.get(name);
+        if (!enclosers) {
+            return false;
+        }
+        return typeScopeStack.some((fullyQualifiedName) => enclosers.has(fullyQualifiedName));
+    }
+
+    /**
      * Generates a fully qualified name string from a class reference identity.
      * For nested types, includes the enclosing type in the qualified name.
      *
@@ -985,10 +1022,17 @@ export class NameRegistry {
                 // A nested type whose name equals the root namespace segment shadows that
                 // namespace within its enclosing type's body, so any `<Root>.<Sub>.Type`
                 // reference emitted there resolves to the nested type and fails with CS0426.
-                // Track it so hasTypeNamespaceConflict() detects the shadow and callers emit
-                // a global:: qualifier at the reference sites. Scoped to the exact collision
-                // so unrelated nested types are not over-qualified.
-                this.trackTypeName(name, namespace);
+                // The shadow is confined to the enclosing type's lexical scope, so — unlike a
+                // top-level conflict — we record the enclosing type rather than tracking the
+                // name globally. hasNestedTypeShadowInScope() then lets reference sites emit a
+                // global:: qualifier only when writing inside that scope, instead of qualifying
+                // every (unrelated) reference to the same root segment elsewhere in the SDK.
+                let enclosers = this.nestedTypeShadows.get(name);
+                if (!enclosers) {
+                    enclosers = new Set();
+                    this.nestedTypeShadows.set(name, enclosers);
+                }
+                enclosers.add(enclosingType.fullyQualifiedName);
             }
 
             for (const each of [this.generation.namespaces.root, ...this.implicitNamespaces]) {

--- a/generators/csharp/sdk/versions.yml
+++ b/generators/csharp/sdk/versions.yml
@@ -8,7 +8,9 @@
         `global::`-qualified references. Previously such a nested type shadowed the
         namespace root within its enclosing type's body, so references like
         `Auth0.ManagementApi.SomeType` resolved to the nested type and failed to compile
-        with CS0426.
+        with CS0426. The `global::` qualifier is applied only to references written inside
+        the enclosing type where the shadow is visible, so unrelated references to the same
+        root segment elsewhere in the SDK are left unqualified.
       type: fix
   createdAt: "2026-07-16"
   irVersion: 67


### PR DESCRIPTION
Stacked on top of #17103.

## Problem
#17103 fixes the CS0426 build break caused by a generated nested type whose name equals the SDK's root namespace segment (e.g. the `auth0` union variant → nested `Auth0` struct in `ConnectionResponseContent`, namespace `Auth0.ManagementApi`). It does so by tracking that nested type as a **global** type-name conflict, which forces a `global::` qualifier onto **every** reference beginning with that segment across the whole SDK — even though the shadow is only visible inside the type that declares it.

On the Auth0 Management SDK that emitted **13,070** `global::Auth0` references; only ~1,438 are actually needed.

## Change
A nested type only shadows the namespace root within its enclosing type's lexical scope, so this qualifies references only where the shadow is actually visible:

- **`name-registry.ts`** — record the *enclosing types* a nested shadow is visible in (`nestedTypeShadows`) instead of tracking the name globally; add `hasNestedTypeShadowInScope(name, scopeStack)`.
- **`Writer.ts`** — track the current enclosing-type scope (`typeScopeStack` + `pushTypeScope`/`popTypeScope`).
- **`Class.ts`** — push/pop the enclosing type's FQN around the class body.
- **`ClassReference.ts`** — `shouldGlobal` now also fires when the reference's root segment is shadowed **and** we're writing inside that scope.
- Tests + changelog updated to the scoped API.

Still on-by-default, no flag. It remains a strict no-op for any SDK without a nested type shadowing its root namespace segment.

## Verification
- `global::Auth0` references on the Auth0 SDK: **13,070 → 1,438** (−89%), confined to exactly the two types that declare a nested `Auth0`.
- `dotnet build` of the regenerated SDK: **`Build succeeded`, 0 errors** across netstandard2.0 / net462 / net8.0 / net9.0 incl. the mock-server test project — no CS0426/CS0118/CS0234, with `experimental-fully-qualified-namespaces` off.
- Generator unit tests pass: codegen 630, model 9, sdk 67.

> Not yet run: the seed snapshot suite — if a committed fixture contains this exact collision its snapshot would legitimately shrink (fewer `global::`).

Generated with [Claude Code](https://claude.com/claude-code)