### PR TITLE
fix(typescript): document base API error and timeout error in @throws JSDoc

### DIFF
--- a/generators/typescript/sdk/changes/unreleased/document-base-and-timeout-errors-in-throws.yml
+++ b/generators/typescript/sdk/changes/unreleased/document-base-and-timeout-errors-in-throws.yml
@@ -1,0 +1,6 @@
+- summary: |
+    Generated endpoint JSDoc now documents all thrown error paths: in addition to
+    the errors declared in the API definition, each method's `@throws` annotations
+    include the base API error class (thrown for any undeclared HTTP error status
+    code) and the timeout error class (thrown when the request times out).
+  type: fix

--- a/generators/typescript/sdk/client-class-generator/src/__test__/GeneratedEndpointResponse.test.ts
+++ b/generators/typescript/sdk/client-class-generator/src/__test__/GeneratedEndpointResponse.test.ts
@@ -227,6 +227,11 @@ function createMockContext(): any {
                     ])
             })
         },
+        timeoutSdkError: {
+            getReferenceToTimeoutSdkError: () => ({
+                getExpression: () => ts.factory.createIdentifier("MyOrgTimeoutError")
+            })
+        },
         sdkErrorSchema: {
             getGeneratedSdkErrorSchema: () => ({
                 deserializeBody: (_context: unknown, { referenceToBody }: { referenceToBody: ts.Expression }) =>
@@ -275,6 +280,9 @@ function createMockContext(): any {
             })
         },
         genericAPISdkError: {
+            getReferenceToGenericAPISdkError: () => ({
+                getExpression: () => ts.factory.createIdentifier("MyOrgError")
+            }),
             getGeneratedGenericAPISdkError: () => ({
                 build: (
                     _context: unknown,
@@ -416,7 +424,7 @@ describe("GeneratedThrowingEndpointResponse", () => {
         it("returns empty array when no errors", () => {
             const instance = createInstance();
             const context = createMockContext();
-            expect(instance.getNamesOfThrownExceptions(context)).toEqual([]);
+            expect(instance.getNamesOfThrownExceptions(context)).toEqual(["MyOrgError", "MyOrgTimeoutError"]);
         });
 
         it("returns error names when errors are defined", () => {
@@ -425,7 +433,7 @@ describe("GeneratedThrowingEndpointResponse", () => {
             });
             const context = createMockContext();
             const names = instance.getNamesOfThrownExceptions(context);
-            expect(names).toEqual(["BadRequestError", "NotFoundError"]);
+            expect(names).toEqual(["BadRequestError", "NotFoundError", "MyOrgError", "MyOrgTimeoutError"]);
         });
     });
 

--- a/generators/typescript/sdk/client-class-generator/src/endpoints/default/endpoint-response/GeneratedThrowingEndpointResponse.ts
+++ b/generators/typescript/sdk/client-class-generator/src/endpoints/default/endpoint-response/GeneratedThrowingEndpointResponse.ts
@@ -710,9 +710,13 @@ export class GeneratedThrowingEndpointResponse implements GeneratedEndpointRespo
     }
 
     public getNamesOfThrownExceptions(context: FileContext): string[] {
-        return this.endpoint.errors.map((error) =>
-            getTextOfTsNode(context.sdkError.getReferenceToError(error.error).getExpression())
-        );
+        return [
+            ...this.endpoint.errors.map((error) =>
+                getTextOfTsNode(context.sdkError.getReferenceToError(error.error).getExpression())
+            ),
+            getTextOfTsNode(context.genericAPISdkError.getReferenceToGenericAPISdkError().getExpression()),
+            getTextOfTsNode(context.timeoutSdkError.getReferenceToTimeoutSdkError().getExpression())
+        ];
     }
 
     public getReturnType(context: FileContext): ts.TypeNode {

--- a/seed/ts-sdk/accept-header/src/api/resources/service/client/Client.ts
+++ b/seed/ts-sdk/accept-header/src/api/resources/service/client/Client.ts
@@ -25,6 +25,8 @@ export class ServiceClient {
      * @param {ServiceClient.RequestOptions} requestOptions - Request-specific configuration.
      *
      * @throws {@link SeedAccept.NotFoundError}
+     * @throws {@link errors.SeedAcceptError}
+     * @throws {@link errors.SeedAcceptTimeoutError}
      *
      * @example
      *     await client.service.endpoint()

--- a/seed/ts-sdk/alias-extends/src/Client.ts
+++ b/seed/ts-sdk/alias-extends/src/Client.ts
@@ -26,6 +26,9 @@ export class SeedAliasExtendsClient {
      * @param {SeedAliasExtends.InlinedChildRequest} request
      * @param {SeedAliasExtendsClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedAliasExtendsError}
+     * @throws {@link errors.SeedAliasExtendsTimeoutError}
+     *
      * @example
      *     await client.extendedInlineRequestBody({
      *         child: "child",

--- a/seed/ts-sdk/alias/src/Client.ts
+++ b/seed/ts-sdk/alias/src/Client.ts
@@ -25,6 +25,9 @@ export class SeedAliasClient {
      * @param {SeedAlias.TypeId} typeId
      * @param {SeedAliasClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedAliasError}
+     * @throws {@link errors.SeedAliasTimeoutError}
+     *
      * @example
      *     await client.get("typeId")
      */

--- a/seed/ts-sdk/allof-inline/src/Client.ts
+++ b/seed/ts-sdk/allof-inline/src/Client.ts
@@ -27,6 +27,9 @@ export class SeedApiClient {
      * @param {SeedApi.SearchRuleTypesRequest} request
      * @param {SeedApiClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedApiError}
+     * @throws {@link errors.SeedApiTimeoutError}
+     *
      * @example
      *     await client.searchRuleTypes()
      */
@@ -85,6 +88,9 @@ export class SeedApiClient {
      * @param {SeedApi.RuleCreateRequest} request
      * @param {SeedApiClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedApiError}
+     * @throws {@link errors.SeedApiTimeoutError}
+     *
      * @example
      *     await client.createRule({
      *         name: "name",
@@ -140,6 +146,9 @@ export class SeedApiClient {
     /**
      * @param {SeedApiClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedApiError}
+     * @throws {@link errors.SeedApiTimeoutError}
+     *
      * @example
      *     await client.listUsers()
      */
@@ -187,6 +196,9 @@ export class SeedApiClient {
     /**
      * @param {SeedApiClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedApiError}
+     * @throws {@link errors.SeedApiTimeoutError}
+     *
      * @example
      *     await client.getEntity()
      */
@@ -231,6 +243,9 @@ export class SeedApiClient {
 
     /**
      * @param {SeedApiClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedApiError}
+     * @throws {@link errors.SeedApiTimeoutError}
      *
      * @example
      *     await client.getOrganization()
@@ -281,6 +296,9 @@ export class SeedApiClient {
      *
      * @param {SeedApi.PlantPost} request
      * @param {SeedApiClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedApiError}
+     * @throws {@link errors.SeedApiTimeoutError}
      *
      * @example
      *     await client.createPlant({
@@ -343,6 +361,9 @@ export class SeedApiClient {
      *
      * @param {SeedApi.TreeRecord} request
      * @param {SeedApiClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedApiError}
+     * @throws {@link errors.SeedApiTimeoutError}
      *
      * @example
      *     await client.createTree({

--- a/seed/ts-sdk/allof/src/Client.ts
+++ b/seed/ts-sdk/allof/src/Client.ts
@@ -27,6 +27,9 @@ export class SeedApiClient {
      * @param {SeedApi.SearchRuleTypesRequest} request
      * @param {SeedApiClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedApiError}
+     * @throws {@link errors.SeedApiTimeoutError}
+     *
      * @example
      *     await client.searchRuleTypes()
      */
@@ -85,6 +88,9 @@ export class SeedApiClient {
      * @param {SeedApi.RuleCreateRequest} request
      * @param {SeedApiClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedApiError}
+     * @throws {@link errors.SeedApiTimeoutError}
+     *
      * @example
      *     await client.createRule({
      *         name: "name",
@@ -140,6 +146,9 @@ export class SeedApiClient {
     /**
      * @param {SeedApiClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedApiError}
+     * @throws {@link errors.SeedApiTimeoutError}
+     *
      * @example
      *     await client.listUsers()
      */
@@ -187,6 +196,9 @@ export class SeedApiClient {
     /**
      * @param {SeedApiClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedApiError}
+     * @throws {@link errors.SeedApiTimeoutError}
+     *
      * @example
      *     await client.getEntity()
      */
@@ -231,6 +243,9 @@ export class SeedApiClient {
 
     /**
      * @param {SeedApiClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedApiError}
+     * @throws {@link errors.SeedApiTimeoutError}
      *
      * @example
      *     await client.getOrganization()
@@ -281,6 +296,9 @@ export class SeedApiClient {
      *
      * @param {SeedApi.PlantPost} request
      * @param {SeedApiClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedApiError}
+     * @throws {@link errors.SeedApiTimeoutError}
      *
      * @example
      *     await client.createPlant({
@@ -341,6 +359,9 @@ export class SeedApiClient {
      *
      * @param {SeedApi.TreeRecord} request
      * @param {SeedApiClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedApiError}
+     * @throws {@link errors.SeedApiTimeoutError}
      *
      * @example
      *     await client.createTree({

--- a/seed/ts-sdk/any-auth/always-send-auth/src/api/resources/auth/client/Client.ts
+++ b/seed/ts-sdk/any-auth/always-send-auth/src/api/resources/auth/client/Client.ts
@@ -26,6 +26,9 @@ export class AuthClient {
      * @param {SeedAnyAuth.GetTokenRequest} request
      * @param {AuthClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedAnyAuthError}
+     * @throws {@link errors.SeedAnyAuthTimeoutError}
+     *
      * @example
      *     await client.auth.getToken({
      *         client_id: "client_id",

--- a/seed/ts-sdk/any-auth/always-send-auth/src/api/resources/user/client/Client.ts
+++ b/seed/ts-sdk/any-auth/always-send-auth/src/api/resources/user/client/Client.ts
@@ -24,6 +24,9 @@ export class UserClient {
     /**
      * @param {UserClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedAnyAuthError}
+     * @throws {@link errors.SeedAnyAuthTimeoutError}
+     *
      * @example
      *     await client.user.get()
      */
@@ -70,6 +73,9 @@ export class UserClient {
 
     /**
      * @param {UserClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedAnyAuthError}
+     * @throws {@link errors.SeedAnyAuthTimeoutError}
      *
      * @example
      *     await client.user.getAdmins()

--- a/seed/ts-sdk/any-auth/generate-endpoint-metadata/src/api/resources/auth/client/Client.ts
+++ b/seed/ts-sdk/any-auth/generate-endpoint-metadata/src/api/resources/auth/client/Client.ts
@@ -26,6 +26,9 @@ export class AuthClient {
      * @param {SeedAnyAuth.GetTokenRequest} request
      * @param {AuthClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedAnyAuthError}
+     * @throws {@link errors.SeedAnyAuthTimeoutError}
+     *
      * @example
      *     await client.auth.getToken({
      *         client_id: "client_id",

--- a/seed/ts-sdk/any-auth/generate-endpoint-metadata/src/api/resources/user/client/Client.ts
+++ b/seed/ts-sdk/any-auth/generate-endpoint-metadata/src/api/resources/user/client/Client.ts
@@ -24,6 +24,9 @@ export class UserClient {
     /**
      * @param {UserClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedAnyAuthError}
+     * @throws {@link errors.SeedAnyAuthTimeoutError}
+     *
      * @example
      *     await client.user.get()
      */
@@ -76,6 +79,9 @@ export class UserClient {
 
     /**
      * @param {UserClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedAnyAuthError}
+     * @throws {@link errors.SeedAnyAuthTimeoutError}
      *
      * @example
      *     await client.user.getAdmins()

--- a/seed/ts-sdk/any-auth/no-custom-config/src/api/resources/auth/client/Client.ts
+++ b/seed/ts-sdk/any-auth/no-custom-config/src/api/resources/auth/client/Client.ts
@@ -26,6 +26,9 @@ export class AuthClient {
      * @param {SeedAnyAuth.GetTokenRequest} request
      * @param {AuthClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedAnyAuthError}
+     * @throws {@link errors.SeedAnyAuthTimeoutError}
+     *
      * @example
      *     await client.auth.getToken({
      *         client_id: "client_id",

--- a/seed/ts-sdk/any-auth/no-custom-config/src/api/resources/user/client/Client.ts
+++ b/seed/ts-sdk/any-auth/no-custom-config/src/api/resources/user/client/Client.ts
@@ -24,6 +24,9 @@ export class UserClient {
     /**
      * @param {UserClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedAnyAuthError}
+     * @throws {@link errors.SeedAnyAuthTimeoutError}
+     *
      * @example
      *     await client.user.get()
      */
@@ -70,6 +73,9 @@ export class UserClient {
 
     /**
      * @param {UserClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedAnyAuthError}
+     * @throws {@link errors.SeedAnyAuthTimeoutError}
      *
      * @example
      *     await client.user.getAdmins()

--- a/seed/ts-sdk/api-wide-base-path-with-default/src/api/resources/widgets/client/Client.ts
+++ b/seed/ts-sdk/api-wide-base-path-with-default/src/api/resources/widgets/client/Client.ts
@@ -26,6 +26,9 @@ export class WidgetsClient {
      * @param {SeedApi.Widget} request
      * @param {WidgetsClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedApiError}
+     * @throws {@link errors.SeedApiTimeoutError}
+     *
      * @example
      *     await client.widgets.create({
      *         name: "name"

--- a/seed/ts-sdk/api-wide-base-path/src/api/resources/service/client/Client.ts
+++ b/seed/ts-sdk/api-wide-base-path/src/api/resources/service/client/Client.ts
@@ -26,6 +26,9 @@ export class ServiceClient {
      * @param {string} resourceParam
      * @param {ServiceClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedApiWideBasePathError}
+     * @throws {@link errors.SeedApiWideBasePathTimeoutError}
+     *
      * @example
      *     await client.service.post("serviceParam", 1, "resourceParam")
      */

--- a/seed/ts-sdk/audiences/no-custom-config/src/api/resources/folderA/resources/service/client/Client.ts
+++ b/seed/ts-sdk/audiences/no-custom-config/src/api/resources/folderA/resources/service/client/Client.ts
@@ -25,6 +25,9 @@ export class ServiceClient {
      * @param {SeedAudiences.folderA.GetDirectThreadRequest} request
      * @param {ServiceClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedAudiencesError}
+     * @throws {@link errors.SeedAudiencesTimeoutError}
+     *
      * @example
      *     await client.folderA.service.getDirectThread({
      *         ids: "ids",

--- a/seed/ts-sdk/audiences/no-custom-config/src/api/resources/folderD/resources/service/client/Client.ts
+++ b/seed/ts-sdk/audiences/no-custom-config/src/api/resources/folderD/resources/service/client/Client.ts
@@ -24,6 +24,9 @@ export class ServiceClient {
     /**
      * @param {ServiceClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedAudiencesError}
+     * @throws {@link errors.SeedAudiencesTimeoutError}
+     *
      * @example
      *     await client.folderD.service.getDirectThread()
      */

--- a/seed/ts-sdk/audiences/no-custom-config/src/api/resources/foo/client/Client.ts
+++ b/seed/ts-sdk/audiences/no-custom-config/src/api/resources/foo/client/Client.ts
@@ -26,6 +26,9 @@ export class FooClient {
      * @param {SeedAudiences.FindRequest} request
      * @param {FooClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedAudiencesError}
+     * @throws {@link errors.SeedAudiencesTimeoutError}
+     *
      * @example
      *     await client.foo.find({
      *         optionalString: "optionalString",

--- a/seed/ts-sdk/audiences/with-partner-audience/src/api/resources/folderD/resources/service/client/Client.ts
+++ b/seed/ts-sdk/audiences/with-partner-audience/src/api/resources/folderD/resources/service/client/Client.ts
@@ -24,6 +24,9 @@ export class ServiceClient {
     /**
      * @param {ServiceClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedAudiencesError}
+     * @throws {@link errors.SeedAudiencesTimeoutError}
+     *
      * @example
      *     await client.folderD.service.getDirectThread()
      */

--- a/seed/ts-sdk/basic-auth-environment-variables/src/api/resources/basicAuth/client/Client.ts
+++ b/seed/ts-sdk/basic-auth-environment-variables/src/api/resources/basicAuth/client/Client.ts
@@ -28,6 +28,8 @@ export class BasicAuthClient {
      * @param {BasicAuthClient.RequestOptions} requestOptions - Request-specific configuration.
      *
      * @throws {@link SeedBasicAuthEnvironmentVariables.UnauthorizedRequest}
+     * @throws {@link errors.SeedBasicAuthEnvironmentVariablesError}
+     * @throws {@link errors.SeedBasicAuthEnvironmentVariablesTimeoutError}
      *
      * @example
      *     await client.basicAuth.getWithBasicAuth()
@@ -91,6 +93,8 @@ export class BasicAuthClient {
      *
      * @throws {@link SeedBasicAuthEnvironmentVariables.UnauthorizedRequest}
      * @throws {@link SeedBasicAuthEnvironmentVariables.BadRequest}
+     * @throws {@link errors.SeedBasicAuthEnvironmentVariablesError}
+     * @throws {@link errors.SeedBasicAuthEnvironmentVariablesTimeoutError}
      *
      * @example
      *     await client.basicAuth.postWithBasicAuth({

--- a/seed/ts-sdk/basic-auth-pw-omitted/src/api/resources/basicAuth/client/Client.ts
+++ b/seed/ts-sdk/basic-auth-pw-omitted/src/api/resources/basicAuth/client/Client.ts
@@ -28,6 +28,8 @@ export class BasicAuthClient {
      * @param {BasicAuthClient.RequestOptions} requestOptions - Request-specific configuration.
      *
      * @throws {@link SeedBasicAuthPwOmitted.UnauthorizedRequest}
+     * @throws {@link errors.SeedBasicAuthPwOmittedError}
+     * @throws {@link errors.SeedBasicAuthPwOmittedTimeoutError}
      *
      * @example
      *     await client.basicAuth.getWithBasicAuth()
@@ -91,6 +93,8 @@ export class BasicAuthClient {
      *
      * @throws {@link SeedBasicAuthPwOmitted.UnauthorizedRequest}
      * @throws {@link SeedBasicAuthPwOmitted.BadRequest}
+     * @throws {@link errors.SeedBasicAuthPwOmittedError}
+     * @throws {@link errors.SeedBasicAuthPwOmittedTimeoutError}
      *
      * @example
      *     await client.basicAuth.postWithBasicAuth({

--- a/seed/ts-sdk/basic-auth/src/api/resources/basicAuth/client/Client.ts
+++ b/seed/ts-sdk/basic-auth/src/api/resources/basicAuth/client/Client.ts
@@ -28,6 +28,8 @@ export class BasicAuthClient {
      * @param {BasicAuthClient.RequestOptions} requestOptions - Request-specific configuration.
      *
      * @throws {@link SeedBasicAuth.UnauthorizedRequest}
+     * @throws {@link errors.SeedBasicAuthError}
+     * @throws {@link errors.SeedBasicAuthTimeoutError}
      *
      * @example
      *     await client.basicAuth.getWithBasicAuth()
@@ -91,6 +93,8 @@ export class BasicAuthClient {
      *
      * @throws {@link SeedBasicAuth.UnauthorizedRequest}
      * @throws {@link SeedBasicAuth.BadRequest}
+     * @throws {@link errors.SeedBasicAuthError}
+     * @throws {@link errors.SeedBasicAuthTimeoutError}
      *
      * @example
      *     await client.basicAuth.postWithBasicAuth({

--- a/seed/ts-sdk/bearer-token-environment-variable/src/api/resources/service/client/Client.ts
+++ b/seed/ts-sdk/bearer-token-environment-variable/src/api/resources/service/client/Client.ts
@@ -25,6 +25,9 @@ export class ServiceClient {
      *
      * @param {ServiceClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedBearerTokenEnvironmentVariableError}
+     * @throws {@link errors.SeedBearerTokenEnvironmentVariableTimeoutError}
+     *
      * @example
      *     await client.service.getWithBearerToken()
      */

--- a/seed/ts-sdk/bytes-download/src/api/resources/service/client/Client.ts
+++ b/seed/ts-sdk/bytes-download/src/api/resources/service/client/Client.ts
@@ -23,6 +23,9 @@ export class ServiceClient {
     /**
      * @param {ServiceClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedBytesDownloadError}
+     * @throws {@link errors.SeedBytesDownloadTimeoutError}
+     *
      * @example
      *     await client.service.simple()
      */
@@ -62,6 +65,10 @@ export class ServiceClient {
         return handleNonStatusCodeError(_response.error, _response.rawResponse, "POST", "/snippet");
     }
 
+    /**
+     * @throws {@link errors.SeedBytesDownloadError}
+     * @throws {@link errors.SeedBytesDownloadTimeoutError}
+     */
     public download(
         id: string,
         requestOptions?: ServiceClient.RequestOptions,

--- a/seed/ts-sdk/bytes-upload/src/api/resources/service/client/Client.ts
+++ b/seed/ts-sdk/bytes-upload/src/api/resources/service/client/Client.ts
@@ -25,6 +25,9 @@ export class ServiceClient {
      * @param {core.file.Uploadable} uploadable
      * @param {ServiceClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedBytesUploadError}
+     * @throws {@link errors.SeedBytesUploadTimeoutError}
+     *
      * @example
      *     import { createReadStream } from "fs";
      *     await client.service.upload(createReadStream("path/to/file"))
@@ -84,6 +87,9 @@ export class ServiceClient {
      * @param {core.file.Uploadable} uploadable
      * @param {SeedBytesUpload.UploadWithQueryParamsRequest} request
      * @param {ServiceClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedBytesUploadError}
+     * @throws {@link errors.SeedBytesUploadTimeoutError}
      *
      * @example
      *     import { createReadStream } from "fs";

--- a/seed/ts-sdk/cli-multi-spec-namespaced/src/api/resources/v1/client/Client.ts
+++ b/seed/ts-sdk/cli-multi-spec-namespaced/src/api/resources/v1/client/Client.ts
@@ -25,6 +25,9 @@ export class V1Client {
     /**
      * @param {V1Client.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedApiError}
+     * @throws {@link errors.SeedApiTimeoutError}
+     *
      * @example
      *     await client.v1.listUsers()
      */

--- a/seed/ts-sdk/cli-multi-spec-namespaced/src/api/resources/v2/client/Client.ts
+++ b/seed/ts-sdk/cli-multi-spec-namespaced/src/api/resources/v2/client/Client.ts
@@ -26,6 +26,9 @@ export class V2Client {
      * @param {SeedApi.v2.ListUsersRequest} request
      * @param {V2Client.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedApiError}
+     * @throws {@link errors.SeedApiTimeoutError}
+     *
      * @example
      *     await client.v2.listUsers()
      */

--- a/seed/ts-sdk/cli-multi-spec/src/Client.ts
+++ b/seed/ts-sdk/cli-multi-spec/src/Client.ts
@@ -25,6 +25,9 @@ export class SeedApiClient {
     /**
      * @param {SeedApiClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedApiError}
+     * @throws {@link errors.SeedApiTimeoutError}
+     *
      * @example
      *     await client.listUsers()
      */
@@ -70,6 +73,9 @@ export class SeedApiClient {
     /**
      * @param {SeedApi.GetUserRequest} request
      * @param {SeedApiClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedApiError}
+     * @throws {@link errors.SeedApiTimeoutError}
      *
      * @example
      *     await client.getUser({
@@ -123,6 +129,9 @@ export class SeedApiClient {
     /**
      * @param {SeedApiClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedApiError}
+     * @throws {@link errors.SeedApiTimeoutError}
+     *
      * @example
      *     await client.listInvoices()
      */
@@ -168,6 +177,9 @@ export class SeedApiClient {
     /**
      * @param {SeedApi.GetInvoiceRequest} request
      * @param {SeedApiClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedApiError}
+     * @throws {@link errors.SeedApiTimeoutError}
      *
      * @example
      *     await client.getInvoice({

--- a/seed/ts-sdk/client-side-params/src/api/resources/service/client/Client.ts
+++ b/seed/ts-sdk/client-side-params/src/api/resources/service/client/Client.ts
@@ -29,6 +29,9 @@ export class ServiceClient {
      * @param {SeedClientSideParams.ListResourcesRequest} request
      * @param {ServiceClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedClientSideParamsError}
+     * @throws {@link errors.SeedClientSideParamsTimeoutError}
+     *
      * @example
      *     await client.service.listResources({
      *         page: 1,
@@ -103,6 +106,9 @@ export class ServiceClient {
      * @param {SeedClientSideParams.GetResourceRequest} request
      * @param {ServiceClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedClientSideParamsError}
+     * @throws {@link errors.SeedClientSideParamsTimeoutError}
+     *
      * @example
      *     await client.service.getResource("resourceId", {
      *         include_metadata: true,
@@ -167,6 +173,9 @@ export class ServiceClient {
      *
      * @param {SeedClientSideParams.SearchResourcesRequest} request
      * @param {ServiceClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedClientSideParamsError}
+     * @throws {@link errors.SeedClientSideParamsTimeoutError}
      *
      * @example
      *     await client.service.searchResources({
@@ -239,6 +248,9 @@ export class ServiceClient {
      *
      * @param {SeedClientSideParams.ListUsersRequest} request
      * @param {ServiceClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedClientSideParamsError}
+     * @throws {@link errors.SeedClientSideParamsTimeoutError}
      *
      * @example
      *     await client.service.listUsers({
@@ -328,6 +340,9 @@ export class ServiceClient {
      * @param {SeedClientSideParams.GetUserRequest} request
      * @param {ServiceClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedClientSideParamsError}
+     * @throws {@link errors.SeedClientSideParamsTimeoutError}
+     *
      * @example
      *     await client.service.getUserById("userId", {
      *         fields: "fields",
@@ -392,6 +407,9 @@ export class ServiceClient {
      *
      * @param {SeedClientSideParams.CreateUserRequest} request
      * @param {ServiceClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedClientSideParamsError}
+     * @throws {@link errors.SeedClientSideParamsTimeoutError}
      *
      * @example
      *     await client.service.createUser({
@@ -465,6 +483,9 @@ export class ServiceClient {
      * @param {string} userId
      * @param {SeedClientSideParams.UpdateUserRequest} request
      * @param {ServiceClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedClientSideParamsError}
+     * @throws {@link errors.SeedClientSideParamsTimeoutError}
      *
      * @example
      *     await client.service.updateUser("userId", {
@@ -540,6 +561,9 @@ export class ServiceClient {
      * @param {string} userId
      * @param {ServiceClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedClientSideParamsError}
+     * @throws {@link errors.SeedClientSideParamsTimeoutError}
+     *
      * @example
      *     await client.service.deleteUser("userId")
      */
@@ -587,6 +611,9 @@ export class ServiceClient {
      *
      * @param {SeedClientSideParams.ListConnectionsRequest} request
      * @param {ServiceClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedClientSideParamsError}
+     * @throws {@link errors.SeedClientSideParamsTimeoutError}
      *
      * @example
      *     await client.service.listConnections({
@@ -653,6 +680,9 @@ export class ServiceClient {
      * @param {string} connectionId
      * @param {SeedClientSideParams.GetConnectionRequest} request
      * @param {ServiceClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedClientSideParamsError}
+     * @throws {@link errors.SeedClientSideParamsTimeoutError}
      *
      * @example
      *     await client.service.getConnection("connectionId", {
@@ -721,6 +751,9 @@ export class ServiceClient {
      *
      * @param {SeedClientSideParams.ListClientsRequest} request
      * @param {ServiceClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedClientSideParamsError}
+     * @throws {@link errors.SeedClientSideParamsTimeoutError}
      *
      * @example
      *     await client.service.listClients({
@@ -809,6 +842,9 @@ export class ServiceClient {
      * @param {string} clientId
      * @param {SeedClientSideParams.GetClientRequest} request
      * @param {ServiceClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedClientSideParamsError}
+     * @throws {@link errors.SeedClientSideParamsTimeoutError}
      *
      * @example
      *     await client.service.getClient("clientId", {

--- a/seed/ts-sdk/content-type/src/api/resources/service/client/Client.ts
+++ b/seed/ts-sdk/content-type/src/api/resources/service/client/Client.ts
@@ -26,6 +26,9 @@ export class ServiceClient {
      * @param {SeedContentTypes.PatchProxyRequest} request
      * @param {ServiceClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedContentTypesError}
+     * @throws {@link errors.SeedContentTypesTimeoutError}
+     *
      * @example
      *     await client.service.patch({
      *         application: "application",
@@ -84,6 +87,9 @@ export class ServiceClient {
      * @param {string} id
      * @param {SeedContentTypes.PatchComplexRequest} request
      * @param {ServiceClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedContentTypesError}
+     * @throws {@link errors.SeedContentTypesTimeoutError}
      *
      * @example
      *     await client.service.patchComplex("id", {
@@ -162,6 +168,9 @@ export class ServiceClient {
      * @param {SeedContentTypes.NamedMixedPatchRequest} request
      * @param {ServiceClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedContentTypesError}
+     * @throws {@link errors.SeedContentTypesTimeoutError}
+     *
      * @example
      *     await client.service.namedPatchWithMixed("id", {
      *         appId: "appId",
@@ -225,6 +234,9 @@ export class ServiceClient {
      * @param {SeedContentTypes.OptionalMergePatchRequest} request
      * @param {ServiceClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedContentTypesError}
+     * @throws {@link errors.SeedContentTypesTimeoutError}
+     *
      * @example
      *     await client.service.optionalMergePatchTest({
      *         requiredField: "requiredField",
@@ -285,6 +297,9 @@ export class ServiceClient {
      * @param {string} id
      * @param {SeedContentTypes.RegularPatchRequest} request
      * @param {ServiceClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedContentTypesError}
+     * @throws {@link errors.SeedContentTypesTimeoutError}
      *
      * @example
      *     await client.service.regularPatch("id", {

--- a/seed/ts-sdk/cross-package-type-names/no-custom-config/src/api/resources/folderA/resources/service/client/Client.ts
+++ b/seed/ts-sdk/cross-package-type-names/no-custom-config/src/api/resources/folderA/resources/service/client/Client.ts
@@ -24,6 +24,9 @@ export class ServiceClient {
     /**
      * @param {ServiceClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedCrossPackageTypeNamesError}
+     * @throws {@link errors.SeedCrossPackageTypeNamesTimeoutError}
+     *
      * @example
      *     await client.folderA.service.getDirectThread()
      */

--- a/seed/ts-sdk/cross-package-type-names/no-custom-config/src/api/resources/folderD/resources/service/client/Client.ts
+++ b/seed/ts-sdk/cross-package-type-names/no-custom-config/src/api/resources/folderD/resources/service/client/Client.ts
@@ -24,6 +24,9 @@ export class ServiceClient {
     /**
      * @param {ServiceClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedCrossPackageTypeNamesError}
+     * @throws {@link errors.SeedCrossPackageTypeNamesTimeoutError}
+     *
      * @example
      *     await client.folderD.service.getDirectThread()
      */

--- a/seed/ts-sdk/cross-package-type-names/no-custom-config/src/api/resources/foo/client/Client.ts
+++ b/seed/ts-sdk/cross-package-type-names/no-custom-config/src/api/resources/foo/client/Client.ts
@@ -26,6 +26,9 @@ export class FooClient {
      * @param {SeedCrossPackageTypeNames.FindRequest} request
      * @param {FooClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedCrossPackageTypeNamesError}
+     * @throws {@link errors.SeedCrossPackageTypeNamesTimeoutError}
+     *
      * @example
      *     await client.foo.find({
      *         optionalString: "optionalString",

--- a/seed/ts-sdk/cross-package-type-names/serde-layer/src/api/resources/folderA/resources/service/client/Client.ts
+++ b/seed/ts-sdk/cross-package-type-names/serde-layer/src/api/resources/folderA/resources/service/client/Client.ts
@@ -25,6 +25,9 @@ export class ServiceClient {
     /**
      * @param {ServiceClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedCrossPackageTypeNamesError}
+     * @throws {@link errors.SeedCrossPackageTypeNamesTimeoutError}
+     *
      * @example
      *     await client.folderA.service.getDirectThread()
      */

--- a/seed/ts-sdk/cross-package-type-names/serde-layer/src/api/resources/folderD/resources/service/client/Client.ts
+++ b/seed/ts-sdk/cross-package-type-names/serde-layer/src/api/resources/folderD/resources/service/client/Client.ts
@@ -25,6 +25,9 @@ export class ServiceClient {
     /**
      * @param {ServiceClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedCrossPackageTypeNamesError}
+     * @throws {@link errors.SeedCrossPackageTypeNamesTimeoutError}
+     *
      * @example
      *     await client.folderD.service.getDirectThread()
      */

--- a/seed/ts-sdk/cross-package-type-names/serde-layer/src/api/resources/foo/client/Client.ts
+++ b/seed/ts-sdk/cross-package-type-names/serde-layer/src/api/resources/foo/client/Client.ts
@@ -27,6 +27,9 @@ export class FooClient {
      * @param {SeedCrossPackageTypeNames.FindRequest} request
      * @param {FooClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedCrossPackageTypeNamesError}
+     * @throws {@link errors.SeedCrossPackageTypeNamesTimeoutError}
+     *
      * @example
      *     await client.foo.find({
      *         optionalString: "optionalString",

--- a/seed/ts-sdk/discriminated-union-with-nested-oneof/src/Client.ts
+++ b/seed/ts-sdk/discriminated-union-with-nested-oneof/src/Client.ts
@@ -5,6 +5,7 @@ import type { BaseClientOptions, BaseRequestOptions } from "./BaseClient.js";
 import { type NormalizedClientOptions, normalizeClientOptions } from "./BaseClient.js";
 import { mergeHeaders } from "./core/headers.js";
 import * as core from "./core/index.js";
+import { mergeAdditionalBodyParameters } from "./core/requestBody.js";
 import { handleNonStatusCodeError } from "./errors/handleNonStatusCodeError.js";
 import * as errors from "./errors/index.js";
 
@@ -24,6 +25,9 @@ export class SeedApiClient {
     /**
      * @param {SeedApi.AstNode} request
      * @param {SeedApiClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedApiError}
+     * @throws {@link errors.SeedApiTimeoutError}
      *
      * @example
      *     await client.createAst({
@@ -54,7 +58,7 @@ export class SeedApiClient {
             contentType: "application/json",
             queryString: core.url.queryBuilder().mergeAdditional(requestOptions?.queryParams).build(),
             requestType: "json",
-            body: request,
+            body: mergeAdditionalBodyParameters(request, requestOptions?.additionalBodyParameters),
             timeoutMs: (requestOptions?.timeoutInSeconds ?? this._options?.timeoutInSeconds ?? 60) * 1000,
             maxRetries: requestOptions?.maxRetries ?? this._options?.maxRetries,
             abortSignal: requestOptions?.abortSignal,

--- a/seed/ts-sdk/endpoint-security-auth/src/api/resources/auth/client/Client.ts
+++ b/seed/ts-sdk/endpoint-security-auth/src/api/resources/auth/client/Client.ts
@@ -26,6 +26,9 @@ export class AuthClient {
      * @param {SeedEndpointSecurityAuth.GetTokenRequest} request
      * @param {AuthClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedEndpointSecurityAuthError}
+     * @throws {@link errors.SeedEndpointSecurityAuthTimeoutError}
+     *
      * @example
      *     await client.auth.getToken({
      *         client_id: "client_id",

--- a/seed/ts-sdk/endpoint-security-auth/src/api/resources/user/client/Client.ts
+++ b/seed/ts-sdk/endpoint-security-auth/src/api/resources/user/client/Client.ts
@@ -24,6 +24,9 @@ export class UserClient {
     /**
      * @param {UserClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedEndpointSecurityAuthError}
+     * @throws {@link errors.SeedEndpointSecurityAuthTimeoutError}
+     *
      * @example
      *     await client.user.getWithBearer()
      */
@@ -78,6 +81,9 @@ export class UserClient {
 
     /**
      * @param {UserClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedEndpointSecurityAuthError}
+     * @throws {@link errors.SeedEndpointSecurityAuthTimeoutError}
      *
      * @example
      *     await client.user.getWithApiKey()
@@ -134,6 +140,9 @@ export class UserClient {
     /**
      * @param {UserClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedEndpointSecurityAuthError}
+     * @throws {@link errors.SeedEndpointSecurityAuthTimeoutError}
+     *
      * @example
      *     await client.user.getWithOAuth()
      */
@@ -188,6 +197,9 @@ export class UserClient {
 
     /**
      * @param {UserClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedEndpointSecurityAuthError}
+     * @throws {@link errors.SeedEndpointSecurityAuthTimeoutError}
      *
      * @example
      *     await client.user.getWithBasic()
@@ -244,6 +256,9 @@ export class UserClient {
     /**
      * @param {UserClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedEndpointSecurityAuthError}
+     * @throws {@link errors.SeedEndpointSecurityAuthTimeoutError}
+     *
      * @example
      *     await client.user.getWithInferredAuth()
      */
@@ -298,6 +313,9 @@ export class UserClient {
 
     /**
      * @param {UserClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedEndpointSecurityAuthError}
+     * @throws {@link errors.SeedEndpointSecurityAuthTimeoutError}
      *
      * @example
      *     await client.user.getWithAnyAuth()
@@ -355,6 +373,9 @@ export class UserClient {
 
     /**
      * @param {UserClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedEndpointSecurityAuthError}
+     * @throws {@link errors.SeedEndpointSecurityAuthTimeoutError}
      *
      * @example
      *     await client.user.getWithAllAuth()

--- a/seed/ts-sdk/enum/forward-compatible-enums-with-serde/src/api/resources/headers/client/Client.ts
+++ b/seed/ts-sdk/enum/forward-compatible-enums-with-serde/src/api/resources/headers/client/Client.ts
@@ -27,6 +27,9 @@ export class HeadersClient {
      * @param {SeedEnum.SendEnumAsHeaderRequest} request
      * @param {HeadersClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedEnumError}
+     * @throws {@link errors.SeedEnumTimeoutError}
+     *
      * @example
      *     await client.headers.send({
      *         operand: ">",

--- a/seed/ts-sdk/enum/forward-compatible-enums-with-serde/src/api/resources/inlinedRequest/client/Client.ts
+++ b/seed/ts-sdk/enum/forward-compatible-enums-with-serde/src/api/resources/inlinedRequest/client/Client.ts
@@ -27,6 +27,9 @@ export class InlinedRequestClient {
      * @param {SeedEnum.SendEnumInlinedRequest} request
      * @param {InlinedRequestClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedEnumError}
+     * @throws {@link errors.SeedEnumTimeoutError}
+     *
      * @example
      *     await client.inlinedRequest.send({
      *         operand: ">",

--- a/seed/ts-sdk/enum/forward-compatible-enums-with-serde/src/api/resources/multipartForm/client/Client.ts
+++ b/seed/ts-sdk/enum/forward-compatible-enums-with-serde/src/api/resources/multipartForm/client/Client.ts
@@ -25,6 +25,9 @@ export class MultipartFormClient {
     /**
      * @param {SeedEnum.MultipartFormRequest} request
      * @param {MultipartFormClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedEnumError}
+     * @throws {@link errors.SeedEnumTimeoutError}
      */
     public multipartForm(
         request: SeedEnum.MultipartFormRequest,

--- a/seed/ts-sdk/enum/forward-compatible-enums-with-serde/src/api/resources/pathParam/client/Client.ts
+++ b/seed/ts-sdk/enum/forward-compatible-enums-with-serde/src/api/resources/pathParam/client/Client.ts
@@ -27,6 +27,9 @@ export class PathParamClient {
      * @param {SeedEnum.ColorOrOperand} operandOrColor
      * @param {PathParamClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedEnumError}
+     * @throws {@link errors.SeedEnumTimeoutError}
+     *
      * @example
      *     await client.pathParam.send(">", "red")
      */

--- a/seed/ts-sdk/enum/forward-compatible-enums-with-serde/src/api/resources/queryParam/client/Client.ts
+++ b/seed/ts-sdk/enum/forward-compatible-enums-with-serde/src/api/resources/queryParam/client/Client.ts
@@ -27,6 +27,9 @@ export class QueryParamClient {
      * @param {SeedEnum.SendEnumAsQueryParamRequest} request
      * @param {QueryParamClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedEnumError}
+     * @throws {@link errors.SeedEnumTimeoutError}
+     *
      * @example
      *     await client.queryParam.send({
      *         operand: ">",
@@ -129,6 +132,9 @@ export class QueryParamClient {
     /**
      * @param {SeedEnum.SendEnumListAsQueryParamRequest} request
      * @param {QueryParamClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedEnumError}
+     * @throws {@link errors.SeedEnumTimeoutError}
      *
      * @example
      *     await client.queryParam.sendList({

--- a/seed/ts-sdk/enum/forward-compatible-enums/src/api/resources/headers/client/Client.ts
+++ b/seed/ts-sdk/enum/forward-compatible-enums/src/api/resources/headers/client/Client.ts
@@ -26,6 +26,9 @@ export class HeadersClient {
      * @param {SeedEnum.SendEnumAsHeaderRequest} request
      * @param {HeadersClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedEnumError}
+     * @throws {@link errors.SeedEnumTimeoutError}
+     *
      * @example
      *     await client.headers.send({
      *         operand: ">",

--- a/seed/ts-sdk/enum/forward-compatible-enums/src/api/resources/inlinedRequest/client/Client.ts
+++ b/seed/ts-sdk/enum/forward-compatible-enums/src/api/resources/inlinedRequest/client/Client.ts
@@ -26,6 +26,9 @@ export class InlinedRequestClient {
      * @param {SeedEnum.SendEnumInlinedRequest} request
      * @param {InlinedRequestClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedEnumError}
+     * @throws {@link errors.SeedEnumTimeoutError}
+     *
      * @example
      *     await client.inlinedRequest.send({
      *         operand: ">",

--- a/seed/ts-sdk/enum/forward-compatible-enums/src/api/resources/multipartForm/client/Client.ts
+++ b/seed/ts-sdk/enum/forward-compatible-enums/src/api/resources/multipartForm/client/Client.ts
@@ -24,6 +24,9 @@ export class MultipartFormClient {
     /**
      * @param {SeedEnum.MultipartFormRequest} request
      * @param {MultipartFormClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedEnumError}
+     * @throws {@link errors.SeedEnumTimeoutError}
      */
     public multipartForm(
         request: SeedEnum.MultipartFormRequest,

--- a/seed/ts-sdk/enum/forward-compatible-enums/src/api/resources/pathParam/client/Client.ts
+++ b/seed/ts-sdk/enum/forward-compatible-enums/src/api/resources/pathParam/client/Client.ts
@@ -26,6 +26,9 @@ export class PathParamClient {
      * @param {SeedEnum.ColorOrOperand} operandOrColor
      * @param {PathParamClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedEnumError}
+     * @throws {@link errors.SeedEnumTimeoutError}
+     *
      * @example
      *     await client.pathParam.send(">", "red")
      */

--- a/seed/ts-sdk/enum/forward-compatible-enums/src/api/resources/queryParam/client/Client.ts
+++ b/seed/ts-sdk/enum/forward-compatible-enums/src/api/resources/queryParam/client/Client.ts
@@ -26,6 +26,9 @@ export class QueryParamClient {
      * @param {SeedEnum.SendEnumAsQueryParamRequest} request
      * @param {QueryParamClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedEnumError}
+     * @throws {@link errors.SeedEnumTimeoutError}
+     *
      * @example
      *     await client.queryParam.send({
      *         operand: ">",
@@ -98,6 +101,9 @@ export class QueryParamClient {
     /**
      * @param {SeedEnum.SendEnumListAsQueryParamRequest} request
      * @param {QueryParamClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedEnumError}
+     * @throws {@link errors.SeedEnumTimeoutError}
      *
      * @example
      *     await client.queryParam.sendList({

--- a/seed/ts-sdk/enum/no-custom-config/src/api/resources/headers/client/Client.ts
+++ b/seed/ts-sdk/enum/no-custom-config/src/api/resources/headers/client/Client.ts
@@ -26,6 +26,9 @@ export class HeadersClient {
      * @param {SeedEnum.SendEnumAsHeaderRequest} request
      * @param {HeadersClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedEnumError}
+     * @throws {@link errors.SeedEnumTimeoutError}
+     *
      * @example
      *     await client.headers.send({
      *         operand: ">",

--- a/seed/ts-sdk/enum/no-custom-config/src/api/resources/inlinedRequest/client/Client.ts
+++ b/seed/ts-sdk/enum/no-custom-config/src/api/resources/inlinedRequest/client/Client.ts
@@ -26,6 +26,9 @@ export class InlinedRequestClient {
      * @param {SeedEnum.SendEnumInlinedRequest} request
      * @param {InlinedRequestClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedEnumError}
+     * @throws {@link errors.SeedEnumTimeoutError}
+     *
      * @example
      *     await client.inlinedRequest.send({
      *         operand: ">",

--- a/seed/ts-sdk/enum/no-custom-config/src/api/resources/multipartForm/client/Client.ts
+++ b/seed/ts-sdk/enum/no-custom-config/src/api/resources/multipartForm/client/Client.ts
@@ -24,6 +24,9 @@ export class MultipartFormClient {
     /**
      * @param {SeedEnum.MultipartFormRequest} request
      * @param {MultipartFormClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedEnumError}
+     * @throws {@link errors.SeedEnumTimeoutError}
      */
     public multipartForm(
         request: SeedEnum.MultipartFormRequest,

--- a/seed/ts-sdk/enum/no-custom-config/src/api/resources/pathParam/client/Client.ts
+++ b/seed/ts-sdk/enum/no-custom-config/src/api/resources/pathParam/client/Client.ts
@@ -26,6 +26,9 @@ export class PathParamClient {
      * @param {SeedEnum.ColorOrOperand} operandOrColor
      * @param {PathParamClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedEnumError}
+     * @throws {@link errors.SeedEnumTimeoutError}
+     *
      * @example
      *     await client.pathParam.send(">", "red")
      */

--- a/seed/ts-sdk/enum/no-custom-config/src/api/resources/queryParam/client/Client.ts
+++ b/seed/ts-sdk/enum/no-custom-config/src/api/resources/queryParam/client/Client.ts
@@ -26,6 +26,9 @@ export class QueryParamClient {
      * @param {SeedEnum.SendEnumAsQueryParamRequest} request
      * @param {QueryParamClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedEnumError}
+     * @throws {@link errors.SeedEnumTimeoutError}
+     *
      * @example
      *     await client.queryParam.send({
      *         operand: ">",
@@ -98,6 +101,9 @@ export class QueryParamClient {
     /**
      * @param {SeedEnum.SendEnumListAsQueryParamRequest} request
      * @param {QueryParamClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedEnumError}
+     * @throws {@link errors.SeedEnumTimeoutError}
      *
      * @example
      *     await client.queryParam.sendList({

--- a/seed/ts-sdk/enum/serde/src/api/resources/headers/client/Client.ts
+++ b/seed/ts-sdk/enum/serde/src/api/resources/headers/client/Client.ts
@@ -27,6 +27,9 @@ export class HeadersClient {
      * @param {SeedEnum.SendEnumAsHeaderRequest} request
      * @param {HeadersClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedEnumError}
+     * @throws {@link errors.SeedEnumTimeoutError}
+     *
      * @example
      *     await client.headers.send({
      *         operand: ">",

--- a/seed/ts-sdk/enum/serde/src/api/resources/inlinedRequest/client/Client.ts
+++ b/seed/ts-sdk/enum/serde/src/api/resources/inlinedRequest/client/Client.ts
@@ -27,6 +27,9 @@ export class InlinedRequestClient {
      * @param {SeedEnum.SendEnumInlinedRequest} request
      * @param {InlinedRequestClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedEnumError}
+     * @throws {@link errors.SeedEnumTimeoutError}
+     *
      * @example
      *     await client.inlinedRequest.send({
      *         operand: ">",

--- a/seed/ts-sdk/enum/serde/src/api/resources/multipartForm/client/Client.ts
+++ b/seed/ts-sdk/enum/serde/src/api/resources/multipartForm/client/Client.ts
@@ -25,6 +25,9 @@ export class MultipartFormClient {
     /**
      * @param {SeedEnum.MultipartFormRequest} request
      * @param {MultipartFormClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedEnumError}
+     * @throws {@link errors.SeedEnumTimeoutError}
      */
     public multipartForm(
         request: SeedEnum.MultipartFormRequest,

--- a/seed/ts-sdk/enum/serde/src/api/resources/pathParam/client/Client.ts
+++ b/seed/ts-sdk/enum/serde/src/api/resources/pathParam/client/Client.ts
@@ -27,6 +27,9 @@ export class PathParamClient {
      * @param {SeedEnum.ColorOrOperand} operandOrColor
      * @param {PathParamClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedEnumError}
+     * @throws {@link errors.SeedEnumTimeoutError}
+     *
      * @example
      *     await client.pathParam.send(">", "red")
      */

--- a/seed/ts-sdk/enum/serde/src/api/resources/queryParam/client/Client.ts
+++ b/seed/ts-sdk/enum/serde/src/api/resources/queryParam/client/Client.ts
@@ -27,6 +27,9 @@ export class QueryParamClient {
      * @param {SeedEnum.SendEnumAsQueryParamRequest} request
      * @param {QueryParamClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedEnumError}
+     * @throws {@link errors.SeedEnumTimeoutError}
+     *
      * @example
      *     await client.queryParam.send({
      *         operand: ">",
@@ -129,6 +132,9 @@ export class QueryParamClient {
     /**
      * @param {SeedEnum.SendEnumListAsQueryParamRequest} request
      * @param {QueryParamClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedEnumError}
+     * @throws {@link errors.SeedEnumTimeoutError}
      *
      * @example
      *     await client.queryParam.sendList({

--- a/seed/ts-sdk/error-property/no-custom-config/src/api/resources/propertyBasedError/client/Client.ts
+++ b/seed/ts-sdk/error-property/no-custom-config/src/api/resources/propertyBasedError/client/Client.ts
@@ -27,6 +27,8 @@ export class PropertyBasedErrorClient {
      * @param {PropertyBasedErrorClient.RequestOptions} requestOptions - Request-specific configuration.
      *
      * @throws {@link SeedErrorProperty.PropertyBasedErrorTest}
+     * @throws {@link errors.SeedErrorPropertyError}
+     * @throws {@link errors.SeedErrorPropertyTimeoutError}
      *
      * @example
      *     await client.propertyBasedError.throwError()

--- a/seed/ts-sdk/error-property/union-utils/src/api/resources/propertyBasedError/client/Client.ts
+++ b/seed/ts-sdk/error-property/union-utils/src/api/resources/propertyBasedError/client/Client.ts
@@ -27,6 +27,8 @@ export class PropertyBasedErrorClient {
      * @param {PropertyBasedErrorClient.RequestOptions} requestOptions - Request-specific configuration.
      *
      * @throws {@link SeedErrorProperty.PropertyBasedErrorTest}
+     * @throws {@link errors.SeedErrorPropertyError}
+     * @throws {@link errors.SeedErrorPropertyTimeoutError}
      *
      * @example
      *     await client.propertyBasedError.throwError()

--- a/seed/ts-sdk/errors/src/api/resources/simple/client/Client.ts
+++ b/seed/ts-sdk/errors/src/api/resources/simple/client/Client.ts
@@ -29,6 +29,8 @@ export class SimpleClient {
      * @throws {@link SeedErrors.NotFoundError}
      * @throws {@link SeedErrors.BadRequestError}
      * @throws {@link SeedErrors.InternalServerError}
+     * @throws {@link errors.SeedErrorsError}
+     * @throws {@link errors.SeedErrorsTimeoutError}
      *
      * @example
      *     await client.simple.fooWithoutEndpointError({
@@ -107,6 +109,8 @@ export class SimpleClient {
      * @throws {@link SeedErrors.NotFoundError}
      * @throws {@link SeedErrors.BadRequestError}
      * @throws {@link SeedErrors.InternalServerError}
+     * @throws {@link errors.SeedErrorsError}
+     * @throws {@link errors.SeedErrorsTimeoutError}
      *
      * @example
      *     await client.simple.foo({
@@ -190,6 +194,8 @@ export class SimpleClient {
      * @throws {@link SeedErrors.NotFoundError}
      * @throws {@link SeedErrors.BadRequestError}
      * @throws {@link SeedErrors.InternalServerError}
+     * @throws {@link errors.SeedErrorsError}
+     * @throws {@link errors.SeedErrorsTimeoutError}
      *
      * @example
      *     await client.simple.fooWithExamples({

--- a/seed/ts-sdk/examples/examples-with-api-reference/src/Client.ts
+++ b/seed/ts-sdk/examples/examples-with-api-reference/src/Client.ts
@@ -44,6 +44,9 @@ export class SeedExamplesClient {
      * @param {string} request
      * @param {SeedExamplesClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExamplesError}
+     * @throws {@link errors.SeedExamplesTimeoutError}
+     *
      * @example
      *     await client.echo("Hello world!\\n\\nwith\\n\\tnewlines")
      */
@@ -90,6 +93,9 @@ export class SeedExamplesClient {
     /**
      * @param {SeedExamples.Type} request
      * @param {SeedExamplesClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExamplesError}
+     * @throws {@link errors.SeedExamplesTimeoutError}
      *
      * @example
      *     await client.createType("primitive")

--- a/seed/ts-sdk/examples/examples-with-api-reference/src/api/resources/file/resources/notification/resources/service/client/Client.ts
+++ b/seed/ts-sdk/examples/examples-with-api-reference/src/api/resources/file/resources/notification/resources/service/client/Client.ts
@@ -28,6 +28,9 @@ export class ServiceClient {
      * @param {string} notificationId
      * @param {ServiceClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExamplesError}
+     * @throws {@link errors.SeedExamplesTimeoutError}
+     *
      * @example
      *     await client.file.notification.service.getException("notification-hsy129x")
      */

--- a/seed/ts-sdk/examples/examples-with-api-reference/src/api/resources/file/resources/service/client/Client.ts
+++ b/seed/ts-sdk/examples/examples-with-api-reference/src/api/resources/file/resources/service/client/Client.ts
@@ -29,6 +29,8 @@ export class ServiceClient {
      * @param {ServiceClient.RequestOptions} requestOptions - Request-specific configuration.
      *
      * @throws {@link SeedExamples.NotFoundError}
+     * @throws {@link errors.SeedExamplesError}
+     * @throws {@link errors.SeedExamplesTimeoutError}
      *
      * @example
      *     await client.file.service.getFile("file.txt", {

--- a/seed/ts-sdk/examples/examples-with-api-reference/src/api/resources/health/resources/service/client/Client.ts
+++ b/seed/ts-sdk/examples/examples-with-api-reference/src/api/resources/health/resources/service/client/Client.ts
@@ -26,6 +26,9 @@ export class ServiceClient {
      * @param {string} id - The id to check
      * @param {ServiceClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExamplesError}
+     * @throws {@link errors.SeedExamplesTimeoutError}
+     *
      * @example
      *     await client.health.service.check("id-2sdx82h")
      *
@@ -80,6 +83,9 @@ export class ServiceClient {
      * This endpoint checks the health of the service.
      *
      * @param {ServiceClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExamplesError}
+     * @throws {@link errors.SeedExamplesTimeoutError}
      *
      * @example
      *     await client.health.service.ping()

--- a/seed/ts-sdk/examples/examples-with-api-reference/src/api/resources/service/client/Client.ts
+++ b/seed/ts-sdk/examples/examples-with-api-reference/src/api/resources/service/client/Client.ts
@@ -26,6 +26,9 @@ export class ServiceClient {
      * @param {SeedExamples.MovieId} movieId
      * @param {ServiceClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExamplesError}
+     * @throws {@link errors.SeedExamplesTimeoutError}
+     *
      * @example
      *     await client.service.getMovie("movie-c06a4ad7")
      */
@@ -74,6 +77,9 @@ export class ServiceClient {
     /**
      * @param {SeedExamples.Movie} request
      * @param {ServiceClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExamplesError}
+     * @throws {@link errors.SeedExamplesTimeoutError}
      *
      * @example
      *     await client.service.createMovie({
@@ -148,6 +154,9 @@ export class ServiceClient {
      * @param {SeedExamples.GetMetadataRequest} request
      * @param {ServiceClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExamplesError}
+     * @throws {@link errors.SeedExamplesTimeoutError}
+     *
      * @example
      *     await client.service.getMetadata({
      *         "X-API-Version": "0.0.1",
@@ -213,6 +222,9 @@ export class ServiceClient {
     /**
      * @param {SeedExamples.BigEntity} request
      * @param {ServiceClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExamplesError}
+     * @throws {@link errors.SeedExamplesTimeoutError}
      *
      * @example
      *     await client.service.createBigEntity({
@@ -425,6 +437,9 @@ export class ServiceClient {
     /**
      * @param {SeedExamples.RefreshTokenRequest} request
      * @param {ServiceClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExamplesError}
+     * @throws {@link errors.SeedExamplesTimeoutError}
      *
      * @example
      *     await client.service.refreshToken(undefined)

--- a/seed/ts-sdk/examples/retain-original-casing/src/Client.ts
+++ b/seed/ts-sdk/examples/retain-original-casing/src/Client.ts
@@ -44,6 +44,9 @@ export class SeedExamplesClient {
      * @param {string} request
      * @param {SeedExamplesClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExamplesError}
+     * @throws {@link errors.SeedExamplesTimeoutError}
+     *
      * @example
      *     await client.echo("Hello world!\\n\\nwith\\n\\tnewlines")
      */
@@ -90,6 +93,9 @@ export class SeedExamplesClient {
     /**
      * @param {SeedExamples.Type} request
      * @param {SeedExamplesClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExamplesError}
+     * @throws {@link errors.SeedExamplesTimeoutError}
      *
      * @example
      *     await client.createType("primitive")

--- a/seed/ts-sdk/examples/retain-original-casing/src/api/resources/file/resources/notification/resources/service/client/Client.ts
+++ b/seed/ts-sdk/examples/retain-original-casing/src/api/resources/file/resources/notification/resources/service/client/Client.ts
@@ -28,6 +28,9 @@ export class ServiceClient {
      * @param {string} notificationId
      * @param {ServiceClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExamplesError}
+     * @throws {@link errors.SeedExamplesTimeoutError}
+     *
      * @example
      *     await client.file.notification.service.getException("notification-hsy129x")
      */

--- a/seed/ts-sdk/examples/retain-original-casing/src/api/resources/file/resources/service/client/Client.ts
+++ b/seed/ts-sdk/examples/retain-original-casing/src/api/resources/file/resources/service/client/Client.ts
@@ -29,6 +29,8 @@ export class ServiceClient {
      * @param {ServiceClient.RequestOptions} requestOptions - Request-specific configuration.
      *
      * @throws {@link SeedExamples.NotFoundError}
+     * @throws {@link errors.SeedExamplesError}
+     * @throws {@link errors.SeedExamplesTimeoutError}
      *
      * @example
      *     await client.file.service.getFile("file.txt", {

--- a/seed/ts-sdk/examples/retain-original-casing/src/api/resources/health/resources/service/client/Client.ts
+++ b/seed/ts-sdk/examples/retain-original-casing/src/api/resources/health/resources/service/client/Client.ts
@@ -26,6 +26,9 @@ export class ServiceClient {
      * @param {string} id - The id to check
      * @param {ServiceClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExamplesError}
+     * @throws {@link errors.SeedExamplesTimeoutError}
+     *
      * @example
      *     await client.health.service.check("id-2sdx82h")
      *
@@ -80,6 +83,9 @@ export class ServiceClient {
      * This endpoint checks the health of the service.
      *
      * @param {ServiceClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExamplesError}
+     * @throws {@link errors.SeedExamplesTimeoutError}
      *
      * @example
      *     await client.health.service.ping()

--- a/seed/ts-sdk/examples/retain-original-casing/src/api/resources/service/client/Client.ts
+++ b/seed/ts-sdk/examples/retain-original-casing/src/api/resources/service/client/Client.ts
@@ -26,6 +26,9 @@ export class ServiceClient {
      * @param {SeedExamples.MovieId} movieId
      * @param {ServiceClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExamplesError}
+     * @throws {@link errors.SeedExamplesTimeoutError}
+     *
      * @example
      *     await client.service.getMovie("movie-c06a4ad7")
      */
@@ -74,6 +77,9 @@ export class ServiceClient {
     /**
      * @param {SeedExamples.Movie} request
      * @param {ServiceClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExamplesError}
+     * @throws {@link errors.SeedExamplesTimeoutError}
      *
      * @example
      *     await client.service.createMovie({
@@ -148,6 +154,9 @@ export class ServiceClient {
      * @param {SeedExamples.GetMetadataRequest} request
      * @param {ServiceClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExamplesError}
+     * @throws {@link errors.SeedExamplesTimeoutError}
+     *
      * @example
      *     await client.service.getMetadata({
      *         "X-API-Version": "0.0.1",
@@ -213,6 +222,9 @@ export class ServiceClient {
     /**
      * @param {SeedExamples.BigEntity} request
      * @param {ServiceClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExamplesError}
+     * @throws {@link errors.SeedExamplesTimeoutError}
      *
      * @example
      *     await client.service.createBigEntity({
@@ -425,6 +437,9 @@ export class ServiceClient {
     /**
      * @param {SeedExamples.RefreshTokenRequest} request
      * @param {ServiceClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExamplesError}
+     * @throws {@link errors.SeedExamplesTimeoutError}
      *
      * @example
      *     await client.service.refreshToken(undefined)

--- a/seed/ts-sdk/exhaustive/allow-extra-fields/src/api/resources/endpoints/resources/container/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/allow-extra-fields/src/api/resources/endpoints/resources/container/client/Client.ts
@@ -26,6 +26,9 @@ export class ContainerClient {
      * @param {string[]} request
      * @param {ContainerClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.container.getAndReturnListOfPrimitives(["string", "string"])
      */
@@ -87,6 +90,9 @@ export class ContainerClient {
     /**
      * @param {SeedExhaustive.types.ObjectWithRequiredField[]} request
      * @param {ContainerClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.container.getAndReturnListOfObjects([{
@@ -152,6 +158,9 @@ export class ContainerClient {
      * @param {string[]} request
      * @param {ContainerClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.container.getAndReturnSetOfPrimitives(["string"])
      */
@@ -208,6 +217,9 @@ export class ContainerClient {
     /**
      * @param {SeedExhaustive.types.ObjectWithRequiredField[]} request
      * @param {ContainerClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.container.getAndReturnSetOfObjects([{
@@ -271,6 +283,9 @@ export class ContainerClient {
      * @param {Record<string, string>} request
      * @param {ContainerClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.container.getAndReturnMapPrimToPrim({
      *         "string": "string"
@@ -329,6 +344,9 @@ export class ContainerClient {
     /**
      * @param {Record<string, SeedExhaustive.types.ObjectWithRequiredField>} request
      * @param {ContainerClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.container.getAndReturnMapOfPrimToObject({
@@ -399,6 +417,9 @@ export class ContainerClient {
      * @param {Record<string, SeedExhaustive.types.MixedType>} request
      * @param {ContainerClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.container.getAndReturnMapOfPrimToUndiscriminatedUnion({
      *         "string": 1.1
@@ -462,6 +483,9 @@ export class ContainerClient {
     /**
      * @param {SeedExhaustive.types.ObjectWithRequiredField} request
      * @param {ContainerClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.container.getAndReturnOptional({

--- a/seed/ts-sdk/exhaustive/allow-extra-fields/src/api/resources/endpoints/resources/contentType/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/allow-extra-fields/src/api/resources/endpoints/resources/contentType/client/Client.ts
@@ -26,6 +26,9 @@ export class ContentTypeClient {
      * @param {SeedExhaustive.types.ObjectWithOptionalField} request
      * @param {ContentTypeClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.contentType.postJsonPatchContentType({
      *         string: "string",
@@ -98,6 +101,9 @@ export class ContentTypeClient {
     /**
      * @param {SeedExhaustive.types.ObjectWithOptionalField} request
      * @param {ContentTypeClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.contentType.postJsonPatchContentWithCharsetType({

--- a/seed/ts-sdk/exhaustive/allow-extra-fields/src/api/resources/endpoints/resources/enum/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/allow-extra-fields/src/api/resources/endpoints/resources/enum/client/Client.ts
@@ -26,6 +26,9 @@ export class EnumClient {
      * @param {SeedExhaustive.types.WeatherReport} request
      * @param {EnumClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.enum.getAndReturnEnum("SUNNY")
      */

--- a/seed/ts-sdk/exhaustive/allow-extra-fields/src/api/resources/endpoints/resources/httpMethods/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/allow-extra-fields/src/api/resources/endpoints/resources/httpMethods/client/Client.ts
@@ -26,6 +26,9 @@ export class HttpMethodsClient {
      * @param {string} id
      * @param {HttpMethodsClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.httpMethods.testGet("id")
      */
@@ -78,6 +81,9 @@ export class HttpMethodsClient {
      *
      * @param {SeedExhaustive.types.ObjectWithRequiredField} request
      * @param {HttpMethodsClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.httpMethods.testPost({
@@ -143,6 +149,9 @@ export class HttpMethodsClient {
      * @param {string} id
      * @param {SeedExhaustive.types.ObjectWithRequiredField} request
      * @param {HttpMethodsClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.httpMethods.testPut("id", {
@@ -210,6 +219,9 @@ export class HttpMethodsClient {
      * @param {string} id
      * @param {SeedExhaustive.types.ObjectWithOptionalField} request
      * @param {HttpMethodsClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.httpMethods.testPatch("id", {
@@ -290,6 +302,9 @@ export class HttpMethodsClient {
      *
      * @param {string} id
      * @param {HttpMethodsClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.httpMethods.testDelete("id")

--- a/seed/ts-sdk/exhaustive/allow-extra-fields/src/api/resources/endpoints/resources/object/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/allow-extra-fields/src/api/resources/endpoints/resources/object/client/Client.ts
@@ -26,6 +26,9 @@ export class ObjectClient {
      * @param {SeedExhaustive.types.ObjectWithOptionalField} request
      * @param {ObjectClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.object.getAndReturnWithOptionalField({
      *         string: "string",
@@ -107,6 +110,9 @@ export class ObjectClient {
      * @param {SeedExhaustive.types.ObjectWithRequiredField} request
      * @param {ObjectClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.object.getAndReturnWithRequiredField({
      *         string: "string"
@@ -173,6 +179,9 @@ export class ObjectClient {
     /**
      * @param {SeedExhaustive.types.ObjectWithMapOfMap} request
      * @param {ObjectClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.object.getAndReturnWithMapOfMap({
@@ -244,6 +253,9 @@ export class ObjectClient {
     /**
      * @param {SeedExhaustive.types.NestedObjectWithOptionalField} request
      * @param {ObjectClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.object.getAndReturnNestedWithOptionalField({
@@ -332,6 +344,9 @@ export class ObjectClient {
      * @param {SeedExhaustive.types.NestedObjectWithRequiredField} request
      * @param {ObjectClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.object.getAndReturnNestedWithRequiredField("string", {
      *         string: "string",
@@ -419,6 +434,9 @@ export class ObjectClient {
     /**
      * @param {SeedExhaustive.types.NestedObjectWithRequiredField[]} request
      * @param {ObjectClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.object.getAndReturnNestedWithRequiredFieldAsList([{
@@ -525,6 +543,9 @@ export class ObjectClient {
      * @param {SeedExhaustive.types.ObjectWithUnknownField} request
      * @param {ObjectClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.object.getAndReturnWithUnknownField({
      *         unknown: {
@@ -593,6 +614,9 @@ export class ObjectClient {
     /**
      * @param {SeedExhaustive.types.ObjectWithDocumentedUnknownType} request
      * @param {ObjectClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.object.getAndReturnWithDocumentedUnknownType({
@@ -664,6 +688,9 @@ export class ObjectClient {
     /**
      * @param {SeedExhaustive.types.MapOfDocumentedUnknownType} request
      * @param {ObjectClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.object.getAndReturnMapOfDocumentedUnknownType({
@@ -738,6 +765,9 @@ export class ObjectClient {
      *
      * @param {SeedExhaustive.types.ObjectWithMixedRequiredAndOptionalFields} request
      * @param {ObjectClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.object.getAndReturnWithMixedRequiredAndOptionalFields({
@@ -816,6 +846,9 @@ export class ObjectClient {
      * @param {SeedExhaustive.types.ObjectWithRequiredNestedObject} request
      * @param {ObjectClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.object.getAndReturnWithRequiredNestedObject({
      *         requiredString: "hello",
@@ -892,6 +925,9 @@ export class ObjectClient {
      *
      * @param {SeedExhaustive.types.ObjectWithDatetimeLikeString} request
      * @param {ObjectClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.object.getAndReturnWithDatetimeLikeString({

--- a/seed/ts-sdk/exhaustive/allow-extra-fields/src/api/resources/endpoints/resources/pagination/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/allow-extra-fields/src/api/resources/endpoints/resources/pagination/client/Client.ts
@@ -27,6 +27,9 @@ export class PaginationClient {
      * @param {SeedExhaustive.endpoints.ListItemsRequest} request
      * @param {PaginationClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.pagination.listItems({
      *         cursor: "cursor",

--- a/seed/ts-sdk/exhaustive/allow-extra-fields/src/api/resources/endpoints/resources/params/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/allow-extra-fields/src/api/resources/endpoints/resources/params/client/Client.ts
@@ -28,6 +28,9 @@ export class ParamsClient {
      * @param {string} param
      * @param {ParamsClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.params.getWithPath("param")
      */
@@ -80,6 +83,9 @@ export class ParamsClient {
      *
      * @param {SeedExhaustive.endpoints.GetWithInlinePath} request
      * @param {ParamsClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.params.getWithInlinePath({
@@ -139,6 +145,9 @@ export class ParamsClient {
      *
      * @param {SeedExhaustive.endpoints.GetWithQuery} request
      * @param {ParamsClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.params.getWithQuery({
@@ -207,6 +216,9 @@ export class ParamsClient {
      *
      * @param {SeedExhaustive.endpoints.GetWithMultipleQuery} request
      * @param {ParamsClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.params.getWithAllowMultipleQuery({
@@ -277,6 +289,9 @@ export class ParamsClient {
      * @param {SeedExhaustive.endpoints.GetWithPathAndQuery} request
      * @param {ParamsClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.params.getWithPathAndQuery("param", {
      *         query: "query"
@@ -344,6 +359,9 @@ export class ParamsClient {
      *
      * @param {SeedExhaustive.endpoints.GetWithInlinePathAndQuery} request
      * @param {ParamsClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.params.getWithInlinePathAndQuery({
@@ -413,6 +431,9 @@ export class ParamsClient {
      * @param {string} request
      * @param {ParamsClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.params.modifyWithPath("param", "string")
      */
@@ -473,6 +494,9 @@ export class ParamsClient {
      *
      * @param {SeedExhaustive.endpoints.ModifyResourceAtInlinedPath} request
      * @param {ParamsClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.params.modifyWithInlinePath({
@@ -537,6 +561,9 @@ export class ParamsClient {
      * @param {core.file.Uploadable} uploadable
      * @param {string} param
      * @param {ParamsClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     import { createReadStream } from "fs";
@@ -604,6 +631,9 @@ export class ParamsClient {
      *
      * @param {SeedExhaustive.endpoints.CreateWithBodyAndQuery} request
      * @param {ParamsClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.params.createWithBodyAndQuery({
@@ -680,6 +710,9 @@ export class ParamsClient {
      * @param {core.file.Uploadable} uploadable
      * @param {SeedExhaustive.endpoints.UploadBytesWithQuery} request
      * @param {ParamsClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      */
     public uploadBytesWithQuery(
         uploadable: core.file.Uploadable,
@@ -751,6 +784,9 @@ export class ParamsClient {
      * @param {boolean} param
      * @param {ParamsClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.params.getWithBooleanPath(true)
      */
@@ -808,6 +844,8 @@ export class ParamsClient {
      * @param {ParamsClient.RequestOptions} requestOptions - Request-specific configuration.
      *
      * @throws {@link SeedExhaustive.BadRequestBody}
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.params.getWithPathAndErrors("param")

--- a/seed/ts-sdk/exhaustive/allow-extra-fields/src/api/resources/endpoints/resources/primitive/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/allow-extra-fields/src/api/resources/endpoints/resources/primitive/client/Client.ts
@@ -25,6 +25,9 @@ export class PrimitiveClient {
      * @param {string} request
      * @param {PrimitiveClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.primitive.getAndReturnString("string")
      */
@@ -81,6 +84,9 @@ export class PrimitiveClient {
     /**
      * @param {number} request
      * @param {PrimitiveClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.primitive.getAndReturnInt(1)
@@ -139,6 +145,9 @@ export class PrimitiveClient {
      * @param {number} request
      * @param {PrimitiveClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.primitive.getAndReturnLong(1000000)
      */
@@ -195,6 +204,9 @@ export class PrimitiveClient {
     /**
      * @param {number} request
      * @param {PrimitiveClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.primitive.getAndReturnDouble(1.1)
@@ -253,6 +265,9 @@ export class PrimitiveClient {
      * @param {boolean} request
      * @param {PrimitiveClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.primitive.getAndReturnBool(true)
      */
@@ -309,6 +324,9 @@ export class PrimitiveClient {
     /**
      * @param {string} request
      * @param {PrimitiveClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.primitive.getAndReturnDatetime("2024-01-15T09:30:00Z")
@@ -367,6 +385,9 @@ export class PrimitiveClient {
      * @param {string} request
      * @param {PrimitiveClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.primitive.getAndReturnDate("2023-01-15")
      */
@@ -424,6 +445,9 @@ export class PrimitiveClient {
      * @param {string} request
      * @param {PrimitiveClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.primitive.getAndReturnUuid("d5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32")
      */
@@ -480,6 +504,9 @@ export class PrimitiveClient {
     /**
      * @param {string} request
      * @param {PrimitiveClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.primitive.getAndReturnBase64("SGVsbG8gd29ybGQh")

--- a/seed/ts-sdk/exhaustive/allow-extra-fields/src/api/resources/endpoints/resources/put/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/allow-extra-fields/src/api/resources/endpoints/resources/put/client/Client.ts
@@ -25,6 +25,9 @@ export class PutClient {
      * @param {SeedExhaustive.endpoints.PutRequest} request
      * @param {PutClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.put.add({
      *         id: "id"

--- a/seed/ts-sdk/exhaustive/allow-extra-fields/src/api/resources/endpoints/resources/union/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/allow-extra-fields/src/api/resources/endpoints/resources/union/client/Client.ts
@@ -26,6 +26,9 @@ export class UnionClient {
      * @param {SeedExhaustive.types.Animal} request
      * @param {UnionClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.union.getAndReturnUnion({
      *         animal: "dog",

--- a/seed/ts-sdk/exhaustive/allow-extra-fields/src/api/resources/endpoints/resources/urls/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/allow-extra-fields/src/api/resources/endpoints/resources/urls/client/Client.ts
@@ -23,6 +23,9 @@ export class UrlsClient {
     /**
      * @param {UrlsClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.urls.withMixedCase()
      */
@@ -69,6 +72,9 @@ export class UrlsClient {
 
     /**
      * @param {UrlsClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.urls.noEndingSlash()
@@ -117,6 +123,9 @@ export class UrlsClient {
     /**
      * @param {UrlsClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.urls.withEndingSlash()
      */
@@ -163,6 +172,9 @@ export class UrlsClient {
 
     /**
      * @param {UrlsClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.urls.withUnderscores()

--- a/seed/ts-sdk/exhaustive/allow-extra-fields/src/api/resources/inlinedRequests/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/allow-extra-fields/src/api/resources/inlinedRequests/client/Client.ts
@@ -29,6 +29,8 @@ export class InlinedRequestsClient {
      * @param {InlinedRequestsClient.RequestOptions} requestOptions - Request-specific configuration.
      *
      * @throws {@link SeedExhaustive.BadRequestBody}
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.inlinedRequests.postWithObjectBodyandResponse({
@@ -114,6 +116,9 @@ export class InlinedRequestsClient {
      *
      * @param {SeedExhaustive.PostWithArrayBodyAndHeaders} request
      * @param {InlinedRequestsClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.inlinedRequests.postWithArrayBodyAndHeaders({

--- a/seed/ts-sdk/exhaustive/allow-extra-fields/src/api/resources/noAuth/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/allow-extra-fields/src/api/resources/noAuth/client/Client.ts
@@ -29,6 +29,8 @@ export class NoAuthClient {
      * @param {NoAuthClient.RequestOptions} requestOptions - Request-specific configuration.
      *
      * @throws {@link SeedExhaustive.BadRequestBody}
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.noAuth.postWithNoAuth({

--- a/seed/ts-sdk/exhaustive/allow-extra-fields/src/api/resources/noReqBody/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/allow-extra-fields/src/api/resources/noReqBody/client/Client.ts
@@ -24,6 +24,9 @@ export class NoReqBodyClient {
     /**
      * @param {NoReqBodyClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.noReqBody.getWithNoRequestBody()
      */
@@ -77,6 +80,9 @@ export class NoReqBodyClient {
 
     /**
      * @param {NoReqBodyClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.noReqBody.postWithNoRequestBody()

--- a/seed/ts-sdk/exhaustive/allow-extra-fields/src/api/resources/reqWithHeaders/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/allow-extra-fields/src/api/resources/reqWithHeaders/client/Client.ts
@@ -26,6 +26,9 @@ export class ReqWithHeadersClient {
      * @param {SeedExhaustive.ReqWithHeaders} request
      * @param {ReqWithHeadersClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.reqWithHeaders.getWithCustomHeader({
      *         "X-TEST-SERVICE-HEADER": "X-TEST-SERVICE-HEADER",

--- a/seed/ts-sdk/exhaustive/bigint-serde-layer/src/api/resources/endpoints/resources/container/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/bigint-serde-layer/src/api/resources/endpoints/resources/container/client/Client.ts
@@ -27,6 +27,9 @@ export class ContainerClient {
      * @param {string[]} request
      * @param {ContainerClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.container.getAndReturnListOfPrimitives(["string", "string"])
      */
@@ -107,6 +110,9 @@ export class ContainerClient {
      * @param {SeedExhaustive.types.ObjectWithRequiredField[]} request
      * @param {ContainerClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.container.getAndReturnListOfObjects([{
      *             string: "string"
@@ -183,6 +189,9 @@ export class ContainerClient {
      * @param {Set<string>} request
      * @param {ContainerClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.container.getAndReturnSetOfPrimitives(new Set(["string"]))
      */
@@ -258,6 +267,9 @@ export class ContainerClient {
      * @param {SeedExhaustive.types.ObjectWithRequiredField[]} request
      * @param {ContainerClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.container.getAndReturnSetOfObjects([{
      *             string: "string"
@@ -332,6 +344,9 @@ export class ContainerClient {
      * @param {Record<string, string>} request
      * @param {ContainerClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.container.getAndReturnMapPrimToPrim({
      *         "string": "string"
@@ -405,6 +420,9 @@ export class ContainerClient {
     /**
      * @param {Record<string, SeedExhaustive.types.ObjectWithRequiredField>} request
      * @param {ContainerClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.container.getAndReturnMapOfPrimToObject({
@@ -490,6 +508,9 @@ export class ContainerClient {
      * @param {Record<string, SeedExhaustive.types.MixedType>} request
      * @param {ContainerClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.container.getAndReturnMapOfPrimToUndiscriminatedUnion({
      *         "string": 1.1
@@ -568,6 +589,9 @@ export class ContainerClient {
     /**
      * @param {SeedExhaustive.types.ObjectWithRequiredField} request
      * @param {ContainerClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.container.getAndReturnOptional({

--- a/seed/ts-sdk/exhaustive/bigint-serde-layer/src/api/resources/endpoints/resources/contentType/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/bigint-serde-layer/src/api/resources/endpoints/resources/contentType/client/Client.ts
@@ -27,6 +27,9 @@ export class ContentTypeClient {
      * @param {SeedExhaustive.types.ObjectWithOptionalField} request
      * @param {ContentTypeClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.contentType.postJsonPatchContentType({
      *         string: "string",
@@ -105,6 +108,9 @@ export class ContentTypeClient {
     /**
      * @param {SeedExhaustive.types.ObjectWithOptionalField} request
      * @param {ContentTypeClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.contentType.postJsonPatchContentWithCharsetType({

--- a/seed/ts-sdk/exhaustive/bigint-serde-layer/src/api/resources/endpoints/resources/enum/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/bigint-serde-layer/src/api/resources/endpoints/resources/enum/client/Client.ts
@@ -27,6 +27,9 @@ export class EnumClient {
      * @param {SeedExhaustive.types.WeatherReport} request
      * @param {EnumClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.enum.getAndReturnEnum("SUNNY")
      */

--- a/seed/ts-sdk/exhaustive/bigint-serde-layer/src/api/resources/endpoints/resources/httpMethods/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/bigint-serde-layer/src/api/resources/endpoints/resources/httpMethods/client/Client.ts
@@ -27,6 +27,9 @@ export class HttpMethodsClient {
      * @param {string} id
      * @param {HttpMethodsClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.httpMethods.testGet("id")
      */
@@ -88,6 +91,9 @@ export class HttpMethodsClient {
      *
      * @param {SeedExhaustive.types.ObjectWithRequiredField} request
      * @param {HttpMethodsClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.httpMethods.testPost({
@@ -165,6 +171,9 @@ export class HttpMethodsClient {
      * @param {string} id
      * @param {SeedExhaustive.types.ObjectWithRequiredField} request
      * @param {HttpMethodsClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.httpMethods.testPut("id", {
@@ -244,6 +253,9 @@ export class HttpMethodsClient {
      * @param {string} id
      * @param {SeedExhaustive.types.ObjectWithOptionalField} request
      * @param {HttpMethodsClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.httpMethods.testPatch("id", {
@@ -336,6 +348,9 @@ export class HttpMethodsClient {
      *
      * @param {string} id
      * @param {HttpMethodsClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.httpMethods.testDelete("id")

--- a/seed/ts-sdk/exhaustive/bigint-serde-layer/src/api/resources/endpoints/resources/object/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/bigint-serde-layer/src/api/resources/endpoints/resources/object/client/Client.ts
@@ -27,6 +27,9 @@ export class ObjectClient {
      * @param {SeedExhaustive.types.ObjectWithOptionalField} request
      * @param {ObjectClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.object.getAndReturnWithOptionalField({
      *         string: "string",
@@ -120,6 +123,9 @@ export class ObjectClient {
      * @param {SeedExhaustive.types.ObjectWithRequiredField} request
      * @param {ObjectClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.object.getAndReturnWithRequiredField({
      *         string: "string"
@@ -198,6 +204,9 @@ export class ObjectClient {
     /**
      * @param {SeedExhaustive.types.ObjectWithMapOfMap} request
      * @param {ObjectClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.object.getAndReturnWithMapOfMap({
@@ -281,6 +290,9 @@ export class ObjectClient {
     /**
      * @param {SeedExhaustive.types.NestedObjectWithOptionalField} request
      * @param {ObjectClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.object.getAndReturnNestedWithOptionalField({
@@ -381,6 +393,9 @@ export class ObjectClient {
      * @param {SeedExhaustive.types.NestedObjectWithRequiredField} request
      * @param {ObjectClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.object.getAndReturnNestedWithRequiredField("string", {
      *         string: "string",
@@ -480,6 +495,9 @@ export class ObjectClient {
     /**
      * @param {SeedExhaustive.types.NestedObjectWithRequiredField[]} request
      * @param {ObjectClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.object.getAndReturnNestedWithRequiredFieldAsList([{
@@ -598,6 +616,9 @@ export class ObjectClient {
      * @param {SeedExhaustive.types.ObjectWithUnknownField} request
      * @param {ObjectClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.object.getAndReturnWithUnknownField({
      *         unknown: {
@@ -678,6 +699,9 @@ export class ObjectClient {
     /**
      * @param {SeedExhaustive.types.ObjectWithDocumentedUnknownType} request
      * @param {ObjectClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.object.getAndReturnWithDocumentedUnknownType({
@@ -761,6 +785,9 @@ export class ObjectClient {
     /**
      * @param {SeedExhaustive.types.MapOfDocumentedUnknownType} request
      * @param {ObjectClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.object.getAndReturnMapOfDocumentedUnknownType({
@@ -847,6 +874,9 @@ export class ObjectClient {
      *
      * @param {SeedExhaustive.types.ObjectWithMixedRequiredAndOptionalFields} request
      * @param {ObjectClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.object.getAndReturnWithMixedRequiredAndOptionalFields({
@@ -937,6 +967,9 @@ export class ObjectClient {
      * @param {SeedExhaustive.types.ObjectWithRequiredNestedObject} request
      * @param {ObjectClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.object.getAndReturnWithRequiredNestedObject({
      *         requiredString: "hello",
@@ -1025,6 +1058,9 @@ export class ObjectClient {
      *
      * @param {SeedExhaustive.types.ObjectWithDatetimeLikeString} request
      * @param {ObjectClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.object.getAndReturnWithDatetimeLikeString({

--- a/seed/ts-sdk/exhaustive/bigint-serde-layer/src/api/resources/endpoints/resources/pagination/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/bigint-serde-layer/src/api/resources/endpoints/resources/pagination/client/Client.ts
@@ -28,6 +28,9 @@ export class PaginationClient {
      * @param {SeedExhaustive.endpoints.ListItemsRequest} request
      * @param {PaginationClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.pagination.listItems({
      *         cursor: "cursor",

--- a/seed/ts-sdk/exhaustive/bigint-serde-layer/src/api/resources/endpoints/resources/params/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/bigint-serde-layer/src/api/resources/endpoints/resources/params/client/Client.ts
@@ -29,6 +29,9 @@ export class ParamsClient {
      * @param {string} param
      * @param {ParamsClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.params.getWithPath("param")
      */
@@ -90,6 +93,9 @@ export class ParamsClient {
      *
      * @param {SeedExhaustive.endpoints.GetWithInlinePath} request
      * @param {ParamsClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.params.getWithInlinePath({
@@ -159,6 +165,9 @@ export class ParamsClient {
      * @param {SeedExhaustive.endpoints.GetWithQuery} request
      * @param {ParamsClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.params.getWithQuery({
      *         query: "query",
@@ -226,6 +235,9 @@ export class ParamsClient {
      *
      * @param {SeedExhaustive.endpoints.GetWithMultipleQuery} request
      * @param {ParamsClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.params.getWithAllowMultipleQuery({
@@ -296,6 +308,9 @@ export class ParamsClient {
      * @param {SeedExhaustive.endpoints.GetWithPathAndQuery} request
      * @param {ParamsClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.params.getWithPathAndQuery("param", {
      *         query: "query"
@@ -364,6 +379,9 @@ export class ParamsClient {
      * @param {SeedExhaustive.endpoints.GetWithInlinePathAndQuery} request
      * @param {ParamsClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.params.getWithInlinePathAndQuery({
      *         param: "param",
@@ -431,6 +449,9 @@ export class ParamsClient {
      * @param {string} param
      * @param {string} request
      * @param {ParamsClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.params.modifyWithPath("param", "string")
@@ -507,6 +528,9 @@ export class ParamsClient {
      *
      * @param {SeedExhaustive.endpoints.ModifyResourceAtInlinedPath} request
      * @param {ParamsClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.params.modifyWithInlinePath({
@@ -587,6 +611,9 @@ export class ParamsClient {
      * @param {string} param
      * @param {ParamsClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     import { createReadStream } from "fs";
      *     await client.endpoints.params.uploadWithPath(createReadStream("path/to/file"), "upload-path")
@@ -659,6 +686,9 @@ export class ParamsClient {
      *
      * @param {SeedExhaustive.endpoints.CreateWithBodyAndQuery} request
      * @param {ParamsClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.params.createWithBodyAndQuery({
@@ -747,6 +777,9 @@ export class ParamsClient {
      * @param {core.file.Uploadable} uploadable
      * @param {SeedExhaustive.endpoints.UploadBytesWithQuery} request
      * @param {ParamsClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      */
     public uploadBytesWithQuery(
         uploadable: core.file.Uploadable,
@@ -824,6 +857,9 @@ export class ParamsClient {
      * @param {boolean} param
      * @param {ParamsClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.params.getWithBooleanPath(true)
      */
@@ -890,6 +926,8 @@ export class ParamsClient {
      * @param {ParamsClient.RequestOptions} requestOptions - Request-specific configuration.
      *
      * @throws {@link SeedExhaustive.BadRequestBody}
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.params.getWithPathAndErrors("param")

--- a/seed/ts-sdk/exhaustive/bigint-serde-layer/src/api/resources/endpoints/resources/primitive/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/bigint-serde-layer/src/api/resources/endpoints/resources/primitive/client/Client.ts
@@ -26,6 +26,9 @@ export class PrimitiveClient {
      * @param {string} request
      * @param {PrimitiveClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.primitive.getAndReturnString("string")
      */
@@ -97,6 +100,9 @@ export class PrimitiveClient {
     /**
      * @param {number} request
      * @param {PrimitiveClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.primitive.getAndReturnInt(1)
@@ -170,6 +176,9 @@ export class PrimitiveClient {
      * @param {bigint} request
      * @param {PrimitiveClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.primitive.getAndReturnLong(BigInt("1000000"))
      */
@@ -241,6 +250,9 @@ export class PrimitiveClient {
     /**
      * @param {number} request
      * @param {PrimitiveClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.primitive.getAndReturnDouble(1.1)
@@ -314,6 +326,9 @@ export class PrimitiveClient {
      * @param {boolean} request
      * @param {PrimitiveClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.primitive.getAndReturnBool(true)
      */
@@ -385,6 +400,9 @@ export class PrimitiveClient {
     /**
      * @param {Date} request
      * @param {PrimitiveClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.primitive.getAndReturnDatetime(new Date("2024-01-15T09:30:00.000Z"))
@@ -458,6 +476,9 @@ export class PrimitiveClient {
      * @param {string} request
      * @param {PrimitiveClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.primitive.getAndReturnDate("2023-01-15")
      */
@@ -530,6 +551,9 @@ export class PrimitiveClient {
      * @param {string} request
      * @param {PrimitiveClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.primitive.getAndReturnUuid("d5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32")
      */
@@ -601,6 +625,9 @@ export class PrimitiveClient {
     /**
      * @param {string} request
      * @param {PrimitiveClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.primitive.getAndReturnBase64("SGVsbG8gd29ybGQh")

--- a/seed/ts-sdk/exhaustive/bigint-serde-layer/src/api/resources/endpoints/resources/put/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/bigint-serde-layer/src/api/resources/endpoints/resources/put/client/Client.ts
@@ -26,6 +26,9 @@ export class PutClient {
      * @param {SeedExhaustive.endpoints.PutRequest} request
      * @param {PutClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.put.add({
      *         id: "id"

--- a/seed/ts-sdk/exhaustive/bigint-serde-layer/src/api/resources/endpoints/resources/union/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/bigint-serde-layer/src/api/resources/endpoints/resources/union/client/Client.ts
@@ -27,6 +27,9 @@ export class UnionClient {
      * @param {SeedExhaustive.types.Animal} request
      * @param {UnionClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.union.getAndReturnUnion({
      *         animal: "dog",

--- a/seed/ts-sdk/exhaustive/bigint-serde-layer/src/api/resources/endpoints/resources/urls/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/bigint-serde-layer/src/api/resources/endpoints/resources/urls/client/Client.ts
@@ -24,6 +24,9 @@ export class UrlsClient {
     /**
      * @param {UrlsClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.urls.withMixedCase()
      */
@@ -79,6 +82,9 @@ export class UrlsClient {
 
     /**
      * @param {UrlsClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.urls.noEndingSlash()
@@ -136,6 +142,9 @@ export class UrlsClient {
     /**
      * @param {UrlsClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.urls.withEndingSlash()
      */
@@ -191,6 +200,9 @@ export class UrlsClient {
 
     /**
      * @param {UrlsClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.urls.withUnderscores()

--- a/seed/ts-sdk/exhaustive/bigint-serde-layer/src/api/resources/inlinedRequests/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/bigint-serde-layer/src/api/resources/inlinedRequests/client/Client.ts
@@ -30,6 +30,8 @@ export class InlinedRequestsClient {
      * @param {InlinedRequestsClient.RequestOptions} requestOptions - Request-specific configuration.
      *
      * @throws {@link SeedExhaustive.BadRequestBody}
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.inlinedRequests.postWithObjectBodyandResponse({
@@ -133,6 +135,9 @@ export class InlinedRequestsClient {
      *
      * @param {SeedExhaustive.PostWithArrayBodyAndHeaders} request
      * @param {InlinedRequestsClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.inlinedRequests.postWithArrayBodyAndHeaders({

--- a/seed/ts-sdk/exhaustive/bigint-serde-layer/src/api/resources/noAuth/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/bigint-serde-layer/src/api/resources/noAuth/client/Client.ts
@@ -30,6 +30,8 @@ export class NoAuthClient {
      * @param {NoAuthClient.RequestOptions} requestOptions - Request-specific configuration.
      *
      * @throws {@link SeedExhaustive.BadRequestBody}
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.noAuth.postWithNoAuth({

--- a/seed/ts-sdk/exhaustive/bigint-serde-layer/src/api/resources/noReqBody/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/bigint-serde-layer/src/api/resources/noReqBody/client/Client.ts
@@ -25,6 +25,9 @@ export class NoReqBodyClient {
     /**
      * @param {NoReqBodyClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.noReqBody.getWithNoRequestBody()
      */
@@ -84,6 +87,9 @@ export class NoReqBodyClient {
 
     /**
      * @param {NoReqBodyClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.noReqBody.postWithNoRequestBody()

--- a/seed/ts-sdk/exhaustive/bigint-serde-layer/src/api/resources/reqWithHeaders/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/bigint-serde-layer/src/api/resources/reqWithHeaders/client/Client.ts
@@ -27,6 +27,9 @@ export class ReqWithHeadersClient {
      * @param {SeedExhaustive.ReqWithHeaders} request
      * @param {ReqWithHeadersClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.reqWithHeaders.getWithCustomHeader({
      *         xTestServiceHeader: "X-TEST-SERVICE-HEADER",

--- a/seed/ts-sdk/exhaustive/bigint/src/api/resources/endpoints/resources/container/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/bigint/src/api/resources/endpoints/resources/container/client/Client.ts
@@ -26,6 +26,9 @@ export class ContainerClient {
      * @param {string[]} request
      * @param {ContainerClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.container.getAndReturnListOfPrimitives(["string", "string"])
      */
@@ -87,6 +90,9 @@ export class ContainerClient {
     /**
      * @param {SeedExhaustive.types.ObjectWithRequiredField[]} request
      * @param {ContainerClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.container.getAndReturnListOfObjects([{
@@ -152,6 +158,9 @@ export class ContainerClient {
      * @param {string[]} request
      * @param {ContainerClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.container.getAndReturnSetOfPrimitives(["string"])
      */
@@ -208,6 +217,9 @@ export class ContainerClient {
     /**
      * @param {SeedExhaustive.types.ObjectWithRequiredField[]} request
      * @param {ContainerClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.container.getAndReturnSetOfObjects([{
@@ -271,6 +283,9 @@ export class ContainerClient {
      * @param {Record<string, string>} request
      * @param {ContainerClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.container.getAndReturnMapPrimToPrim({
      *         "string": "string"
@@ -329,6 +344,9 @@ export class ContainerClient {
     /**
      * @param {Record<string, SeedExhaustive.types.ObjectWithRequiredField>} request
      * @param {ContainerClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.container.getAndReturnMapOfPrimToObject({
@@ -399,6 +417,9 @@ export class ContainerClient {
      * @param {Record<string, SeedExhaustive.types.MixedType>} request
      * @param {ContainerClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.container.getAndReturnMapOfPrimToUndiscriminatedUnion({
      *         "string": 1.1
@@ -462,6 +483,9 @@ export class ContainerClient {
     /**
      * @param {SeedExhaustive.types.ObjectWithRequiredField} request
      * @param {ContainerClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.container.getAndReturnOptional({

--- a/seed/ts-sdk/exhaustive/bigint/src/api/resources/endpoints/resources/contentType/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/bigint/src/api/resources/endpoints/resources/contentType/client/Client.ts
@@ -26,6 +26,9 @@ export class ContentTypeClient {
      * @param {SeedExhaustive.types.ObjectWithOptionalField} request
      * @param {ContentTypeClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.contentType.postJsonPatchContentType({
      *         string: "string",
@@ -98,6 +101,9 @@ export class ContentTypeClient {
     /**
      * @param {SeedExhaustive.types.ObjectWithOptionalField} request
      * @param {ContentTypeClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.contentType.postJsonPatchContentWithCharsetType({

--- a/seed/ts-sdk/exhaustive/bigint/src/api/resources/endpoints/resources/enum/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/bigint/src/api/resources/endpoints/resources/enum/client/Client.ts
@@ -26,6 +26,9 @@ export class EnumClient {
      * @param {SeedExhaustive.types.WeatherReport} request
      * @param {EnumClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.enum.getAndReturnEnum("SUNNY")
      */

--- a/seed/ts-sdk/exhaustive/bigint/src/api/resources/endpoints/resources/httpMethods/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/bigint/src/api/resources/endpoints/resources/httpMethods/client/Client.ts
@@ -26,6 +26,9 @@ export class HttpMethodsClient {
      * @param {string} id
      * @param {HttpMethodsClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.httpMethods.testGet("id")
      */
@@ -78,6 +81,9 @@ export class HttpMethodsClient {
      *
      * @param {SeedExhaustive.types.ObjectWithRequiredField} request
      * @param {HttpMethodsClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.httpMethods.testPost({
@@ -143,6 +149,9 @@ export class HttpMethodsClient {
      * @param {string} id
      * @param {SeedExhaustive.types.ObjectWithRequiredField} request
      * @param {HttpMethodsClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.httpMethods.testPut("id", {
@@ -210,6 +219,9 @@ export class HttpMethodsClient {
      * @param {string} id
      * @param {SeedExhaustive.types.ObjectWithOptionalField} request
      * @param {HttpMethodsClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.httpMethods.testPatch("id", {
@@ -290,6 +302,9 @@ export class HttpMethodsClient {
      *
      * @param {string} id
      * @param {HttpMethodsClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.httpMethods.testDelete("id")

--- a/seed/ts-sdk/exhaustive/bigint/src/api/resources/endpoints/resources/object/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/bigint/src/api/resources/endpoints/resources/object/client/Client.ts
@@ -26,6 +26,9 @@ export class ObjectClient {
      * @param {SeedExhaustive.types.ObjectWithOptionalField} request
      * @param {ObjectClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.object.getAndReturnWithOptionalField({
      *         string: "string",
@@ -107,6 +110,9 @@ export class ObjectClient {
      * @param {SeedExhaustive.types.ObjectWithRequiredField} request
      * @param {ObjectClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.object.getAndReturnWithRequiredField({
      *         string: "string"
@@ -173,6 +179,9 @@ export class ObjectClient {
     /**
      * @param {SeedExhaustive.types.ObjectWithMapOfMap} request
      * @param {ObjectClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.object.getAndReturnWithMapOfMap({
@@ -244,6 +253,9 @@ export class ObjectClient {
     /**
      * @param {SeedExhaustive.types.NestedObjectWithOptionalField} request
      * @param {ObjectClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.object.getAndReturnNestedWithOptionalField({
@@ -332,6 +344,9 @@ export class ObjectClient {
      * @param {SeedExhaustive.types.NestedObjectWithRequiredField} request
      * @param {ObjectClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.object.getAndReturnNestedWithRequiredField("string", {
      *         string: "string",
@@ -419,6 +434,9 @@ export class ObjectClient {
     /**
      * @param {SeedExhaustive.types.NestedObjectWithRequiredField[]} request
      * @param {ObjectClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.object.getAndReturnNestedWithRequiredFieldAsList([{
@@ -525,6 +543,9 @@ export class ObjectClient {
      * @param {SeedExhaustive.types.ObjectWithUnknownField} request
      * @param {ObjectClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.object.getAndReturnWithUnknownField({
      *         unknown: {
@@ -593,6 +614,9 @@ export class ObjectClient {
     /**
      * @param {SeedExhaustive.types.ObjectWithDocumentedUnknownType} request
      * @param {ObjectClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.object.getAndReturnWithDocumentedUnknownType({
@@ -664,6 +688,9 @@ export class ObjectClient {
     /**
      * @param {SeedExhaustive.types.MapOfDocumentedUnknownType} request
      * @param {ObjectClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.object.getAndReturnMapOfDocumentedUnknownType({
@@ -738,6 +765,9 @@ export class ObjectClient {
      *
      * @param {SeedExhaustive.types.ObjectWithMixedRequiredAndOptionalFields} request
      * @param {ObjectClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.object.getAndReturnWithMixedRequiredAndOptionalFields({
@@ -816,6 +846,9 @@ export class ObjectClient {
      * @param {SeedExhaustive.types.ObjectWithRequiredNestedObject} request
      * @param {ObjectClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.object.getAndReturnWithRequiredNestedObject({
      *         requiredString: "hello",
@@ -892,6 +925,9 @@ export class ObjectClient {
      *
      * @param {SeedExhaustive.types.ObjectWithDatetimeLikeString} request
      * @param {ObjectClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.object.getAndReturnWithDatetimeLikeString({

--- a/seed/ts-sdk/exhaustive/bigint/src/api/resources/endpoints/resources/pagination/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/bigint/src/api/resources/endpoints/resources/pagination/client/Client.ts
@@ -27,6 +27,9 @@ export class PaginationClient {
      * @param {SeedExhaustive.endpoints.ListItemsRequest} request
      * @param {PaginationClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.pagination.listItems({
      *         cursor: "cursor",

--- a/seed/ts-sdk/exhaustive/bigint/src/api/resources/endpoints/resources/params/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/bigint/src/api/resources/endpoints/resources/params/client/Client.ts
@@ -28,6 +28,9 @@ export class ParamsClient {
      * @param {string} param
      * @param {ParamsClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.params.getWithPath("param")
      */
@@ -80,6 +83,9 @@ export class ParamsClient {
      *
      * @param {SeedExhaustive.endpoints.GetWithInlinePath} request
      * @param {ParamsClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.params.getWithInlinePath({
@@ -139,6 +145,9 @@ export class ParamsClient {
      *
      * @param {SeedExhaustive.endpoints.GetWithQuery} request
      * @param {ParamsClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.params.getWithQuery({
@@ -207,6 +216,9 @@ export class ParamsClient {
      *
      * @param {SeedExhaustive.endpoints.GetWithMultipleQuery} request
      * @param {ParamsClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.params.getWithAllowMultipleQuery({
@@ -277,6 +289,9 @@ export class ParamsClient {
      * @param {SeedExhaustive.endpoints.GetWithPathAndQuery} request
      * @param {ParamsClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.params.getWithPathAndQuery("param", {
      *         query: "query"
@@ -344,6 +359,9 @@ export class ParamsClient {
      *
      * @param {SeedExhaustive.endpoints.GetWithInlinePathAndQuery} request
      * @param {ParamsClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.params.getWithInlinePathAndQuery({
@@ -413,6 +431,9 @@ export class ParamsClient {
      * @param {string} request
      * @param {ParamsClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.params.modifyWithPath("param", "string")
      */
@@ -473,6 +494,9 @@ export class ParamsClient {
      *
      * @param {SeedExhaustive.endpoints.ModifyResourceAtInlinedPath} request
      * @param {ParamsClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.params.modifyWithInlinePath({
@@ -537,6 +561,9 @@ export class ParamsClient {
      * @param {core.file.Uploadable} uploadable
      * @param {string} param
      * @param {ParamsClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     import { createReadStream } from "fs";
@@ -604,6 +631,9 @@ export class ParamsClient {
      *
      * @param {SeedExhaustive.endpoints.CreateWithBodyAndQuery} request
      * @param {ParamsClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.params.createWithBodyAndQuery({
@@ -680,6 +710,9 @@ export class ParamsClient {
      * @param {core.file.Uploadable} uploadable
      * @param {SeedExhaustive.endpoints.UploadBytesWithQuery} request
      * @param {ParamsClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      */
     public uploadBytesWithQuery(
         uploadable: core.file.Uploadable,
@@ -751,6 +784,9 @@ export class ParamsClient {
      * @param {boolean} param
      * @param {ParamsClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.params.getWithBooleanPath(true)
      */
@@ -808,6 +844,8 @@ export class ParamsClient {
      * @param {ParamsClient.RequestOptions} requestOptions - Request-specific configuration.
      *
      * @throws {@link SeedExhaustive.BadRequestBody}
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.params.getWithPathAndErrors("param")

--- a/seed/ts-sdk/exhaustive/bigint/src/api/resources/endpoints/resources/primitive/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/bigint/src/api/resources/endpoints/resources/primitive/client/Client.ts
@@ -25,6 +25,9 @@ export class PrimitiveClient {
      * @param {string} request
      * @param {PrimitiveClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.primitive.getAndReturnString("string")
      */
@@ -81,6 +84,9 @@ export class PrimitiveClient {
     /**
      * @param {number} request
      * @param {PrimitiveClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.primitive.getAndReturnInt(1)
@@ -139,6 +145,9 @@ export class PrimitiveClient {
      * @param {number | bigint} request
      * @param {PrimitiveClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.primitive.getAndReturnLong(BigInt("1000000"))
      */
@@ -195,6 +204,9 @@ export class PrimitiveClient {
     /**
      * @param {number} request
      * @param {PrimitiveClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.primitive.getAndReturnDouble(1.1)
@@ -253,6 +265,9 @@ export class PrimitiveClient {
      * @param {boolean} request
      * @param {PrimitiveClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.primitive.getAndReturnBool(true)
      */
@@ -309,6 +324,9 @@ export class PrimitiveClient {
     /**
      * @param {string} request
      * @param {PrimitiveClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.primitive.getAndReturnDatetime("2024-01-15T09:30:00Z")
@@ -367,6 +385,9 @@ export class PrimitiveClient {
      * @param {string} request
      * @param {PrimitiveClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.primitive.getAndReturnDate("2023-01-15")
      */
@@ -424,6 +445,9 @@ export class PrimitiveClient {
      * @param {string} request
      * @param {PrimitiveClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.primitive.getAndReturnUuid("d5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32")
      */
@@ -480,6 +504,9 @@ export class PrimitiveClient {
     /**
      * @param {string} request
      * @param {PrimitiveClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.primitive.getAndReturnBase64("SGVsbG8gd29ybGQh")

--- a/seed/ts-sdk/exhaustive/bigint/src/api/resources/endpoints/resources/put/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/bigint/src/api/resources/endpoints/resources/put/client/Client.ts
@@ -25,6 +25,9 @@ export class PutClient {
      * @param {SeedExhaustive.endpoints.PutRequest} request
      * @param {PutClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.put.add({
      *         id: "id"

--- a/seed/ts-sdk/exhaustive/bigint/src/api/resources/endpoints/resources/union/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/bigint/src/api/resources/endpoints/resources/union/client/Client.ts
@@ -26,6 +26,9 @@ export class UnionClient {
      * @param {SeedExhaustive.types.Animal} request
      * @param {UnionClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.union.getAndReturnUnion({
      *         animal: "dog",

--- a/seed/ts-sdk/exhaustive/bigint/src/api/resources/endpoints/resources/urls/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/bigint/src/api/resources/endpoints/resources/urls/client/Client.ts
@@ -23,6 +23,9 @@ export class UrlsClient {
     /**
      * @param {UrlsClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.urls.withMixedCase()
      */
@@ -69,6 +72,9 @@ export class UrlsClient {
 
     /**
      * @param {UrlsClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.urls.noEndingSlash()
@@ -117,6 +123,9 @@ export class UrlsClient {
     /**
      * @param {UrlsClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.urls.withEndingSlash()
      */
@@ -163,6 +172,9 @@ export class UrlsClient {
 
     /**
      * @param {UrlsClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.urls.withUnderscores()

--- a/seed/ts-sdk/exhaustive/bigint/src/api/resources/inlinedRequests/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/bigint/src/api/resources/inlinedRequests/client/Client.ts
@@ -29,6 +29,8 @@ export class InlinedRequestsClient {
      * @param {InlinedRequestsClient.RequestOptions} requestOptions - Request-specific configuration.
      *
      * @throws {@link SeedExhaustive.BadRequestBody}
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.inlinedRequests.postWithObjectBodyandResponse({
@@ -114,6 +116,9 @@ export class InlinedRequestsClient {
      *
      * @param {SeedExhaustive.PostWithArrayBodyAndHeaders} request
      * @param {InlinedRequestsClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.inlinedRequests.postWithArrayBodyAndHeaders({

--- a/seed/ts-sdk/exhaustive/bigint/src/api/resources/noAuth/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/bigint/src/api/resources/noAuth/client/Client.ts
@@ -29,6 +29,8 @@ export class NoAuthClient {
      * @param {NoAuthClient.RequestOptions} requestOptions - Request-specific configuration.
      *
      * @throws {@link SeedExhaustive.BadRequestBody}
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.noAuth.postWithNoAuth({

--- a/seed/ts-sdk/exhaustive/bigint/src/api/resources/noReqBody/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/bigint/src/api/resources/noReqBody/client/Client.ts
@@ -24,6 +24,9 @@ export class NoReqBodyClient {
     /**
      * @param {NoReqBodyClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.noReqBody.getWithNoRequestBody()
      */
@@ -77,6 +80,9 @@ export class NoReqBodyClient {
 
     /**
      * @param {NoReqBodyClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.noReqBody.postWithNoRequestBody()

--- a/seed/ts-sdk/exhaustive/bigint/src/api/resources/reqWithHeaders/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/bigint/src/api/resources/reqWithHeaders/client/Client.ts
@@ -26,6 +26,9 @@ export class ReqWithHeadersClient {
      * @param {SeedExhaustive.ReqWithHeaders} request
      * @param {ReqWithHeadersClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.reqWithHeaders.getWithCustomHeader({
      *         "X-TEST-SERVICE-HEADER": "X-TEST-SERVICE-HEADER",

--- a/seed/ts-sdk/exhaustive/consolidate-type-files/src/api/resources/endpoints/resources/container/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/consolidate-type-files/src/api/resources/endpoints/resources/container/client/Client.ts
@@ -26,6 +26,9 @@ export class ContainerClient {
      * @param {string[]} request
      * @param {ContainerClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.container.getAndReturnListOfPrimitives(["string", "string"])
      */
@@ -87,6 +90,9 @@ export class ContainerClient {
     /**
      * @param {SeedExhaustive.types.ObjectWithRequiredField[]} request
      * @param {ContainerClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.container.getAndReturnListOfObjects([{
@@ -152,6 +158,9 @@ export class ContainerClient {
      * @param {string[]} request
      * @param {ContainerClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.container.getAndReturnSetOfPrimitives(["string"])
      */
@@ -208,6 +217,9 @@ export class ContainerClient {
     /**
      * @param {SeedExhaustive.types.ObjectWithRequiredField[]} request
      * @param {ContainerClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.container.getAndReturnSetOfObjects([{
@@ -271,6 +283,9 @@ export class ContainerClient {
      * @param {Record<string, string>} request
      * @param {ContainerClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.container.getAndReturnMapPrimToPrim({
      *         "string": "string"
@@ -329,6 +344,9 @@ export class ContainerClient {
     /**
      * @param {Record<string, SeedExhaustive.types.ObjectWithRequiredField>} request
      * @param {ContainerClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.container.getAndReturnMapOfPrimToObject({
@@ -399,6 +417,9 @@ export class ContainerClient {
      * @param {Record<string, SeedExhaustive.types.MixedType>} request
      * @param {ContainerClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.container.getAndReturnMapOfPrimToUndiscriminatedUnion({
      *         "string": 1.1
@@ -462,6 +483,9 @@ export class ContainerClient {
     /**
      * @param {SeedExhaustive.types.ObjectWithRequiredField} request
      * @param {ContainerClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.container.getAndReturnOptional({

--- a/seed/ts-sdk/exhaustive/consolidate-type-files/src/api/resources/endpoints/resources/contentType/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/consolidate-type-files/src/api/resources/endpoints/resources/contentType/client/Client.ts
@@ -26,6 +26,9 @@ export class ContentTypeClient {
      * @param {SeedExhaustive.types.ObjectWithOptionalField} request
      * @param {ContentTypeClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.contentType.postJsonPatchContentType({
      *         string: "string",
@@ -98,6 +101,9 @@ export class ContentTypeClient {
     /**
      * @param {SeedExhaustive.types.ObjectWithOptionalField} request
      * @param {ContentTypeClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.contentType.postJsonPatchContentWithCharsetType({

--- a/seed/ts-sdk/exhaustive/consolidate-type-files/src/api/resources/endpoints/resources/enum/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/consolidate-type-files/src/api/resources/endpoints/resources/enum/client/Client.ts
@@ -26,6 +26,9 @@ export class EnumClient {
      * @param {SeedExhaustive.types.WeatherReport} request
      * @param {EnumClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.enum.getAndReturnEnum("SUNNY")
      */

--- a/seed/ts-sdk/exhaustive/consolidate-type-files/src/api/resources/endpoints/resources/httpMethods/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/consolidate-type-files/src/api/resources/endpoints/resources/httpMethods/client/Client.ts
@@ -26,6 +26,9 @@ export class HttpMethodsClient {
      * @param {string} id
      * @param {HttpMethodsClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.httpMethods.testGet("id")
      */
@@ -78,6 +81,9 @@ export class HttpMethodsClient {
      *
      * @param {SeedExhaustive.types.ObjectWithRequiredField} request
      * @param {HttpMethodsClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.httpMethods.testPost({
@@ -143,6 +149,9 @@ export class HttpMethodsClient {
      * @param {string} id
      * @param {SeedExhaustive.types.ObjectWithRequiredField} request
      * @param {HttpMethodsClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.httpMethods.testPut("id", {
@@ -210,6 +219,9 @@ export class HttpMethodsClient {
      * @param {string} id
      * @param {SeedExhaustive.types.ObjectWithOptionalField} request
      * @param {HttpMethodsClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.httpMethods.testPatch("id", {
@@ -290,6 +302,9 @@ export class HttpMethodsClient {
      *
      * @param {string} id
      * @param {HttpMethodsClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.httpMethods.testDelete("id")

--- a/seed/ts-sdk/exhaustive/consolidate-type-files/src/api/resources/endpoints/resources/object/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/consolidate-type-files/src/api/resources/endpoints/resources/object/client/Client.ts
@@ -26,6 +26,9 @@ export class ObjectClient {
      * @param {SeedExhaustive.types.ObjectWithOptionalField} request
      * @param {ObjectClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.object.getAndReturnWithOptionalField({
      *         string: "string",
@@ -107,6 +110,9 @@ export class ObjectClient {
      * @param {SeedExhaustive.types.ObjectWithRequiredField} request
      * @param {ObjectClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.object.getAndReturnWithRequiredField({
      *         string: "string"
@@ -173,6 +179,9 @@ export class ObjectClient {
     /**
      * @param {SeedExhaustive.types.ObjectWithMapOfMap} request
      * @param {ObjectClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.object.getAndReturnWithMapOfMap({
@@ -244,6 +253,9 @@ export class ObjectClient {
     /**
      * @param {SeedExhaustive.types.NestedObjectWithOptionalField} request
      * @param {ObjectClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.object.getAndReturnNestedWithOptionalField({
@@ -332,6 +344,9 @@ export class ObjectClient {
      * @param {SeedExhaustive.types.NestedObjectWithRequiredField} request
      * @param {ObjectClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.object.getAndReturnNestedWithRequiredField("string", {
      *         string: "string",
@@ -419,6 +434,9 @@ export class ObjectClient {
     /**
      * @param {SeedExhaustive.types.NestedObjectWithRequiredField[]} request
      * @param {ObjectClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.object.getAndReturnNestedWithRequiredFieldAsList([{
@@ -525,6 +543,9 @@ export class ObjectClient {
      * @param {SeedExhaustive.types.ObjectWithUnknownField} request
      * @param {ObjectClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.object.getAndReturnWithUnknownField({
      *         unknown: {
@@ -593,6 +614,9 @@ export class ObjectClient {
     /**
      * @param {SeedExhaustive.types.ObjectWithDocumentedUnknownType} request
      * @param {ObjectClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.object.getAndReturnWithDocumentedUnknownType({
@@ -664,6 +688,9 @@ export class ObjectClient {
     /**
      * @param {SeedExhaustive.types.MapOfDocumentedUnknownType} request
      * @param {ObjectClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.object.getAndReturnMapOfDocumentedUnknownType({
@@ -738,6 +765,9 @@ export class ObjectClient {
      *
      * @param {SeedExhaustive.types.ObjectWithMixedRequiredAndOptionalFields} request
      * @param {ObjectClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.object.getAndReturnWithMixedRequiredAndOptionalFields({
@@ -816,6 +846,9 @@ export class ObjectClient {
      * @param {SeedExhaustive.types.ObjectWithRequiredNestedObject} request
      * @param {ObjectClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.object.getAndReturnWithRequiredNestedObject({
      *         requiredString: "hello",
@@ -892,6 +925,9 @@ export class ObjectClient {
      *
      * @param {SeedExhaustive.types.ObjectWithDatetimeLikeString} request
      * @param {ObjectClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.object.getAndReturnWithDatetimeLikeString({

--- a/seed/ts-sdk/exhaustive/consolidate-type-files/src/api/resources/endpoints/resources/pagination/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/consolidate-type-files/src/api/resources/endpoints/resources/pagination/client/Client.ts
@@ -27,6 +27,9 @@ export class PaginationClient {
      * @param {SeedExhaustive.endpoints.ListItemsRequest} request
      * @param {PaginationClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.pagination.listItems({
      *         cursor: "cursor",

--- a/seed/ts-sdk/exhaustive/consolidate-type-files/src/api/resources/endpoints/resources/params/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/consolidate-type-files/src/api/resources/endpoints/resources/params/client/Client.ts
@@ -28,6 +28,9 @@ export class ParamsClient {
      * @param {string} param
      * @param {ParamsClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.params.getWithPath("param")
      */
@@ -80,6 +83,9 @@ export class ParamsClient {
      *
      * @param {SeedExhaustive.endpoints.GetWithInlinePath} request
      * @param {ParamsClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.params.getWithInlinePath({
@@ -139,6 +145,9 @@ export class ParamsClient {
      *
      * @param {SeedExhaustive.endpoints.GetWithQuery} request
      * @param {ParamsClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.params.getWithQuery({
@@ -207,6 +216,9 @@ export class ParamsClient {
      *
      * @param {SeedExhaustive.endpoints.GetWithMultipleQuery} request
      * @param {ParamsClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.params.getWithAllowMultipleQuery({
@@ -277,6 +289,9 @@ export class ParamsClient {
      * @param {SeedExhaustive.endpoints.GetWithPathAndQuery} request
      * @param {ParamsClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.params.getWithPathAndQuery("param", {
      *         query: "query"
@@ -344,6 +359,9 @@ export class ParamsClient {
      *
      * @param {SeedExhaustive.endpoints.GetWithInlinePathAndQuery} request
      * @param {ParamsClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.params.getWithInlinePathAndQuery({
@@ -413,6 +431,9 @@ export class ParamsClient {
      * @param {string} request
      * @param {ParamsClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.params.modifyWithPath("param", "string")
      */
@@ -473,6 +494,9 @@ export class ParamsClient {
      *
      * @param {SeedExhaustive.endpoints.ModifyResourceAtInlinedPath} request
      * @param {ParamsClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.params.modifyWithInlinePath({
@@ -537,6 +561,9 @@ export class ParamsClient {
      * @param {core.file.Uploadable} uploadable
      * @param {string} param
      * @param {ParamsClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     import { createReadStream } from "fs";
@@ -604,6 +631,9 @@ export class ParamsClient {
      *
      * @param {SeedExhaustive.endpoints.CreateWithBodyAndQuery} request
      * @param {ParamsClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.params.createWithBodyAndQuery({
@@ -680,6 +710,9 @@ export class ParamsClient {
      * @param {core.file.Uploadable} uploadable
      * @param {SeedExhaustive.endpoints.UploadBytesWithQuery} request
      * @param {ParamsClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      */
     public uploadBytesWithQuery(
         uploadable: core.file.Uploadable,
@@ -751,6 +784,9 @@ export class ParamsClient {
      * @param {boolean} param
      * @param {ParamsClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.params.getWithBooleanPath(true)
      */
@@ -808,6 +844,8 @@ export class ParamsClient {
      * @param {ParamsClient.RequestOptions} requestOptions - Request-specific configuration.
      *
      * @throws {@link SeedExhaustive.BadRequestBody}
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.params.getWithPathAndErrors("param")

--- a/seed/ts-sdk/exhaustive/consolidate-type-files/src/api/resources/endpoints/resources/primitive/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/consolidate-type-files/src/api/resources/endpoints/resources/primitive/client/Client.ts
@@ -25,6 +25,9 @@ export class PrimitiveClient {
      * @param {string} request
      * @param {PrimitiveClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.primitive.getAndReturnString("string")
      */
@@ -81,6 +84,9 @@ export class PrimitiveClient {
     /**
      * @param {number} request
      * @param {PrimitiveClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.primitive.getAndReturnInt(1)
@@ -139,6 +145,9 @@ export class PrimitiveClient {
      * @param {number} request
      * @param {PrimitiveClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.primitive.getAndReturnLong(1000000)
      */
@@ -195,6 +204,9 @@ export class PrimitiveClient {
     /**
      * @param {number} request
      * @param {PrimitiveClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.primitive.getAndReturnDouble(1.1)
@@ -253,6 +265,9 @@ export class PrimitiveClient {
      * @param {boolean} request
      * @param {PrimitiveClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.primitive.getAndReturnBool(true)
      */
@@ -309,6 +324,9 @@ export class PrimitiveClient {
     /**
      * @param {string} request
      * @param {PrimitiveClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.primitive.getAndReturnDatetime("2024-01-15T09:30:00Z")
@@ -367,6 +385,9 @@ export class PrimitiveClient {
      * @param {string} request
      * @param {PrimitiveClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.primitive.getAndReturnDate("2023-01-15")
      */
@@ -424,6 +445,9 @@ export class PrimitiveClient {
      * @param {string} request
      * @param {PrimitiveClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.primitive.getAndReturnUuid("d5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32")
      */
@@ -480,6 +504,9 @@ export class PrimitiveClient {
     /**
      * @param {string} request
      * @param {PrimitiveClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.primitive.getAndReturnBase64("SGVsbG8gd29ybGQh")

--- a/seed/ts-sdk/exhaustive/consolidate-type-files/src/api/resources/endpoints/resources/put/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/consolidate-type-files/src/api/resources/endpoints/resources/put/client/Client.ts
@@ -25,6 +25,9 @@ export class PutClient {
      * @param {SeedExhaustive.endpoints.PutRequest} request
      * @param {PutClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.put.add({
      *         id: "id"

--- a/seed/ts-sdk/exhaustive/consolidate-type-files/src/api/resources/endpoints/resources/union/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/consolidate-type-files/src/api/resources/endpoints/resources/union/client/Client.ts
@@ -26,6 +26,9 @@ export class UnionClient {
      * @param {SeedExhaustive.types.Animal} request
      * @param {UnionClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.union.getAndReturnUnion({
      *         animal: "dog",

--- a/seed/ts-sdk/exhaustive/consolidate-type-files/src/api/resources/endpoints/resources/urls/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/consolidate-type-files/src/api/resources/endpoints/resources/urls/client/Client.ts
@@ -23,6 +23,9 @@ export class UrlsClient {
     /**
      * @param {UrlsClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.urls.withMixedCase()
      */
@@ -69,6 +72,9 @@ export class UrlsClient {
 
     /**
      * @param {UrlsClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.urls.noEndingSlash()
@@ -117,6 +123,9 @@ export class UrlsClient {
     /**
      * @param {UrlsClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.urls.withEndingSlash()
      */
@@ -163,6 +172,9 @@ export class UrlsClient {
 
     /**
      * @param {UrlsClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.urls.withUnderscores()

--- a/seed/ts-sdk/exhaustive/consolidate-type-files/src/api/resources/inlinedRequests/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/consolidate-type-files/src/api/resources/inlinedRequests/client/Client.ts
@@ -29,6 +29,8 @@ export class InlinedRequestsClient {
      * @param {InlinedRequestsClient.RequestOptions} requestOptions - Request-specific configuration.
      *
      * @throws {@link SeedExhaustive.BadRequestBody}
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.inlinedRequests.postWithObjectBodyandResponse({
@@ -114,6 +116,9 @@ export class InlinedRequestsClient {
      *
      * @param {SeedExhaustive.PostWithArrayBodyAndHeaders} request
      * @param {InlinedRequestsClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.inlinedRequests.postWithArrayBodyAndHeaders({

--- a/seed/ts-sdk/exhaustive/consolidate-type-files/src/api/resources/noAuth/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/consolidate-type-files/src/api/resources/noAuth/client/Client.ts
@@ -29,6 +29,8 @@ export class NoAuthClient {
      * @param {NoAuthClient.RequestOptions} requestOptions - Request-specific configuration.
      *
      * @throws {@link SeedExhaustive.BadRequestBody}
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.noAuth.postWithNoAuth({

--- a/seed/ts-sdk/exhaustive/consolidate-type-files/src/api/resources/noReqBody/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/consolidate-type-files/src/api/resources/noReqBody/client/Client.ts
@@ -24,6 +24,9 @@ export class NoReqBodyClient {
     /**
      * @param {NoReqBodyClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.noReqBody.getWithNoRequestBody()
      */
@@ -77,6 +80,9 @@ export class NoReqBodyClient {
 
     /**
      * @param {NoReqBodyClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.noReqBody.postWithNoRequestBody()

--- a/seed/ts-sdk/exhaustive/consolidate-type-files/src/api/resources/reqWithHeaders/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/consolidate-type-files/src/api/resources/reqWithHeaders/client/Client.ts
@@ -26,6 +26,9 @@ export class ReqWithHeadersClient {
      * @param {SeedExhaustive.ReqWithHeaders} request
      * @param {ReqWithHeadersClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.reqWithHeaders.getWithCustomHeader({
      *         "X-TEST-SERVICE-HEADER": "X-TEST-SERVICE-HEADER",

--- a/seed/ts-sdk/exhaustive/export-all-requests-at-root/src/api/resources/endpoints/resources/container/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/export-all-requests-at-root/src/api/resources/endpoints/resources/container/client/Client.ts
@@ -26,6 +26,9 @@ export class ContainerClient {
      * @param {string[]} request
      * @param {ContainerClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.container.getAndReturnListOfPrimitives(["string", "string"])
      */
@@ -87,6 +90,9 @@ export class ContainerClient {
     /**
      * @param {SeedExhaustive.types.ObjectWithRequiredField[]} request
      * @param {ContainerClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.container.getAndReturnListOfObjects([{
@@ -152,6 +158,9 @@ export class ContainerClient {
      * @param {string[]} request
      * @param {ContainerClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.container.getAndReturnSetOfPrimitives(["string"])
      */
@@ -208,6 +217,9 @@ export class ContainerClient {
     /**
      * @param {SeedExhaustive.types.ObjectWithRequiredField[]} request
      * @param {ContainerClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.container.getAndReturnSetOfObjects([{
@@ -271,6 +283,9 @@ export class ContainerClient {
      * @param {Record<string, string>} request
      * @param {ContainerClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.container.getAndReturnMapPrimToPrim({
      *         "string": "string"
@@ -329,6 +344,9 @@ export class ContainerClient {
     /**
      * @param {Record<string, SeedExhaustive.types.ObjectWithRequiredField>} request
      * @param {ContainerClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.container.getAndReturnMapOfPrimToObject({
@@ -399,6 +417,9 @@ export class ContainerClient {
      * @param {Record<string, SeedExhaustive.types.MixedType>} request
      * @param {ContainerClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.container.getAndReturnMapOfPrimToUndiscriminatedUnion({
      *         "string": 1.1
@@ -462,6 +483,9 @@ export class ContainerClient {
     /**
      * @param {SeedExhaustive.types.ObjectWithRequiredField} request
      * @param {ContainerClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.container.getAndReturnOptional({

--- a/seed/ts-sdk/exhaustive/export-all-requests-at-root/src/api/resources/endpoints/resources/contentType/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/export-all-requests-at-root/src/api/resources/endpoints/resources/contentType/client/Client.ts
@@ -26,6 +26,9 @@ export class ContentTypeClient {
      * @param {SeedExhaustive.types.ObjectWithOptionalField} request
      * @param {ContentTypeClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.contentType.postJsonPatchContentType({
      *         string: "string",
@@ -98,6 +101,9 @@ export class ContentTypeClient {
     /**
      * @param {SeedExhaustive.types.ObjectWithOptionalField} request
      * @param {ContentTypeClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.contentType.postJsonPatchContentWithCharsetType({

--- a/seed/ts-sdk/exhaustive/export-all-requests-at-root/src/api/resources/endpoints/resources/enum/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/export-all-requests-at-root/src/api/resources/endpoints/resources/enum/client/Client.ts
@@ -26,6 +26,9 @@ export class EnumClient {
      * @param {SeedExhaustive.types.WeatherReport} request
      * @param {EnumClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.enum.getAndReturnEnum("SUNNY")
      */

--- a/seed/ts-sdk/exhaustive/export-all-requests-at-root/src/api/resources/endpoints/resources/httpMethods/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/export-all-requests-at-root/src/api/resources/endpoints/resources/httpMethods/client/Client.ts
@@ -26,6 +26,9 @@ export class HttpMethodsClient {
      * @param {string} id
      * @param {HttpMethodsClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.httpMethods.testGet("id")
      */
@@ -78,6 +81,9 @@ export class HttpMethodsClient {
      *
      * @param {SeedExhaustive.types.ObjectWithRequiredField} request
      * @param {HttpMethodsClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.httpMethods.testPost({
@@ -143,6 +149,9 @@ export class HttpMethodsClient {
      * @param {string} id
      * @param {SeedExhaustive.types.ObjectWithRequiredField} request
      * @param {HttpMethodsClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.httpMethods.testPut("id", {
@@ -210,6 +219,9 @@ export class HttpMethodsClient {
      * @param {string} id
      * @param {SeedExhaustive.types.ObjectWithOptionalField} request
      * @param {HttpMethodsClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.httpMethods.testPatch("id", {
@@ -290,6 +302,9 @@ export class HttpMethodsClient {
      *
      * @param {string} id
      * @param {HttpMethodsClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.httpMethods.testDelete("id")

--- a/seed/ts-sdk/exhaustive/export-all-requests-at-root/src/api/resources/endpoints/resources/object/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/export-all-requests-at-root/src/api/resources/endpoints/resources/object/client/Client.ts
@@ -26,6 +26,9 @@ export class ObjectClient {
      * @param {SeedExhaustive.types.ObjectWithOptionalField} request
      * @param {ObjectClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.object.getAndReturnWithOptionalField({
      *         string: "string",
@@ -107,6 +110,9 @@ export class ObjectClient {
      * @param {SeedExhaustive.types.ObjectWithRequiredField} request
      * @param {ObjectClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.object.getAndReturnWithRequiredField({
      *         string: "string"
@@ -173,6 +179,9 @@ export class ObjectClient {
     /**
      * @param {SeedExhaustive.types.ObjectWithMapOfMap} request
      * @param {ObjectClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.object.getAndReturnWithMapOfMap({
@@ -244,6 +253,9 @@ export class ObjectClient {
     /**
      * @param {SeedExhaustive.types.NestedObjectWithOptionalField} request
      * @param {ObjectClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.object.getAndReturnNestedWithOptionalField({
@@ -332,6 +344,9 @@ export class ObjectClient {
      * @param {SeedExhaustive.types.NestedObjectWithRequiredField} request
      * @param {ObjectClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.object.getAndReturnNestedWithRequiredField("string", {
      *         string: "string",
@@ -419,6 +434,9 @@ export class ObjectClient {
     /**
      * @param {SeedExhaustive.types.NestedObjectWithRequiredField[]} request
      * @param {ObjectClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.object.getAndReturnNestedWithRequiredFieldAsList([{
@@ -525,6 +543,9 @@ export class ObjectClient {
      * @param {SeedExhaustive.types.ObjectWithUnknownField} request
      * @param {ObjectClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.object.getAndReturnWithUnknownField({
      *         unknown: {
@@ -593,6 +614,9 @@ export class ObjectClient {
     /**
      * @param {SeedExhaustive.types.ObjectWithDocumentedUnknownType} request
      * @param {ObjectClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.object.getAndReturnWithDocumentedUnknownType({
@@ -664,6 +688,9 @@ export class ObjectClient {
     /**
      * @param {SeedExhaustive.types.MapOfDocumentedUnknownType} request
      * @param {ObjectClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.object.getAndReturnMapOfDocumentedUnknownType({
@@ -738,6 +765,9 @@ export class ObjectClient {
      *
      * @param {SeedExhaustive.types.ObjectWithMixedRequiredAndOptionalFields} request
      * @param {ObjectClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.object.getAndReturnWithMixedRequiredAndOptionalFields({
@@ -816,6 +846,9 @@ export class ObjectClient {
      * @param {SeedExhaustive.types.ObjectWithRequiredNestedObject} request
      * @param {ObjectClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.object.getAndReturnWithRequiredNestedObject({
      *         requiredString: "hello",
@@ -892,6 +925,9 @@ export class ObjectClient {
      *
      * @param {SeedExhaustive.types.ObjectWithDatetimeLikeString} request
      * @param {ObjectClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.object.getAndReturnWithDatetimeLikeString({

--- a/seed/ts-sdk/exhaustive/export-all-requests-at-root/src/api/resources/endpoints/resources/pagination/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/export-all-requests-at-root/src/api/resources/endpoints/resources/pagination/client/Client.ts
@@ -27,6 +27,9 @@ export class PaginationClient {
      * @param {SeedExhaustive.ListItemsRequest} request
      * @param {PaginationClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.pagination.listItems({
      *         cursor: "cursor",

--- a/seed/ts-sdk/exhaustive/export-all-requests-at-root/src/api/resources/endpoints/resources/params/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/export-all-requests-at-root/src/api/resources/endpoints/resources/params/client/Client.ts
@@ -28,6 +28,9 @@ export class ParamsClient {
      * @param {string} param
      * @param {ParamsClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.params.getWithPath("param")
      */
@@ -80,6 +83,9 @@ export class ParamsClient {
      *
      * @param {SeedExhaustive.GetWithInlinePath} request
      * @param {ParamsClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.params.getWithInlinePath({
@@ -139,6 +145,9 @@ export class ParamsClient {
      *
      * @param {SeedExhaustive.GetWithQuery} request
      * @param {ParamsClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.params.getWithQuery({
@@ -207,6 +216,9 @@ export class ParamsClient {
      *
      * @param {SeedExhaustive.GetWithMultipleQuery} request
      * @param {ParamsClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.params.getWithAllowMultipleQuery({
@@ -277,6 +289,9 @@ export class ParamsClient {
      * @param {SeedExhaustive.GetWithPathAndQuery} request
      * @param {ParamsClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.params.getWithPathAndQuery("param", {
      *         query: "query"
@@ -344,6 +359,9 @@ export class ParamsClient {
      *
      * @param {SeedExhaustive.GetWithInlinePathAndQuery} request
      * @param {ParamsClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.params.getWithInlinePathAndQuery({
@@ -413,6 +431,9 @@ export class ParamsClient {
      * @param {string} request
      * @param {ParamsClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.params.modifyWithPath("param", "string")
      */
@@ -473,6 +494,9 @@ export class ParamsClient {
      *
      * @param {SeedExhaustive.ModifyResourceAtInlinedPath} request
      * @param {ParamsClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.params.modifyWithInlinePath({
@@ -537,6 +561,9 @@ export class ParamsClient {
      * @param {core.file.Uploadable} uploadable
      * @param {string} param
      * @param {ParamsClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     import { createReadStream } from "fs";
@@ -604,6 +631,9 @@ export class ParamsClient {
      *
      * @param {SeedExhaustive.CreateWithBodyAndQuery} request
      * @param {ParamsClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.params.createWithBodyAndQuery({
@@ -680,6 +710,9 @@ export class ParamsClient {
      * @param {core.file.Uploadable} uploadable
      * @param {SeedExhaustive.UploadBytesWithQuery} request
      * @param {ParamsClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      */
     public uploadBytesWithQuery(
         uploadable: core.file.Uploadable,
@@ -751,6 +784,9 @@ export class ParamsClient {
      * @param {boolean} param
      * @param {ParamsClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.params.getWithBooleanPath(true)
      */
@@ -808,6 +844,8 @@ export class ParamsClient {
      * @param {ParamsClient.RequestOptions} requestOptions - Request-specific configuration.
      *
      * @throws {@link SeedExhaustive.BadRequestBody}
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.params.getWithPathAndErrors("param")

--- a/seed/ts-sdk/exhaustive/export-all-requests-at-root/src/api/resources/endpoints/resources/primitive/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/export-all-requests-at-root/src/api/resources/endpoints/resources/primitive/client/Client.ts
@@ -25,6 +25,9 @@ export class PrimitiveClient {
      * @param {string} request
      * @param {PrimitiveClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.primitive.getAndReturnString("string")
      */
@@ -81,6 +84,9 @@ export class PrimitiveClient {
     /**
      * @param {number} request
      * @param {PrimitiveClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.primitive.getAndReturnInt(1)
@@ -139,6 +145,9 @@ export class PrimitiveClient {
      * @param {number} request
      * @param {PrimitiveClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.primitive.getAndReturnLong(1000000)
      */
@@ -195,6 +204,9 @@ export class PrimitiveClient {
     /**
      * @param {number} request
      * @param {PrimitiveClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.primitive.getAndReturnDouble(1.1)
@@ -253,6 +265,9 @@ export class PrimitiveClient {
      * @param {boolean} request
      * @param {PrimitiveClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.primitive.getAndReturnBool(true)
      */
@@ -309,6 +324,9 @@ export class PrimitiveClient {
     /**
      * @param {string} request
      * @param {PrimitiveClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.primitive.getAndReturnDatetime("2024-01-15T09:30:00Z")
@@ -367,6 +385,9 @@ export class PrimitiveClient {
      * @param {string} request
      * @param {PrimitiveClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.primitive.getAndReturnDate("2023-01-15")
      */
@@ -424,6 +445,9 @@ export class PrimitiveClient {
      * @param {string} request
      * @param {PrimitiveClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.primitive.getAndReturnUuid("d5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32")
      */
@@ -480,6 +504,9 @@ export class PrimitiveClient {
     /**
      * @param {string} request
      * @param {PrimitiveClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.primitive.getAndReturnBase64("SGVsbG8gd29ybGQh")

--- a/seed/ts-sdk/exhaustive/export-all-requests-at-root/src/api/resources/endpoints/resources/put/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/export-all-requests-at-root/src/api/resources/endpoints/resources/put/client/Client.ts
@@ -25,6 +25,9 @@ export class PutClient {
      * @param {SeedExhaustive.PutRequest} request
      * @param {PutClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.put.add({
      *         id: "id"

--- a/seed/ts-sdk/exhaustive/export-all-requests-at-root/src/api/resources/endpoints/resources/union/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/export-all-requests-at-root/src/api/resources/endpoints/resources/union/client/Client.ts
@@ -26,6 +26,9 @@ export class UnionClient {
      * @param {SeedExhaustive.types.Animal} request
      * @param {UnionClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.union.getAndReturnUnion({
      *         animal: "dog",

--- a/seed/ts-sdk/exhaustive/export-all-requests-at-root/src/api/resources/endpoints/resources/urls/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/export-all-requests-at-root/src/api/resources/endpoints/resources/urls/client/Client.ts
@@ -23,6 +23,9 @@ export class UrlsClient {
     /**
      * @param {UrlsClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.urls.withMixedCase()
      */
@@ -69,6 +72,9 @@ export class UrlsClient {
 
     /**
      * @param {UrlsClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.urls.noEndingSlash()
@@ -117,6 +123,9 @@ export class UrlsClient {
     /**
      * @param {UrlsClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.urls.withEndingSlash()
      */
@@ -163,6 +172,9 @@ export class UrlsClient {
 
     /**
      * @param {UrlsClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.urls.withUnderscores()

--- a/seed/ts-sdk/exhaustive/export-all-requests-at-root/src/api/resources/inlinedRequests/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/export-all-requests-at-root/src/api/resources/inlinedRequests/client/Client.ts
@@ -29,6 +29,8 @@ export class InlinedRequestsClient {
      * @param {InlinedRequestsClient.RequestOptions} requestOptions - Request-specific configuration.
      *
      * @throws {@link SeedExhaustive.BadRequestBody}
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.inlinedRequests.postWithObjectBodyandResponse({
@@ -114,6 +116,9 @@ export class InlinedRequestsClient {
      *
      * @param {SeedExhaustive.PostWithArrayBodyAndHeaders} request
      * @param {InlinedRequestsClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.inlinedRequests.postWithArrayBodyAndHeaders({

--- a/seed/ts-sdk/exhaustive/export-all-requests-at-root/src/api/resources/noAuth/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/export-all-requests-at-root/src/api/resources/noAuth/client/Client.ts
@@ -29,6 +29,8 @@ export class NoAuthClient {
      * @param {NoAuthClient.RequestOptions} requestOptions - Request-specific configuration.
      *
      * @throws {@link SeedExhaustive.BadRequestBody}
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.noAuth.postWithNoAuth({

--- a/seed/ts-sdk/exhaustive/export-all-requests-at-root/src/api/resources/noReqBody/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/export-all-requests-at-root/src/api/resources/noReqBody/client/Client.ts
@@ -24,6 +24,9 @@ export class NoReqBodyClient {
     /**
      * @param {NoReqBodyClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.noReqBody.getWithNoRequestBody()
      */
@@ -77,6 +80,9 @@ export class NoReqBodyClient {
 
     /**
      * @param {NoReqBodyClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.noReqBody.postWithNoRequestBody()

--- a/seed/ts-sdk/exhaustive/export-all-requests-at-root/src/api/resources/reqWithHeaders/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/export-all-requests-at-root/src/api/resources/reqWithHeaders/client/Client.ts
@@ -26,6 +26,9 @@ export class ReqWithHeadersClient {
      * @param {SeedExhaustive.ReqWithHeaders} request
      * @param {ReqWithHeadersClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.reqWithHeaders.getWithCustomHeader({
      *         "X-TEST-SERVICE-HEADER": "X-TEST-SERVICE-HEADER",

--- a/seed/ts-sdk/exhaustive/flatten-request-parameters/src/api/resources/endpoints/resources/container/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/flatten-request-parameters/src/api/resources/endpoints/resources/container/client/Client.ts
@@ -26,6 +26,9 @@ export class ContainerClient {
      * @param {string[]} request
      * @param {ContainerClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.container.getAndReturnListOfPrimitives(["string", "string"])
      */
@@ -87,6 +90,9 @@ export class ContainerClient {
     /**
      * @param {SeedExhaustive.types.ObjectWithRequiredField[]} request
      * @param {ContainerClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.container.getAndReturnListOfObjects([{
@@ -152,6 +158,9 @@ export class ContainerClient {
      * @param {string[]} request
      * @param {ContainerClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.container.getAndReturnSetOfPrimitives(["string"])
      */
@@ -208,6 +217,9 @@ export class ContainerClient {
     /**
      * @param {SeedExhaustive.types.ObjectWithRequiredField[]} request
      * @param {ContainerClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.container.getAndReturnSetOfObjects([{
@@ -271,6 +283,9 @@ export class ContainerClient {
      * @param {Record<string, string>} request
      * @param {ContainerClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.container.getAndReturnMapPrimToPrim({
      *         "string": "string"
@@ -329,6 +344,9 @@ export class ContainerClient {
     /**
      * @param {Record<string, SeedExhaustive.types.ObjectWithRequiredField>} request
      * @param {ContainerClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.container.getAndReturnMapOfPrimToObject({
@@ -399,6 +417,9 @@ export class ContainerClient {
      * @param {Record<string, SeedExhaustive.types.MixedType>} request
      * @param {ContainerClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.container.getAndReturnMapOfPrimToUndiscriminatedUnion({
      *         "string": 1.1
@@ -462,6 +483,9 @@ export class ContainerClient {
     /**
      * @param {SeedExhaustive.types.ObjectWithRequiredField} request
      * @param {ContainerClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.container.getAndReturnOptional({

--- a/seed/ts-sdk/exhaustive/flatten-request-parameters/src/api/resources/endpoints/resources/contentType/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/flatten-request-parameters/src/api/resources/endpoints/resources/contentType/client/Client.ts
@@ -26,6 +26,9 @@ export class ContentTypeClient {
      * @param {SeedExhaustive.types.ObjectWithOptionalField} request
      * @param {ContentTypeClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.contentType.postJsonPatchContentType({
      *         string: "string",
@@ -98,6 +101,9 @@ export class ContentTypeClient {
     /**
      * @param {SeedExhaustive.types.ObjectWithOptionalField} request
      * @param {ContentTypeClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.contentType.postJsonPatchContentWithCharsetType({

--- a/seed/ts-sdk/exhaustive/flatten-request-parameters/src/api/resources/endpoints/resources/enum/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/flatten-request-parameters/src/api/resources/endpoints/resources/enum/client/Client.ts
@@ -26,6 +26,9 @@ export class EnumClient {
      * @param {SeedExhaustive.types.WeatherReport} request
      * @param {EnumClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.enum.getAndReturnEnum("SUNNY")
      */

--- a/seed/ts-sdk/exhaustive/flatten-request-parameters/src/api/resources/endpoints/resources/httpMethods/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/flatten-request-parameters/src/api/resources/endpoints/resources/httpMethods/client/Client.ts
@@ -26,6 +26,9 @@ export class HttpMethodsClient {
      * @param {string} id
      * @param {HttpMethodsClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.httpMethods.testGet("id")
      */
@@ -78,6 +81,9 @@ export class HttpMethodsClient {
      *
      * @param {SeedExhaustive.types.ObjectWithRequiredField} request
      * @param {HttpMethodsClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.httpMethods.testPost({
@@ -143,6 +149,9 @@ export class HttpMethodsClient {
      * @param {string} id
      * @param {SeedExhaustive.types.ObjectWithRequiredField} request
      * @param {HttpMethodsClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.httpMethods.testPut("id", {
@@ -210,6 +219,9 @@ export class HttpMethodsClient {
      * @param {string} id
      * @param {SeedExhaustive.types.ObjectWithOptionalField} request
      * @param {HttpMethodsClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.httpMethods.testPatch("id", {
@@ -290,6 +302,9 @@ export class HttpMethodsClient {
      *
      * @param {string} id
      * @param {HttpMethodsClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.httpMethods.testDelete("id")

--- a/seed/ts-sdk/exhaustive/flatten-request-parameters/src/api/resources/endpoints/resources/object/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/flatten-request-parameters/src/api/resources/endpoints/resources/object/client/Client.ts
@@ -26,6 +26,9 @@ export class ObjectClient {
      * @param {SeedExhaustive.types.ObjectWithOptionalField} request
      * @param {ObjectClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.object.getAndReturnWithOptionalField({
      *         string: "string",
@@ -107,6 +110,9 @@ export class ObjectClient {
      * @param {SeedExhaustive.types.ObjectWithRequiredField} request
      * @param {ObjectClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.object.getAndReturnWithRequiredField({
      *         string: "string"
@@ -173,6 +179,9 @@ export class ObjectClient {
     /**
      * @param {SeedExhaustive.types.ObjectWithMapOfMap} request
      * @param {ObjectClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.object.getAndReturnWithMapOfMap({
@@ -244,6 +253,9 @@ export class ObjectClient {
     /**
      * @param {SeedExhaustive.types.NestedObjectWithOptionalField} request
      * @param {ObjectClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.object.getAndReturnNestedWithOptionalField({
@@ -332,6 +344,9 @@ export class ObjectClient {
      * @param {SeedExhaustive.types.NestedObjectWithRequiredField} request
      * @param {ObjectClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.object.getAndReturnNestedWithRequiredField("string", {
      *         string: "string",
@@ -419,6 +434,9 @@ export class ObjectClient {
     /**
      * @param {SeedExhaustive.types.NestedObjectWithRequiredField[]} request
      * @param {ObjectClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.object.getAndReturnNestedWithRequiredFieldAsList([{
@@ -525,6 +543,9 @@ export class ObjectClient {
      * @param {SeedExhaustive.types.ObjectWithUnknownField} request
      * @param {ObjectClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.object.getAndReturnWithUnknownField({
      *         unknown: {
@@ -593,6 +614,9 @@ export class ObjectClient {
     /**
      * @param {SeedExhaustive.types.ObjectWithDocumentedUnknownType} request
      * @param {ObjectClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.object.getAndReturnWithDocumentedUnknownType({
@@ -664,6 +688,9 @@ export class ObjectClient {
     /**
      * @param {SeedExhaustive.types.MapOfDocumentedUnknownType} request
      * @param {ObjectClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.object.getAndReturnMapOfDocumentedUnknownType({
@@ -738,6 +765,9 @@ export class ObjectClient {
      *
      * @param {SeedExhaustive.types.ObjectWithMixedRequiredAndOptionalFields} request
      * @param {ObjectClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.object.getAndReturnWithMixedRequiredAndOptionalFields({
@@ -816,6 +846,9 @@ export class ObjectClient {
      * @param {SeedExhaustive.types.ObjectWithRequiredNestedObject} request
      * @param {ObjectClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.object.getAndReturnWithRequiredNestedObject({
      *         requiredString: "hello",
@@ -892,6 +925,9 @@ export class ObjectClient {
      *
      * @param {SeedExhaustive.types.ObjectWithDatetimeLikeString} request
      * @param {ObjectClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.object.getAndReturnWithDatetimeLikeString({

--- a/seed/ts-sdk/exhaustive/flatten-request-parameters/src/api/resources/endpoints/resources/pagination/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/flatten-request-parameters/src/api/resources/endpoints/resources/pagination/client/Client.ts
@@ -27,6 +27,9 @@ export class PaginationClient {
      * @param {SeedExhaustive.endpoints.ListItemsRequest} request
      * @param {PaginationClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.pagination.listItems({
      *         cursor: "cursor",

--- a/seed/ts-sdk/exhaustive/flatten-request-parameters/src/api/resources/endpoints/resources/params/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/flatten-request-parameters/src/api/resources/endpoints/resources/params/client/Client.ts
@@ -28,6 +28,9 @@ export class ParamsClient {
      * @param {string} param
      * @param {ParamsClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.params.getWithPath("param")
      */
@@ -80,6 +83,9 @@ export class ParamsClient {
      *
      * @param {SeedExhaustive.endpoints.GetWithInlinePath} request
      * @param {ParamsClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.params.getWithInlinePath({
@@ -139,6 +145,9 @@ export class ParamsClient {
      *
      * @param {SeedExhaustive.endpoints.GetWithQuery} request
      * @param {ParamsClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.params.getWithQuery({
@@ -207,6 +216,9 @@ export class ParamsClient {
      *
      * @param {SeedExhaustive.endpoints.GetWithMultipleQuery} request
      * @param {ParamsClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.params.getWithAllowMultipleQuery({
@@ -277,6 +289,9 @@ export class ParamsClient {
      * @param {SeedExhaustive.endpoints.GetWithPathAndQuery} request
      * @param {ParamsClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.params.getWithPathAndQuery("param", {
      *         query: "query"
@@ -344,6 +359,9 @@ export class ParamsClient {
      *
      * @param {SeedExhaustive.endpoints.GetWithInlinePathAndQuery} request
      * @param {ParamsClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.params.getWithInlinePathAndQuery({
@@ -413,6 +431,9 @@ export class ParamsClient {
      * @param {string} request
      * @param {ParamsClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.params.modifyWithPath("param", "string")
      */
@@ -473,6 +494,9 @@ export class ParamsClient {
      *
      * @param {SeedExhaustive.endpoints.ModifyResourceAtInlinedPath} request
      * @param {ParamsClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.params.modifyWithInlinePath({
@@ -537,6 +561,9 @@ export class ParamsClient {
      * @param {core.file.Uploadable} uploadable
      * @param {string} param
      * @param {ParamsClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     import { createReadStream } from "fs";
@@ -604,6 +631,9 @@ export class ParamsClient {
      *
      * @param {SeedExhaustive.endpoints.CreateWithBodyAndQuery} request
      * @param {ParamsClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.params.createWithBodyAndQuery({
@@ -678,6 +708,9 @@ export class ParamsClient {
      * @param {core.file.Uploadable} uploadable
      * @param {SeedExhaustive.endpoints.UploadBytesWithQuery} request
      * @param {ParamsClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      */
     public uploadBytesWithQuery(
         uploadable: core.file.Uploadable,
@@ -749,6 +782,9 @@ export class ParamsClient {
      * @param {boolean} param
      * @param {ParamsClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.params.getWithBooleanPath(true)
      */
@@ -806,6 +842,8 @@ export class ParamsClient {
      * @param {ParamsClient.RequestOptions} requestOptions - Request-specific configuration.
      *
      * @throws {@link SeedExhaustive.BadRequestBody}
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.params.getWithPathAndErrors("param")

--- a/seed/ts-sdk/exhaustive/flatten-request-parameters/src/api/resources/endpoints/resources/primitive/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/flatten-request-parameters/src/api/resources/endpoints/resources/primitive/client/Client.ts
@@ -25,6 +25,9 @@ export class PrimitiveClient {
      * @param {string} request
      * @param {PrimitiveClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.primitive.getAndReturnString("string")
      */
@@ -81,6 +84,9 @@ export class PrimitiveClient {
     /**
      * @param {number} request
      * @param {PrimitiveClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.primitive.getAndReturnInt(1)
@@ -139,6 +145,9 @@ export class PrimitiveClient {
      * @param {number} request
      * @param {PrimitiveClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.primitive.getAndReturnLong(1000000)
      */
@@ -195,6 +204,9 @@ export class PrimitiveClient {
     /**
      * @param {number} request
      * @param {PrimitiveClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.primitive.getAndReturnDouble(1.1)
@@ -253,6 +265,9 @@ export class PrimitiveClient {
      * @param {boolean} request
      * @param {PrimitiveClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.primitive.getAndReturnBool(true)
      */
@@ -309,6 +324,9 @@ export class PrimitiveClient {
     /**
      * @param {string} request
      * @param {PrimitiveClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.primitive.getAndReturnDatetime("2024-01-15T09:30:00Z")
@@ -367,6 +385,9 @@ export class PrimitiveClient {
      * @param {string} request
      * @param {PrimitiveClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.primitive.getAndReturnDate("2023-01-15")
      */
@@ -424,6 +445,9 @@ export class PrimitiveClient {
      * @param {string} request
      * @param {PrimitiveClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.primitive.getAndReturnUuid("d5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32")
      */
@@ -480,6 +504,9 @@ export class PrimitiveClient {
     /**
      * @param {string} request
      * @param {PrimitiveClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.primitive.getAndReturnBase64("SGVsbG8gd29ybGQh")

--- a/seed/ts-sdk/exhaustive/flatten-request-parameters/src/api/resources/endpoints/resources/put/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/flatten-request-parameters/src/api/resources/endpoints/resources/put/client/Client.ts
@@ -25,6 +25,9 @@ export class PutClient {
      * @param {SeedExhaustive.endpoints.PutRequest} request
      * @param {PutClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.put.add({
      *         id: "id"

--- a/seed/ts-sdk/exhaustive/flatten-request-parameters/src/api/resources/endpoints/resources/union/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/flatten-request-parameters/src/api/resources/endpoints/resources/union/client/Client.ts
@@ -26,6 +26,9 @@ export class UnionClient {
      * @param {SeedExhaustive.types.Animal} request
      * @param {UnionClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.union.getAndReturnUnion({
      *         animal: "dog",

--- a/seed/ts-sdk/exhaustive/flatten-request-parameters/src/api/resources/endpoints/resources/urls/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/flatten-request-parameters/src/api/resources/endpoints/resources/urls/client/Client.ts
@@ -23,6 +23,9 @@ export class UrlsClient {
     /**
      * @param {UrlsClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.urls.withMixedCase()
      */
@@ -69,6 +72,9 @@ export class UrlsClient {
 
     /**
      * @param {UrlsClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.urls.noEndingSlash()
@@ -117,6 +123,9 @@ export class UrlsClient {
     /**
      * @param {UrlsClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.urls.withEndingSlash()
      */
@@ -163,6 +172,9 @@ export class UrlsClient {
 
     /**
      * @param {UrlsClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.urls.withUnderscores()

--- a/seed/ts-sdk/exhaustive/flatten-request-parameters/src/api/resources/inlinedRequests/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/flatten-request-parameters/src/api/resources/inlinedRequests/client/Client.ts
@@ -29,6 +29,8 @@ export class InlinedRequestsClient {
      * @param {InlinedRequestsClient.RequestOptions} requestOptions - Request-specific configuration.
      *
      * @throws {@link SeedExhaustive.BadRequestBody}
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.inlinedRequests.postWithObjectBodyandResponse({
@@ -114,6 +116,9 @@ export class InlinedRequestsClient {
      *
      * @param {SeedExhaustive.PostWithArrayBodyAndHeaders} request
      * @param {InlinedRequestsClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.inlinedRequests.postWithArrayBodyAndHeaders({

--- a/seed/ts-sdk/exhaustive/flatten-request-parameters/src/api/resources/noAuth/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/flatten-request-parameters/src/api/resources/noAuth/client/Client.ts
@@ -29,6 +29,8 @@ export class NoAuthClient {
      * @param {NoAuthClient.RequestOptions} requestOptions - Request-specific configuration.
      *
      * @throws {@link SeedExhaustive.BadRequestBody}
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.noAuth.postWithNoAuth({

--- a/seed/ts-sdk/exhaustive/flatten-request-parameters/src/api/resources/noReqBody/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/flatten-request-parameters/src/api/resources/noReqBody/client/Client.ts
@@ -24,6 +24,9 @@ export class NoReqBodyClient {
     /**
      * @param {NoReqBodyClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.noReqBody.getWithNoRequestBody()
      */
@@ -77,6 +80,9 @@ export class NoReqBodyClient {
 
     /**
      * @param {NoReqBodyClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.noReqBody.postWithNoRequestBody()

--- a/seed/ts-sdk/exhaustive/flatten-request-parameters/src/api/resources/reqWithHeaders/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/flatten-request-parameters/src/api/resources/reqWithHeaders/client/Client.ts
@@ -26,6 +26,9 @@ export class ReqWithHeadersClient {
      * @param {SeedExhaustive.ReqWithHeaders} request
      * @param {ReqWithHeadersClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.reqWithHeaders.getWithCustomHeader({
      *         "X-TEST-SERVICE-HEADER": "X-TEST-SERVICE-HEADER",

--- a/seed/ts-sdk/exhaustive/include-idempotency-key/src/api/resources/endpoints/resources/container/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/include-idempotency-key/src/api/resources/endpoints/resources/container/client/Client.ts
@@ -27,6 +27,9 @@ export class ContainerClient {
      * @param {string[]} request
      * @param {ContainerClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.container.getAndReturnListOfPrimitives(["string", "string"])
      */
@@ -89,6 +92,9 @@ export class ContainerClient {
     /**
      * @param {SeedExhaustive.types.ObjectWithRequiredField[]} request
      * @param {ContainerClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.container.getAndReturnListOfObjects([{
@@ -155,6 +161,9 @@ export class ContainerClient {
      * @param {string[]} request
      * @param {ContainerClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.container.getAndReturnSetOfPrimitives(["string"])
      */
@@ -212,6 +221,9 @@ export class ContainerClient {
     /**
      * @param {SeedExhaustive.types.ObjectWithRequiredField[]} request
      * @param {ContainerClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.container.getAndReturnSetOfObjects([{
@@ -276,6 +288,9 @@ export class ContainerClient {
      * @param {Record<string, string>} request
      * @param {ContainerClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.container.getAndReturnMapPrimToPrim({
      *         "string": "string"
@@ -335,6 +350,9 @@ export class ContainerClient {
     /**
      * @param {Record<string, SeedExhaustive.types.ObjectWithRequiredField>} request
      * @param {ContainerClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.container.getAndReturnMapOfPrimToObject({
@@ -406,6 +424,9 @@ export class ContainerClient {
      * @param {Record<string, SeedExhaustive.types.MixedType>} request
      * @param {ContainerClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.container.getAndReturnMapOfPrimToUndiscriminatedUnion({
      *         "string": 1.1
@@ -470,6 +491,9 @@ export class ContainerClient {
     /**
      * @param {SeedExhaustive.types.ObjectWithRequiredField} request
      * @param {ContainerClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.container.getAndReturnOptional({

--- a/seed/ts-sdk/exhaustive/include-idempotency-key/src/api/resources/endpoints/resources/contentType/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/include-idempotency-key/src/api/resources/endpoints/resources/contentType/client/Client.ts
@@ -27,6 +27,9 @@ export class ContentTypeClient {
      * @param {SeedExhaustive.types.ObjectWithOptionalField} request
      * @param {ContentTypeClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.contentType.postJsonPatchContentType({
      *         string: "string",
@@ -100,6 +103,9 @@ export class ContentTypeClient {
     /**
      * @param {SeedExhaustive.types.ObjectWithOptionalField} request
      * @param {ContentTypeClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.contentType.postJsonPatchContentWithCharsetType({

--- a/seed/ts-sdk/exhaustive/include-idempotency-key/src/api/resources/endpoints/resources/enum/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/include-idempotency-key/src/api/resources/endpoints/resources/enum/client/Client.ts
@@ -27,6 +27,9 @@ export class EnumClient {
      * @param {SeedExhaustive.types.WeatherReport} request
      * @param {EnumClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.enum.getAndReturnEnum("SUNNY")
      */

--- a/seed/ts-sdk/exhaustive/include-idempotency-key/src/api/resources/endpoints/resources/httpMethods/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/include-idempotency-key/src/api/resources/endpoints/resources/httpMethods/client/Client.ts
@@ -27,6 +27,9 @@ export class HttpMethodsClient {
      * @param {string} id
      * @param {HttpMethodsClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.httpMethods.testGet("id")
      */
@@ -79,6 +82,9 @@ export class HttpMethodsClient {
      *
      * @param {SeedExhaustive.types.ObjectWithRequiredField} request
      * @param {HttpMethodsClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.httpMethods.testPost({
@@ -145,6 +151,9 @@ export class HttpMethodsClient {
      * @param {string} id
      * @param {SeedExhaustive.types.ObjectWithRequiredField} request
      * @param {HttpMethodsClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.httpMethods.testPut("id", {
@@ -213,6 +222,9 @@ export class HttpMethodsClient {
      * @param {string} id
      * @param {SeedExhaustive.types.ObjectWithOptionalField} request
      * @param {HttpMethodsClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.httpMethods.testPatch("id", {
@@ -293,6 +305,9 @@ export class HttpMethodsClient {
      *
      * @param {string} id
      * @param {HttpMethodsClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.httpMethods.testDelete("id")

--- a/seed/ts-sdk/exhaustive/include-idempotency-key/src/api/resources/endpoints/resources/object/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/include-idempotency-key/src/api/resources/endpoints/resources/object/client/Client.ts
@@ -27,6 +27,9 @@ export class ObjectClient {
      * @param {SeedExhaustive.types.ObjectWithOptionalField} request
      * @param {ObjectClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.object.getAndReturnWithOptionalField({
      *         string: "string",
@@ -109,6 +112,9 @@ export class ObjectClient {
      * @param {SeedExhaustive.types.ObjectWithRequiredField} request
      * @param {ObjectClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.object.getAndReturnWithRequiredField({
      *         string: "string"
@@ -176,6 +182,9 @@ export class ObjectClient {
     /**
      * @param {SeedExhaustive.types.ObjectWithMapOfMap} request
      * @param {ObjectClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.object.getAndReturnWithMapOfMap({
@@ -248,6 +257,9 @@ export class ObjectClient {
     /**
      * @param {SeedExhaustive.types.NestedObjectWithOptionalField} request
      * @param {ObjectClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.object.getAndReturnNestedWithOptionalField({
@@ -337,6 +349,9 @@ export class ObjectClient {
      * @param {SeedExhaustive.types.NestedObjectWithRequiredField} request
      * @param {ObjectClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.object.getAndReturnNestedWithRequiredField("string", {
      *         string: "string",
@@ -425,6 +440,9 @@ export class ObjectClient {
     /**
      * @param {SeedExhaustive.types.NestedObjectWithRequiredField[]} request
      * @param {ObjectClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.object.getAndReturnNestedWithRequiredFieldAsList([{
@@ -532,6 +550,9 @@ export class ObjectClient {
      * @param {SeedExhaustive.types.ObjectWithUnknownField} request
      * @param {ObjectClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.object.getAndReturnWithUnknownField({
      *         unknown: {
@@ -601,6 +622,9 @@ export class ObjectClient {
     /**
      * @param {SeedExhaustive.types.ObjectWithDocumentedUnknownType} request
      * @param {ObjectClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.object.getAndReturnWithDocumentedUnknownType({
@@ -673,6 +697,9 @@ export class ObjectClient {
     /**
      * @param {SeedExhaustive.types.MapOfDocumentedUnknownType} request
      * @param {ObjectClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.object.getAndReturnMapOfDocumentedUnknownType({
@@ -748,6 +775,9 @@ export class ObjectClient {
      *
      * @param {SeedExhaustive.types.ObjectWithMixedRequiredAndOptionalFields} request
      * @param {ObjectClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.object.getAndReturnWithMixedRequiredAndOptionalFields({
@@ -827,6 +857,9 @@ export class ObjectClient {
      * @param {SeedExhaustive.types.ObjectWithRequiredNestedObject} request
      * @param {ObjectClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.object.getAndReturnWithRequiredNestedObject({
      *         requiredString: "hello",
@@ -904,6 +937,9 @@ export class ObjectClient {
      *
      * @param {SeedExhaustive.types.ObjectWithDatetimeLikeString} request
      * @param {ObjectClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.object.getAndReturnWithDatetimeLikeString({

--- a/seed/ts-sdk/exhaustive/include-idempotency-key/src/api/resources/endpoints/resources/pagination/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/include-idempotency-key/src/api/resources/endpoints/resources/pagination/client/Client.ts
@@ -27,6 +27,9 @@ export class PaginationClient {
      * @param {SeedExhaustive.endpoints.ListItemsRequest} request
      * @param {PaginationClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.pagination.listItems({
      *         cursor: "cursor",

--- a/seed/ts-sdk/exhaustive/include-idempotency-key/src/api/resources/endpoints/resources/params/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/include-idempotency-key/src/api/resources/endpoints/resources/params/client/Client.ts
@@ -29,6 +29,9 @@ export class ParamsClient {
      * @param {string} param
      * @param {ParamsClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.params.getWithPath("param")
      */
@@ -81,6 +84,9 @@ export class ParamsClient {
      *
      * @param {SeedExhaustive.endpoints.GetWithInlinePath} request
      * @param {ParamsClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.params.getWithInlinePath({
@@ -140,6 +146,9 @@ export class ParamsClient {
      *
      * @param {SeedExhaustive.endpoints.GetWithQuery} request
      * @param {ParamsClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.params.getWithQuery({
@@ -208,6 +217,9 @@ export class ParamsClient {
      *
      * @param {SeedExhaustive.endpoints.GetWithMultipleQuery} request
      * @param {ParamsClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.params.getWithAllowMultipleQuery({
@@ -278,6 +290,9 @@ export class ParamsClient {
      * @param {SeedExhaustive.endpoints.GetWithPathAndQuery} request
      * @param {ParamsClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.params.getWithPathAndQuery("param", {
      *         query: "query"
@@ -345,6 +360,9 @@ export class ParamsClient {
      *
      * @param {SeedExhaustive.endpoints.GetWithInlinePathAndQuery} request
      * @param {ParamsClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.params.getWithInlinePathAndQuery({
@@ -414,6 +432,9 @@ export class ParamsClient {
      * @param {string} request
      * @param {ParamsClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.params.modifyWithPath("param", "string")
      */
@@ -475,6 +496,9 @@ export class ParamsClient {
      *
      * @param {SeedExhaustive.endpoints.ModifyResourceAtInlinedPath} request
      * @param {ParamsClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.params.modifyWithInlinePath({
@@ -540,6 +564,9 @@ export class ParamsClient {
      * @param {core.file.Uploadable} uploadable
      * @param {string} param
      * @param {ParamsClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     import { createReadStream } from "fs";
@@ -608,6 +635,9 @@ export class ParamsClient {
      *
      * @param {SeedExhaustive.endpoints.CreateWithBodyAndQuery} request
      * @param {ParamsClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.params.createWithBodyAndQuery({
@@ -685,6 +715,9 @@ export class ParamsClient {
      * @param {core.file.Uploadable} uploadable
      * @param {SeedExhaustive.endpoints.UploadBytesWithQuery} request
      * @param {ParamsClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      */
     public uploadBytesWithQuery(
         uploadable: core.file.Uploadable,
@@ -757,6 +790,9 @@ export class ParamsClient {
      * @param {boolean} param
      * @param {ParamsClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.params.getWithBooleanPath(true)
      */
@@ -814,6 +850,8 @@ export class ParamsClient {
      * @param {ParamsClient.RequestOptions} requestOptions - Request-specific configuration.
      *
      * @throws {@link SeedExhaustive.BadRequestBody}
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.params.getWithPathAndErrors("param")

--- a/seed/ts-sdk/exhaustive/include-idempotency-key/src/api/resources/endpoints/resources/primitive/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/include-idempotency-key/src/api/resources/endpoints/resources/primitive/client/Client.ts
@@ -26,6 +26,9 @@ export class PrimitiveClient {
      * @param {string} request
      * @param {PrimitiveClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.primitive.getAndReturnString("string")
      */
@@ -83,6 +86,9 @@ export class PrimitiveClient {
     /**
      * @param {number} request
      * @param {PrimitiveClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.primitive.getAndReturnInt(1)
@@ -142,6 +148,9 @@ export class PrimitiveClient {
      * @param {number} request
      * @param {PrimitiveClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.primitive.getAndReturnLong(1000000)
      */
@@ -199,6 +208,9 @@ export class PrimitiveClient {
     /**
      * @param {number} request
      * @param {PrimitiveClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.primitive.getAndReturnDouble(1.1)
@@ -258,6 +270,9 @@ export class PrimitiveClient {
      * @param {boolean} request
      * @param {PrimitiveClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.primitive.getAndReturnBool(true)
      */
@@ -315,6 +330,9 @@ export class PrimitiveClient {
     /**
      * @param {string} request
      * @param {PrimitiveClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.primitive.getAndReturnDatetime("2024-01-15T09:30:00Z")
@@ -374,6 +392,9 @@ export class PrimitiveClient {
      * @param {string} request
      * @param {PrimitiveClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.primitive.getAndReturnDate("2023-01-15")
      */
@@ -432,6 +453,9 @@ export class PrimitiveClient {
      * @param {string} request
      * @param {PrimitiveClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.primitive.getAndReturnUuid("d5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32")
      */
@@ -489,6 +513,9 @@ export class PrimitiveClient {
     /**
      * @param {string} request
      * @param {PrimitiveClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.primitive.getAndReturnBase64("SGVsbG8gd29ybGQh")

--- a/seed/ts-sdk/exhaustive/include-idempotency-key/src/api/resources/endpoints/resources/put/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/include-idempotency-key/src/api/resources/endpoints/resources/put/client/Client.ts
@@ -26,6 +26,9 @@ export class PutClient {
      * @param {SeedExhaustive.endpoints.PutRequest} request
      * @param {PutClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.put.add({
      *         id: "id"

--- a/seed/ts-sdk/exhaustive/include-idempotency-key/src/api/resources/endpoints/resources/union/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/include-idempotency-key/src/api/resources/endpoints/resources/union/client/Client.ts
@@ -27,6 +27,9 @@ export class UnionClient {
      * @param {SeedExhaustive.types.Animal} request
      * @param {UnionClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.union.getAndReturnUnion({
      *         animal: "dog",

--- a/seed/ts-sdk/exhaustive/include-idempotency-key/src/api/resources/endpoints/resources/urls/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/include-idempotency-key/src/api/resources/endpoints/resources/urls/client/Client.ts
@@ -23,6 +23,9 @@ export class UrlsClient {
     /**
      * @param {UrlsClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.urls.withMixedCase()
      */
@@ -69,6 +72,9 @@ export class UrlsClient {
 
     /**
      * @param {UrlsClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.urls.noEndingSlash()
@@ -117,6 +123,9 @@ export class UrlsClient {
     /**
      * @param {UrlsClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.urls.withEndingSlash()
      */
@@ -163,6 +172,9 @@ export class UrlsClient {
 
     /**
      * @param {UrlsClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.urls.withUnderscores()

--- a/seed/ts-sdk/exhaustive/include-idempotency-key/src/api/resources/inlinedRequests/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/include-idempotency-key/src/api/resources/inlinedRequests/client/Client.ts
@@ -30,6 +30,8 @@ export class InlinedRequestsClient {
      * @param {InlinedRequestsClient.RequestOptions} requestOptions - Request-specific configuration.
      *
      * @throws {@link SeedExhaustive.BadRequestBody}
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.inlinedRequests.postWithObjectBodyandResponse({
@@ -119,6 +121,9 @@ export class InlinedRequestsClient {
      *
      * @param {SeedExhaustive.PostWithArrayBodyAndHeaders} request
      * @param {InlinedRequestsClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.inlinedRequests.postWithArrayBodyAndHeaders({

--- a/seed/ts-sdk/exhaustive/include-idempotency-key/src/api/resources/noAuth/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/include-idempotency-key/src/api/resources/noAuth/client/Client.ts
@@ -30,6 +30,8 @@ export class NoAuthClient {
      * @param {NoAuthClient.RequestOptions} requestOptions - Request-specific configuration.
      *
      * @throws {@link SeedExhaustive.BadRequestBody}
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.noAuth.postWithNoAuth({

--- a/seed/ts-sdk/exhaustive/include-idempotency-key/src/api/resources/noReqBody/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/include-idempotency-key/src/api/resources/noReqBody/client/Client.ts
@@ -25,6 +25,9 @@ export class NoReqBodyClient {
     /**
      * @param {NoReqBodyClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.noReqBody.getWithNoRequestBody()
      */
@@ -78,6 +81,9 @@ export class NoReqBodyClient {
 
     /**
      * @param {NoReqBodyClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.noReqBody.postWithNoRequestBody()

--- a/seed/ts-sdk/exhaustive/include-idempotency-key/src/api/resources/reqWithHeaders/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/include-idempotency-key/src/api/resources/reqWithHeaders/client/Client.ts
@@ -27,6 +27,9 @@ export class ReqWithHeadersClient {
      * @param {SeedExhaustive.ReqWithHeaders} request
      * @param {ReqWithHeadersClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.reqWithHeaders.getWithCustomHeader({
      *         "X-TEST-SERVICE-HEADER": "X-TEST-SERVICE-HEADER",

--- a/seed/ts-sdk/exhaustive/local-files-no-source/cjs/api/resources/endpoints/resources/container/client/Client.d.ts
+++ b/seed/ts-sdk/exhaustive/local-files-no-source/cjs/api/resources/endpoints/resources/container/client/Client.d.ts
@@ -14,6 +14,9 @@ export declare class ContainerClient {
      * @param {string[]} request
      * @param {ContainerClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.container.getAndReturnListOfPrimitives(["string", "string"])
      */
@@ -22,6 +25,9 @@ export declare class ContainerClient {
     /**
      * @param {SeedExhaustive.types.ObjectWithRequiredField[]} request
      * @param {ContainerClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.container.getAndReturnListOfObjects([{
@@ -36,6 +42,9 @@ export declare class ContainerClient {
      * @param {string[]} request
      * @param {ContainerClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.container.getAndReturnSetOfPrimitives(["string"])
      */
@@ -44,6 +53,9 @@ export declare class ContainerClient {
     /**
      * @param {SeedExhaustive.types.ObjectWithRequiredField[]} request
      * @param {ContainerClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.container.getAndReturnSetOfObjects([{
@@ -56,6 +68,9 @@ export declare class ContainerClient {
      * @param {Record<string, string>} request
      * @param {ContainerClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.container.getAndReturnMapPrimToPrim({
      *         "string": "string"
@@ -66,6 +81,9 @@ export declare class ContainerClient {
     /**
      * @param {Record<string, SeedExhaustive.types.ObjectWithRequiredField>} request
      * @param {ContainerClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.container.getAndReturnMapOfPrimToObject({
@@ -80,6 +98,9 @@ export declare class ContainerClient {
      * @param {Record<string, SeedExhaustive.types.MixedType>} request
      * @param {ContainerClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.container.getAndReturnMapOfPrimToUndiscriminatedUnion({
      *         "string": 1.1
@@ -90,6 +111,9 @@ export declare class ContainerClient {
     /**
      * @param {SeedExhaustive.types.ObjectWithRequiredField} request
      * @param {ContainerClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.container.getAndReturnOptional({

--- a/seed/ts-sdk/exhaustive/local-files-no-source/cjs/api/resources/endpoints/resources/container/client/Client.js
+++ b/seed/ts-sdk/exhaustive/local-files-no-source/cjs/api/resources/endpoints/resources/container/client/Client.js
@@ -58,6 +58,9 @@ class ContainerClient {
      * @param {string[]} request
      * @param {ContainerClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.container.getAndReturnListOfPrimitives(["string", "string"])
      */
@@ -99,6 +102,9 @@ class ContainerClient {
     /**
      * @param {SeedExhaustive.types.ObjectWithRequiredField[]} request
      * @param {ContainerClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.container.getAndReturnListOfObjects([{
@@ -149,6 +155,9 @@ class ContainerClient {
      * @param {string[]} request
      * @param {ContainerClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.container.getAndReturnSetOfPrimitives(["string"])
      */
@@ -190,6 +199,9 @@ class ContainerClient {
     /**
      * @param {SeedExhaustive.types.ObjectWithRequiredField[]} request
      * @param {ContainerClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.container.getAndReturnSetOfObjects([{
@@ -238,6 +250,9 @@ class ContainerClient {
      * @param {Record<string, string>} request
      * @param {ContainerClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.container.getAndReturnMapPrimToPrim({
      *         "string": "string"
@@ -281,6 +296,9 @@ class ContainerClient {
     /**
      * @param {Record<string, SeedExhaustive.types.ObjectWithRequiredField>} request
      * @param {ContainerClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.container.getAndReturnMapOfPrimToObject({
@@ -331,6 +349,9 @@ class ContainerClient {
      * @param {Record<string, SeedExhaustive.types.MixedType>} request
      * @param {ContainerClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.container.getAndReturnMapOfPrimToUndiscriminatedUnion({
      *         "string": 1.1
@@ -377,6 +398,9 @@ class ContainerClient {
     /**
      * @param {SeedExhaustive.types.ObjectWithRequiredField} request
      * @param {ContainerClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.container.getAndReturnOptional({

--- a/seed/ts-sdk/exhaustive/local-files-no-source/cjs/api/resources/endpoints/resources/contentType/client/Client.d.ts
+++ b/seed/ts-sdk/exhaustive/local-files-no-source/cjs/api/resources/endpoints/resources/contentType/client/Client.d.ts
@@ -14,6 +14,9 @@ export declare class ContentTypeClient {
      * @param {SeedExhaustive.types.ObjectWithOptionalField} request
      * @param {ContentTypeClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.contentType.postJsonPatchContentType({
      *         string: "string",
@@ -38,6 +41,9 @@ export declare class ContentTypeClient {
     /**
      * @param {SeedExhaustive.types.ObjectWithOptionalField} request
      * @param {ContentTypeClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.contentType.postJsonPatchContentWithCharsetType({

--- a/seed/ts-sdk/exhaustive/local-files-no-source/cjs/api/resources/endpoints/resources/contentType/client/Client.js
+++ b/seed/ts-sdk/exhaustive/local-files-no-source/cjs/api/resources/endpoints/resources/contentType/client/Client.js
@@ -58,6 +58,9 @@ class ContentTypeClient {
      * @param {SeedExhaustive.types.ObjectWithOptionalField} request
      * @param {ContentTypeClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.contentType.postJsonPatchContentType({
      *         string: "string",
@@ -115,6 +118,9 @@ class ContentTypeClient {
     /**
      * @param {SeedExhaustive.types.ObjectWithOptionalField} request
      * @param {ContentTypeClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.contentType.postJsonPatchContentWithCharsetType({

--- a/seed/ts-sdk/exhaustive/local-files-no-source/cjs/api/resources/endpoints/resources/enum/client/Client.d.ts
+++ b/seed/ts-sdk/exhaustive/local-files-no-source/cjs/api/resources/endpoints/resources/enum/client/Client.d.ts
@@ -14,6 +14,9 @@ export declare class EnumClient {
      * @param {SeedExhaustive.types.WeatherReport} request
      * @param {EnumClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.enum.getAndReturnEnum("SUNNY")
      */

--- a/seed/ts-sdk/exhaustive/local-files-no-source/cjs/api/resources/endpoints/resources/enum/client/Client.js
+++ b/seed/ts-sdk/exhaustive/local-files-no-source/cjs/api/resources/endpoints/resources/enum/client/Client.js
@@ -58,6 +58,9 @@ class EnumClient {
      * @param {SeedExhaustive.types.WeatherReport} request
      * @param {EnumClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.enum.getAndReturnEnum("SUNNY")
      */

--- a/seed/ts-sdk/exhaustive/local-files-no-source/cjs/api/resources/endpoints/resources/httpMethods/client/Client.d.ts
+++ b/seed/ts-sdk/exhaustive/local-files-no-source/cjs/api/resources/endpoints/resources/httpMethods/client/Client.d.ts
@@ -14,6 +14,9 @@ export declare class HttpMethodsClient {
      * @param {string} id
      * @param {HttpMethodsClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.httpMethods.testGet("id")
      */
@@ -24,6 +27,9 @@ export declare class HttpMethodsClient {
      *
      * @param {SeedExhaustive.types.ObjectWithRequiredField} request
      * @param {HttpMethodsClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.httpMethods.testPost({
@@ -39,6 +45,9 @@ export declare class HttpMethodsClient {
      * @param {SeedExhaustive.types.ObjectWithRequiredField} request
      * @param {HttpMethodsClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.httpMethods.testPut("id", {
      *         string: "string"
@@ -52,6 +61,9 @@ export declare class HttpMethodsClient {
      * @param {string} id
      * @param {SeedExhaustive.types.ObjectWithOptionalField} request
      * @param {HttpMethodsClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.httpMethods.testPatch("id", {
@@ -79,6 +91,9 @@ export declare class HttpMethodsClient {
      *
      * @param {string} id
      * @param {HttpMethodsClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.httpMethods.testDelete("id")

--- a/seed/ts-sdk/exhaustive/local-files-no-source/cjs/api/resources/endpoints/resources/httpMethods/client/Client.js
+++ b/seed/ts-sdk/exhaustive/local-files-no-source/cjs/api/resources/endpoints/resources/httpMethods/client/Client.js
@@ -58,6 +58,9 @@ class HttpMethodsClient {
      * @param {string} id
      * @param {HttpMethodsClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.httpMethods.testGet("id")
      */
@@ -98,6 +101,9 @@ class HttpMethodsClient {
      *
      * @param {SeedExhaustive.types.ObjectWithRequiredField} request
      * @param {HttpMethodsClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.httpMethods.testPost({
@@ -149,6 +155,9 @@ class HttpMethodsClient {
      * @param {SeedExhaustive.types.ObjectWithRequiredField} request
      * @param {HttpMethodsClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.httpMethods.testPut("id", {
      *         string: "string"
@@ -198,6 +207,9 @@ class HttpMethodsClient {
      * @param {string} id
      * @param {SeedExhaustive.types.ObjectWithOptionalField} request
      * @param {HttpMethodsClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.httpMethods.testPatch("id", {
@@ -261,6 +273,9 @@ class HttpMethodsClient {
      *
      * @param {string} id
      * @param {HttpMethodsClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.httpMethods.testDelete("id")

--- a/seed/ts-sdk/exhaustive/local-files-no-source/cjs/api/resources/endpoints/resources/object/client/Client.d.ts
+++ b/seed/ts-sdk/exhaustive/local-files-no-source/cjs/api/resources/endpoints/resources/object/client/Client.d.ts
@@ -14,6 +14,9 @@ export declare class ObjectClient {
      * @param {SeedExhaustive.types.ObjectWithOptionalField} request
      * @param {ObjectClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.object.getAndReturnWithOptionalField({
      *         string: "string",
@@ -39,6 +42,9 @@ export declare class ObjectClient {
      * @param {SeedExhaustive.types.ObjectWithRequiredField} request
      * @param {ObjectClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.object.getAndReturnWithRequiredField({
      *         string: "string"
@@ -49,6 +55,9 @@ export declare class ObjectClient {
     /**
      * @param {SeedExhaustive.types.ObjectWithMapOfMap} request
      * @param {ObjectClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.object.getAndReturnWithMapOfMap({
@@ -64,6 +73,9 @@ export declare class ObjectClient {
     /**
      * @param {SeedExhaustive.types.NestedObjectWithOptionalField} request
      * @param {ObjectClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.object.getAndReturnNestedWithOptionalField({
@@ -94,6 +106,9 @@ export declare class ObjectClient {
      * @param {SeedExhaustive.types.NestedObjectWithRequiredField} request
      * @param {ObjectClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.object.getAndReturnNestedWithRequiredField("string", {
      *         string: "string",
@@ -121,6 +136,9 @@ export declare class ObjectClient {
     /**
      * @param {SeedExhaustive.types.NestedObjectWithRequiredField[]} request
      * @param {ObjectClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.object.getAndReturnNestedWithRequiredFieldAsList([{
@@ -169,6 +187,9 @@ export declare class ObjectClient {
      * @param {SeedExhaustive.types.ObjectWithUnknownField} request
      * @param {ObjectClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.object.getAndReturnWithUnknownField({
      *         unknown: {
@@ -182,6 +203,9 @@ export declare class ObjectClient {
      * @param {SeedExhaustive.types.ObjectWithDocumentedUnknownType} request
      * @param {ObjectClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.object.getAndReturnWithDocumentedUnknownType({
      *         documentedUnknownType: {
@@ -194,6 +218,9 @@ export declare class ObjectClient {
     /**
      * @param {SeedExhaustive.types.MapOfDocumentedUnknownType} request
      * @param {ObjectClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.object.getAndReturnMapOfDocumentedUnknownType({
@@ -210,6 +237,9 @@ export declare class ObjectClient {
      *
      * @param {SeedExhaustive.types.ObjectWithMixedRequiredAndOptionalFields} request
      * @param {ObjectClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.object.getAndReturnWithMixedRequiredAndOptionalFields({
@@ -230,6 +260,9 @@ export declare class ObjectClient {
      * @param {SeedExhaustive.types.ObjectWithRequiredNestedObject} request
      * @param {ObjectClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.object.getAndReturnWithRequiredNestedObject({
      *         requiredString: "hello",
@@ -248,6 +281,9 @@ export declare class ObjectClient {
      *
      * @param {SeedExhaustive.types.ObjectWithDatetimeLikeString} request
      * @param {ObjectClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.object.getAndReturnWithDatetimeLikeString({

--- a/seed/ts-sdk/exhaustive/local-files-no-source/cjs/api/resources/endpoints/resources/object/client/Client.js
+++ b/seed/ts-sdk/exhaustive/local-files-no-source/cjs/api/resources/endpoints/resources/object/client/Client.js
@@ -58,6 +58,9 @@ class ObjectClient {
      * @param {SeedExhaustive.types.ObjectWithOptionalField} request
      * @param {ObjectClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.object.getAndReturnWithOptionalField({
      *         string: "string",
@@ -119,6 +122,9 @@ class ObjectClient {
      * @param {SeedExhaustive.types.ObjectWithRequiredField} request
      * @param {ObjectClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.object.getAndReturnWithRequiredField({
      *         string: "string"
@@ -165,6 +171,9 @@ class ObjectClient {
     /**
      * @param {SeedExhaustive.types.ObjectWithMapOfMap} request
      * @param {ObjectClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.object.getAndReturnWithMapOfMap({
@@ -216,6 +225,9 @@ class ObjectClient {
     /**
      * @param {SeedExhaustive.types.NestedObjectWithOptionalField} request
      * @param {ObjectClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.object.getAndReturnNestedWithOptionalField({
@@ -282,6 +294,9 @@ class ObjectClient {
      * @param {SeedExhaustive.types.NestedObjectWithRequiredField} request
      * @param {ObjectClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.object.getAndReturnNestedWithRequiredField("string", {
      *         string: "string",
@@ -345,6 +360,9 @@ class ObjectClient {
     /**
      * @param {SeedExhaustive.types.NestedObjectWithRequiredField[]} request
      * @param {ObjectClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.object.getAndReturnNestedWithRequiredFieldAsList([{
@@ -429,6 +447,9 @@ class ObjectClient {
      * @param {SeedExhaustive.types.ObjectWithUnknownField} request
      * @param {ObjectClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.object.getAndReturnWithUnknownField({
      *         unknown: {
@@ -478,6 +499,9 @@ class ObjectClient {
      * @param {SeedExhaustive.types.ObjectWithDocumentedUnknownType} request
      * @param {ObjectClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.object.getAndReturnWithDocumentedUnknownType({
      *         documentedUnknownType: {
@@ -526,6 +550,9 @@ class ObjectClient {
     /**
      * @param {SeedExhaustive.types.MapOfDocumentedUnknownType} request
      * @param {ObjectClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.object.getAndReturnMapOfDocumentedUnknownType({
@@ -578,6 +605,9 @@ class ObjectClient {
      *
      * @param {SeedExhaustive.types.ObjectWithMixedRequiredAndOptionalFields} request
      * @param {ObjectClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.object.getAndReturnWithMixedRequiredAndOptionalFields({
@@ -634,6 +664,9 @@ class ObjectClient {
      * @param {SeedExhaustive.types.ObjectWithRequiredNestedObject} request
      * @param {ObjectClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.object.getAndReturnWithRequiredNestedObject({
      *         requiredString: "hello",
@@ -688,6 +721,9 @@ class ObjectClient {
      *
      * @param {SeedExhaustive.types.ObjectWithDatetimeLikeString} request
      * @param {ObjectClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.object.getAndReturnWithDatetimeLikeString({

--- a/seed/ts-sdk/exhaustive/local-files-no-source/cjs/api/resources/endpoints/resources/pagination/client/Client.d.ts
+++ b/seed/ts-sdk/exhaustive/local-files-no-source/cjs/api/resources/endpoints/resources/pagination/client/Client.d.ts
@@ -16,6 +16,9 @@ export declare class PaginationClient {
      * @param {SeedExhaustive.endpoints.ListItemsRequest} request
      * @param {PaginationClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.pagination.listItems({
      *         cursor: "cursor",

--- a/seed/ts-sdk/exhaustive/local-files-no-source/cjs/api/resources/endpoints/resources/pagination/client/Client.js
+++ b/seed/ts-sdk/exhaustive/local-files-no-source/cjs/api/resources/endpoints/resources/pagination/client/Client.js
@@ -59,6 +59,9 @@ class PaginationClient {
      * @param {SeedExhaustive.endpoints.ListItemsRequest} request
      * @param {PaginationClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.pagination.listItems({
      *         cursor: "cursor",

--- a/seed/ts-sdk/exhaustive/local-files-no-source/cjs/api/resources/endpoints/resources/params/client/Client.d.ts
+++ b/seed/ts-sdk/exhaustive/local-files-no-source/cjs/api/resources/endpoints/resources/params/client/Client.d.ts
@@ -16,6 +16,9 @@ export declare class ParamsClient {
      * @param {string} param
      * @param {ParamsClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.params.getWithPath("param")
      */
@@ -26,6 +29,9 @@ export declare class ParamsClient {
      *
      * @param {SeedExhaustive.endpoints.GetWithInlinePath} request
      * @param {ParamsClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.params.getWithInlinePath({
@@ -40,6 +46,9 @@ export declare class ParamsClient {
      * @param {SeedExhaustive.endpoints.GetWithQuery} request
      * @param {ParamsClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.params.getWithQuery({
      *         query: "query",
@@ -53,6 +62,9 @@ export declare class ParamsClient {
      *
      * @param {SeedExhaustive.endpoints.GetWithMultipleQuery} request
      * @param {ParamsClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.params.getWithAllowMultipleQuery({
@@ -69,6 +81,9 @@ export declare class ParamsClient {
      * @param {SeedExhaustive.endpoints.GetWithPathAndQuery} request
      * @param {ParamsClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.params.getWithPathAndQuery("param", {
      *         query: "query"
@@ -81,6 +96,9 @@ export declare class ParamsClient {
      *
      * @param {SeedExhaustive.endpoints.GetWithInlinePathAndQuery} request
      * @param {ParamsClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.params.getWithInlinePathAndQuery({
@@ -97,6 +115,9 @@ export declare class ParamsClient {
      * @param {string} request
      * @param {ParamsClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.params.modifyWithPath("param", "string")
      */
@@ -107,6 +128,9 @@ export declare class ParamsClient {
      *
      * @param {SeedExhaustive.endpoints.ModifyResourceAtInlinedPath} request
      * @param {ParamsClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.params.modifyWithInlinePath({
@@ -123,6 +147,9 @@ export declare class ParamsClient {
      * @param {string} param
      * @param {ParamsClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     import { createReadStream } from "fs";
      *     await client.endpoints.params.uploadWithPath(createReadStream("path/to/file"), "upload-path")
@@ -134,6 +161,9 @@ export declare class ParamsClient {
      *
      * @param {SeedExhaustive.endpoints.CreateWithBodyAndQuery} request
      * @param {ParamsClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.params.createWithBodyAndQuery({
@@ -151,6 +181,9 @@ export declare class ParamsClient {
      * @param {core.file.Uploadable} uploadable
      * @param {SeedExhaustive.endpoints.UploadBytesWithQuery} request
      * @param {ParamsClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      */
     uploadBytesWithQuery(uploadable: core.file.Uploadable, request: SeedExhaustive.endpoints.UploadBytesWithQuery, requestOptions?: ParamsClient.RequestOptions): core.HttpResponsePromise<SeedExhaustive.types.ObjectWithOptionalField>;
     private __uploadBytesWithQuery;
@@ -159,6 +192,9 @@ export declare class ParamsClient {
      *
      * @param {boolean} param
      * @param {ParamsClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.params.getWithBooleanPath(true)
@@ -172,6 +208,8 @@ export declare class ParamsClient {
      * @param {ParamsClient.RequestOptions} requestOptions - Request-specific configuration.
      *
      * @throws {@link SeedExhaustive.BadRequestBody}
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.params.getWithPathAndErrors("param")

--- a/seed/ts-sdk/exhaustive/local-files-no-source/cjs/api/resources/endpoints/resources/params/client/Client.js
+++ b/seed/ts-sdk/exhaustive/local-files-no-source/cjs/api/resources/endpoints/resources/params/client/Client.js
@@ -61,6 +61,9 @@ class ParamsClient {
      * @param {string} param
      * @param {ParamsClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.params.getWithPath("param")
      */
@@ -101,6 +104,9 @@ class ParamsClient {
      *
      * @param {SeedExhaustive.endpoints.GetWithInlinePath} request
      * @param {ParamsClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.params.getWithInlinePath({
@@ -145,6 +151,9 @@ class ParamsClient {
      *
      * @param {SeedExhaustive.endpoints.GetWithQuery} request
      * @param {ParamsClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.params.getWithQuery({
@@ -198,6 +207,9 @@ class ParamsClient {
      *
      * @param {SeedExhaustive.endpoints.GetWithMultipleQuery} request
      * @param {ParamsClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.params.getWithAllowMultipleQuery({
@@ -253,6 +265,9 @@ class ParamsClient {
      * @param {SeedExhaustive.endpoints.GetWithPathAndQuery} request
      * @param {ParamsClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.params.getWithPathAndQuery("param", {
      *         query: "query"
@@ -303,6 +318,9 @@ class ParamsClient {
      *
      * @param {SeedExhaustive.endpoints.GetWithInlinePathAndQuery} request
      * @param {ParamsClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.params.getWithInlinePathAndQuery({
@@ -357,6 +375,9 @@ class ParamsClient {
      * @param {string} request
      * @param {ParamsClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.params.modifyWithPath("param", "string")
      */
@@ -400,6 +421,9 @@ class ParamsClient {
      *
      * @param {SeedExhaustive.endpoints.ModifyResourceAtInlinedPath} request
      * @param {ParamsClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.params.modifyWithInlinePath({
@@ -450,6 +474,9 @@ class ParamsClient {
      * @param {string} param
      * @param {ParamsClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     import { createReadStream } from "fs";
      *     await client.endpoints.params.uploadWithPath(createReadStream("path/to/file"), "upload-path")
@@ -498,6 +525,9 @@ class ParamsClient {
      *
      * @param {SeedExhaustive.endpoints.CreateWithBodyAndQuery} request
      * @param {ParamsClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.params.createWithBodyAndQuery({
@@ -559,6 +589,9 @@ class ParamsClient {
      * @param {core.file.Uploadable} uploadable
      * @param {SeedExhaustive.endpoints.UploadBytesWithQuery} request
      * @param {ParamsClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      */
     uploadBytesWithQuery(uploadable, request, requestOptions) {
         return core.HttpResponsePromise.fromPromise(this.__uploadBytesWithQuery(uploadable, request, requestOptions));
@@ -612,6 +645,9 @@ class ParamsClient {
      * @param {boolean} param
      * @param {ParamsClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.params.getWithBooleanPath(true)
      */
@@ -654,6 +690,8 @@ class ParamsClient {
      * @param {ParamsClient.RequestOptions} requestOptions - Request-specific configuration.
      *
      * @throws {@link SeedExhaustive.BadRequestBody}
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.params.getWithPathAndErrors("param")

--- a/seed/ts-sdk/exhaustive/local-files-no-source/cjs/api/resources/endpoints/resources/primitive/client/Client.d.ts
+++ b/seed/ts-sdk/exhaustive/local-files-no-source/cjs/api/resources/endpoints/resources/primitive/client/Client.d.ts
@@ -13,6 +13,9 @@ export declare class PrimitiveClient {
      * @param {string} request
      * @param {PrimitiveClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.primitive.getAndReturnString("string")
      */
@@ -21,6 +24,9 @@ export declare class PrimitiveClient {
     /**
      * @param {number} request
      * @param {PrimitiveClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.primitive.getAndReturnInt(1)
@@ -31,6 +37,9 @@ export declare class PrimitiveClient {
      * @param {number} request
      * @param {PrimitiveClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.primitive.getAndReturnLong(1000000)
      */
@@ -39,6 +48,9 @@ export declare class PrimitiveClient {
     /**
      * @param {number} request
      * @param {PrimitiveClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.primitive.getAndReturnDouble(1.1)
@@ -49,6 +61,9 @@ export declare class PrimitiveClient {
      * @param {boolean} request
      * @param {PrimitiveClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.primitive.getAndReturnBool(true)
      */
@@ -57,6 +72,9 @@ export declare class PrimitiveClient {
     /**
      * @param {string} request
      * @param {PrimitiveClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.primitive.getAndReturnDatetime("2024-01-15T09:30:00Z")
@@ -67,6 +85,9 @@ export declare class PrimitiveClient {
      * @param {string} request
      * @param {PrimitiveClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.primitive.getAndReturnDate("2023-01-15")
      */
@@ -76,6 +97,9 @@ export declare class PrimitiveClient {
      * @param {string} request
      * @param {PrimitiveClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.primitive.getAndReturnUuid("d5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32")
      */
@@ -84,6 +108,9 @@ export declare class PrimitiveClient {
     /**
      * @param {string} request
      * @param {PrimitiveClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.primitive.getAndReturnBase64("SGVsbG8gd29ybGQh")

--- a/seed/ts-sdk/exhaustive/local-files-no-source/cjs/api/resources/endpoints/resources/primitive/client/Client.js
+++ b/seed/ts-sdk/exhaustive/local-files-no-source/cjs/api/resources/endpoints/resources/primitive/client/Client.js
@@ -58,6 +58,9 @@ class PrimitiveClient {
      * @param {string} request
      * @param {PrimitiveClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.primitive.getAndReturnString("string")
      */
@@ -99,6 +102,9 @@ class PrimitiveClient {
     /**
      * @param {number} request
      * @param {PrimitiveClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.primitive.getAndReturnInt(1)
@@ -142,6 +148,9 @@ class PrimitiveClient {
      * @param {number} request
      * @param {PrimitiveClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.primitive.getAndReturnLong(1000000)
      */
@@ -183,6 +192,9 @@ class PrimitiveClient {
     /**
      * @param {number} request
      * @param {PrimitiveClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.primitive.getAndReturnDouble(1.1)
@@ -226,6 +238,9 @@ class PrimitiveClient {
      * @param {boolean} request
      * @param {PrimitiveClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.primitive.getAndReturnBool(true)
      */
@@ -267,6 +282,9 @@ class PrimitiveClient {
     /**
      * @param {string} request
      * @param {PrimitiveClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.primitive.getAndReturnDatetime("2024-01-15T09:30:00Z")
@@ -310,6 +328,9 @@ class PrimitiveClient {
      * @param {string} request
      * @param {PrimitiveClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.primitive.getAndReturnDate("2023-01-15")
      */
@@ -352,6 +373,9 @@ class PrimitiveClient {
      * @param {string} request
      * @param {PrimitiveClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.primitive.getAndReturnUuid("d5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32")
      */
@@ -393,6 +417,9 @@ class PrimitiveClient {
     /**
      * @param {string} request
      * @param {PrimitiveClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.primitive.getAndReturnBase64("SGVsbG8gd29ybGQh")

--- a/seed/ts-sdk/exhaustive/local-files-no-source/cjs/api/resources/endpoints/resources/put/client/Client.d.ts
+++ b/seed/ts-sdk/exhaustive/local-files-no-source/cjs/api/resources/endpoints/resources/put/client/Client.d.ts
@@ -14,6 +14,9 @@ export declare class PutClient {
      * @param {SeedExhaustive.endpoints.PutRequest} request
      * @param {PutClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.put.add({
      *         id: "id"

--- a/seed/ts-sdk/exhaustive/local-files-no-source/cjs/api/resources/endpoints/resources/put/client/Client.js
+++ b/seed/ts-sdk/exhaustive/local-files-no-source/cjs/api/resources/endpoints/resources/put/client/Client.js
@@ -57,6 +57,9 @@ class PutClient {
      * @param {SeedExhaustive.endpoints.PutRequest} request
      * @param {PutClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.put.add({
      *         id: "id"

--- a/seed/ts-sdk/exhaustive/local-files-no-source/cjs/api/resources/endpoints/resources/union/client/Client.d.ts
+++ b/seed/ts-sdk/exhaustive/local-files-no-source/cjs/api/resources/endpoints/resources/union/client/Client.d.ts
@@ -14,6 +14,9 @@ export declare class UnionClient {
      * @param {SeedExhaustive.types.Animal} request
      * @param {UnionClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.union.getAndReturnUnion({
      *         animal: "dog",

--- a/seed/ts-sdk/exhaustive/local-files-no-source/cjs/api/resources/endpoints/resources/union/client/Client.js
+++ b/seed/ts-sdk/exhaustive/local-files-no-source/cjs/api/resources/endpoints/resources/union/client/Client.js
@@ -58,6 +58,9 @@ class UnionClient {
      * @param {SeedExhaustive.types.Animal} request
      * @param {UnionClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.union.getAndReturnUnion({
      *         animal: "dog",

--- a/seed/ts-sdk/exhaustive/local-files-no-source/cjs/api/resources/endpoints/resources/urls/client/Client.d.ts
+++ b/seed/ts-sdk/exhaustive/local-files-no-source/cjs/api/resources/endpoints/resources/urls/client/Client.d.ts
@@ -12,6 +12,9 @@ export declare class UrlsClient {
     /**
      * @param {UrlsClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.urls.withMixedCase()
      */
@@ -19,6 +22,9 @@ export declare class UrlsClient {
     private __withMixedCase;
     /**
      * @param {UrlsClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.urls.noEndingSlash()
@@ -28,6 +34,9 @@ export declare class UrlsClient {
     /**
      * @param {UrlsClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.urls.withEndingSlash()
      */
@@ -35,6 +44,9 @@ export declare class UrlsClient {
     private __withEndingSlash;
     /**
      * @param {UrlsClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.urls.withUnderscores()

--- a/seed/ts-sdk/exhaustive/local-files-no-source/cjs/api/resources/endpoints/resources/urls/client/Client.js
+++ b/seed/ts-sdk/exhaustive/local-files-no-source/cjs/api/resources/endpoints/resources/urls/client/Client.js
@@ -56,6 +56,9 @@ class UrlsClient {
     /**
      * @param {UrlsClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.urls.withMixedCase()
      */
@@ -93,6 +96,9 @@ class UrlsClient {
     }
     /**
      * @param {UrlsClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.urls.noEndingSlash()
@@ -132,6 +138,9 @@ class UrlsClient {
     /**
      * @param {UrlsClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.urls.withEndingSlash()
      */
@@ -169,6 +178,9 @@ class UrlsClient {
     }
     /**
      * @param {UrlsClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.urls.withUnderscores()

--- a/seed/ts-sdk/exhaustive/local-files-no-source/cjs/api/resources/inlinedRequests/client/Client.d.ts
+++ b/seed/ts-sdk/exhaustive/local-files-no-source/cjs/api/resources/inlinedRequests/client/Client.d.ts
@@ -17,6 +17,8 @@ export declare class InlinedRequestsClient {
      * @param {InlinedRequestsClient.RequestOptions} requestOptions - Request-specific configuration.
      *
      * @throws {@link SeedExhaustive.BadRequestBody}
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.inlinedRequests.postWithObjectBodyandResponse({
@@ -48,6 +50,9 @@ export declare class InlinedRequestsClient {
      *
      * @param {SeedExhaustive.PostWithArrayBodyAndHeaders} request
      * @param {InlinedRequestsClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.inlinedRequests.postWithArrayBodyAndHeaders({

--- a/seed/ts-sdk/exhaustive/local-files-no-source/cjs/api/resources/inlinedRequests/client/Client.js
+++ b/seed/ts-sdk/exhaustive/local-files-no-source/cjs/api/resources/inlinedRequests/client/Client.js
@@ -62,6 +62,8 @@ class InlinedRequestsClient {
      * @param {InlinedRequestsClient.RequestOptions} requestOptions - Request-specific configuration.
      *
      * @throws {@link SeedExhaustive.BadRequestBody}
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.inlinedRequests.postWithObjectBodyandResponse({
@@ -133,6 +135,9 @@ class InlinedRequestsClient {
      *
      * @param {SeedExhaustive.PostWithArrayBodyAndHeaders} request
      * @param {InlinedRequestsClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.inlinedRequests.postWithArrayBodyAndHeaders({

--- a/seed/ts-sdk/exhaustive/local-files-no-source/cjs/api/resources/noAuth/client/Client.d.ts
+++ b/seed/ts-sdk/exhaustive/local-files-no-source/cjs/api/resources/noAuth/client/Client.d.ts
@@ -16,6 +16,8 @@ export declare class NoAuthClient {
      * @param {NoAuthClient.RequestOptions} requestOptions - Request-specific configuration.
      *
      * @throws {@link SeedExhaustive.BadRequestBody}
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.noAuth.postWithNoAuth({

--- a/seed/ts-sdk/exhaustive/local-files-no-source/cjs/api/resources/noAuth/client/Client.js
+++ b/seed/ts-sdk/exhaustive/local-files-no-source/cjs/api/resources/noAuth/client/Client.js
@@ -62,6 +62,8 @@ class NoAuthClient {
      * @param {NoAuthClient.RequestOptions} requestOptions - Request-specific configuration.
      *
      * @throws {@link SeedExhaustive.BadRequestBody}
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.noAuth.postWithNoAuth({

--- a/seed/ts-sdk/exhaustive/local-files-no-source/cjs/api/resources/noReqBody/client/Client.d.ts
+++ b/seed/ts-sdk/exhaustive/local-files-no-source/cjs/api/resources/noReqBody/client/Client.d.ts
@@ -13,6 +13,9 @@ export declare class NoReqBodyClient {
     /**
      * @param {NoReqBodyClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.noReqBody.getWithNoRequestBody()
      */
@@ -20,6 +23,9 @@ export declare class NoReqBodyClient {
     private __getWithNoRequestBody;
     /**
      * @param {NoReqBodyClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.noReqBody.postWithNoRequestBody()

--- a/seed/ts-sdk/exhaustive/local-files-no-source/cjs/api/resources/noReqBody/client/Client.js
+++ b/seed/ts-sdk/exhaustive/local-files-no-source/cjs/api/resources/noReqBody/client/Client.js
@@ -56,6 +56,9 @@ class NoReqBodyClient {
     /**
      * @param {NoReqBodyClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.noReqBody.getWithNoRequestBody()
      */
@@ -96,6 +99,9 @@ class NoReqBodyClient {
     }
     /**
      * @param {NoReqBodyClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.noReqBody.postWithNoRequestBody()

--- a/seed/ts-sdk/exhaustive/local-files-no-source/cjs/api/resources/reqWithHeaders/client/Client.d.ts
+++ b/seed/ts-sdk/exhaustive/local-files-no-source/cjs/api/resources/reqWithHeaders/client/Client.d.ts
@@ -14,6 +14,9 @@ export declare class ReqWithHeadersClient {
      * @param {SeedExhaustive.ReqWithHeaders} request
      * @param {ReqWithHeadersClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.reqWithHeaders.getWithCustomHeader({
      *         "X-TEST-SERVICE-HEADER": "X-TEST-SERVICE-HEADER",

--- a/seed/ts-sdk/exhaustive/local-files-no-source/cjs/api/resources/reqWithHeaders/client/Client.js
+++ b/seed/ts-sdk/exhaustive/local-files-no-source/cjs/api/resources/reqWithHeaders/client/Client.js
@@ -58,6 +58,9 @@ class ReqWithHeadersClient {
      * @param {SeedExhaustive.ReqWithHeaders} request
      * @param {ReqWithHeadersClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.reqWithHeaders.getWithCustomHeader({
      *         "X-TEST-SERVICE-HEADER": "X-TEST-SERVICE-HEADER",

--- a/seed/ts-sdk/exhaustive/local-files-no-source/esm/api/resources/endpoints/resources/container/client/Client.d.mts
+++ b/seed/ts-sdk/exhaustive/local-files-no-source/esm/api/resources/endpoints/resources/container/client/Client.d.mts
@@ -14,6 +14,9 @@ export declare class ContainerClient {
      * @param {string[]} request
      * @param {ContainerClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.container.getAndReturnListOfPrimitives(["string", "string"])
      */
@@ -22,6 +25,9 @@ export declare class ContainerClient {
     /**
      * @param {SeedExhaustive.types.ObjectWithRequiredField[]} request
      * @param {ContainerClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.container.getAndReturnListOfObjects([{
@@ -36,6 +42,9 @@ export declare class ContainerClient {
      * @param {string[]} request
      * @param {ContainerClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.container.getAndReturnSetOfPrimitives(["string"])
      */
@@ -44,6 +53,9 @@ export declare class ContainerClient {
     /**
      * @param {SeedExhaustive.types.ObjectWithRequiredField[]} request
      * @param {ContainerClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.container.getAndReturnSetOfObjects([{
@@ -56,6 +68,9 @@ export declare class ContainerClient {
      * @param {Record<string, string>} request
      * @param {ContainerClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.container.getAndReturnMapPrimToPrim({
      *         "string": "string"
@@ -66,6 +81,9 @@ export declare class ContainerClient {
     /**
      * @param {Record<string, SeedExhaustive.types.ObjectWithRequiredField>} request
      * @param {ContainerClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.container.getAndReturnMapOfPrimToObject({
@@ -80,6 +98,9 @@ export declare class ContainerClient {
      * @param {Record<string, SeedExhaustive.types.MixedType>} request
      * @param {ContainerClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.container.getAndReturnMapOfPrimToUndiscriminatedUnion({
      *         "string": 1.1
@@ -90,6 +111,9 @@ export declare class ContainerClient {
     /**
      * @param {SeedExhaustive.types.ObjectWithRequiredField} request
      * @param {ContainerClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.container.getAndReturnOptional({

--- a/seed/ts-sdk/exhaustive/local-files-no-source/esm/api/resources/endpoints/resources/container/client/Client.mjs
+++ b/seed/ts-sdk/exhaustive/local-files-no-source/esm/api/resources/endpoints/resources/container/client/Client.mjs
@@ -22,6 +22,9 @@ export class ContainerClient {
      * @param {string[]} request
      * @param {ContainerClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.container.getAndReturnListOfPrimitives(["string", "string"])
      */
@@ -63,6 +66,9 @@ export class ContainerClient {
     /**
      * @param {SeedExhaustive.types.ObjectWithRequiredField[]} request
      * @param {ContainerClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.container.getAndReturnListOfObjects([{
@@ -113,6 +119,9 @@ export class ContainerClient {
      * @param {string[]} request
      * @param {ContainerClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.container.getAndReturnSetOfPrimitives(["string"])
      */
@@ -154,6 +163,9 @@ export class ContainerClient {
     /**
      * @param {SeedExhaustive.types.ObjectWithRequiredField[]} request
      * @param {ContainerClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.container.getAndReturnSetOfObjects([{
@@ -202,6 +214,9 @@ export class ContainerClient {
      * @param {Record<string, string>} request
      * @param {ContainerClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.container.getAndReturnMapPrimToPrim({
      *         "string": "string"
@@ -245,6 +260,9 @@ export class ContainerClient {
     /**
      * @param {Record<string, SeedExhaustive.types.ObjectWithRequiredField>} request
      * @param {ContainerClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.container.getAndReturnMapOfPrimToObject({
@@ -295,6 +313,9 @@ export class ContainerClient {
      * @param {Record<string, SeedExhaustive.types.MixedType>} request
      * @param {ContainerClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.container.getAndReturnMapOfPrimToUndiscriminatedUnion({
      *         "string": 1.1
@@ -341,6 +362,9 @@ export class ContainerClient {
     /**
      * @param {SeedExhaustive.types.ObjectWithRequiredField} request
      * @param {ContainerClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.container.getAndReturnOptional({

--- a/seed/ts-sdk/exhaustive/local-files-no-source/esm/api/resources/endpoints/resources/contentType/client/Client.d.mts
+++ b/seed/ts-sdk/exhaustive/local-files-no-source/esm/api/resources/endpoints/resources/contentType/client/Client.d.mts
@@ -14,6 +14,9 @@ export declare class ContentTypeClient {
      * @param {SeedExhaustive.types.ObjectWithOptionalField} request
      * @param {ContentTypeClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.contentType.postJsonPatchContentType({
      *         string: "string",
@@ -38,6 +41,9 @@ export declare class ContentTypeClient {
     /**
      * @param {SeedExhaustive.types.ObjectWithOptionalField} request
      * @param {ContentTypeClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.contentType.postJsonPatchContentWithCharsetType({

--- a/seed/ts-sdk/exhaustive/local-files-no-source/esm/api/resources/endpoints/resources/contentType/client/Client.mjs
+++ b/seed/ts-sdk/exhaustive/local-files-no-source/esm/api/resources/endpoints/resources/contentType/client/Client.mjs
@@ -22,6 +22,9 @@ export class ContentTypeClient {
      * @param {SeedExhaustive.types.ObjectWithOptionalField} request
      * @param {ContentTypeClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.contentType.postJsonPatchContentType({
      *         string: "string",
@@ -79,6 +82,9 @@ export class ContentTypeClient {
     /**
      * @param {SeedExhaustive.types.ObjectWithOptionalField} request
      * @param {ContentTypeClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.contentType.postJsonPatchContentWithCharsetType({

--- a/seed/ts-sdk/exhaustive/local-files-no-source/esm/api/resources/endpoints/resources/enum/client/Client.d.mts
+++ b/seed/ts-sdk/exhaustive/local-files-no-source/esm/api/resources/endpoints/resources/enum/client/Client.d.mts
@@ -14,6 +14,9 @@ export declare class EnumClient {
      * @param {SeedExhaustive.types.WeatherReport} request
      * @param {EnumClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.enum.getAndReturnEnum("SUNNY")
      */

--- a/seed/ts-sdk/exhaustive/local-files-no-source/esm/api/resources/endpoints/resources/enum/client/Client.mjs
+++ b/seed/ts-sdk/exhaustive/local-files-no-source/esm/api/resources/endpoints/resources/enum/client/Client.mjs
@@ -22,6 +22,9 @@ export class EnumClient {
      * @param {SeedExhaustive.types.WeatherReport} request
      * @param {EnumClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.enum.getAndReturnEnum("SUNNY")
      */

--- a/seed/ts-sdk/exhaustive/local-files-no-source/esm/api/resources/endpoints/resources/httpMethods/client/Client.d.mts
+++ b/seed/ts-sdk/exhaustive/local-files-no-source/esm/api/resources/endpoints/resources/httpMethods/client/Client.d.mts
@@ -14,6 +14,9 @@ export declare class HttpMethodsClient {
      * @param {string} id
      * @param {HttpMethodsClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.httpMethods.testGet("id")
      */
@@ -24,6 +27,9 @@ export declare class HttpMethodsClient {
      *
      * @param {SeedExhaustive.types.ObjectWithRequiredField} request
      * @param {HttpMethodsClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.httpMethods.testPost({
@@ -39,6 +45,9 @@ export declare class HttpMethodsClient {
      * @param {SeedExhaustive.types.ObjectWithRequiredField} request
      * @param {HttpMethodsClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.httpMethods.testPut("id", {
      *         string: "string"
@@ -52,6 +61,9 @@ export declare class HttpMethodsClient {
      * @param {string} id
      * @param {SeedExhaustive.types.ObjectWithOptionalField} request
      * @param {HttpMethodsClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.httpMethods.testPatch("id", {
@@ -79,6 +91,9 @@ export declare class HttpMethodsClient {
      *
      * @param {string} id
      * @param {HttpMethodsClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.httpMethods.testDelete("id")

--- a/seed/ts-sdk/exhaustive/local-files-no-source/esm/api/resources/endpoints/resources/httpMethods/client/Client.mjs
+++ b/seed/ts-sdk/exhaustive/local-files-no-source/esm/api/resources/endpoints/resources/httpMethods/client/Client.mjs
@@ -22,6 +22,9 @@ export class HttpMethodsClient {
      * @param {string} id
      * @param {HttpMethodsClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.httpMethods.testGet("id")
      */
@@ -62,6 +65,9 @@ export class HttpMethodsClient {
      *
      * @param {SeedExhaustive.types.ObjectWithRequiredField} request
      * @param {HttpMethodsClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.httpMethods.testPost({
@@ -113,6 +119,9 @@ export class HttpMethodsClient {
      * @param {SeedExhaustive.types.ObjectWithRequiredField} request
      * @param {HttpMethodsClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.httpMethods.testPut("id", {
      *         string: "string"
@@ -162,6 +171,9 @@ export class HttpMethodsClient {
      * @param {string} id
      * @param {SeedExhaustive.types.ObjectWithOptionalField} request
      * @param {HttpMethodsClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.httpMethods.testPatch("id", {
@@ -225,6 +237,9 @@ export class HttpMethodsClient {
      *
      * @param {string} id
      * @param {HttpMethodsClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.httpMethods.testDelete("id")

--- a/seed/ts-sdk/exhaustive/local-files-no-source/esm/api/resources/endpoints/resources/object/client/Client.d.mts
+++ b/seed/ts-sdk/exhaustive/local-files-no-source/esm/api/resources/endpoints/resources/object/client/Client.d.mts
@@ -14,6 +14,9 @@ export declare class ObjectClient {
      * @param {SeedExhaustive.types.ObjectWithOptionalField} request
      * @param {ObjectClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.object.getAndReturnWithOptionalField({
      *         string: "string",
@@ -39,6 +42,9 @@ export declare class ObjectClient {
      * @param {SeedExhaustive.types.ObjectWithRequiredField} request
      * @param {ObjectClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.object.getAndReturnWithRequiredField({
      *         string: "string"
@@ -49,6 +55,9 @@ export declare class ObjectClient {
     /**
      * @param {SeedExhaustive.types.ObjectWithMapOfMap} request
      * @param {ObjectClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.object.getAndReturnWithMapOfMap({
@@ -64,6 +73,9 @@ export declare class ObjectClient {
     /**
      * @param {SeedExhaustive.types.NestedObjectWithOptionalField} request
      * @param {ObjectClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.object.getAndReturnNestedWithOptionalField({
@@ -94,6 +106,9 @@ export declare class ObjectClient {
      * @param {SeedExhaustive.types.NestedObjectWithRequiredField} request
      * @param {ObjectClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.object.getAndReturnNestedWithRequiredField("string", {
      *         string: "string",
@@ -121,6 +136,9 @@ export declare class ObjectClient {
     /**
      * @param {SeedExhaustive.types.NestedObjectWithRequiredField[]} request
      * @param {ObjectClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.object.getAndReturnNestedWithRequiredFieldAsList([{
@@ -169,6 +187,9 @@ export declare class ObjectClient {
      * @param {SeedExhaustive.types.ObjectWithUnknownField} request
      * @param {ObjectClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.object.getAndReturnWithUnknownField({
      *         unknown: {
@@ -182,6 +203,9 @@ export declare class ObjectClient {
      * @param {SeedExhaustive.types.ObjectWithDocumentedUnknownType} request
      * @param {ObjectClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.object.getAndReturnWithDocumentedUnknownType({
      *         documentedUnknownType: {
@@ -194,6 +218,9 @@ export declare class ObjectClient {
     /**
      * @param {SeedExhaustive.types.MapOfDocumentedUnknownType} request
      * @param {ObjectClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.object.getAndReturnMapOfDocumentedUnknownType({
@@ -210,6 +237,9 @@ export declare class ObjectClient {
      *
      * @param {SeedExhaustive.types.ObjectWithMixedRequiredAndOptionalFields} request
      * @param {ObjectClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.object.getAndReturnWithMixedRequiredAndOptionalFields({
@@ -230,6 +260,9 @@ export declare class ObjectClient {
      * @param {SeedExhaustive.types.ObjectWithRequiredNestedObject} request
      * @param {ObjectClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.object.getAndReturnWithRequiredNestedObject({
      *         requiredString: "hello",
@@ -248,6 +281,9 @@ export declare class ObjectClient {
      *
      * @param {SeedExhaustive.types.ObjectWithDatetimeLikeString} request
      * @param {ObjectClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.object.getAndReturnWithDatetimeLikeString({

--- a/seed/ts-sdk/exhaustive/local-files-no-source/esm/api/resources/endpoints/resources/object/client/Client.mjs
+++ b/seed/ts-sdk/exhaustive/local-files-no-source/esm/api/resources/endpoints/resources/object/client/Client.mjs
@@ -22,6 +22,9 @@ export class ObjectClient {
      * @param {SeedExhaustive.types.ObjectWithOptionalField} request
      * @param {ObjectClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.object.getAndReturnWithOptionalField({
      *         string: "string",
@@ -83,6 +86,9 @@ export class ObjectClient {
      * @param {SeedExhaustive.types.ObjectWithRequiredField} request
      * @param {ObjectClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.object.getAndReturnWithRequiredField({
      *         string: "string"
@@ -129,6 +135,9 @@ export class ObjectClient {
     /**
      * @param {SeedExhaustive.types.ObjectWithMapOfMap} request
      * @param {ObjectClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.object.getAndReturnWithMapOfMap({
@@ -180,6 +189,9 @@ export class ObjectClient {
     /**
      * @param {SeedExhaustive.types.NestedObjectWithOptionalField} request
      * @param {ObjectClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.object.getAndReturnNestedWithOptionalField({
@@ -246,6 +258,9 @@ export class ObjectClient {
      * @param {SeedExhaustive.types.NestedObjectWithRequiredField} request
      * @param {ObjectClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.object.getAndReturnNestedWithRequiredField("string", {
      *         string: "string",
@@ -309,6 +324,9 @@ export class ObjectClient {
     /**
      * @param {SeedExhaustive.types.NestedObjectWithRequiredField[]} request
      * @param {ObjectClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.object.getAndReturnNestedWithRequiredFieldAsList([{
@@ -393,6 +411,9 @@ export class ObjectClient {
      * @param {SeedExhaustive.types.ObjectWithUnknownField} request
      * @param {ObjectClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.object.getAndReturnWithUnknownField({
      *         unknown: {
@@ -442,6 +463,9 @@ export class ObjectClient {
      * @param {SeedExhaustive.types.ObjectWithDocumentedUnknownType} request
      * @param {ObjectClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.object.getAndReturnWithDocumentedUnknownType({
      *         documentedUnknownType: {
@@ -490,6 +514,9 @@ export class ObjectClient {
     /**
      * @param {SeedExhaustive.types.MapOfDocumentedUnknownType} request
      * @param {ObjectClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.object.getAndReturnMapOfDocumentedUnknownType({
@@ -542,6 +569,9 @@ export class ObjectClient {
      *
      * @param {SeedExhaustive.types.ObjectWithMixedRequiredAndOptionalFields} request
      * @param {ObjectClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.object.getAndReturnWithMixedRequiredAndOptionalFields({
@@ -598,6 +628,9 @@ export class ObjectClient {
      * @param {SeedExhaustive.types.ObjectWithRequiredNestedObject} request
      * @param {ObjectClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.object.getAndReturnWithRequiredNestedObject({
      *         requiredString: "hello",
@@ -652,6 +685,9 @@ export class ObjectClient {
      *
      * @param {SeedExhaustive.types.ObjectWithDatetimeLikeString} request
      * @param {ObjectClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.object.getAndReturnWithDatetimeLikeString({

--- a/seed/ts-sdk/exhaustive/local-files-no-source/esm/api/resources/endpoints/resources/pagination/client/Client.d.mts
+++ b/seed/ts-sdk/exhaustive/local-files-no-source/esm/api/resources/endpoints/resources/pagination/client/Client.d.mts
@@ -16,6 +16,9 @@ export declare class PaginationClient {
      * @param {SeedExhaustive.endpoints.ListItemsRequest} request
      * @param {PaginationClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.pagination.listItems({
      *         cursor: "cursor",

--- a/seed/ts-sdk/exhaustive/local-files-no-source/esm/api/resources/endpoints/resources/pagination/client/Client.mjs
+++ b/seed/ts-sdk/exhaustive/local-files-no-source/esm/api/resources/endpoints/resources/pagination/client/Client.mjs
@@ -23,6 +23,9 @@ export class PaginationClient {
      * @param {SeedExhaustive.endpoints.ListItemsRequest} request
      * @param {PaginationClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.pagination.listItems({
      *         cursor: "cursor",

--- a/seed/ts-sdk/exhaustive/local-files-no-source/esm/api/resources/endpoints/resources/params/client/Client.d.mts
+++ b/seed/ts-sdk/exhaustive/local-files-no-source/esm/api/resources/endpoints/resources/params/client/Client.d.mts
@@ -16,6 +16,9 @@ export declare class ParamsClient {
      * @param {string} param
      * @param {ParamsClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.params.getWithPath("param")
      */
@@ -26,6 +29,9 @@ export declare class ParamsClient {
      *
      * @param {SeedExhaustive.endpoints.GetWithInlinePath} request
      * @param {ParamsClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.params.getWithInlinePath({
@@ -40,6 +46,9 @@ export declare class ParamsClient {
      * @param {SeedExhaustive.endpoints.GetWithQuery} request
      * @param {ParamsClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.params.getWithQuery({
      *         query: "query",
@@ -53,6 +62,9 @@ export declare class ParamsClient {
      *
      * @param {SeedExhaustive.endpoints.GetWithMultipleQuery} request
      * @param {ParamsClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.params.getWithAllowMultipleQuery({
@@ -69,6 +81,9 @@ export declare class ParamsClient {
      * @param {SeedExhaustive.endpoints.GetWithPathAndQuery} request
      * @param {ParamsClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.params.getWithPathAndQuery("param", {
      *         query: "query"
@@ -81,6 +96,9 @@ export declare class ParamsClient {
      *
      * @param {SeedExhaustive.endpoints.GetWithInlinePathAndQuery} request
      * @param {ParamsClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.params.getWithInlinePathAndQuery({
@@ -97,6 +115,9 @@ export declare class ParamsClient {
      * @param {string} request
      * @param {ParamsClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.params.modifyWithPath("param", "string")
      */
@@ -107,6 +128,9 @@ export declare class ParamsClient {
      *
      * @param {SeedExhaustive.endpoints.ModifyResourceAtInlinedPath} request
      * @param {ParamsClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.params.modifyWithInlinePath({
@@ -123,6 +147,9 @@ export declare class ParamsClient {
      * @param {string} param
      * @param {ParamsClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     import { createReadStream } from "fs";
      *     await client.endpoints.params.uploadWithPath(createReadStream("path/to/file"), "upload-path")
@@ -134,6 +161,9 @@ export declare class ParamsClient {
      *
      * @param {SeedExhaustive.endpoints.CreateWithBodyAndQuery} request
      * @param {ParamsClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.params.createWithBodyAndQuery({
@@ -151,6 +181,9 @@ export declare class ParamsClient {
      * @param {core.file.Uploadable} uploadable
      * @param {SeedExhaustive.endpoints.UploadBytesWithQuery} request
      * @param {ParamsClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      */
     uploadBytesWithQuery(uploadable: core.file.Uploadable, request: SeedExhaustive.endpoints.UploadBytesWithQuery, requestOptions?: ParamsClient.RequestOptions): core.HttpResponsePromise<SeedExhaustive.types.ObjectWithOptionalField>;
     private __uploadBytesWithQuery;
@@ -159,6 +192,9 @@ export declare class ParamsClient {
      *
      * @param {boolean} param
      * @param {ParamsClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.params.getWithBooleanPath(true)
@@ -172,6 +208,8 @@ export declare class ParamsClient {
      * @param {ParamsClient.RequestOptions} requestOptions - Request-specific configuration.
      *
      * @throws {@link SeedExhaustive.BadRequestBody}
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.params.getWithPathAndErrors("param")

--- a/seed/ts-sdk/exhaustive/local-files-no-source/esm/api/resources/endpoints/resources/params/client/Client.mjs
+++ b/seed/ts-sdk/exhaustive/local-files-no-source/esm/api/resources/endpoints/resources/params/client/Client.mjs
@@ -25,6 +25,9 @@ export class ParamsClient {
      * @param {string} param
      * @param {ParamsClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.params.getWithPath("param")
      */
@@ -65,6 +68,9 @@ export class ParamsClient {
      *
      * @param {SeedExhaustive.endpoints.GetWithInlinePath} request
      * @param {ParamsClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.params.getWithInlinePath({
@@ -109,6 +115,9 @@ export class ParamsClient {
      *
      * @param {SeedExhaustive.endpoints.GetWithQuery} request
      * @param {ParamsClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.params.getWithQuery({
@@ -162,6 +171,9 @@ export class ParamsClient {
      *
      * @param {SeedExhaustive.endpoints.GetWithMultipleQuery} request
      * @param {ParamsClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.params.getWithAllowMultipleQuery({
@@ -217,6 +229,9 @@ export class ParamsClient {
      * @param {SeedExhaustive.endpoints.GetWithPathAndQuery} request
      * @param {ParamsClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.params.getWithPathAndQuery("param", {
      *         query: "query"
@@ -267,6 +282,9 @@ export class ParamsClient {
      *
      * @param {SeedExhaustive.endpoints.GetWithInlinePathAndQuery} request
      * @param {ParamsClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.params.getWithInlinePathAndQuery({
@@ -321,6 +339,9 @@ export class ParamsClient {
      * @param {string} request
      * @param {ParamsClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.params.modifyWithPath("param", "string")
      */
@@ -364,6 +385,9 @@ export class ParamsClient {
      *
      * @param {SeedExhaustive.endpoints.ModifyResourceAtInlinedPath} request
      * @param {ParamsClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.params.modifyWithInlinePath({
@@ -414,6 +438,9 @@ export class ParamsClient {
      * @param {string} param
      * @param {ParamsClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     import { createReadStream } from "fs";
      *     await client.endpoints.params.uploadWithPath(createReadStream("path/to/file"), "upload-path")
@@ -462,6 +489,9 @@ export class ParamsClient {
      *
      * @param {SeedExhaustive.endpoints.CreateWithBodyAndQuery} request
      * @param {ParamsClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.params.createWithBodyAndQuery({
@@ -523,6 +553,9 @@ export class ParamsClient {
      * @param {core.file.Uploadable} uploadable
      * @param {SeedExhaustive.endpoints.UploadBytesWithQuery} request
      * @param {ParamsClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      */
     uploadBytesWithQuery(uploadable, request, requestOptions) {
         return core.HttpResponsePromise.fromPromise(this.__uploadBytesWithQuery(uploadable, request, requestOptions));
@@ -576,6 +609,9 @@ export class ParamsClient {
      * @param {boolean} param
      * @param {ParamsClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.params.getWithBooleanPath(true)
      */
@@ -618,6 +654,8 @@ export class ParamsClient {
      * @param {ParamsClient.RequestOptions} requestOptions - Request-specific configuration.
      *
      * @throws {@link SeedExhaustive.BadRequestBody}
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.params.getWithPathAndErrors("param")

--- a/seed/ts-sdk/exhaustive/local-files-no-source/esm/api/resources/endpoints/resources/primitive/client/Client.d.mts
+++ b/seed/ts-sdk/exhaustive/local-files-no-source/esm/api/resources/endpoints/resources/primitive/client/Client.d.mts
@@ -13,6 +13,9 @@ export declare class PrimitiveClient {
      * @param {string} request
      * @param {PrimitiveClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.primitive.getAndReturnString("string")
      */
@@ -21,6 +24,9 @@ export declare class PrimitiveClient {
     /**
      * @param {number} request
      * @param {PrimitiveClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.primitive.getAndReturnInt(1)
@@ -31,6 +37,9 @@ export declare class PrimitiveClient {
      * @param {number} request
      * @param {PrimitiveClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.primitive.getAndReturnLong(1000000)
      */
@@ -39,6 +48,9 @@ export declare class PrimitiveClient {
     /**
      * @param {number} request
      * @param {PrimitiveClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.primitive.getAndReturnDouble(1.1)
@@ -49,6 +61,9 @@ export declare class PrimitiveClient {
      * @param {boolean} request
      * @param {PrimitiveClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.primitive.getAndReturnBool(true)
      */
@@ -57,6 +72,9 @@ export declare class PrimitiveClient {
     /**
      * @param {string} request
      * @param {PrimitiveClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.primitive.getAndReturnDatetime("2024-01-15T09:30:00Z")
@@ -67,6 +85,9 @@ export declare class PrimitiveClient {
      * @param {string} request
      * @param {PrimitiveClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.primitive.getAndReturnDate("2023-01-15")
      */
@@ -76,6 +97,9 @@ export declare class PrimitiveClient {
      * @param {string} request
      * @param {PrimitiveClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.primitive.getAndReturnUuid("d5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32")
      */
@@ -84,6 +108,9 @@ export declare class PrimitiveClient {
     /**
      * @param {string} request
      * @param {PrimitiveClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.primitive.getAndReturnBase64("SGVsbG8gd29ybGQh")

--- a/seed/ts-sdk/exhaustive/local-files-no-source/esm/api/resources/endpoints/resources/primitive/client/Client.mjs
+++ b/seed/ts-sdk/exhaustive/local-files-no-source/esm/api/resources/endpoints/resources/primitive/client/Client.mjs
@@ -22,6 +22,9 @@ export class PrimitiveClient {
      * @param {string} request
      * @param {PrimitiveClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.primitive.getAndReturnString("string")
      */
@@ -63,6 +66,9 @@ export class PrimitiveClient {
     /**
      * @param {number} request
      * @param {PrimitiveClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.primitive.getAndReturnInt(1)
@@ -106,6 +112,9 @@ export class PrimitiveClient {
      * @param {number} request
      * @param {PrimitiveClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.primitive.getAndReturnLong(1000000)
      */
@@ -147,6 +156,9 @@ export class PrimitiveClient {
     /**
      * @param {number} request
      * @param {PrimitiveClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.primitive.getAndReturnDouble(1.1)
@@ -190,6 +202,9 @@ export class PrimitiveClient {
      * @param {boolean} request
      * @param {PrimitiveClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.primitive.getAndReturnBool(true)
      */
@@ -231,6 +246,9 @@ export class PrimitiveClient {
     /**
      * @param {string} request
      * @param {PrimitiveClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.primitive.getAndReturnDatetime("2024-01-15T09:30:00Z")
@@ -274,6 +292,9 @@ export class PrimitiveClient {
      * @param {string} request
      * @param {PrimitiveClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.primitive.getAndReturnDate("2023-01-15")
      */
@@ -316,6 +337,9 @@ export class PrimitiveClient {
      * @param {string} request
      * @param {PrimitiveClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.primitive.getAndReturnUuid("d5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32")
      */
@@ -357,6 +381,9 @@ export class PrimitiveClient {
     /**
      * @param {string} request
      * @param {PrimitiveClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.primitive.getAndReturnBase64("SGVsbG8gd29ybGQh")

--- a/seed/ts-sdk/exhaustive/local-files-no-source/esm/api/resources/endpoints/resources/put/client/Client.d.mts
+++ b/seed/ts-sdk/exhaustive/local-files-no-source/esm/api/resources/endpoints/resources/put/client/Client.d.mts
@@ -14,6 +14,9 @@ export declare class PutClient {
      * @param {SeedExhaustive.endpoints.PutRequest} request
      * @param {PutClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.put.add({
      *         id: "id"

--- a/seed/ts-sdk/exhaustive/local-files-no-source/esm/api/resources/endpoints/resources/put/client/Client.mjs
+++ b/seed/ts-sdk/exhaustive/local-files-no-source/esm/api/resources/endpoints/resources/put/client/Client.mjs
@@ -21,6 +21,9 @@ export class PutClient {
      * @param {SeedExhaustive.endpoints.PutRequest} request
      * @param {PutClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.put.add({
      *         id: "id"

--- a/seed/ts-sdk/exhaustive/local-files-no-source/esm/api/resources/endpoints/resources/union/client/Client.d.mts
+++ b/seed/ts-sdk/exhaustive/local-files-no-source/esm/api/resources/endpoints/resources/union/client/Client.d.mts
@@ -14,6 +14,9 @@ export declare class UnionClient {
      * @param {SeedExhaustive.types.Animal} request
      * @param {UnionClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.union.getAndReturnUnion({
      *         animal: "dog",

--- a/seed/ts-sdk/exhaustive/local-files-no-source/esm/api/resources/endpoints/resources/union/client/Client.mjs
+++ b/seed/ts-sdk/exhaustive/local-files-no-source/esm/api/resources/endpoints/resources/union/client/Client.mjs
@@ -22,6 +22,9 @@ export class UnionClient {
      * @param {SeedExhaustive.types.Animal} request
      * @param {UnionClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.union.getAndReturnUnion({
      *         animal: "dog",

--- a/seed/ts-sdk/exhaustive/local-files-no-source/esm/api/resources/endpoints/resources/urls/client/Client.d.mts
+++ b/seed/ts-sdk/exhaustive/local-files-no-source/esm/api/resources/endpoints/resources/urls/client/Client.d.mts
@@ -12,6 +12,9 @@ export declare class UrlsClient {
     /**
      * @param {UrlsClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.urls.withMixedCase()
      */
@@ -19,6 +22,9 @@ export declare class UrlsClient {
     private __withMixedCase;
     /**
      * @param {UrlsClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.urls.noEndingSlash()
@@ -28,6 +34,9 @@ export declare class UrlsClient {
     /**
      * @param {UrlsClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.urls.withEndingSlash()
      */
@@ -35,6 +44,9 @@ export declare class UrlsClient {
     private __withEndingSlash;
     /**
      * @param {UrlsClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.urls.withUnderscores()

--- a/seed/ts-sdk/exhaustive/local-files-no-source/esm/api/resources/endpoints/resources/urls/client/Client.mjs
+++ b/seed/ts-sdk/exhaustive/local-files-no-source/esm/api/resources/endpoints/resources/urls/client/Client.mjs
@@ -20,6 +20,9 @@ export class UrlsClient {
     /**
      * @param {UrlsClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.urls.withMixedCase()
      */
@@ -57,6 +60,9 @@ export class UrlsClient {
     }
     /**
      * @param {UrlsClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.urls.noEndingSlash()
@@ -96,6 +102,9 @@ export class UrlsClient {
     /**
      * @param {UrlsClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.urls.withEndingSlash()
      */
@@ -133,6 +142,9 @@ export class UrlsClient {
     }
     /**
      * @param {UrlsClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.urls.withUnderscores()

--- a/seed/ts-sdk/exhaustive/local-files-no-source/esm/api/resources/inlinedRequests/client/Client.d.mts
+++ b/seed/ts-sdk/exhaustive/local-files-no-source/esm/api/resources/inlinedRequests/client/Client.d.mts
@@ -17,6 +17,8 @@ export declare class InlinedRequestsClient {
      * @param {InlinedRequestsClient.RequestOptions} requestOptions - Request-specific configuration.
      *
      * @throws {@link SeedExhaustive.BadRequestBody}
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.inlinedRequests.postWithObjectBodyandResponse({
@@ -48,6 +50,9 @@ export declare class InlinedRequestsClient {
      *
      * @param {SeedExhaustive.PostWithArrayBodyAndHeaders} request
      * @param {InlinedRequestsClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.inlinedRequests.postWithArrayBodyAndHeaders({

--- a/seed/ts-sdk/exhaustive/local-files-no-source/esm/api/resources/inlinedRequests/client/Client.mjs
+++ b/seed/ts-sdk/exhaustive/local-files-no-source/esm/api/resources/inlinedRequests/client/Client.mjs
@@ -26,6 +26,8 @@ export class InlinedRequestsClient {
      * @param {InlinedRequestsClient.RequestOptions} requestOptions - Request-specific configuration.
      *
      * @throws {@link SeedExhaustive.BadRequestBody}
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.inlinedRequests.postWithObjectBodyandResponse({
@@ -97,6 +99,9 @@ export class InlinedRequestsClient {
      *
      * @param {SeedExhaustive.PostWithArrayBodyAndHeaders} request
      * @param {InlinedRequestsClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.inlinedRequests.postWithArrayBodyAndHeaders({

--- a/seed/ts-sdk/exhaustive/local-files-no-source/esm/api/resources/noAuth/client/Client.d.mts
+++ b/seed/ts-sdk/exhaustive/local-files-no-source/esm/api/resources/noAuth/client/Client.d.mts
@@ -16,6 +16,8 @@ export declare class NoAuthClient {
      * @param {NoAuthClient.RequestOptions} requestOptions - Request-specific configuration.
      *
      * @throws {@link SeedExhaustive.BadRequestBody}
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.noAuth.postWithNoAuth({

--- a/seed/ts-sdk/exhaustive/local-files-no-source/esm/api/resources/noAuth/client/Client.mjs
+++ b/seed/ts-sdk/exhaustive/local-files-no-source/esm/api/resources/noAuth/client/Client.mjs
@@ -26,6 +26,8 @@ export class NoAuthClient {
      * @param {NoAuthClient.RequestOptions} requestOptions - Request-specific configuration.
      *
      * @throws {@link SeedExhaustive.BadRequestBody}
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.noAuth.postWithNoAuth({

--- a/seed/ts-sdk/exhaustive/local-files-no-source/esm/api/resources/noReqBody/client/Client.d.mts
+++ b/seed/ts-sdk/exhaustive/local-files-no-source/esm/api/resources/noReqBody/client/Client.d.mts
@@ -13,6 +13,9 @@ export declare class NoReqBodyClient {
     /**
      * @param {NoReqBodyClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.noReqBody.getWithNoRequestBody()
      */
@@ -20,6 +23,9 @@ export declare class NoReqBodyClient {
     private __getWithNoRequestBody;
     /**
      * @param {NoReqBodyClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.noReqBody.postWithNoRequestBody()

--- a/seed/ts-sdk/exhaustive/local-files-no-source/esm/api/resources/noReqBody/client/Client.mjs
+++ b/seed/ts-sdk/exhaustive/local-files-no-source/esm/api/resources/noReqBody/client/Client.mjs
@@ -20,6 +20,9 @@ export class NoReqBodyClient {
     /**
      * @param {NoReqBodyClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.noReqBody.getWithNoRequestBody()
      */
@@ -60,6 +63,9 @@ export class NoReqBodyClient {
     }
     /**
      * @param {NoReqBodyClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.noReqBody.postWithNoRequestBody()

--- a/seed/ts-sdk/exhaustive/local-files-no-source/esm/api/resources/reqWithHeaders/client/Client.d.mts
+++ b/seed/ts-sdk/exhaustive/local-files-no-source/esm/api/resources/reqWithHeaders/client/Client.d.mts
@@ -14,6 +14,9 @@ export declare class ReqWithHeadersClient {
      * @param {SeedExhaustive.ReqWithHeaders} request
      * @param {ReqWithHeadersClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.reqWithHeaders.getWithCustomHeader({
      *         "X-TEST-SERVICE-HEADER": "X-TEST-SERVICE-HEADER",

--- a/seed/ts-sdk/exhaustive/local-files-no-source/esm/api/resources/reqWithHeaders/client/Client.mjs
+++ b/seed/ts-sdk/exhaustive/local-files-no-source/esm/api/resources/reqWithHeaders/client/Client.mjs
@@ -22,6 +22,9 @@ export class ReqWithHeadersClient {
      * @param {SeedExhaustive.ReqWithHeaders} request
      * @param {ReqWithHeadersClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.reqWithHeaders.getWithCustomHeader({
      *         "X-TEST-SERVICE-HEADER": "X-TEST-SERVICE-HEADER",

--- a/seed/ts-sdk/exhaustive/local-files/api/resources/endpoints/resources/container/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/local-files/api/resources/endpoints/resources/container/client/Client.ts
@@ -26,6 +26,9 @@ export class ContainerClient {
      * @param {string[]} request
      * @param {ContainerClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.container.getAndReturnListOfPrimitives(["string", "string"])
      */
@@ -87,6 +90,9 @@ export class ContainerClient {
     /**
      * @param {SeedExhaustive.types.ObjectWithRequiredField[]} request
      * @param {ContainerClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.container.getAndReturnListOfObjects([{
@@ -152,6 +158,9 @@ export class ContainerClient {
      * @param {string[]} request
      * @param {ContainerClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.container.getAndReturnSetOfPrimitives(["string"])
      */
@@ -208,6 +217,9 @@ export class ContainerClient {
     /**
      * @param {SeedExhaustive.types.ObjectWithRequiredField[]} request
      * @param {ContainerClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.container.getAndReturnSetOfObjects([{
@@ -271,6 +283,9 @@ export class ContainerClient {
      * @param {Record<string, string>} request
      * @param {ContainerClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.container.getAndReturnMapPrimToPrim({
      *         "string": "string"
@@ -329,6 +344,9 @@ export class ContainerClient {
     /**
      * @param {Record<string, SeedExhaustive.types.ObjectWithRequiredField>} request
      * @param {ContainerClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.container.getAndReturnMapOfPrimToObject({
@@ -399,6 +417,9 @@ export class ContainerClient {
      * @param {Record<string, SeedExhaustive.types.MixedType>} request
      * @param {ContainerClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.container.getAndReturnMapOfPrimToUndiscriminatedUnion({
      *         "string": 1.1
@@ -462,6 +483,9 @@ export class ContainerClient {
     /**
      * @param {SeedExhaustive.types.ObjectWithRequiredField} request
      * @param {ContainerClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.container.getAndReturnOptional({

--- a/seed/ts-sdk/exhaustive/local-files/api/resources/endpoints/resources/contentType/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/local-files/api/resources/endpoints/resources/contentType/client/Client.ts
@@ -26,6 +26,9 @@ export class ContentTypeClient {
      * @param {SeedExhaustive.types.ObjectWithOptionalField} request
      * @param {ContentTypeClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.contentType.postJsonPatchContentType({
      *         string: "string",
@@ -98,6 +101,9 @@ export class ContentTypeClient {
     /**
      * @param {SeedExhaustive.types.ObjectWithOptionalField} request
      * @param {ContentTypeClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.contentType.postJsonPatchContentWithCharsetType({

--- a/seed/ts-sdk/exhaustive/local-files/api/resources/endpoints/resources/enum/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/local-files/api/resources/endpoints/resources/enum/client/Client.ts
@@ -26,6 +26,9 @@ export class EnumClient {
      * @param {SeedExhaustive.types.WeatherReport} request
      * @param {EnumClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.enum.getAndReturnEnum("SUNNY")
      */

--- a/seed/ts-sdk/exhaustive/local-files/api/resources/endpoints/resources/httpMethods/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/local-files/api/resources/endpoints/resources/httpMethods/client/Client.ts
@@ -26,6 +26,9 @@ export class HttpMethodsClient {
      * @param {string} id
      * @param {HttpMethodsClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.httpMethods.testGet("id")
      */
@@ -78,6 +81,9 @@ export class HttpMethodsClient {
      *
      * @param {SeedExhaustive.types.ObjectWithRequiredField} request
      * @param {HttpMethodsClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.httpMethods.testPost({
@@ -143,6 +149,9 @@ export class HttpMethodsClient {
      * @param {string} id
      * @param {SeedExhaustive.types.ObjectWithRequiredField} request
      * @param {HttpMethodsClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.httpMethods.testPut("id", {
@@ -210,6 +219,9 @@ export class HttpMethodsClient {
      * @param {string} id
      * @param {SeedExhaustive.types.ObjectWithOptionalField} request
      * @param {HttpMethodsClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.httpMethods.testPatch("id", {
@@ -290,6 +302,9 @@ export class HttpMethodsClient {
      *
      * @param {string} id
      * @param {HttpMethodsClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.httpMethods.testDelete("id")

--- a/seed/ts-sdk/exhaustive/local-files/api/resources/endpoints/resources/object/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/local-files/api/resources/endpoints/resources/object/client/Client.ts
@@ -26,6 +26,9 @@ export class ObjectClient {
      * @param {SeedExhaustive.types.ObjectWithOptionalField} request
      * @param {ObjectClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.object.getAndReturnWithOptionalField({
      *         string: "string",
@@ -107,6 +110,9 @@ export class ObjectClient {
      * @param {SeedExhaustive.types.ObjectWithRequiredField} request
      * @param {ObjectClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.object.getAndReturnWithRequiredField({
      *         string: "string"
@@ -173,6 +179,9 @@ export class ObjectClient {
     /**
      * @param {SeedExhaustive.types.ObjectWithMapOfMap} request
      * @param {ObjectClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.object.getAndReturnWithMapOfMap({
@@ -244,6 +253,9 @@ export class ObjectClient {
     /**
      * @param {SeedExhaustive.types.NestedObjectWithOptionalField} request
      * @param {ObjectClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.object.getAndReturnNestedWithOptionalField({
@@ -332,6 +344,9 @@ export class ObjectClient {
      * @param {SeedExhaustive.types.NestedObjectWithRequiredField} request
      * @param {ObjectClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.object.getAndReturnNestedWithRequiredField("string", {
      *         string: "string",
@@ -419,6 +434,9 @@ export class ObjectClient {
     /**
      * @param {SeedExhaustive.types.NestedObjectWithRequiredField[]} request
      * @param {ObjectClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.object.getAndReturnNestedWithRequiredFieldAsList([{
@@ -525,6 +543,9 @@ export class ObjectClient {
      * @param {SeedExhaustive.types.ObjectWithUnknownField} request
      * @param {ObjectClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.object.getAndReturnWithUnknownField({
      *         unknown: {
@@ -593,6 +614,9 @@ export class ObjectClient {
     /**
      * @param {SeedExhaustive.types.ObjectWithDocumentedUnknownType} request
      * @param {ObjectClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.object.getAndReturnWithDocumentedUnknownType({
@@ -664,6 +688,9 @@ export class ObjectClient {
     /**
      * @param {SeedExhaustive.types.MapOfDocumentedUnknownType} request
      * @param {ObjectClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.object.getAndReturnMapOfDocumentedUnknownType({
@@ -738,6 +765,9 @@ export class ObjectClient {
      *
      * @param {SeedExhaustive.types.ObjectWithMixedRequiredAndOptionalFields} request
      * @param {ObjectClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.object.getAndReturnWithMixedRequiredAndOptionalFields({
@@ -816,6 +846,9 @@ export class ObjectClient {
      * @param {SeedExhaustive.types.ObjectWithRequiredNestedObject} request
      * @param {ObjectClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.object.getAndReturnWithRequiredNestedObject({
      *         requiredString: "hello",
@@ -892,6 +925,9 @@ export class ObjectClient {
      *
      * @param {SeedExhaustive.types.ObjectWithDatetimeLikeString} request
      * @param {ObjectClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.object.getAndReturnWithDatetimeLikeString({

--- a/seed/ts-sdk/exhaustive/local-files/api/resources/endpoints/resources/pagination/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/local-files/api/resources/endpoints/resources/pagination/client/Client.ts
@@ -27,6 +27,9 @@ export class PaginationClient {
      * @param {SeedExhaustive.endpoints.ListItemsRequest} request
      * @param {PaginationClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.pagination.listItems({
      *         cursor: "cursor",

--- a/seed/ts-sdk/exhaustive/local-files/api/resources/endpoints/resources/params/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/local-files/api/resources/endpoints/resources/params/client/Client.ts
@@ -28,6 +28,9 @@ export class ParamsClient {
      * @param {string} param
      * @param {ParamsClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.params.getWithPath("param")
      */
@@ -80,6 +83,9 @@ export class ParamsClient {
      *
      * @param {SeedExhaustive.endpoints.GetWithInlinePath} request
      * @param {ParamsClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.params.getWithInlinePath({
@@ -139,6 +145,9 @@ export class ParamsClient {
      *
      * @param {SeedExhaustive.endpoints.GetWithQuery} request
      * @param {ParamsClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.params.getWithQuery({
@@ -207,6 +216,9 @@ export class ParamsClient {
      *
      * @param {SeedExhaustive.endpoints.GetWithMultipleQuery} request
      * @param {ParamsClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.params.getWithAllowMultipleQuery({
@@ -277,6 +289,9 @@ export class ParamsClient {
      * @param {SeedExhaustive.endpoints.GetWithPathAndQuery} request
      * @param {ParamsClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.params.getWithPathAndQuery("param", {
      *         query: "query"
@@ -344,6 +359,9 @@ export class ParamsClient {
      *
      * @param {SeedExhaustive.endpoints.GetWithInlinePathAndQuery} request
      * @param {ParamsClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.params.getWithInlinePathAndQuery({
@@ -413,6 +431,9 @@ export class ParamsClient {
      * @param {string} request
      * @param {ParamsClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.params.modifyWithPath("param", "string")
      */
@@ -473,6 +494,9 @@ export class ParamsClient {
      *
      * @param {SeedExhaustive.endpoints.ModifyResourceAtInlinedPath} request
      * @param {ParamsClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.params.modifyWithInlinePath({
@@ -537,6 +561,9 @@ export class ParamsClient {
      * @param {core.file.Uploadable} uploadable
      * @param {string} param
      * @param {ParamsClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     import { createReadStream } from "fs";
@@ -604,6 +631,9 @@ export class ParamsClient {
      *
      * @param {SeedExhaustive.endpoints.CreateWithBodyAndQuery} request
      * @param {ParamsClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.params.createWithBodyAndQuery({
@@ -680,6 +710,9 @@ export class ParamsClient {
      * @param {core.file.Uploadable} uploadable
      * @param {SeedExhaustive.endpoints.UploadBytesWithQuery} request
      * @param {ParamsClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      */
     public uploadBytesWithQuery(
         uploadable: core.file.Uploadable,
@@ -751,6 +784,9 @@ export class ParamsClient {
      * @param {boolean} param
      * @param {ParamsClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.params.getWithBooleanPath(true)
      */
@@ -808,6 +844,8 @@ export class ParamsClient {
      * @param {ParamsClient.RequestOptions} requestOptions - Request-specific configuration.
      *
      * @throws {@link SeedExhaustive.BadRequestBody}
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.params.getWithPathAndErrors("param")

--- a/seed/ts-sdk/exhaustive/local-files/api/resources/endpoints/resources/primitive/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/local-files/api/resources/endpoints/resources/primitive/client/Client.ts
@@ -25,6 +25,9 @@ export class PrimitiveClient {
      * @param {string} request
      * @param {PrimitiveClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.primitive.getAndReturnString("string")
      */
@@ -81,6 +84,9 @@ export class PrimitiveClient {
     /**
      * @param {number} request
      * @param {PrimitiveClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.primitive.getAndReturnInt(1)
@@ -139,6 +145,9 @@ export class PrimitiveClient {
      * @param {number} request
      * @param {PrimitiveClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.primitive.getAndReturnLong(1000000)
      */
@@ -195,6 +204,9 @@ export class PrimitiveClient {
     /**
      * @param {number} request
      * @param {PrimitiveClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.primitive.getAndReturnDouble(1.1)
@@ -253,6 +265,9 @@ export class PrimitiveClient {
      * @param {boolean} request
      * @param {PrimitiveClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.primitive.getAndReturnBool(true)
      */
@@ -309,6 +324,9 @@ export class PrimitiveClient {
     /**
      * @param {string} request
      * @param {PrimitiveClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.primitive.getAndReturnDatetime("2024-01-15T09:30:00Z")
@@ -367,6 +385,9 @@ export class PrimitiveClient {
      * @param {string} request
      * @param {PrimitiveClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.primitive.getAndReturnDate("2023-01-15")
      */
@@ -424,6 +445,9 @@ export class PrimitiveClient {
      * @param {string} request
      * @param {PrimitiveClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.primitive.getAndReturnUuid("d5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32")
      */
@@ -480,6 +504,9 @@ export class PrimitiveClient {
     /**
      * @param {string} request
      * @param {PrimitiveClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.primitive.getAndReturnBase64("SGVsbG8gd29ybGQh")

--- a/seed/ts-sdk/exhaustive/local-files/api/resources/endpoints/resources/put/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/local-files/api/resources/endpoints/resources/put/client/Client.ts
@@ -25,6 +25,9 @@ export class PutClient {
      * @param {SeedExhaustive.endpoints.PutRequest} request
      * @param {PutClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.put.add({
      *         id: "id"

--- a/seed/ts-sdk/exhaustive/local-files/api/resources/endpoints/resources/union/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/local-files/api/resources/endpoints/resources/union/client/Client.ts
@@ -26,6 +26,9 @@ export class UnionClient {
      * @param {SeedExhaustive.types.Animal} request
      * @param {UnionClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.union.getAndReturnUnion({
      *         animal: "dog",

--- a/seed/ts-sdk/exhaustive/local-files/api/resources/endpoints/resources/urls/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/local-files/api/resources/endpoints/resources/urls/client/Client.ts
@@ -23,6 +23,9 @@ export class UrlsClient {
     /**
      * @param {UrlsClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.urls.withMixedCase()
      */
@@ -69,6 +72,9 @@ export class UrlsClient {
 
     /**
      * @param {UrlsClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.urls.noEndingSlash()
@@ -117,6 +123,9 @@ export class UrlsClient {
     /**
      * @param {UrlsClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.urls.withEndingSlash()
      */
@@ -163,6 +172,9 @@ export class UrlsClient {
 
     /**
      * @param {UrlsClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.urls.withUnderscores()

--- a/seed/ts-sdk/exhaustive/local-files/api/resources/inlinedRequests/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/local-files/api/resources/inlinedRequests/client/Client.ts
@@ -29,6 +29,8 @@ export class InlinedRequestsClient {
      * @param {InlinedRequestsClient.RequestOptions} requestOptions - Request-specific configuration.
      *
      * @throws {@link SeedExhaustive.BadRequestBody}
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.inlinedRequests.postWithObjectBodyandResponse({
@@ -114,6 +116,9 @@ export class InlinedRequestsClient {
      *
      * @param {SeedExhaustive.PostWithArrayBodyAndHeaders} request
      * @param {InlinedRequestsClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.inlinedRequests.postWithArrayBodyAndHeaders({

--- a/seed/ts-sdk/exhaustive/local-files/api/resources/noAuth/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/local-files/api/resources/noAuth/client/Client.ts
@@ -29,6 +29,8 @@ export class NoAuthClient {
      * @param {NoAuthClient.RequestOptions} requestOptions - Request-specific configuration.
      *
      * @throws {@link SeedExhaustive.BadRequestBody}
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.noAuth.postWithNoAuth({

--- a/seed/ts-sdk/exhaustive/local-files/api/resources/noReqBody/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/local-files/api/resources/noReqBody/client/Client.ts
@@ -24,6 +24,9 @@ export class NoReqBodyClient {
     /**
      * @param {NoReqBodyClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.noReqBody.getWithNoRequestBody()
      */
@@ -77,6 +80,9 @@ export class NoReqBodyClient {
 
     /**
      * @param {NoReqBodyClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.noReqBody.postWithNoRequestBody()

--- a/seed/ts-sdk/exhaustive/local-files/api/resources/reqWithHeaders/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/local-files/api/resources/reqWithHeaders/client/Client.ts
@@ -26,6 +26,9 @@ export class ReqWithHeadersClient {
      * @param {SeedExhaustive.ReqWithHeaders} request
      * @param {ReqWithHeadersClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.reqWithHeaders.getWithCustomHeader({
      *         "X-TEST-SERVICE-HEADER": "X-TEST-SERVICE-HEADER",

--- a/seed/ts-sdk/exhaustive/multiple-exports/src/api/resources/endpoints/resources/container/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/multiple-exports/src/api/resources/endpoints/resources/container/client/Client.ts
@@ -26,6 +26,9 @@ export class ContainerClient {
      * @param {string[]} request
      * @param {ContainerClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.container.getAndReturnListOfPrimitives(["string", "string"])
      */
@@ -87,6 +90,9 @@ export class ContainerClient {
     /**
      * @param {SeedExhaustive.types.ObjectWithRequiredField[]} request
      * @param {ContainerClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.container.getAndReturnListOfObjects([{
@@ -152,6 +158,9 @@ export class ContainerClient {
      * @param {string[]} request
      * @param {ContainerClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.container.getAndReturnSetOfPrimitives(["string"])
      */
@@ -208,6 +217,9 @@ export class ContainerClient {
     /**
      * @param {SeedExhaustive.types.ObjectWithRequiredField[]} request
      * @param {ContainerClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.container.getAndReturnSetOfObjects([{
@@ -271,6 +283,9 @@ export class ContainerClient {
      * @param {Record<string, string>} request
      * @param {ContainerClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.container.getAndReturnMapPrimToPrim({
      *         "string": "string"
@@ -329,6 +344,9 @@ export class ContainerClient {
     /**
      * @param {Record<string, SeedExhaustive.types.ObjectWithRequiredField>} request
      * @param {ContainerClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.container.getAndReturnMapOfPrimToObject({
@@ -399,6 +417,9 @@ export class ContainerClient {
      * @param {Record<string, SeedExhaustive.types.MixedType>} request
      * @param {ContainerClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.container.getAndReturnMapOfPrimToUndiscriminatedUnion({
      *         "string": 1.1
@@ -462,6 +483,9 @@ export class ContainerClient {
     /**
      * @param {SeedExhaustive.types.ObjectWithRequiredField} request
      * @param {ContainerClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.container.getAndReturnOptional({

--- a/seed/ts-sdk/exhaustive/multiple-exports/src/api/resources/endpoints/resources/contentType/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/multiple-exports/src/api/resources/endpoints/resources/contentType/client/Client.ts
@@ -26,6 +26,9 @@ export class ContentTypeClient {
      * @param {SeedExhaustive.types.ObjectWithOptionalField} request
      * @param {ContentTypeClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.contentType.postJsonPatchContentType({
      *         string: "string",
@@ -98,6 +101,9 @@ export class ContentTypeClient {
     /**
      * @param {SeedExhaustive.types.ObjectWithOptionalField} request
      * @param {ContentTypeClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.contentType.postJsonPatchContentWithCharsetType({

--- a/seed/ts-sdk/exhaustive/multiple-exports/src/api/resources/endpoints/resources/enum/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/multiple-exports/src/api/resources/endpoints/resources/enum/client/Client.ts
@@ -26,6 +26,9 @@ export class EnumClient {
      * @param {SeedExhaustive.types.WeatherReport} request
      * @param {EnumClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.enum.getAndReturnEnum("SUNNY")
      */

--- a/seed/ts-sdk/exhaustive/multiple-exports/src/api/resources/endpoints/resources/httpMethods/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/multiple-exports/src/api/resources/endpoints/resources/httpMethods/client/Client.ts
@@ -26,6 +26,9 @@ export class HttpMethodsClient {
      * @param {string} id
      * @param {HttpMethodsClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.httpMethods.testGet("id")
      */
@@ -78,6 +81,9 @@ export class HttpMethodsClient {
      *
      * @param {SeedExhaustive.types.ObjectWithRequiredField} request
      * @param {HttpMethodsClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.httpMethods.testPost({
@@ -143,6 +149,9 @@ export class HttpMethodsClient {
      * @param {string} id
      * @param {SeedExhaustive.types.ObjectWithRequiredField} request
      * @param {HttpMethodsClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.httpMethods.testPut("id", {
@@ -210,6 +219,9 @@ export class HttpMethodsClient {
      * @param {string} id
      * @param {SeedExhaustive.types.ObjectWithOptionalField} request
      * @param {HttpMethodsClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.httpMethods.testPatch("id", {
@@ -290,6 +302,9 @@ export class HttpMethodsClient {
      *
      * @param {string} id
      * @param {HttpMethodsClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.httpMethods.testDelete("id")

--- a/seed/ts-sdk/exhaustive/multiple-exports/src/api/resources/endpoints/resources/object/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/multiple-exports/src/api/resources/endpoints/resources/object/client/Client.ts
@@ -26,6 +26,9 @@ export class ObjectClient {
      * @param {SeedExhaustive.types.ObjectWithOptionalField} request
      * @param {ObjectClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.object.getAndReturnWithOptionalField({
      *         string: "string",
@@ -107,6 +110,9 @@ export class ObjectClient {
      * @param {SeedExhaustive.types.ObjectWithRequiredField} request
      * @param {ObjectClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.object.getAndReturnWithRequiredField({
      *         string: "string"
@@ -173,6 +179,9 @@ export class ObjectClient {
     /**
      * @param {SeedExhaustive.types.ObjectWithMapOfMap} request
      * @param {ObjectClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.object.getAndReturnWithMapOfMap({
@@ -244,6 +253,9 @@ export class ObjectClient {
     /**
      * @param {SeedExhaustive.types.NestedObjectWithOptionalField} request
      * @param {ObjectClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.object.getAndReturnNestedWithOptionalField({
@@ -332,6 +344,9 @@ export class ObjectClient {
      * @param {SeedExhaustive.types.NestedObjectWithRequiredField} request
      * @param {ObjectClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.object.getAndReturnNestedWithRequiredField("string", {
      *         string: "string",
@@ -419,6 +434,9 @@ export class ObjectClient {
     /**
      * @param {SeedExhaustive.types.NestedObjectWithRequiredField[]} request
      * @param {ObjectClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.object.getAndReturnNestedWithRequiredFieldAsList([{
@@ -525,6 +543,9 @@ export class ObjectClient {
      * @param {SeedExhaustive.types.ObjectWithUnknownField} request
      * @param {ObjectClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.object.getAndReturnWithUnknownField({
      *         unknown: {
@@ -593,6 +614,9 @@ export class ObjectClient {
     /**
      * @param {SeedExhaustive.types.ObjectWithDocumentedUnknownType} request
      * @param {ObjectClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.object.getAndReturnWithDocumentedUnknownType({
@@ -664,6 +688,9 @@ export class ObjectClient {
     /**
      * @param {SeedExhaustive.types.MapOfDocumentedUnknownType} request
      * @param {ObjectClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.object.getAndReturnMapOfDocumentedUnknownType({
@@ -738,6 +765,9 @@ export class ObjectClient {
      *
      * @param {SeedExhaustive.types.ObjectWithMixedRequiredAndOptionalFields} request
      * @param {ObjectClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.object.getAndReturnWithMixedRequiredAndOptionalFields({
@@ -816,6 +846,9 @@ export class ObjectClient {
      * @param {SeedExhaustive.types.ObjectWithRequiredNestedObject} request
      * @param {ObjectClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.object.getAndReturnWithRequiredNestedObject({
      *         requiredString: "hello",
@@ -892,6 +925,9 @@ export class ObjectClient {
      *
      * @param {SeedExhaustive.types.ObjectWithDatetimeLikeString} request
      * @param {ObjectClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.object.getAndReturnWithDatetimeLikeString({

--- a/seed/ts-sdk/exhaustive/multiple-exports/src/api/resources/endpoints/resources/pagination/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/multiple-exports/src/api/resources/endpoints/resources/pagination/client/Client.ts
@@ -27,6 +27,9 @@ export class PaginationClient {
      * @param {SeedExhaustive.endpoints.ListItemsRequest} request
      * @param {PaginationClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.pagination.listItems({
      *         cursor: "cursor",

--- a/seed/ts-sdk/exhaustive/multiple-exports/src/api/resources/endpoints/resources/params/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/multiple-exports/src/api/resources/endpoints/resources/params/client/Client.ts
@@ -28,6 +28,9 @@ export class ParamsClient {
      * @param {string} param
      * @param {ParamsClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.params.getWithPath("param")
      */
@@ -80,6 +83,9 @@ export class ParamsClient {
      *
      * @param {SeedExhaustive.endpoints.GetWithInlinePath} request
      * @param {ParamsClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.params.getWithInlinePath({
@@ -139,6 +145,9 @@ export class ParamsClient {
      *
      * @param {SeedExhaustive.endpoints.GetWithQuery} request
      * @param {ParamsClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.params.getWithQuery({
@@ -207,6 +216,9 @@ export class ParamsClient {
      *
      * @param {SeedExhaustive.endpoints.GetWithMultipleQuery} request
      * @param {ParamsClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.params.getWithAllowMultipleQuery({
@@ -277,6 +289,9 @@ export class ParamsClient {
      * @param {SeedExhaustive.endpoints.GetWithPathAndQuery} request
      * @param {ParamsClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.params.getWithPathAndQuery("param", {
      *         query: "query"
@@ -344,6 +359,9 @@ export class ParamsClient {
      *
      * @param {SeedExhaustive.endpoints.GetWithInlinePathAndQuery} request
      * @param {ParamsClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.params.getWithInlinePathAndQuery({
@@ -413,6 +431,9 @@ export class ParamsClient {
      * @param {string} request
      * @param {ParamsClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.params.modifyWithPath("param", "string")
      */
@@ -473,6 +494,9 @@ export class ParamsClient {
      *
      * @param {SeedExhaustive.endpoints.ModifyResourceAtInlinedPath} request
      * @param {ParamsClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.params.modifyWithInlinePath({
@@ -537,6 +561,9 @@ export class ParamsClient {
      * @param {core.file.Uploadable} uploadable
      * @param {string} param
      * @param {ParamsClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     import { createReadStream } from "fs";
@@ -604,6 +631,9 @@ export class ParamsClient {
      *
      * @param {SeedExhaustive.endpoints.CreateWithBodyAndQuery} request
      * @param {ParamsClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.params.createWithBodyAndQuery({
@@ -680,6 +710,9 @@ export class ParamsClient {
      * @param {core.file.Uploadable} uploadable
      * @param {SeedExhaustive.endpoints.UploadBytesWithQuery} request
      * @param {ParamsClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      */
     public uploadBytesWithQuery(
         uploadable: core.file.Uploadable,
@@ -751,6 +784,9 @@ export class ParamsClient {
      * @param {boolean} param
      * @param {ParamsClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.params.getWithBooleanPath(true)
      */
@@ -808,6 +844,8 @@ export class ParamsClient {
      * @param {ParamsClient.RequestOptions} requestOptions - Request-specific configuration.
      *
      * @throws {@link SeedExhaustive.BadRequestBody}
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.params.getWithPathAndErrors("param")

--- a/seed/ts-sdk/exhaustive/multiple-exports/src/api/resources/endpoints/resources/primitive/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/multiple-exports/src/api/resources/endpoints/resources/primitive/client/Client.ts
@@ -25,6 +25,9 @@ export class PrimitiveClient {
      * @param {string} request
      * @param {PrimitiveClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.primitive.getAndReturnString("string")
      */
@@ -81,6 +84,9 @@ export class PrimitiveClient {
     /**
      * @param {number} request
      * @param {PrimitiveClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.primitive.getAndReturnInt(1)
@@ -139,6 +145,9 @@ export class PrimitiveClient {
      * @param {number} request
      * @param {PrimitiveClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.primitive.getAndReturnLong(1000000)
      */
@@ -195,6 +204,9 @@ export class PrimitiveClient {
     /**
      * @param {number} request
      * @param {PrimitiveClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.primitive.getAndReturnDouble(1.1)
@@ -253,6 +265,9 @@ export class PrimitiveClient {
      * @param {boolean} request
      * @param {PrimitiveClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.primitive.getAndReturnBool(true)
      */
@@ -309,6 +324,9 @@ export class PrimitiveClient {
     /**
      * @param {string} request
      * @param {PrimitiveClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.primitive.getAndReturnDatetime("2024-01-15T09:30:00Z")
@@ -367,6 +385,9 @@ export class PrimitiveClient {
      * @param {string} request
      * @param {PrimitiveClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.primitive.getAndReturnDate("2023-01-15")
      */
@@ -424,6 +445,9 @@ export class PrimitiveClient {
      * @param {string} request
      * @param {PrimitiveClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.primitive.getAndReturnUuid("d5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32")
      */
@@ -480,6 +504,9 @@ export class PrimitiveClient {
     /**
      * @param {string} request
      * @param {PrimitiveClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.primitive.getAndReturnBase64("SGVsbG8gd29ybGQh")

--- a/seed/ts-sdk/exhaustive/multiple-exports/src/api/resources/endpoints/resources/put/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/multiple-exports/src/api/resources/endpoints/resources/put/client/Client.ts
@@ -25,6 +25,9 @@ export class PutClient {
      * @param {SeedExhaustive.endpoints.PutRequest} request
      * @param {PutClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.put.add({
      *         id: "id"

--- a/seed/ts-sdk/exhaustive/multiple-exports/src/api/resources/endpoints/resources/union/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/multiple-exports/src/api/resources/endpoints/resources/union/client/Client.ts
@@ -26,6 +26,9 @@ export class UnionClient {
      * @param {SeedExhaustive.types.Animal} request
      * @param {UnionClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.union.getAndReturnUnion({
      *         animal: "dog",

--- a/seed/ts-sdk/exhaustive/multiple-exports/src/api/resources/endpoints/resources/urls/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/multiple-exports/src/api/resources/endpoints/resources/urls/client/Client.ts
@@ -23,6 +23,9 @@ export class UrlsClient {
     /**
      * @param {UrlsClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.urls.withMixedCase()
      */
@@ -69,6 +72,9 @@ export class UrlsClient {
 
     /**
      * @param {UrlsClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.urls.noEndingSlash()
@@ -117,6 +123,9 @@ export class UrlsClient {
     /**
      * @param {UrlsClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.urls.withEndingSlash()
      */
@@ -163,6 +172,9 @@ export class UrlsClient {
 
     /**
      * @param {UrlsClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.urls.withUnderscores()

--- a/seed/ts-sdk/exhaustive/multiple-exports/src/api/resources/inlinedRequests/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/multiple-exports/src/api/resources/inlinedRequests/client/Client.ts
@@ -29,6 +29,8 @@ export class InlinedRequestsClient {
      * @param {InlinedRequestsClient.RequestOptions} requestOptions - Request-specific configuration.
      *
      * @throws {@link SeedExhaustive.BadRequestBody}
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.inlinedRequests.postWithObjectBodyandResponse({
@@ -114,6 +116,9 @@ export class InlinedRequestsClient {
      *
      * @param {SeedExhaustive.PostWithArrayBodyAndHeaders} request
      * @param {InlinedRequestsClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.inlinedRequests.postWithArrayBodyAndHeaders({

--- a/seed/ts-sdk/exhaustive/multiple-exports/src/api/resources/noAuth/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/multiple-exports/src/api/resources/noAuth/client/Client.ts
@@ -29,6 +29,8 @@ export class NoAuthClient {
      * @param {NoAuthClient.RequestOptions} requestOptions - Request-specific configuration.
      *
      * @throws {@link SeedExhaustive.BadRequestBody}
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.noAuth.postWithNoAuth({

--- a/seed/ts-sdk/exhaustive/multiple-exports/src/api/resources/noReqBody/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/multiple-exports/src/api/resources/noReqBody/client/Client.ts
@@ -24,6 +24,9 @@ export class NoReqBodyClient {
     /**
      * @param {NoReqBodyClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.noReqBody.getWithNoRequestBody()
      */
@@ -77,6 +80,9 @@ export class NoReqBodyClient {
 
     /**
      * @param {NoReqBodyClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.noReqBody.postWithNoRequestBody()

--- a/seed/ts-sdk/exhaustive/multiple-exports/src/api/resources/reqWithHeaders/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/multiple-exports/src/api/resources/reqWithHeaders/client/Client.ts
@@ -26,6 +26,9 @@ export class ReqWithHeadersClient {
      * @param {SeedExhaustive.ReqWithHeaders} request
      * @param {ReqWithHeadersClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.reqWithHeaders.getWithCustomHeader({
      *         "X-TEST-SERVICE-HEADER": "X-TEST-SERVICE-HEADER",

--- a/seed/ts-sdk/exhaustive/no-custom-config/src/api/resources/endpoints/resources/container/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/no-custom-config/src/api/resources/endpoints/resources/container/client/Client.ts
@@ -26,6 +26,9 @@ export class ContainerClient {
      * @param {string[]} request
      * @param {ContainerClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.container.getAndReturnListOfPrimitives(["string", "string"])
      */
@@ -87,6 +90,9 @@ export class ContainerClient {
     /**
      * @param {SeedExhaustive.types.ObjectWithRequiredField[]} request
      * @param {ContainerClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.container.getAndReturnListOfObjects([{
@@ -152,6 +158,9 @@ export class ContainerClient {
      * @param {string[]} request
      * @param {ContainerClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.container.getAndReturnSetOfPrimitives(["string"])
      */
@@ -208,6 +217,9 @@ export class ContainerClient {
     /**
      * @param {SeedExhaustive.types.ObjectWithRequiredField[]} request
      * @param {ContainerClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.container.getAndReturnSetOfObjects([{
@@ -271,6 +283,9 @@ export class ContainerClient {
      * @param {Record<string, string>} request
      * @param {ContainerClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.container.getAndReturnMapPrimToPrim({
      *         "string": "string"
@@ -329,6 +344,9 @@ export class ContainerClient {
     /**
      * @param {Record<string, SeedExhaustive.types.ObjectWithRequiredField>} request
      * @param {ContainerClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.container.getAndReturnMapOfPrimToObject({
@@ -399,6 +417,9 @@ export class ContainerClient {
      * @param {Record<string, SeedExhaustive.types.MixedType>} request
      * @param {ContainerClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.container.getAndReturnMapOfPrimToUndiscriminatedUnion({
      *         "string": 1.1
@@ -462,6 +483,9 @@ export class ContainerClient {
     /**
      * @param {SeedExhaustive.types.ObjectWithRequiredField} request
      * @param {ContainerClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.container.getAndReturnOptional({

--- a/seed/ts-sdk/exhaustive/no-custom-config/src/api/resources/endpoints/resources/contentType/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/no-custom-config/src/api/resources/endpoints/resources/contentType/client/Client.ts
@@ -26,6 +26,9 @@ export class ContentTypeClient {
      * @param {SeedExhaustive.types.ObjectWithOptionalField} request
      * @param {ContentTypeClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.contentType.postJsonPatchContentType({
      *         string: "string",
@@ -98,6 +101,9 @@ export class ContentTypeClient {
     /**
      * @param {SeedExhaustive.types.ObjectWithOptionalField} request
      * @param {ContentTypeClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.contentType.postJsonPatchContentWithCharsetType({

--- a/seed/ts-sdk/exhaustive/no-custom-config/src/api/resources/endpoints/resources/enum/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/no-custom-config/src/api/resources/endpoints/resources/enum/client/Client.ts
@@ -26,6 +26,9 @@ export class EnumClient {
      * @param {SeedExhaustive.types.WeatherReport} request
      * @param {EnumClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.enum.getAndReturnEnum("SUNNY")
      */

--- a/seed/ts-sdk/exhaustive/no-custom-config/src/api/resources/endpoints/resources/httpMethods/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/no-custom-config/src/api/resources/endpoints/resources/httpMethods/client/Client.ts
@@ -26,6 +26,9 @@ export class HttpMethodsClient {
      * @param {string} id
      * @param {HttpMethodsClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.httpMethods.testGet("id")
      */
@@ -78,6 +81,9 @@ export class HttpMethodsClient {
      *
      * @param {SeedExhaustive.types.ObjectWithRequiredField} request
      * @param {HttpMethodsClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.httpMethods.testPost({
@@ -143,6 +149,9 @@ export class HttpMethodsClient {
      * @param {string} id
      * @param {SeedExhaustive.types.ObjectWithRequiredField} request
      * @param {HttpMethodsClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.httpMethods.testPut("id", {
@@ -210,6 +219,9 @@ export class HttpMethodsClient {
      * @param {string} id
      * @param {SeedExhaustive.types.ObjectWithOptionalField} request
      * @param {HttpMethodsClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.httpMethods.testPatch("id", {
@@ -290,6 +302,9 @@ export class HttpMethodsClient {
      *
      * @param {string} id
      * @param {HttpMethodsClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.httpMethods.testDelete("id")

--- a/seed/ts-sdk/exhaustive/no-custom-config/src/api/resources/endpoints/resources/object/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/no-custom-config/src/api/resources/endpoints/resources/object/client/Client.ts
@@ -26,6 +26,9 @@ export class ObjectClient {
      * @param {SeedExhaustive.types.ObjectWithOptionalField} request
      * @param {ObjectClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.object.getAndReturnWithOptionalField({
      *         string: "string",
@@ -107,6 +110,9 @@ export class ObjectClient {
      * @param {SeedExhaustive.types.ObjectWithRequiredField} request
      * @param {ObjectClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.object.getAndReturnWithRequiredField({
      *         string: "string"
@@ -173,6 +179,9 @@ export class ObjectClient {
     /**
      * @param {SeedExhaustive.types.ObjectWithMapOfMap} request
      * @param {ObjectClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.object.getAndReturnWithMapOfMap({
@@ -244,6 +253,9 @@ export class ObjectClient {
     /**
      * @param {SeedExhaustive.types.NestedObjectWithOptionalField} request
      * @param {ObjectClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.object.getAndReturnNestedWithOptionalField({
@@ -332,6 +344,9 @@ export class ObjectClient {
      * @param {SeedExhaustive.types.NestedObjectWithRequiredField} request
      * @param {ObjectClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.object.getAndReturnNestedWithRequiredField("string", {
      *         string: "string",
@@ -419,6 +434,9 @@ export class ObjectClient {
     /**
      * @param {SeedExhaustive.types.NestedObjectWithRequiredField[]} request
      * @param {ObjectClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.object.getAndReturnNestedWithRequiredFieldAsList([{
@@ -525,6 +543,9 @@ export class ObjectClient {
      * @param {SeedExhaustive.types.ObjectWithUnknownField} request
      * @param {ObjectClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.object.getAndReturnWithUnknownField({
      *         unknown: {
@@ -593,6 +614,9 @@ export class ObjectClient {
     /**
      * @param {SeedExhaustive.types.ObjectWithDocumentedUnknownType} request
      * @param {ObjectClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.object.getAndReturnWithDocumentedUnknownType({
@@ -664,6 +688,9 @@ export class ObjectClient {
     /**
      * @param {SeedExhaustive.types.MapOfDocumentedUnknownType} request
      * @param {ObjectClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.object.getAndReturnMapOfDocumentedUnknownType({
@@ -738,6 +765,9 @@ export class ObjectClient {
      *
      * @param {SeedExhaustive.types.ObjectWithMixedRequiredAndOptionalFields} request
      * @param {ObjectClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.object.getAndReturnWithMixedRequiredAndOptionalFields({
@@ -816,6 +846,9 @@ export class ObjectClient {
      * @param {SeedExhaustive.types.ObjectWithRequiredNestedObject} request
      * @param {ObjectClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.object.getAndReturnWithRequiredNestedObject({
      *         requiredString: "hello",
@@ -892,6 +925,9 @@ export class ObjectClient {
      *
      * @param {SeedExhaustive.types.ObjectWithDatetimeLikeString} request
      * @param {ObjectClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.object.getAndReturnWithDatetimeLikeString({

--- a/seed/ts-sdk/exhaustive/no-custom-config/src/api/resources/endpoints/resources/pagination/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/no-custom-config/src/api/resources/endpoints/resources/pagination/client/Client.ts
@@ -27,6 +27,9 @@ export class PaginationClient {
      * @param {SeedExhaustive.endpoints.ListItemsRequest} request
      * @param {PaginationClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.pagination.listItems({
      *         cursor: "cursor",

--- a/seed/ts-sdk/exhaustive/no-custom-config/src/api/resources/endpoints/resources/params/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/no-custom-config/src/api/resources/endpoints/resources/params/client/Client.ts
@@ -28,6 +28,9 @@ export class ParamsClient {
      * @param {string} param
      * @param {ParamsClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.params.getWithPath("param")
      */
@@ -80,6 +83,9 @@ export class ParamsClient {
      *
      * @param {SeedExhaustive.endpoints.GetWithInlinePath} request
      * @param {ParamsClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.params.getWithInlinePath({
@@ -139,6 +145,9 @@ export class ParamsClient {
      *
      * @param {SeedExhaustive.endpoints.GetWithQuery} request
      * @param {ParamsClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.params.getWithQuery({
@@ -207,6 +216,9 @@ export class ParamsClient {
      *
      * @param {SeedExhaustive.endpoints.GetWithMultipleQuery} request
      * @param {ParamsClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.params.getWithAllowMultipleQuery({
@@ -277,6 +289,9 @@ export class ParamsClient {
      * @param {SeedExhaustive.endpoints.GetWithPathAndQuery} request
      * @param {ParamsClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.params.getWithPathAndQuery("param", {
      *         query: "query"
@@ -344,6 +359,9 @@ export class ParamsClient {
      *
      * @param {SeedExhaustive.endpoints.GetWithInlinePathAndQuery} request
      * @param {ParamsClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.params.getWithInlinePathAndQuery({
@@ -413,6 +431,9 @@ export class ParamsClient {
      * @param {string} request
      * @param {ParamsClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.params.modifyWithPath("param", "string")
      */
@@ -473,6 +494,9 @@ export class ParamsClient {
      *
      * @param {SeedExhaustive.endpoints.ModifyResourceAtInlinedPath} request
      * @param {ParamsClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.params.modifyWithInlinePath({
@@ -537,6 +561,9 @@ export class ParamsClient {
      * @param {core.file.Uploadable} uploadable
      * @param {string} param
      * @param {ParamsClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     import { createReadStream } from "fs";
@@ -604,6 +631,9 @@ export class ParamsClient {
      *
      * @param {SeedExhaustive.endpoints.CreateWithBodyAndQuery} request
      * @param {ParamsClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.params.createWithBodyAndQuery({
@@ -680,6 +710,9 @@ export class ParamsClient {
      * @param {core.file.Uploadable} uploadable
      * @param {SeedExhaustive.endpoints.UploadBytesWithQuery} request
      * @param {ParamsClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      */
     public uploadBytesWithQuery(
         uploadable: core.file.Uploadable,
@@ -751,6 +784,9 @@ export class ParamsClient {
      * @param {boolean} param
      * @param {ParamsClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.params.getWithBooleanPath(true)
      */
@@ -808,6 +844,8 @@ export class ParamsClient {
      * @param {ParamsClient.RequestOptions} requestOptions - Request-specific configuration.
      *
      * @throws {@link SeedExhaustive.BadRequestBody}
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.params.getWithPathAndErrors("param")

--- a/seed/ts-sdk/exhaustive/no-custom-config/src/api/resources/endpoints/resources/primitive/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/no-custom-config/src/api/resources/endpoints/resources/primitive/client/Client.ts
@@ -25,6 +25,9 @@ export class PrimitiveClient {
      * @param {string} request
      * @param {PrimitiveClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.primitive.getAndReturnString("string")
      */
@@ -81,6 +84,9 @@ export class PrimitiveClient {
     /**
      * @param {number} request
      * @param {PrimitiveClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.primitive.getAndReturnInt(1)
@@ -139,6 +145,9 @@ export class PrimitiveClient {
      * @param {number} request
      * @param {PrimitiveClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.primitive.getAndReturnLong(1000000)
      */
@@ -195,6 +204,9 @@ export class PrimitiveClient {
     /**
      * @param {number} request
      * @param {PrimitiveClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.primitive.getAndReturnDouble(1.1)
@@ -253,6 +265,9 @@ export class PrimitiveClient {
      * @param {boolean} request
      * @param {PrimitiveClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.primitive.getAndReturnBool(true)
      */
@@ -309,6 +324,9 @@ export class PrimitiveClient {
     /**
      * @param {string} request
      * @param {PrimitiveClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.primitive.getAndReturnDatetime("2024-01-15T09:30:00Z")
@@ -367,6 +385,9 @@ export class PrimitiveClient {
      * @param {string} request
      * @param {PrimitiveClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.primitive.getAndReturnDate("2023-01-15")
      */
@@ -424,6 +445,9 @@ export class PrimitiveClient {
      * @param {string} request
      * @param {PrimitiveClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.primitive.getAndReturnUuid("d5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32")
      */
@@ -480,6 +504,9 @@ export class PrimitiveClient {
     /**
      * @param {string} request
      * @param {PrimitiveClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.primitive.getAndReturnBase64("SGVsbG8gd29ybGQh")

--- a/seed/ts-sdk/exhaustive/no-custom-config/src/api/resources/endpoints/resources/put/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/no-custom-config/src/api/resources/endpoints/resources/put/client/Client.ts
@@ -25,6 +25,9 @@ export class PutClient {
      * @param {SeedExhaustive.endpoints.PutRequest} request
      * @param {PutClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.put.add({
      *         id: "id"

--- a/seed/ts-sdk/exhaustive/no-custom-config/src/api/resources/endpoints/resources/union/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/no-custom-config/src/api/resources/endpoints/resources/union/client/Client.ts
@@ -26,6 +26,9 @@ export class UnionClient {
      * @param {SeedExhaustive.types.Animal} request
      * @param {UnionClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.union.getAndReturnUnion({
      *         animal: "dog",

--- a/seed/ts-sdk/exhaustive/no-custom-config/src/api/resources/endpoints/resources/urls/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/no-custom-config/src/api/resources/endpoints/resources/urls/client/Client.ts
@@ -23,6 +23,9 @@ export class UrlsClient {
     /**
      * @param {UrlsClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.urls.withMixedCase()
      */
@@ -69,6 +72,9 @@ export class UrlsClient {
 
     /**
      * @param {UrlsClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.urls.noEndingSlash()
@@ -117,6 +123,9 @@ export class UrlsClient {
     /**
      * @param {UrlsClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.urls.withEndingSlash()
      */
@@ -163,6 +172,9 @@ export class UrlsClient {
 
     /**
      * @param {UrlsClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.urls.withUnderscores()

--- a/seed/ts-sdk/exhaustive/no-custom-config/src/api/resources/inlinedRequests/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/no-custom-config/src/api/resources/inlinedRequests/client/Client.ts
@@ -29,6 +29,8 @@ export class InlinedRequestsClient {
      * @param {InlinedRequestsClient.RequestOptions} requestOptions - Request-specific configuration.
      *
      * @throws {@link SeedExhaustive.BadRequestBody}
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.inlinedRequests.postWithObjectBodyandResponse({
@@ -114,6 +116,9 @@ export class InlinedRequestsClient {
      *
      * @param {SeedExhaustive.PostWithArrayBodyAndHeaders} request
      * @param {InlinedRequestsClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.inlinedRequests.postWithArrayBodyAndHeaders({

--- a/seed/ts-sdk/exhaustive/no-custom-config/src/api/resources/noAuth/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/no-custom-config/src/api/resources/noAuth/client/Client.ts
@@ -29,6 +29,8 @@ export class NoAuthClient {
      * @param {NoAuthClient.RequestOptions} requestOptions - Request-specific configuration.
      *
      * @throws {@link SeedExhaustive.BadRequestBody}
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.noAuth.postWithNoAuth({

--- a/seed/ts-sdk/exhaustive/no-custom-config/src/api/resources/noReqBody/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/no-custom-config/src/api/resources/noReqBody/client/Client.ts
@@ -24,6 +24,9 @@ export class NoReqBodyClient {
     /**
      * @param {NoReqBodyClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.noReqBody.getWithNoRequestBody()
      */
@@ -77,6 +80,9 @@ export class NoReqBodyClient {
 
     /**
      * @param {NoReqBodyClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.noReqBody.postWithNoRequestBody()

--- a/seed/ts-sdk/exhaustive/no-custom-config/src/api/resources/reqWithHeaders/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/no-custom-config/src/api/resources/reqWithHeaders/client/Client.ts
@@ -26,6 +26,9 @@ export class ReqWithHeadersClient {
      * @param {SeedExhaustive.ReqWithHeaders} request
      * @param {ReqWithHeadersClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.reqWithHeaders.getWithCustomHeader({
      *         "X-TEST-SERVICE-HEADER": "X-TEST-SERVICE-HEADER",

--- a/seed/ts-sdk/exhaustive/node-fetch/src/api/resources/endpoints/resources/container/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/node-fetch/src/api/resources/endpoints/resources/container/client/Client.ts
@@ -26,6 +26,9 @@ export class ContainerClient {
      * @param {string[]} request
      * @param {ContainerClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.container.getAndReturnListOfPrimitives(["string", "string"])
      */
@@ -87,6 +90,9 @@ export class ContainerClient {
     /**
      * @param {SeedExhaustive.types.ObjectWithRequiredField[]} request
      * @param {ContainerClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.container.getAndReturnListOfObjects([{
@@ -152,6 +158,9 @@ export class ContainerClient {
      * @param {string[]} request
      * @param {ContainerClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.container.getAndReturnSetOfPrimitives(["string"])
      */
@@ -208,6 +217,9 @@ export class ContainerClient {
     /**
      * @param {SeedExhaustive.types.ObjectWithRequiredField[]} request
      * @param {ContainerClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.container.getAndReturnSetOfObjects([{
@@ -271,6 +283,9 @@ export class ContainerClient {
      * @param {Record<string, string>} request
      * @param {ContainerClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.container.getAndReturnMapPrimToPrim({
      *         "string": "string"
@@ -329,6 +344,9 @@ export class ContainerClient {
     /**
      * @param {Record<string, SeedExhaustive.types.ObjectWithRequiredField>} request
      * @param {ContainerClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.container.getAndReturnMapOfPrimToObject({
@@ -399,6 +417,9 @@ export class ContainerClient {
      * @param {Record<string, SeedExhaustive.types.MixedType>} request
      * @param {ContainerClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.container.getAndReturnMapOfPrimToUndiscriminatedUnion({
      *         "string": 1.1
@@ -462,6 +483,9 @@ export class ContainerClient {
     /**
      * @param {SeedExhaustive.types.ObjectWithRequiredField} request
      * @param {ContainerClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.container.getAndReturnOptional({

--- a/seed/ts-sdk/exhaustive/node-fetch/src/api/resources/endpoints/resources/contentType/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/node-fetch/src/api/resources/endpoints/resources/contentType/client/Client.ts
@@ -26,6 +26,9 @@ export class ContentTypeClient {
      * @param {SeedExhaustive.types.ObjectWithOptionalField} request
      * @param {ContentTypeClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.contentType.postJsonPatchContentType({
      *         string: "string",
@@ -98,6 +101,9 @@ export class ContentTypeClient {
     /**
      * @param {SeedExhaustive.types.ObjectWithOptionalField} request
      * @param {ContentTypeClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.contentType.postJsonPatchContentWithCharsetType({

--- a/seed/ts-sdk/exhaustive/node-fetch/src/api/resources/endpoints/resources/enum/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/node-fetch/src/api/resources/endpoints/resources/enum/client/Client.ts
@@ -26,6 +26,9 @@ export class EnumClient {
      * @param {SeedExhaustive.types.WeatherReport} request
      * @param {EnumClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.enum.getAndReturnEnum("SUNNY")
      */

--- a/seed/ts-sdk/exhaustive/node-fetch/src/api/resources/endpoints/resources/httpMethods/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/node-fetch/src/api/resources/endpoints/resources/httpMethods/client/Client.ts
@@ -26,6 +26,9 @@ export class HttpMethodsClient {
      * @param {string} id
      * @param {HttpMethodsClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.httpMethods.testGet("id")
      */
@@ -78,6 +81,9 @@ export class HttpMethodsClient {
      *
      * @param {SeedExhaustive.types.ObjectWithRequiredField} request
      * @param {HttpMethodsClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.httpMethods.testPost({
@@ -143,6 +149,9 @@ export class HttpMethodsClient {
      * @param {string} id
      * @param {SeedExhaustive.types.ObjectWithRequiredField} request
      * @param {HttpMethodsClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.httpMethods.testPut("id", {
@@ -210,6 +219,9 @@ export class HttpMethodsClient {
      * @param {string} id
      * @param {SeedExhaustive.types.ObjectWithOptionalField} request
      * @param {HttpMethodsClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.httpMethods.testPatch("id", {
@@ -290,6 +302,9 @@ export class HttpMethodsClient {
      *
      * @param {string} id
      * @param {HttpMethodsClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.httpMethods.testDelete("id")

--- a/seed/ts-sdk/exhaustive/node-fetch/src/api/resources/endpoints/resources/object/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/node-fetch/src/api/resources/endpoints/resources/object/client/Client.ts
@@ -26,6 +26,9 @@ export class ObjectClient {
      * @param {SeedExhaustive.types.ObjectWithOptionalField} request
      * @param {ObjectClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.object.getAndReturnWithOptionalField({
      *         string: "string",
@@ -107,6 +110,9 @@ export class ObjectClient {
      * @param {SeedExhaustive.types.ObjectWithRequiredField} request
      * @param {ObjectClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.object.getAndReturnWithRequiredField({
      *         string: "string"
@@ -173,6 +179,9 @@ export class ObjectClient {
     /**
      * @param {SeedExhaustive.types.ObjectWithMapOfMap} request
      * @param {ObjectClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.object.getAndReturnWithMapOfMap({
@@ -244,6 +253,9 @@ export class ObjectClient {
     /**
      * @param {SeedExhaustive.types.NestedObjectWithOptionalField} request
      * @param {ObjectClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.object.getAndReturnNestedWithOptionalField({
@@ -332,6 +344,9 @@ export class ObjectClient {
      * @param {SeedExhaustive.types.NestedObjectWithRequiredField} request
      * @param {ObjectClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.object.getAndReturnNestedWithRequiredField("string", {
      *         string: "string",
@@ -419,6 +434,9 @@ export class ObjectClient {
     /**
      * @param {SeedExhaustive.types.NestedObjectWithRequiredField[]} request
      * @param {ObjectClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.object.getAndReturnNestedWithRequiredFieldAsList([{
@@ -525,6 +543,9 @@ export class ObjectClient {
      * @param {SeedExhaustive.types.ObjectWithUnknownField} request
      * @param {ObjectClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.object.getAndReturnWithUnknownField({
      *         unknown: {
@@ -593,6 +614,9 @@ export class ObjectClient {
     /**
      * @param {SeedExhaustive.types.ObjectWithDocumentedUnknownType} request
      * @param {ObjectClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.object.getAndReturnWithDocumentedUnknownType({
@@ -664,6 +688,9 @@ export class ObjectClient {
     /**
      * @param {SeedExhaustive.types.MapOfDocumentedUnknownType} request
      * @param {ObjectClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.object.getAndReturnMapOfDocumentedUnknownType({
@@ -738,6 +765,9 @@ export class ObjectClient {
      *
      * @param {SeedExhaustive.types.ObjectWithMixedRequiredAndOptionalFields} request
      * @param {ObjectClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.object.getAndReturnWithMixedRequiredAndOptionalFields({
@@ -816,6 +846,9 @@ export class ObjectClient {
      * @param {SeedExhaustive.types.ObjectWithRequiredNestedObject} request
      * @param {ObjectClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.object.getAndReturnWithRequiredNestedObject({
      *         requiredString: "hello",
@@ -892,6 +925,9 @@ export class ObjectClient {
      *
      * @param {SeedExhaustive.types.ObjectWithDatetimeLikeString} request
      * @param {ObjectClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.object.getAndReturnWithDatetimeLikeString({

--- a/seed/ts-sdk/exhaustive/node-fetch/src/api/resources/endpoints/resources/pagination/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/node-fetch/src/api/resources/endpoints/resources/pagination/client/Client.ts
@@ -27,6 +27,9 @@ export class PaginationClient {
      * @param {SeedExhaustive.endpoints.ListItemsRequest} request
      * @param {PaginationClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.pagination.listItems({
      *         cursor: "cursor",

--- a/seed/ts-sdk/exhaustive/node-fetch/src/api/resources/endpoints/resources/params/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/node-fetch/src/api/resources/endpoints/resources/params/client/Client.ts
@@ -28,6 +28,9 @@ export class ParamsClient {
      * @param {string} param
      * @param {ParamsClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.params.getWithPath("param")
      */
@@ -80,6 +83,9 @@ export class ParamsClient {
      *
      * @param {SeedExhaustive.endpoints.GetWithInlinePath} request
      * @param {ParamsClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.params.getWithInlinePath({
@@ -139,6 +145,9 @@ export class ParamsClient {
      *
      * @param {SeedExhaustive.endpoints.GetWithQuery} request
      * @param {ParamsClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.params.getWithQuery({
@@ -207,6 +216,9 @@ export class ParamsClient {
      *
      * @param {SeedExhaustive.endpoints.GetWithMultipleQuery} request
      * @param {ParamsClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.params.getWithAllowMultipleQuery({
@@ -277,6 +289,9 @@ export class ParamsClient {
      * @param {SeedExhaustive.endpoints.GetWithPathAndQuery} request
      * @param {ParamsClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.params.getWithPathAndQuery("param", {
      *         query: "query"
@@ -344,6 +359,9 @@ export class ParamsClient {
      *
      * @param {SeedExhaustive.endpoints.GetWithInlinePathAndQuery} request
      * @param {ParamsClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.params.getWithInlinePathAndQuery({
@@ -413,6 +431,9 @@ export class ParamsClient {
      * @param {string} request
      * @param {ParamsClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.params.modifyWithPath("param", "string")
      */
@@ -473,6 +494,9 @@ export class ParamsClient {
      *
      * @param {SeedExhaustive.endpoints.ModifyResourceAtInlinedPath} request
      * @param {ParamsClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.params.modifyWithInlinePath({
@@ -537,6 +561,9 @@ export class ParamsClient {
      * @param {core.file.Uploadable} uploadable
      * @param {string} param
      * @param {ParamsClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     import { createReadStream } from "fs";
@@ -604,6 +631,9 @@ export class ParamsClient {
      *
      * @param {SeedExhaustive.endpoints.CreateWithBodyAndQuery} request
      * @param {ParamsClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.params.createWithBodyAndQuery({
@@ -680,6 +710,9 @@ export class ParamsClient {
      * @param {core.file.Uploadable} uploadable
      * @param {SeedExhaustive.endpoints.UploadBytesWithQuery} request
      * @param {ParamsClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      */
     public uploadBytesWithQuery(
         uploadable: core.file.Uploadable,
@@ -751,6 +784,9 @@ export class ParamsClient {
      * @param {boolean} param
      * @param {ParamsClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.params.getWithBooleanPath(true)
      */
@@ -808,6 +844,8 @@ export class ParamsClient {
      * @param {ParamsClient.RequestOptions} requestOptions - Request-specific configuration.
      *
      * @throws {@link SeedExhaustive.BadRequestBody}
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.params.getWithPathAndErrors("param")

--- a/seed/ts-sdk/exhaustive/node-fetch/src/api/resources/endpoints/resources/primitive/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/node-fetch/src/api/resources/endpoints/resources/primitive/client/Client.ts
@@ -25,6 +25,9 @@ export class PrimitiveClient {
      * @param {string} request
      * @param {PrimitiveClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.primitive.getAndReturnString("string")
      */
@@ -81,6 +84,9 @@ export class PrimitiveClient {
     /**
      * @param {number} request
      * @param {PrimitiveClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.primitive.getAndReturnInt(1)
@@ -139,6 +145,9 @@ export class PrimitiveClient {
      * @param {number} request
      * @param {PrimitiveClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.primitive.getAndReturnLong(1000000)
      */
@@ -195,6 +204,9 @@ export class PrimitiveClient {
     /**
      * @param {number} request
      * @param {PrimitiveClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.primitive.getAndReturnDouble(1.1)
@@ -253,6 +265,9 @@ export class PrimitiveClient {
      * @param {boolean} request
      * @param {PrimitiveClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.primitive.getAndReturnBool(true)
      */
@@ -309,6 +324,9 @@ export class PrimitiveClient {
     /**
      * @param {string} request
      * @param {PrimitiveClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.primitive.getAndReturnDatetime("2024-01-15T09:30:00Z")
@@ -367,6 +385,9 @@ export class PrimitiveClient {
      * @param {string} request
      * @param {PrimitiveClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.primitive.getAndReturnDate("2023-01-15")
      */
@@ -424,6 +445,9 @@ export class PrimitiveClient {
      * @param {string} request
      * @param {PrimitiveClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.primitive.getAndReturnUuid("d5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32")
      */
@@ -480,6 +504,9 @@ export class PrimitiveClient {
     /**
      * @param {string} request
      * @param {PrimitiveClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.primitive.getAndReturnBase64("SGVsbG8gd29ybGQh")

--- a/seed/ts-sdk/exhaustive/node-fetch/src/api/resources/endpoints/resources/put/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/node-fetch/src/api/resources/endpoints/resources/put/client/Client.ts
@@ -25,6 +25,9 @@ export class PutClient {
      * @param {SeedExhaustive.endpoints.PutRequest} request
      * @param {PutClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.put.add({
      *         id: "id"

--- a/seed/ts-sdk/exhaustive/node-fetch/src/api/resources/endpoints/resources/union/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/node-fetch/src/api/resources/endpoints/resources/union/client/Client.ts
@@ -26,6 +26,9 @@ export class UnionClient {
      * @param {SeedExhaustive.types.Animal} request
      * @param {UnionClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.union.getAndReturnUnion({
      *         animal: "dog",

--- a/seed/ts-sdk/exhaustive/node-fetch/src/api/resources/endpoints/resources/urls/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/node-fetch/src/api/resources/endpoints/resources/urls/client/Client.ts
@@ -23,6 +23,9 @@ export class UrlsClient {
     /**
      * @param {UrlsClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.urls.withMixedCase()
      */
@@ -69,6 +72,9 @@ export class UrlsClient {
 
     /**
      * @param {UrlsClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.urls.noEndingSlash()
@@ -117,6 +123,9 @@ export class UrlsClient {
     /**
      * @param {UrlsClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.urls.withEndingSlash()
      */
@@ -163,6 +172,9 @@ export class UrlsClient {
 
     /**
      * @param {UrlsClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.urls.withUnderscores()

--- a/seed/ts-sdk/exhaustive/node-fetch/src/api/resources/inlinedRequests/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/node-fetch/src/api/resources/inlinedRequests/client/Client.ts
@@ -29,6 +29,8 @@ export class InlinedRequestsClient {
      * @param {InlinedRequestsClient.RequestOptions} requestOptions - Request-specific configuration.
      *
      * @throws {@link SeedExhaustive.BadRequestBody}
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.inlinedRequests.postWithObjectBodyandResponse({
@@ -114,6 +116,9 @@ export class InlinedRequestsClient {
      *
      * @param {SeedExhaustive.PostWithArrayBodyAndHeaders} request
      * @param {InlinedRequestsClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.inlinedRequests.postWithArrayBodyAndHeaders({

--- a/seed/ts-sdk/exhaustive/node-fetch/src/api/resources/noAuth/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/node-fetch/src/api/resources/noAuth/client/Client.ts
@@ -29,6 +29,8 @@ export class NoAuthClient {
      * @param {NoAuthClient.RequestOptions} requestOptions - Request-specific configuration.
      *
      * @throws {@link SeedExhaustive.BadRequestBody}
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.noAuth.postWithNoAuth({

--- a/seed/ts-sdk/exhaustive/node-fetch/src/api/resources/noReqBody/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/node-fetch/src/api/resources/noReqBody/client/Client.ts
@@ -24,6 +24,9 @@ export class NoReqBodyClient {
     /**
      * @param {NoReqBodyClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.noReqBody.getWithNoRequestBody()
      */
@@ -77,6 +80,9 @@ export class NoReqBodyClient {
 
     /**
      * @param {NoReqBodyClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.noReqBody.postWithNoRequestBody()

--- a/seed/ts-sdk/exhaustive/node-fetch/src/api/resources/reqWithHeaders/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/node-fetch/src/api/resources/reqWithHeaders/client/Client.ts
@@ -26,6 +26,9 @@ export class ReqWithHeadersClient {
      * @param {SeedExhaustive.ReqWithHeaders} request
      * @param {ReqWithHeadersClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.reqWithHeaders.getWithCustomHeader({
      *         "X-TEST-SERVICE-HEADER": "X-TEST-SERVICE-HEADER",

--- a/seed/ts-sdk/exhaustive/output-src-only/api/resources/endpoints/resources/container/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/output-src-only/api/resources/endpoints/resources/container/client/Client.ts
@@ -26,6 +26,9 @@ export class ContainerClient {
      * @param {string[]} request
      * @param {ContainerClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.container.getAndReturnListOfPrimitives(["string", "string"])
      */
@@ -87,6 +90,9 @@ export class ContainerClient {
     /**
      * @param {SeedExhaustive.types.ObjectWithRequiredField[]} request
      * @param {ContainerClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.container.getAndReturnListOfObjects([{
@@ -152,6 +158,9 @@ export class ContainerClient {
      * @param {string[]} request
      * @param {ContainerClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.container.getAndReturnSetOfPrimitives(["string"])
      */
@@ -208,6 +217,9 @@ export class ContainerClient {
     /**
      * @param {SeedExhaustive.types.ObjectWithRequiredField[]} request
      * @param {ContainerClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.container.getAndReturnSetOfObjects([{
@@ -271,6 +283,9 @@ export class ContainerClient {
      * @param {Record<string, string>} request
      * @param {ContainerClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.container.getAndReturnMapPrimToPrim({
      *         "string": "string"
@@ -329,6 +344,9 @@ export class ContainerClient {
     /**
      * @param {Record<string, SeedExhaustive.types.ObjectWithRequiredField>} request
      * @param {ContainerClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.container.getAndReturnMapOfPrimToObject({
@@ -399,6 +417,9 @@ export class ContainerClient {
      * @param {Record<string, SeedExhaustive.types.MixedType>} request
      * @param {ContainerClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.container.getAndReturnMapOfPrimToUndiscriminatedUnion({
      *         "string": 1.1
@@ -462,6 +483,9 @@ export class ContainerClient {
     /**
      * @param {SeedExhaustive.types.ObjectWithRequiredField} request
      * @param {ContainerClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.container.getAndReturnOptional({

--- a/seed/ts-sdk/exhaustive/output-src-only/api/resources/endpoints/resources/contentType/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/output-src-only/api/resources/endpoints/resources/contentType/client/Client.ts
@@ -26,6 +26,9 @@ export class ContentTypeClient {
      * @param {SeedExhaustive.types.ObjectWithOptionalField} request
      * @param {ContentTypeClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.contentType.postJsonPatchContentType({
      *         string: "string",
@@ -98,6 +101,9 @@ export class ContentTypeClient {
     /**
      * @param {SeedExhaustive.types.ObjectWithOptionalField} request
      * @param {ContentTypeClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.contentType.postJsonPatchContentWithCharsetType({

--- a/seed/ts-sdk/exhaustive/output-src-only/api/resources/endpoints/resources/enum/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/output-src-only/api/resources/endpoints/resources/enum/client/Client.ts
@@ -26,6 +26,9 @@ export class EnumClient {
      * @param {SeedExhaustive.types.WeatherReport} request
      * @param {EnumClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.enum.getAndReturnEnum("SUNNY")
      */

--- a/seed/ts-sdk/exhaustive/output-src-only/api/resources/endpoints/resources/httpMethods/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/output-src-only/api/resources/endpoints/resources/httpMethods/client/Client.ts
@@ -26,6 +26,9 @@ export class HttpMethodsClient {
      * @param {string} id
      * @param {HttpMethodsClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.httpMethods.testGet("id")
      */
@@ -78,6 +81,9 @@ export class HttpMethodsClient {
      *
      * @param {SeedExhaustive.types.ObjectWithRequiredField} request
      * @param {HttpMethodsClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.httpMethods.testPost({
@@ -143,6 +149,9 @@ export class HttpMethodsClient {
      * @param {string} id
      * @param {SeedExhaustive.types.ObjectWithRequiredField} request
      * @param {HttpMethodsClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.httpMethods.testPut("id", {
@@ -210,6 +219,9 @@ export class HttpMethodsClient {
      * @param {string} id
      * @param {SeedExhaustive.types.ObjectWithOptionalField} request
      * @param {HttpMethodsClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.httpMethods.testPatch("id", {
@@ -290,6 +302,9 @@ export class HttpMethodsClient {
      *
      * @param {string} id
      * @param {HttpMethodsClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.httpMethods.testDelete("id")

--- a/seed/ts-sdk/exhaustive/output-src-only/api/resources/endpoints/resources/object/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/output-src-only/api/resources/endpoints/resources/object/client/Client.ts
@@ -26,6 +26,9 @@ export class ObjectClient {
      * @param {SeedExhaustive.types.ObjectWithOptionalField} request
      * @param {ObjectClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.object.getAndReturnWithOptionalField({
      *         string: "string",
@@ -107,6 +110,9 @@ export class ObjectClient {
      * @param {SeedExhaustive.types.ObjectWithRequiredField} request
      * @param {ObjectClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.object.getAndReturnWithRequiredField({
      *         string: "string"
@@ -173,6 +179,9 @@ export class ObjectClient {
     /**
      * @param {SeedExhaustive.types.ObjectWithMapOfMap} request
      * @param {ObjectClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.object.getAndReturnWithMapOfMap({
@@ -244,6 +253,9 @@ export class ObjectClient {
     /**
      * @param {SeedExhaustive.types.NestedObjectWithOptionalField} request
      * @param {ObjectClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.object.getAndReturnNestedWithOptionalField({
@@ -332,6 +344,9 @@ export class ObjectClient {
      * @param {SeedExhaustive.types.NestedObjectWithRequiredField} request
      * @param {ObjectClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.object.getAndReturnNestedWithRequiredField("string", {
      *         string: "string",
@@ -419,6 +434,9 @@ export class ObjectClient {
     /**
      * @param {SeedExhaustive.types.NestedObjectWithRequiredField[]} request
      * @param {ObjectClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.object.getAndReturnNestedWithRequiredFieldAsList([{
@@ -525,6 +543,9 @@ export class ObjectClient {
      * @param {SeedExhaustive.types.ObjectWithUnknownField} request
      * @param {ObjectClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.object.getAndReturnWithUnknownField({
      *         unknown: {
@@ -593,6 +614,9 @@ export class ObjectClient {
     /**
      * @param {SeedExhaustive.types.ObjectWithDocumentedUnknownType} request
      * @param {ObjectClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.object.getAndReturnWithDocumentedUnknownType({
@@ -664,6 +688,9 @@ export class ObjectClient {
     /**
      * @param {SeedExhaustive.types.MapOfDocumentedUnknownType} request
      * @param {ObjectClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.object.getAndReturnMapOfDocumentedUnknownType({
@@ -738,6 +765,9 @@ export class ObjectClient {
      *
      * @param {SeedExhaustive.types.ObjectWithMixedRequiredAndOptionalFields} request
      * @param {ObjectClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.object.getAndReturnWithMixedRequiredAndOptionalFields({
@@ -816,6 +846,9 @@ export class ObjectClient {
      * @param {SeedExhaustive.types.ObjectWithRequiredNestedObject} request
      * @param {ObjectClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.object.getAndReturnWithRequiredNestedObject({
      *         requiredString: "hello",
@@ -892,6 +925,9 @@ export class ObjectClient {
      *
      * @param {SeedExhaustive.types.ObjectWithDatetimeLikeString} request
      * @param {ObjectClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.object.getAndReturnWithDatetimeLikeString({

--- a/seed/ts-sdk/exhaustive/output-src-only/api/resources/endpoints/resources/pagination/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/output-src-only/api/resources/endpoints/resources/pagination/client/Client.ts
@@ -27,6 +27,9 @@ export class PaginationClient {
      * @param {SeedExhaustive.endpoints.ListItemsRequest} request
      * @param {PaginationClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.pagination.listItems({
      *         cursor: "cursor",

--- a/seed/ts-sdk/exhaustive/output-src-only/api/resources/endpoints/resources/params/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/output-src-only/api/resources/endpoints/resources/params/client/Client.ts
@@ -28,6 +28,9 @@ export class ParamsClient {
      * @param {string} param
      * @param {ParamsClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.params.getWithPath("param")
      */
@@ -80,6 +83,9 @@ export class ParamsClient {
      *
      * @param {SeedExhaustive.endpoints.GetWithInlinePath} request
      * @param {ParamsClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.params.getWithInlinePath({
@@ -139,6 +145,9 @@ export class ParamsClient {
      *
      * @param {SeedExhaustive.endpoints.GetWithQuery} request
      * @param {ParamsClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.params.getWithQuery({
@@ -207,6 +216,9 @@ export class ParamsClient {
      *
      * @param {SeedExhaustive.endpoints.GetWithMultipleQuery} request
      * @param {ParamsClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.params.getWithAllowMultipleQuery({
@@ -277,6 +289,9 @@ export class ParamsClient {
      * @param {SeedExhaustive.endpoints.GetWithPathAndQuery} request
      * @param {ParamsClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.params.getWithPathAndQuery("param", {
      *         query: "query"
@@ -344,6 +359,9 @@ export class ParamsClient {
      *
      * @param {SeedExhaustive.endpoints.GetWithInlinePathAndQuery} request
      * @param {ParamsClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.params.getWithInlinePathAndQuery({
@@ -413,6 +431,9 @@ export class ParamsClient {
      * @param {string} request
      * @param {ParamsClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.params.modifyWithPath("param", "string")
      */
@@ -473,6 +494,9 @@ export class ParamsClient {
      *
      * @param {SeedExhaustive.endpoints.ModifyResourceAtInlinedPath} request
      * @param {ParamsClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.params.modifyWithInlinePath({
@@ -537,6 +561,9 @@ export class ParamsClient {
      * @param {core.file.Uploadable} uploadable
      * @param {string} param
      * @param {ParamsClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     import { createReadStream } from "fs";
@@ -604,6 +631,9 @@ export class ParamsClient {
      *
      * @param {SeedExhaustive.endpoints.CreateWithBodyAndQuery} request
      * @param {ParamsClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.params.createWithBodyAndQuery({
@@ -680,6 +710,9 @@ export class ParamsClient {
      * @param {core.file.Uploadable} uploadable
      * @param {SeedExhaustive.endpoints.UploadBytesWithQuery} request
      * @param {ParamsClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      */
     public uploadBytesWithQuery(
         uploadable: core.file.Uploadable,
@@ -751,6 +784,9 @@ export class ParamsClient {
      * @param {boolean} param
      * @param {ParamsClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.params.getWithBooleanPath(true)
      */
@@ -808,6 +844,8 @@ export class ParamsClient {
      * @param {ParamsClient.RequestOptions} requestOptions - Request-specific configuration.
      *
      * @throws {@link SeedExhaustive.BadRequestBody}
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.params.getWithPathAndErrors("param")

--- a/seed/ts-sdk/exhaustive/output-src-only/api/resources/endpoints/resources/primitive/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/output-src-only/api/resources/endpoints/resources/primitive/client/Client.ts
@@ -25,6 +25,9 @@ export class PrimitiveClient {
      * @param {string} request
      * @param {PrimitiveClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.primitive.getAndReturnString("string")
      */
@@ -81,6 +84,9 @@ export class PrimitiveClient {
     /**
      * @param {number} request
      * @param {PrimitiveClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.primitive.getAndReturnInt(1)
@@ -139,6 +145,9 @@ export class PrimitiveClient {
      * @param {number} request
      * @param {PrimitiveClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.primitive.getAndReturnLong(1000000)
      */
@@ -195,6 +204,9 @@ export class PrimitiveClient {
     /**
      * @param {number} request
      * @param {PrimitiveClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.primitive.getAndReturnDouble(1.1)
@@ -253,6 +265,9 @@ export class PrimitiveClient {
      * @param {boolean} request
      * @param {PrimitiveClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.primitive.getAndReturnBool(true)
      */
@@ -309,6 +324,9 @@ export class PrimitiveClient {
     /**
      * @param {string} request
      * @param {PrimitiveClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.primitive.getAndReturnDatetime("2024-01-15T09:30:00Z")
@@ -367,6 +385,9 @@ export class PrimitiveClient {
      * @param {string} request
      * @param {PrimitiveClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.primitive.getAndReturnDate("2023-01-15")
      */
@@ -424,6 +445,9 @@ export class PrimitiveClient {
      * @param {string} request
      * @param {PrimitiveClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.primitive.getAndReturnUuid("d5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32")
      */
@@ -480,6 +504,9 @@ export class PrimitiveClient {
     /**
      * @param {string} request
      * @param {PrimitiveClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.primitive.getAndReturnBase64("SGVsbG8gd29ybGQh")

--- a/seed/ts-sdk/exhaustive/output-src-only/api/resources/endpoints/resources/put/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/output-src-only/api/resources/endpoints/resources/put/client/Client.ts
@@ -25,6 +25,9 @@ export class PutClient {
      * @param {SeedExhaustive.endpoints.PutRequest} request
      * @param {PutClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.put.add({
      *         id: "id"

--- a/seed/ts-sdk/exhaustive/output-src-only/api/resources/endpoints/resources/union/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/output-src-only/api/resources/endpoints/resources/union/client/Client.ts
@@ -26,6 +26,9 @@ export class UnionClient {
      * @param {SeedExhaustive.types.Animal} request
      * @param {UnionClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.union.getAndReturnUnion({
      *         animal: "dog",

--- a/seed/ts-sdk/exhaustive/output-src-only/api/resources/endpoints/resources/urls/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/output-src-only/api/resources/endpoints/resources/urls/client/Client.ts
@@ -23,6 +23,9 @@ export class UrlsClient {
     /**
      * @param {UrlsClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.urls.withMixedCase()
      */
@@ -69,6 +72,9 @@ export class UrlsClient {
 
     /**
      * @param {UrlsClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.urls.noEndingSlash()
@@ -117,6 +123,9 @@ export class UrlsClient {
     /**
      * @param {UrlsClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.urls.withEndingSlash()
      */
@@ -163,6 +172,9 @@ export class UrlsClient {
 
     /**
      * @param {UrlsClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.urls.withUnderscores()

--- a/seed/ts-sdk/exhaustive/output-src-only/api/resources/inlinedRequests/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/output-src-only/api/resources/inlinedRequests/client/Client.ts
@@ -29,6 +29,8 @@ export class InlinedRequestsClient {
      * @param {InlinedRequestsClient.RequestOptions} requestOptions - Request-specific configuration.
      *
      * @throws {@link SeedExhaustive.BadRequestBody}
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.inlinedRequests.postWithObjectBodyandResponse({
@@ -114,6 +116,9 @@ export class InlinedRequestsClient {
      *
      * @param {SeedExhaustive.PostWithArrayBodyAndHeaders} request
      * @param {InlinedRequestsClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.inlinedRequests.postWithArrayBodyAndHeaders({

--- a/seed/ts-sdk/exhaustive/output-src-only/api/resources/noAuth/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/output-src-only/api/resources/noAuth/client/Client.ts
@@ -29,6 +29,8 @@ export class NoAuthClient {
      * @param {NoAuthClient.RequestOptions} requestOptions - Request-specific configuration.
      *
      * @throws {@link SeedExhaustive.BadRequestBody}
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.noAuth.postWithNoAuth({

--- a/seed/ts-sdk/exhaustive/output-src-only/api/resources/noReqBody/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/output-src-only/api/resources/noReqBody/client/Client.ts
@@ -24,6 +24,9 @@ export class NoReqBodyClient {
     /**
      * @param {NoReqBodyClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.noReqBody.getWithNoRequestBody()
      */
@@ -77,6 +80,9 @@ export class NoReqBodyClient {
 
     /**
      * @param {NoReqBodyClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.noReqBody.postWithNoRequestBody()

--- a/seed/ts-sdk/exhaustive/output-src-only/api/resources/reqWithHeaders/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/output-src-only/api/resources/reqWithHeaders/client/Client.ts
@@ -26,6 +26,9 @@ export class ReqWithHeadersClient {
      * @param {SeedExhaustive.ReqWithHeaders} request
      * @param {ReqWithHeadersClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.reqWithHeaders.getWithCustomHeader({
      *         "X-TEST-SERVICE-HEADER": "X-TEST-SERVICE-HEADER",

--- a/seed/ts-sdk/exhaustive/package-path/src/test-packagePath/api/resources/endpoints/resources/container/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/package-path/src/test-packagePath/api/resources/endpoints/resources/container/client/Client.ts
@@ -26,6 +26,9 @@ export class ContainerClient {
      * @param {string[]} request
      * @param {ContainerClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.container.getAndReturnListOfPrimitives(["string", "string"])
      */
@@ -87,6 +90,9 @@ export class ContainerClient {
     /**
      * @param {SeedExhaustive.types.ObjectWithRequiredField[]} request
      * @param {ContainerClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.container.getAndReturnListOfObjects([{
@@ -152,6 +158,9 @@ export class ContainerClient {
      * @param {string[]} request
      * @param {ContainerClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.container.getAndReturnSetOfPrimitives(["string"])
      */
@@ -208,6 +217,9 @@ export class ContainerClient {
     /**
      * @param {SeedExhaustive.types.ObjectWithRequiredField[]} request
      * @param {ContainerClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.container.getAndReturnSetOfObjects([{
@@ -271,6 +283,9 @@ export class ContainerClient {
      * @param {Record<string, string>} request
      * @param {ContainerClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.container.getAndReturnMapPrimToPrim({
      *         "string": "string"
@@ -329,6 +344,9 @@ export class ContainerClient {
     /**
      * @param {Record<string, SeedExhaustive.types.ObjectWithRequiredField>} request
      * @param {ContainerClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.container.getAndReturnMapOfPrimToObject({
@@ -399,6 +417,9 @@ export class ContainerClient {
      * @param {Record<string, SeedExhaustive.types.MixedType>} request
      * @param {ContainerClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.container.getAndReturnMapOfPrimToUndiscriminatedUnion({
      *         "string": 1.1
@@ -462,6 +483,9 @@ export class ContainerClient {
     /**
      * @param {SeedExhaustive.types.ObjectWithRequiredField} request
      * @param {ContainerClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.container.getAndReturnOptional({

--- a/seed/ts-sdk/exhaustive/package-path/src/test-packagePath/api/resources/endpoints/resources/contentType/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/package-path/src/test-packagePath/api/resources/endpoints/resources/contentType/client/Client.ts
@@ -26,6 +26,9 @@ export class ContentTypeClient {
      * @param {SeedExhaustive.types.ObjectWithOptionalField} request
      * @param {ContentTypeClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.contentType.postJsonPatchContentType({
      *         string: "string",
@@ -98,6 +101,9 @@ export class ContentTypeClient {
     /**
      * @param {SeedExhaustive.types.ObjectWithOptionalField} request
      * @param {ContentTypeClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.contentType.postJsonPatchContentWithCharsetType({

--- a/seed/ts-sdk/exhaustive/package-path/src/test-packagePath/api/resources/endpoints/resources/enum/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/package-path/src/test-packagePath/api/resources/endpoints/resources/enum/client/Client.ts
@@ -26,6 +26,9 @@ export class EnumClient {
      * @param {SeedExhaustive.types.WeatherReport} request
      * @param {EnumClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.enum.getAndReturnEnum("SUNNY")
      */

--- a/seed/ts-sdk/exhaustive/package-path/src/test-packagePath/api/resources/endpoints/resources/httpMethods/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/package-path/src/test-packagePath/api/resources/endpoints/resources/httpMethods/client/Client.ts
@@ -26,6 +26,9 @@ export class HttpMethodsClient {
      * @param {string} id
      * @param {HttpMethodsClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.httpMethods.testGet("id")
      */
@@ -78,6 +81,9 @@ export class HttpMethodsClient {
      *
      * @param {SeedExhaustive.types.ObjectWithRequiredField} request
      * @param {HttpMethodsClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.httpMethods.testPost({
@@ -143,6 +149,9 @@ export class HttpMethodsClient {
      * @param {string} id
      * @param {SeedExhaustive.types.ObjectWithRequiredField} request
      * @param {HttpMethodsClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.httpMethods.testPut("id", {
@@ -210,6 +219,9 @@ export class HttpMethodsClient {
      * @param {string} id
      * @param {SeedExhaustive.types.ObjectWithOptionalField} request
      * @param {HttpMethodsClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.httpMethods.testPatch("id", {
@@ -290,6 +302,9 @@ export class HttpMethodsClient {
      *
      * @param {string} id
      * @param {HttpMethodsClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.httpMethods.testDelete("id")

--- a/seed/ts-sdk/exhaustive/package-path/src/test-packagePath/api/resources/endpoints/resources/object/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/package-path/src/test-packagePath/api/resources/endpoints/resources/object/client/Client.ts
@@ -26,6 +26,9 @@ export class ObjectClient {
      * @param {SeedExhaustive.types.ObjectWithOptionalField} request
      * @param {ObjectClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.object.getAndReturnWithOptionalField({
      *         string: "string",
@@ -107,6 +110,9 @@ export class ObjectClient {
      * @param {SeedExhaustive.types.ObjectWithRequiredField} request
      * @param {ObjectClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.object.getAndReturnWithRequiredField({
      *         string: "string"
@@ -173,6 +179,9 @@ export class ObjectClient {
     /**
      * @param {SeedExhaustive.types.ObjectWithMapOfMap} request
      * @param {ObjectClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.object.getAndReturnWithMapOfMap({
@@ -244,6 +253,9 @@ export class ObjectClient {
     /**
      * @param {SeedExhaustive.types.NestedObjectWithOptionalField} request
      * @param {ObjectClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.object.getAndReturnNestedWithOptionalField({
@@ -332,6 +344,9 @@ export class ObjectClient {
      * @param {SeedExhaustive.types.NestedObjectWithRequiredField} request
      * @param {ObjectClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.object.getAndReturnNestedWithRequiredField("string", {
      *         string: "string",
@@ -419,6 +434,9 @@ export class ObjectClient {
     /**
      * @param {SeedExhaustive.types.NestedObjectWithRequiredField[]} request
      * @param {ObjectClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.object.getAndReturnNestedWithRequiredFieldAsList([{
@@ -525,6 +543,9 @@ export class ObjectClient {
      * @param {SeedExhaustive.types.ObjectWithUnknownField} request
      * @param {ObjectClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.object.getAndReturnWithUnknownField({
      *         unknown: {
@@ -593,6 +614,9 @@ export class ObjectClient {
     /**
      * @param {SeedExhaustive.types.ObjectWithDocumentedUnknownType} request
      * @param {ObjectClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.object.getAndReturnWithDocumentedUnknownType({
@@ -664,6 +688,9 @@ export class ObjectClient {
     /**
      * @param {SeedExhaustive.types.MapOfDocumentedUnknownType} request
      * @param {ObjectClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.object.getAndReturnMapOfDocumentedUnknownType({
@@ -738,6 +765,9 @@ export class ObjectClient {
      *
      * @param {SeedExhaustive.types.ObjectWithMixedRequiredAndOptionalFields} request
      * @param {ObjectClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.object.getAndReturnWithMixedRequiredAndOptionalFields({
@@ -816,6 +846,9 @@ export class ObjectClient {
      * @param {SeedExhaustive.types.ObjectWithRequiredNestedObject} request
      * @param {ObjectClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.object.getAndReturnWithRequiredNestedObject({
      *         requiredString: "hello",
@@ -892,6 +925,9 @@ export class ObjectClient {
      *
      * @param {SeedExhaustive.types.ObjectWithDatetimeLikeString} request
      * @param {ObjectClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.object.getAndReturnWithDatetimeLikeString({

--- a/seed/ts-sdk/exhaustive/package-path/src/test-packagePath/api/resources/endpoints/resources/pagination/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/package-path/src/test-packagePath/api/resources/endpoints/resources/pagination/client/Client.ts
@@ -27,6 +27,9 @@ export class PaginationClient {
      * @param {SeedExhaustive.endpoints.ListItemsRequest} request
      * @param {PaginationClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.pagination.listItems({
      *         cursor: "cursor",

--- a/seed/ts-sdk/exhaustive/package-path/src/test-packagePath/api/resources/endpoints/resources/params/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/package-path/src/test-packagePath/api/resources/endpoints/resources/params/client/Client.ts
@@ -28,6 +28,9 @@ export class ParamsClient {
      * @param {string} param
      * @param {ParamsClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.params.getWithPath("param")
      */
@@ -80,6 +83,9 @@ export class ParamsClient {
      *
      * @param {SeedExhaustive.endpoints.GetWithInlinePath} request
      * @param {ParamsClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.params.getWithInlinePath({
@@ -139,6 +145,9 @@ export class ParamsClient {
      *
      * @param {SeedExhaustive.endpoints.GetWithQuery} request
      * @param {ParamsClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.params.getWithQuery({
@@ -207,6 +216,9 @@ export class ParamsClient {
      *
      * @param {SeedExhaustive.endpoints.GetWithMultipleQuery} request
      * @param {ParamsClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.params.getWithAllowMultipleQuery({
@@ -277,6 +289,9 @@ export class ParamsClient {
      * @param {SeedExhaustive.endpoints.GetWithPathAndQuery} request
      * @param {ParamsClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.params.getWithPathAndQuery("param", {
      *         query: "query"
@@ -344,6 +359,9 @@ export class ParamsClient {
      *
      * @param {SeedExhaustive.endpoints.GetWithInlinePathAndQuery} request
      * @param {ParamsClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.params.getWithInlinePathAndQuery({
@@ -413,6 +431,9 @@ export class ParamsClient {
      * @param {string} request
      * @param {ParamsClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.params.modifyWithPath("param", "string")
      */
@@ -473,6 +494,9 @@ export class ParamsClient {
      *
      * @param {SeedExhaustive.endpoints.ModifyResourceAtInlinedPath} request
      * @param {ParamsClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.params.modifyWithInlinePath({
@@ -537,6 +561,9 @@ export class ParamsClient {
      * @param {core.file.Uploadable} uploadable
      * @param {string} param
      * @param {ParamsClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     import { createReadStream } from "fs";
@@ -604,6 +631,9 @@ export class ParamsClient {
      *
      * @param {SeedExhaustive.endpoints.CreateWithBodyAndQuery} request
      * @param {ParamsClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.params.createWithBodyAndQuery({
@@ -680,6 +710,9 @@ export class ParamsClient {
      * @param {core.file.Uploadable} uploadable
      * @param {SeedExhaustive.endpoints.UploadBytesWithQuery} request
      * @param {ParamsClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      */
     public uploadBytesWithQuery(
         uploadable: core.file.Uploadable,
@@ -751,6 +784,9 @@ export class ParamsClient {
      * @param {boolean} param
      * @param {ParamsClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.params.getWithBooleanPath(true)
      */
@@ -808,6 +844,8 @@ export class ParamsClient {
      * @param {ParamsClient.RequestOptions} requestOptions - Request-specific configuration.
      *
      * @throws {@link SeedExhaustive.BadRequestBody}
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.params.getWithPathAndErrors("param")

--- a/seed/ts-sdk/exhaustive/package-path/src/test-packagePath/api/resources/endpoints/resources/primitive/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/package-path/src/test-packagePath/api/resources/endpoints/resources/primitive/client/Client.ts
@@ -25,6 +25,9 @@ export class PrimitiveClient {
      * @param {string} request
      * @param {PrimitiveClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.primitive.getAndReturnString("string")
      */
@@ -81,6 +84,9 @@ export class PrimitiveClient {
     /**
      * @param {number} request
      * @param {PrimitiveClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.primitive.getAndReturnInt(1)
@@ -139,6 +145,9 @@ export class PrimitiveClient {
      * @param {number} request
      * @param {PrimitiveClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.primitive.getAndReturnLong(1000000)
      */
@@ -195,6 +204,9 @@ export class PrimitiveClient {
     /**
      * @param {number} request
      * @param {PrimitiveClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.primitive.getAndReturnDouble(1.1)
@@ -253,6 +265,9 @@ export class PrimitiveClient {
      * @param {boolean} request
      * @param {PrimitiveClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.primitive.getAndReturnBool(true)
      */
@@ -309,6 +324,9 @@ export class PrimitiveClient {
     /**
      * @param {string} request
      * @param {PrimitiveClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.primitive.getAndReturnDatetime("2024-01-15T09:30:00Z")
@@ -367,6 +385,9 @@ export class PrimitiveClient {
      * @param {string} request
      * @param {PrimitiveClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.primitive.getAndReturnDate("2023-01-15")
      */
@@ -424,6 +445,9 @@ export class PrimitiveClient {
      * @param {string} request
      * @param {PrimitiveClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.primitive.getAndReturnUuid("d5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32")
      */
@@ -480,6 +504,9 @@ export class PrimitiveClient {
     /**
      * @param {string} request
      * @param {PrimitiveClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.primitive.getAndReturnBase64("SGVsbG8gd29ybGQh")

--- a/seed/ts-sdk/exhaustive/package-path/src/test-packagePath/api/resources/endpoints/resources/put/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/package-path/src/test-packagePath/api/resources/endpoints/resources/put/client/Client.ts
@@ -25,6 +25,9 @@ export class PutClient {
      * @param {SeedExhaustive.endpoints.PutRequest} request
      * @param {PutClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.put.add({
      *         id: "id"

--- a/seed/ts-sdk/exhaustive/package-path/src/test-packagePath/api/resources/endpoints/resources/union/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/package-path/src/test-packagePath/api/resources/endpoints/resources/union/client/Client.ts
@@ -26,6 +26,9 @@ export class UnionClient {
      * @param {SeedExhaustive.types.Animal} request
      * @param {UnionClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.union.getAndReturnUnion({
      *         animal: "dog",

--- a/seed/ts-sdk/exhaustive/package-path/src/test-packagePath/api/resources/endpoints/resources/urls/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/package-path/src/test-packagePath/api/resources/endpoints/resources/urls/client/Client.ts
@@ -23,6 +23,9 @@ export class UrlsClient {
     /**
      * @param {UrlsClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.urls.withMixedCase()
      */
@@ -69,6 +72,9 @@ export class UrlsClient {
 
     /**
      * @param {UrlsClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.urls.noEndingSlash()
@@ -117,6 +123,9 @@ export class UrlsClient {
     /**
      * @param {UrlsClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.urls.withEndingSlash()
      */
@@ -163,6 +172,9 @@ export class UrlsClient {
 
     /**
      * @param {UrlsClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.urls.withUnderscores()

--- a/seed/ts-sdk/exhaustive/package-path/src/test-packagePath/api/resources/inlinedRequests/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/package-path/src/test-packagePath/api/resources/inlinedRequests/client/Client.ts
@@ -29,6 +29,8 @@ export class InlinedRequestsClient {
      * @param {InlinedRequestsClient.RequestOptions} requestOptions - Request-specific configuration.
      *
      * @throws {@link SeedExhaustive.BadRequestBody}
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.inlinedRequests.postWithObjectBodyandResponse({
@@ -114,6 +116,9 @@ export class InlinedRequestsClient {
      *
      * @param {SeedExhaustive.PostWithArrayBodyAndHeaders} request
      * @param {InlinedRequestsClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.inlinedRequests.postWithArrayBodyAndHeaders({

--- a/seed/ts-sdk/exhaustive/package-path/src/test-packagePath/api/resources/noAuth/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/package-path/src/test-packagePath/api/resources/noAuth/client/Client.ts
@@ -29,6 +29,8 @@ export class NoAuthClient {
      * @param {NoAuthClient.RequestOptions} requestOptions - Request-specific configuration.
      *
      * @throws {@link SeedExhaustive.BadRequestBody}
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.noAuth.postWithNoAuth({

--- a/seed/ts-sdk/exhaustive/package-path/src/test-packagePath/api/resources/noReqBody/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/package-path/src/test-packagePath/api/resources/noReqBody/client/Client.ts
@@ -24,6 +24,9 @@ export class NoReqBodyClient {
     /**
      * @param {NoReqBodyClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.noReqBody.getWithNoRequestBody()
      */
@@ -77,6 +80,9 @@ export class NoReqBodyClient {
 
     /**
      * @param {NoReqBodyClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.noReqBody.postWithNoRequestBody()

--- a/seed/ts-sdk/exhaustive/package-path/src/test-packagePath/api/resources/reqWithHeaders/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/package-path/src/test-packagePath/api/resources/reqWithHeaders/client/Client.ts
@@ -26,6 +26,9 @@ export class ReqWithHeadersClient {
      * @param {SeedExhaustive.ReqWithHeaders} request
      * @param {ReqWithHeadersClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.reqWithHeaders.getWithCustomHeader({
      *         "X-TEST-SERVICE-HEADER": "X-TEST-SERVICE-HEADER",

--- a/seed/ts-sdk/exhaustive/parameter-naming-camel-case/src/api/resources/endpoints/resources/container/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/parameter-naming-camel-case/src/api/resources/endpoints/resources/container/client/Client.ts
@@ -26,6 +26,9 @@ export class ContainerClient {
      * @param {string[]} request
      * @param {ContainerClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.container.getAndReturnListOfPrimitives(["string", "string"])
      */
@@ -87,6 +90,9 @@ export class ContainerClient {
     /**
      * @param {SeedExhaustive.types.ObjectWithRequiredField[]} request
      * @param {ContainerClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.container.getAndReturnListOfObjects([{
@@ -152,6 +158,9 @@ export class ContainerClient {
      * @param {string[]} request
      * @param {ContainerClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.container.getAndReturnSetOfPrimitives(["string"])
      */
@@ -208,6 +217,9 @@ export class ContainerClient {
     /**
      * @param {SeedExhaustive.types.ObjectWithRequiredField[]} request
      * @param {ContainerClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.container.getAndReturnSetOfObjects([{
@@ -271,6 +283,9 @@ export class ContainerClient {
      * @param {Record<string, string>} request
      * @param {ContainerClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.container.getAndReturnMapPrimToPrim({
      *         "string": "string"
@@ -329,6 +344,9 @@ export class ContainerClient {
     /**
      * @param {Record<string, SeedExhaustive.types.ObjectWithRequiredField>} request
      * @param {ContainerClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.container.getAndReturnMapOfPrimToObject({
@@ -399,6 +417,9 @@ export class ContainerClient {
      * @param {Record<string, SeedExhaustive.types.MixedType>} request
      * @param {ContainerClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.container.getAndReturnMapOfPrimToUndiscriminatedUnion({
      *         "string": 1.1
@@ -462,6 +483,9 @@ export class ContainerClient {
     /**
      * @param {SeedExhaustive.types.ObjectWithRequiredField} request
      * @param {ContainerClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.container.getAndReturnOptional({

--- a/seed/ts-sdk/exhaustive/parameter-naming-camel-case/src/api/resources/endpoints/resources/contentType/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/parameter-naming-camel-case/src/api/resources/endpoints/resources/contentType/client/Client.ts
@@ -26,6 +26,9 @@ export class ContentTypeClient {
      * @param {SeedExhaustive.types.ObjectWithOptionalField} request
      * @param {ContentTypeClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.contentType.postJsonPatchContentType({
      *         string: "string",
@@ -98,6 +101,9 @@ export class ContentTypeClient {
     /**
      * @param {SeedExhaustive.types.ObjectWithOptionalField} request
      * @param {ContentTypeClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.contentType.postJsonPatchContentWithCharsetType({

--- a/seed/ts-sdk/exhaustive/parameter-naming-camel-case/src/api/resources/endpoints/resources/enum/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/parameter-naming-camel-case/src/api/resources/endpoints/resources/enum/client/Client.ts
@@ -26,6 +26,9 @@ export class EnumClient {
      * @param {SeedExhaustive.types.WeatherReport} request
      * @param {EnumClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.enum.getAndReturnEnum("SUNNY")
      */

--- a/seed/ts-sdk/exhaustive/parameter-naming-camel-case/src/api/resources/endpoints/resources/httpMethods/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/parameter-naming-camel-case/src/api/resources/endpoints/resources/httpMethods/client/Client.ts
@@ -26,6 +26,9 @@ export class HttpMethodsClient {
      * @param {string} id
      * @param {HttpMethodsClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.httpMethods.testGet("id")
      */
@@ -78,6 +81,9 @@ export class HttpMethodsClient {
      *
      * @param {SeedExhaustive.types.ObjectWithRequiredField} request
      * @param {HttpMethodsClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.httpMethods.testPost({
@@ -143,6 +149,9 @@ export class HttpMethodsClient {
      * @param {string} id
      * @param {SeedExhaustive.types.ObjectWithRequiredField} request
      * @param {HttpMethodsClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.httpMethods.testPut("id", {
@@ -210,6 +219,9 @@ export class HttpMethodsClient {
      * @param {string} id
      * @param {SeedExhaustive.types.ObjectWithOptionalField} request
      * @param {HttpMethodsClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.httpMethods.testPatch("id", {
@@ -290,6 +302,9 @@ export class HttpMethodsClient {
      *
      * @param {string} id
      * @param {HttpMethodsClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.httpMethods.testDelete("id")

--- a/seed/ts-sdk/exhaustive/parameter-naming-camel-case/src/api/resources/endpoints/resources/object/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/parameter-naming-camel-case/src/api/resources/endpoints/resources/object/client/Client.ts
@@ -26,6 +26,9 @@ export class ObjectClient {
      * @param {SeedExhaustive.types.ObjectWithOptionalField} request
      * @param {ObjectClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.object.getAndReturnWithOptionalField({
      *         string: "string",
@@ -107,6 +110,9 @@ export class ObjectClient {
      * @param {SeedExhaustive.types.ObjectWithRequiredField} request
      * @param {ObjectClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.object.getAndReturnWithRequiredField({
      *         string: "string"
@@ -173,6 +179,9 @@ export class ObjectClient {
     /**
      * @param {SeedExhaustive.types.ObjectWithMapOfMap} request
      * @param {ObjectClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.object.getAndReturnWithMapOfMap({
@@ -244,6 +253,9 @@ export class ObjectClient {
     /**
      * @param {SeedExhaustive.types.NestedObjectWithOptionalField} request
      * @param {ObjectClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.object.getAndReturnNestedWithOptionalField({
@@ -332,6 +344,9 @@ export class ObjectClient {
      * @param {SeedExhaustive.types.NestedObjectWithRequiredField} request
      * @param {ObjectClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.object.getAndReturnNestedWithRequiredField("string", {
      *         string: "string",
@@ -419,6 +434,9 @@ export class ObjectClient {
     /**
      * @param {SeedExhaustive.types.NestedObjectWithRequiredField[]} request
      * @param {ObjectClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.object.getAndReturnNestedWithRequiredFieldAsList([{
@@ -525,6 +543,9 @@ export class ObjectClient {
      * @param {SeedExhaustive.types.ObjectWithUnknownField} request
      * @param {ObjectClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.object.getAndReturnWithUnknownField({
      *         unknown: {
@@ -593,6 +614,9 @@ export class ObjectClient {
     /**
      * @param {SeedExhaustive.types.ObjectWithDocumentedUnknownType} request
      * @param {ObjectClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.object.getAndReturnWithDocumentedUnknownType({
@@ -664,6 +688,9 @@ export class ObjectClient {
     /**
      * @param {SeedExhaustive.types.MapOfDocumentedUnknownType} request
      * @param {ObjectClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.object.getAndReturnMapOfDocumentedUnknownType({
@@ -738,6 +765,9 @@ export class ObjectClient {
      *
      * @param {SeedExhaustive.types.ObjectWithMixedRequiredAndOptionalFields} request
      * @param {ObjectClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.object.getAndReturnWithMixedRequiredAndOptionalFields({
@@ -816,6 +846,9 @@ export class ObjectClient {
      * @param {SeedExhaustive.types.ObjectWithRequiredNestedObject} request
      * @param {ObjectClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.object.getAndReturnWithRequiredNestedObject({
      *         requiredString: "hello",
@@ -892,6 +925,9 @@ export class ObjectClient {
      *
      * @param {SeedExhaustive.types.ObjectWithDatetimeLikeString} request
      * @param {ObjectClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.object.getAndReturnWithDatetimeLikeString({

--- a/seed/ts-sdk/exhaustive/parameter-naming-camel-case/src/api/resources/endpoints/resources/pagination/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/parameter-naming-camel-case/src/api/resources/endpoints/resources/pagination/client/Client.ts
@@ -27,6 +27,9 @@ export class PaginationClient {
      * @param {SeedExhaustive.endpoints.ListItemsRequest} request
      * @param {PaginationClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.pagination.listItems({
      *         cursor: "cursor",

--- a/seed/ts-sdk/exhaustive/parameter-naming-camel-case/src/api/resources/endpoints/resources/params/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/parameter-naming-camel-case/src/api/resources/endpoints/resources/params/client/Client.ts
@@ -28,6 +28,9 @@ export class ParamsClient {
      * @param {string} param
      * @param {ParamsClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.params.getWithPath("param")
      */
@@ -80,6 +83,9 @@ export class ParamsClient {
      *
      * @param {SeedExhaustive.endpoints.GetWithInlinePath} request
      * @param {ParamsClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.params.getWithInlinePath({
@@ -139,6 +145,9 @@ export class ParamsClient {
      *
      * @param {SeedExhaustive.endpoints.GetWithQuery} request
      * @param {ParamsClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.params.getWithQuery({
@@ -207,6 +216,9 @@ export class ParamsClient {
      *
      * @param {SeedExhaustive.endpoints.GetWithMultipleQuery} request
      * @param {ParamsClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.params.getWithAllowMultipleQuery({
@@ -277,6 +289,9 @@ export class ParamsClient {
      * @param {SeedExhaustive.endpoints.GetWithPathAndQuery} request
      * @param {ParamsClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.params.getWithPathAndQuery("param", {
      *         query: "query"
@@ -344,6 +359,9 @@ export class ParamsClient {
      *
      * @param {SeedExhaustive.endpoints.GetWithInlinePathAndQuery} request
      * @param {ParamsClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.params.getWithInlinePathAndQuery({
@@ -413,6 +431,9 @@ export class ParamsClient {
      * @param {string} request
      * @param {ParamsClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.params.modifyWithPath("param", "string")
      */
@@ -473,6 +494,9 @@ export class ParamsClient {
      *
      * @param {SeedExhaustive.endpoints.ModifyResourceAtInlinedPath} request
      * @param {ParamsClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.params.modifyWithInlinePath({
@@ -537,6 +561,9 @@ export class ParamsClient {
      * @param {core.file.Uploadable} uploadable
      * @param {string} param
      * @param {ParamsClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     import { createReadStream } from "fs";
@@ -604,6 +631,9 @@ export class ParamsClient {
      *
      * @param {SeedExhaustive.endpoints.CreateWithBodyAndQuery} request
      * @param {ParamsClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.params.createWithBodyAndQuery({
@@ -680,6 +710,9 @@ export class ParamsClient {
      * @param {core.file.Uploadable} uploadable
      * @param {SeedExhaustive.endpoints.UploadBytesWithQuery} request
      * @param {ParamsClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      */
     public uploadBytesWithQuery(
         uploadable: core.file.Uploadable,
@@ -751,6 +784,9 @@ export class ParamsClient {
      * @param {boolean} param
      * @param {ParamsClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.params.getWithBooleanPath(true)
      */
@@ -808,6 +844,8 @@ export class ParamsClient {
      * @param {ParamsClient.RequestOptions} requestOptions - Request-specific configuration.
      *
      * @throws {@link SeedExhaustive.BadRequestBody}
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.params.getWithPathAndErrors("param")

--- a/seed/ts-sdk/exhaustive/parameter-naming-camel-case/src/api/resources/endpoints/resources/primitive/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/parameter-naming-camel-case/src/api/resources/endpoints/resources/primitive/client/Client.ts
@@ -25,6 +25,9 @@ export class PrimitiveClient {
      * @param {string} request
      * @param {PrimitiveClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.primitive.getAndReturnString("string")
      */
@@ -81,6 +84,9 @@ export class PrimitiveClient {
     /**
      * @param {number} request
      * @param {PrimitiveClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.primitive.getAndReturnInt(1)
@@ -139,6 +145,9 @@ export class PrimitiveClient {
      * @param {number} request
      * @param {PrimitiveClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.primitive.getAndReturnLong(1000000)
      */
@@ -195,6 +204,9 @@ export class PrimitiveClient {
     /**
      * @param {number} request
      * @param {PrimitiveClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.primitive.getAndReturnDouble(1.1)
@@ -253,6 +265,9 @@ export class PrimitiveClient {
      * @param {boolean} request
      * @param {PrimitiveClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.primitive.getAndReturnBool(true)
      */
@@ -309,6 +324,9 @@ export class PrimitiveClient {
     /**
      * @param {string} request
      * @param {PrimitiveClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.primitive.getAndReturnDatetime("2024-01-15T09:30:00Z")
@@ -367,6 +385,9 @@ export class PrimitiveClient {
      * @param {string} request
      * @param {PrimitiveClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.primitive.getAndReturnDate("2023-01-15")
      */
@@ -424,6 +445,9 @@ export class PrimitiveClient {
      * @param {string} request
      * @param {PrimitiveClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.primitive.getAndReturnUuid("d5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32")
      */
@@ -480,6 +504,9 @@ export class PrimitiveClient {
     /**
      * @param {string} request
      * @param {PrimitiveClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.primitive.getAndReturnBase64("SGVsbG8gd29ybGQh")

--- a/seed/ts-sdk/exhaustive/parameter-naming-camel-case/src/api/resources/endpoints/resources/put/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/parameter-naming-camel-case/src/api/resources/endpoints/resources/put/client/Client.ts
@@ -25,6 +25,9 @@ export class PutClient {
      * @param {SeedExhaustive.endpoints.PutRequest} request
      * @param {PutClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.put.add({
      *         id: "id"

--- a/seed/ts-sdk/exhaustive/parameter-naming-camel-case/src/api/resources/endpoints/resources/union/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/parameter-naming-camel-case/src/api/resources/endpoints/resources/union/client/Client.ts
@@ -26,6 +26,9 @@ export class UnionClient {
      * @param {SeedExhaustive.types.Animal} request
      * @param {UnionClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.union.getAndReturnUnion({
      *         animal: "dog",

--- a/seed/ts-sdk/exhaustive/parameter-naming-camel-case/src/api/resources/endpoints/resources/urls/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/parameter-naming-camel-case/src/api/resources/endpoints/resources/urls/client/Client.ts
@@ -23,6 +23,9 @@ export class UrlsClient {
     /**
      * @param {UrlsClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.urls.withMixedCase()
      */
@@ -69,6 +72,9 @@ export class UrlsClient {
 
     /**
      * @param {UrlsClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.urls.noEndingSlash()
@@ -117,6 +123,9 @@ export class UrlsClient {
     /**
      * @param {UrlsClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.urls.withEndingSlash()
      */
@@ -163,6 +172,9 @@ export class UrlsClient {
 
     /**
      * @param {UrlsClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.urls.withUnderscores()

--- a/seed/ts-sdk/exhaustive/parameter-naming-camel-case/src/api/resources/inlinedRequests/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/parameter-naming-camel-case/src/api/resources/inlinedRequests/client/Client.ts
@@ -29,6 +29,8 @@ export class InlinedRequestsClient {
      * @param {InlinedRequestsClient.RequestOptions} requestOptions - Request-specific configuration.
      *
      * @throws {@link SeedExhaustive.BadRequestBody}
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.inlinedRequests.postWithObjectBodyandResponse({
@@ -114,6 +116,9 @@ export class InlinedRequestsClient {
      *
      * @param {SeedExhaustive.PostWithArrayBodyAndHeaders} request
      * @param {InlinedRequestsClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.inlinedRequests.postWithArrayBodyAndHeaders({

--- a/seed/ts-sdk/exhaustive/parameter-naming-camel-case/src/api/resources/noAuth/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/parameter-naming-camel-case/src/api/resources/noAuth/client/Client.ts
@@ -29,6 +29,8 @@ export class NoAuthClient {
      * @param {NoAuthClient.RequestOptions} requestOptions - Request-specific configuration.
      *
      * @throws {@link SeedExhaustive.BadRequestBody}
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.noAuth.postWithNoAuth({

--- a/seed/ts-sdk/exhaustive/parameter-naming-camel-case/src/api/resources/noReqBody/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/parameter-naming-camel-case/src/api/resources/noReqBody/client/Client.ts
@@ -24,6 +24,9 @@ export class NoReqBodyClient {
     /**
      * @param {NoReqBodyClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.noReqBody.getWithNoRequestBody()
      */
@@ -77,6 +80,9 @@ export class NoReqBodyClient {
 
     /**
      * @param {NoReqBodyClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.noReqBody.postWithNoRequestBody()

--- a/seed/ts-sdk/exhaustive/parameter-naming-camel-case/src/api/resources/reqWithHeaders/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/parameter-naming-camel-case/src/api/resources/reqWithHeaders/client/Client.ts
@@ -26,6 +26,9 @@ export class ReqWithHeadersClient {
      * @param {SeedExhaustive.ReqWithHeaders} request
      * @param {ReqWithHeadersClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.reqWithHeaders.getWithCustomHeader({
      *         xTestServiceHeader: "X-TEST-SERVICE-HEADER",

--- a/seed/ts-sdk/exhaustive/parameter-naming-original-name/src/api/resources/endpoints/resources/container/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/parameter-naming-original-name/src/api/resources/endpoints/resources/container/client/Client.ts
@@ -26,6 +26,9 @@ export class ContainerClient {
      * @param {string[]} request
      * @param {ContainerClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.container.getAndReturnListOfPrimitives(["string", "string"])
      */
@@ -87,6 +90,9 @@ export class ContainerClient {
     /**
      * @param {SeedExhaustive.types.ObjectWithRequiredField[]} request
      * @param {ContainerClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.container.getAndReturnListOfObjects([{
@@ -152,6 +158,9 @@ export class ContainerClient {
      * @param {string[]} request
      * @param {ContainerClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.container.getAndReturnSetOfPrimitives(["string"])
      */
@@ -208,6 +217,9 @@ export class ContainerClient {
     /**
      * @param {SeedExhaustive.types.ObjectWithRequiredField[]} request
      * @param {ContainerClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.container.getAndReturnSetOfObjects([{
@@ -271,6 +283,9 @@ export class ContainerClient {
      * @param {Record<string, string>} request
      * @param {ContainerClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.container.getAndReturnMapPrimToPrim({
      *         "string": "string"
@@ -329,6 +344,9 @@ export class ContainerClient {
     /**
      * @param {Record<string, SeedExhaustive.types.ObjectWithRequiredField>} request
      * @param {ContainerClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.container.getAndReturnMapOfPrimToObject({
@@ -399,6 +417,9 @@ export class ContainerClient {
      * @param {Record<string, SeedExhaustive.types.MixedType>} request
      * @param {ContainerClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.container.getAndReturnMapOfPrimToUndiscriminatedUnion({
      *         "string": 1.1
@@ -462,6 +483,9 @@ export class ContainerClient {
     /**
      * @param {SeedExhaustive.types.ObjectWithRequiredField} request
      * @param {ContainerClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.container.getAndReturnOptional({

--- a/seed/ts-sdk/exhaustive/parameter-naming-original-name/src/api/resources/endpoints/resources/contentType/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/parameter-naming-original-name/src/api/resources/endpoints/resources/contentType/client/Client.ts
@@ -26,6 +26,9 @@ export class ContentTypeClient {
      * @param {SeedExhaustive.types.ObjectWithOptionalField} request
      * @param {ContentTypeClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.contentType.postJsonPatchContentType({
      *         string: "string",
@@ -98,6 +101,9 @@ export class ContentTypeClient {
     /**
      * @param {SeedExhaustive.types.ObjectWithOptionalField} request
      * @param {ContentTypeClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.contentType.postJsonPatchContentWithCharsetType({

--- a/seed/ts-sdk/exhaustive/parameter-naming-original-name/src/api/resources/endpoints/resources/enum/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/parameter-naming-original-name/src/api/resources/endpoints/resources/enum/client/Client.ts
@@ -26,6 +26,9 @@ export class EnumClient {
      * @param {SeedExhaustive.types.WeatherReport} request
      * @param {EnumClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.enum.getAndReturnEnum("SUNNY")
      */

--- a/seed/ts-sdk/exhaustive/parameter-naming-original-name/src/api/resources/endpoints/resources/httpMethods/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/parameter-naming-original-name/src/api/resources/endpoints/resources/httpMethods/client/Client.ts
@@ -26,6 +26,9 @@ export class HttpMethodsClient {
      * @param {string} id
      * @param {HttpMethodsClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.httpMethods.testGet("id")
      */
@@ -78,6 +81,9 @@ export class HttpMethodsClient {
      *
      * @param {SeedExhaustive.types.ObjectWithRequiredField} request
      * @param {HttpMethodsClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.httpMethods.testPost({
@@ -143,6 +149,9 @@ export class HttpMethodsClient {
      * @param {string} id
      * @param {SeedExhaustive.types.ObjectWithRequiredField} request
      * @param {HttpMethodsClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.httpMethods.testPut("id", {
@@ -210,6 +219,9 @@ export class HttpMethodsClient {
      * @param {string} id
      * @param {SeedExhaustive.types.ObjectWithOptionalField} request
      * @param {HttpMethodsClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.httpMethods.testPatch("id", {
@@ -290,6 +302,9 @@ export class HttpMethodsClient {
      *
      * @param {string} id
      * @param {HttpMethodsClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.httpMethods.testDelete("id")

--- a/seed/ts-sdk/exhaustive/parameter-naming-original-name/src/api/resources/endpoints/resources/object/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/parameter-naming-original-name/src/api/resources/endpoints/resources/object/client/Client.ts
@@ -26,6 +26,9 @@ export class ObjectClient {
      * @param {SeedExhaustive.types.ObjectWithOptionalField} request
      * @param {ObjectClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.object.getAndReturnWithOptionalField({
      *         string: "string",
@@ -107,6 +110,9 @@ export class ObjectClient {
      * @param {SeedExhaustive.types.ObjectWithRequiredField} request
      * @param {ObjectClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.object.getAndReturnWithRequiredField({
      *         string: "string"
@@ -173,6 +179,9 @@ export class ObjectClient {
     /**
      * @param {SeedExhaustive.types.ObjectWithMapOfMap} request
      * @param {ObjectClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.object.getAndReturnWithMapOfMap({
@@ -244,6 +253,9 @@ export class ObjectClient {
     /**
      * @param {SeedExhaustive.types.NestedObjectWithOptionalField} request
      * @param {ObjectClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.object.getAndReturnNestedWithOptionalField({
@@ -332,6 +344,9 @@ export class ObjectClient {
      * @param {SeedExhaustive.types.NestedObjectWithRequiredField} request
      * @param {ObjectClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.object.getAndReturnNestedWithRequiredField("string", {
      *         string: "string",
@@ -419,6 +434,9 @@ export class ObjectClient {
     /**
      * @param {SeedExhaustive.types.NestedObjectWithRequiredField[]} request
      * @param {ObjectClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.object.getAndReturnNestedWithRequiredFieldAsList([{
@@ -525,6 +543,9 @@ export class ObjectClient {
      * @param {SeedExhaustive.types.ObjectWithUnknownField} request
      * @param {ObjectClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.object.getAndReturnWithUnknownField({
      *         unknown: {
@@ -593,6 +614,9 @@ export class ObjectClient {
     /**
      * @param {SeedExhaustive.types.ObjectWithDocumentedUnknownType} request
      * @param {ObjectClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.object.getAndReturnWithDocumentedUnknownType({
@@ -664,6 +688,9 @@ export class ObjectClient {
     /**
      * @param {SeedExhaustive.types.MapOfDocumentedUnknownType} request
      * @param {ObjectClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.object.getAndReturnMapOfDocumentedUnknownType({
@@ -738,6 +765,9 @@ export class ObjectClient {
      *
      * @param {SeedExhaustive.types.ObjectWithMixedRequiredAndOptionalFields} request
      * @param {ObjectClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.object.getAndReturnWithMixedRequiredAndOptionalFields({
@@ -816,6 +846,9 @@ export class ObjectClient {
      * @param {SeedExhaustive.types.ObjectWithRequiredNestedObject} request
      * @param {ObjectClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.object.getAndReturnWithRequiredNestedObject({
      *         requiredString: "hello",
@@ -892,6 +925,9 @@ export class ObjectClient {
      *
      * @param {SeedExhaustive.types.ObjectWithDatetimeLikeString} request
      * @param {ObjectClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.object.getAndReturnWithDatetimeLikeString({

--- a/seed/ts-sdk/exhaustive/parameter-naming-original-name/src/api/resources/endpoints/resources/pagination/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/parameter-naming-original-name/src/api/resources/endpoints/resources/pagination/client/Client.ts
@@ -27,6 +27,9 @@ export class PaginationClient {
      * @param {SeedExhaustive.endpoints.ListItemsRequest} request
      * @param {PaginationClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.pagination.listItems({
      *         cursor: "cursor",

--- a/seed/ts-sdk/exhaustive/parameter-naming-original-name/src/api/resources/endpoints/resources/params/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/parameter-naming-original-name/src/api/resources/endpoints/resources/params/client/Client.ts
@@ -28,6 +28,9 @@ export class ParamsClient {
      * @param {string} param
      * @param {ParamsClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.params.getWithPath("param")
      */
@@ -80,6 +83,9 @@ export class ParamsClient {
      *
      * @param {SeedExhaustive.endpoints.GetWithInlinePath} request
      * @param {ParamsClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.params.getWithInlinePath({
@@ -139,6 +145,9 @@ export class ParamsClient {
      *
      * @param {SeedExhaustive.endpoints.GetWithQuery} request
      * @param {ParamsClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.params.getWithQuery({
@@ -207,6 +216,9 @@ export class ParamsClient {
      *
      * @param {SeedExhaustive.endpoints.GetWithMultipleQuery} request
      * @param {ParamsClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.params.getWithAllowMultipleQuery({
@@ -277,6 +289,9 @@ export class ParamsClient {
      * @param {SeedExhaustive.endpoints.GetWithPathAndQuery} request
      * @param {ParamsClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.params.getWithPathAndQuery("param", {
      *         query: "query"
@@ -344,6 +359,9 @@ export class ParamsClient {
      *
      * @param {SeedExhaustive.endpoints.GetWithInlinePathAndQuery} request
      * @param {ParamsClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.params.getWithInlinePathAndQuery({
@@ -413,6 +431,9 @@ export class ParamsClient {
      * @param {string} request
      * @param {ParamsClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.params.modifyWithPath("param", "string")
      */
@@ -473,6 +494,9 @@ export class ParamsClient {
      *
      * @param {SeedExhaustive.endpoints.ModifyResourceAtInlinedPath} request
      * @param {ParamsClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.params.modifyWithInlinePath({
@@ -537,6 +561,9 @@ export class ParamsClient {
      * @param {core.file.Uploadable} uploadable
      * @param {string} param
      * @param {ParamsClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     import { createReadStream } from "fs";
@@ -604,6 +631,9 @@ export class ParamsClient {
      *
      * @param {SeedExhaustive.endpoints.CreateWithBodyAndQuery} request
      * @param {ParamsClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.params.createWithBodyAndQuery({
@@ -680,6 +710,9 @@ export class ParamsClient {
      * @param {core.file.Uploadable} uploadable
      * @param {SeedExhaustive.endpoints.UploadBytesWithQuery} request
      * @param {ParamsClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      */
     public uploadBytesWithQuery(
         uploadable: core.file.Uploadable,
@@ -751,6 +784,9 @@ export class ParamsClient {
      * @param {boolean} param
      * @param {ParamsClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.params.getWithBooleanPath(true)
      */
@@ -808,6 +844,8 @@ export class ParamsClient {
      * @param {ParamsClient.RequestOptions} requestOptions - Request-specific configuration.
      *
      * @throws {@link SeedExhaustive.BadRequestBody}
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.params.getWithPathAndErrors("param")

--- a/seed/ts-sdk/exhaustive/parameter-naming-original-name/src/api/resources/endpoints/resources/primitive/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/parameter-naming-original-name/src/api/resources/endpoints/resources/primitive/client/Client.ts
@@ -25,6 +25,9 @@ export class PrimitiveClient {
      * @param {string} request
      * @param {PrimitiveClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.primitive.getAndReturnString("string")
      */
@@ -81,6 +84,9 @@ export class PrimitiveClient {
     /**
      * @param {number} request
      * @param {PrimitiveClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.primitive.getAndReturnInt(1)
@@ -139,6 +145,9 @@ export class PrimitiveClient {
      * @param {number} request
      * @param {PrimitiveClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.primitive.getAndReturnLong(1000000)
      */
@@ -195,6 +204,9 @@ export class PrimitiveClient {
     /**
      * @param {number} request
      * @param {PrimitiveClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.primitive.getAndReturnDouble(1.1)
@@ -253,6 +265,9 @@ export class PrimitiveClient {
      * @param {boolean} request
      * @param {PrimitiveClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.primitive.getAndReturnBool(true)
      */
@@ -309,6 +324,9 @@ export class PrimitiveClient {
     /**
      * @param {string} request
      * @param {PrimitiveClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.primitive.getAndReturnDatetime("2024-01-15T09:30:00Z")
@@ -367,6 +385,9 @@ export class PrimitiveClient {
      * @param {string} request
      * @param {PrimitiveClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.primitive.getAndReturnDate("2023-01-15")
      */
@@ -424,6 +445,9 @@ export class PrimitiveClient {
      * @param {string} request
      * @param {PrimitiveClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.primitive.getAndReturnUuid("d5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32")
      */
@@ -480,6 +504,9 @@ export class PrimitiveClient {
     /**
      * @param {string} request
      * @param {PrimitiveClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.primitive.getAndReturnBase64("SGVsbG8gd29ybGQh")

--- a/seed/ts-sdk/exhaustive/parameter-naming-original-name/src/api/resources/endpoints/resources/put/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/parameter-naming-original-name/src/api/resources/endpoints/resources/put/client/Client.ts
@@ -25,6 +25,9 @@ export class PutClient {
      * @param {SeedExhaustive.endpoints.PutRequest} request
      * @param {PutClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.put.add({
      *         id: "id"

--- a/seed/ts-sdk/exhaustive/parameter-naming-original-name/src/api/resources/endpoints/resources/union/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/parameter-naming-original-name/src/api/resources/endpoints/resources/union/client/Client.ts
@@ -26,6 +26,9 @@ export class UnionClient {
      * @param {SeedExhaustive.types.Animal} request
      * @param {UnionClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.union.getAndReturnUnion({
      *         animal: "dog",

--- a/seed/ts-sdk/exhaustive/parameter-naming-original-name/src/api/resources/endpoints/resources/urls/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/parameter-naming-original-name/src/api/resources/endpoints/resources/urls/client/Client.ts
@@ -23,6 +23,9 @@ export class UrlsClient {
     /**
      * @param {UrlsClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.urls.withMixedCase()
      */
@@ -69,6 +72,9 @@ export class UrlsClient {
 
     /**
      * @param {UrlsClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.urls.noEndingSlash()
@@ -117,6 +123,9 @@ export class UrlsClient {
     /**
      * @param {UrlsClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.urls.withEndingSlash()
      */
@@ -163,6 +172,9 @@ export class UrlsClient {
 
     /**
      * @param {UrlsClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.urls.withUnderscores()

--- a/seed/ts-sdk/exhaustive/parameter-naming-original-name/src/api/resources/inlinedRequests/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/parameter-naming-original-name/src/api/resources/inlinedRequests/client/Client.ts
@@ -29,6 +29,8 @@ export class InlinedRequestsClient {
      * @param {InlinedRequestsClient.RequestOptions} requestOptions - Request-specific configuration.
      *
      * @throws {@link SeedExhaustive.BadRequestBody}
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.inlinedRequests.postWithObjectBodyandResponse({
@@ -114,6 +116,9 @@ export class InlinedRequestsClient {
      *
      * @param {SeedExhaustive.PostWithArrayBodyAndHeaders} request
      * @param {InlinedRequestsClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.inlinedRequests.postWithArrayBodyAndHeaders({

--- a/seed/ts-sdk/exhaustive/parameter-naming-original-name/src/api/resources/noAuth/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/parameter-naming-original-name/src/api/resources/noAuth/client/Client.ts
@@ -29,6 +29,8 @@ export class NoAuthClient {
      * @param {NoAuthClient.RequestOptions} requestOptions - Request-specific configuration.
      *
      * @throws {@link SeedExhaustive.BadRequestBody}
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.noAuth.postWithNoAuth({

--- a/seed/ts-sdk/exhaustive/parameter-naming-original-name/src/api/resources/noReqBody/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/parameter-naming-original-name/src/api/resources/noReqBody/client/Client.ts
@@ -24,6 +24,9 @@ export class NoReqBodyClient {
     /**
      * @param {NoReqBodyClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.noReqBody.getWithNoRequestBody()
      */
@@ -77,6 +80,9 @@ export class NoReqBodyClient {
 
     /**
      * @param {NoReqBodyClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.noReqBody.postWithNoRequestBody()

--- a/seed/ts-sdk/exhaustive/parameter-naming-original-name/src/api/resources/reqWithHeaders/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/parameter-naming-original-name/src/api/resources/reqWithHeaders/client/Client.ts
@@ -26,6 +26,9 @@ export class ReqWithHeadersClient {
      * @param {SeedExhaustive.ReqWithHeaders} request
      * @param {ReqWithHeadersClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.reqWithHeaders.getWithCustomHeader({
      *         "X-TEST-SERVICE-HEADER": "X-TEST-SERVICE-HEADER",

--- a/seed/ts-sdk/exhaustive/parameter-naming-snake-case/src/api/resources/endpoints/resources/container/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/parameter-naming-snake-case/src/api/resources/endpoints/resources/container/client/Client.ts
@@ -26,6 +26,9 @@ export class ContainerClient {
      * @param {string[]} request
      * @param {ContainerClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.container.getAndReturnListOfPrimitives(["string", "string"])
      */
@@ -87,6 +90,9 @@ export class ContainerClient {
     /**
      * @param {SeedExhaustive.types.ObjectWithRequiredField[]} request
      * @param {ContainerClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.container.getAndReturnListOfObjects([{
@@ -152,6 +158,9 @@ export class ContainerClient {
      * @param {string[]} request
      * @param {ContainerClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.container.getAndReturnSetOfPrimitives(["string"])
      */
@@ -208,6 +217,9 @@ export class ContainerClient {
     /**
      * @param {SeedExhaustive.types.ObjectWithRequiredField[]} request
      * @param {ContainerClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.container.getAndReturnSetOfObjects([{
@@ -271,6 +283,9 @@ export class ContainerClient {
      * @param {Record<string, string>} request
      * @param {ContainerClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.container.getAndReturnMapPrimToPrim({
      *         "string": "string"
@@ -329,6 +344,9 @@ export class ContainerClient {
     /**
      * @param {Record<string, SeedExhaustive.types.ObjectWithRequiredField>} request
      * @param {ContainerClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.container.getAndReturnMapOfPrimToObject({
@@ -399,6 +417,9 @@ export class ContainerClient {
      * @param {Record<string, SeedExhaustive.types.MixedType>} request
      * @param {ContainerClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.container.getAndReturnMapOfPrimToUndiscriminatedUnion({
      *         "string": 1.1
@@ -462,6 +483,9 @@ export class ContainerClient {
     /**
      * @param {SeedExhaustive.types.ObjectWithRequiredField} request
      * @param {ContainerClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.container.getAndReturnOptional({

--- a/seed/ts-sdk/exhaustive/parameter-naming-snake-case/src/api/resources/endpoints/resources/contentType/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/parameter-naming-snake-case/src/api/resources/endpoints/resources/contentType/client/Client.ts
@@ -26,6 +26,9 @@ export class ContentTypeClient {
      * @param {SeedExhaustive.types.ObjectWithOptionalField} request
      * @param {ContentTypeClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.contentType.postJsonPatchContentType({
      *         string: "string",
@@ -98,6 +101,9 @@ export class ContentTypeClient {
     /**
      * @param {SeedExhaustive.types.ObjectWithOptionalField} request
      * @param {ContentTypeClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.contentType.postJsonPatchContentWithCharsetType({

--- a/seed/ts-sdk/exhaustive/parameter-naming-snake-case/src/api/resources/endpoints/resources/enum/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/parameter-naming-snake-case/src/api/resources/endpoints/resources/enum/client/Client.ts
@@ -26,6 +26,9 @@ export class EnumClient {
      * @param {SeedExhaustive.types.WeatherReport} request
      * @param {EnumClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.enum.getAndReturnEnum("SUNNY")
      */

--- a/seed/ts-sdk/exhaustive/parameter-naming-snake-case/src/api/resources/endpoints/resources/httpMethods/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/parameter-naming-snake-case/src/api/resources/endpoints/resources/httpMethods/client/Client.ts
@@ -26,6 +26,9 @@ export class HttpMethodsClient {
      * @param {string} id
      * @param {HttpMethodsClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.httpMethods.testGet("id")
      */
@@ -78,6 +81,9 @@ export class HttpMethodsClient {
      *
      * @param {SeedExhaustive.types.ObjectWithRequiredField} request
      * @param {HttpMethodsClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.httpMethods.testPost({
@@ -143,6 +149,9 @@ export class HttpMethodsClient {
      * @param {string} id
      * @param {SeedExhaustive.types.ObjectWithRequiredField} request
      * @param {HttpMethodsClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.httpMethods.testPut("id", {
@@ -210,6 +219,9 @@ export class HttpMethodsClient {
      * @param {string} id
      * @param {SeedExhaustive.types.ObjectWithOptionalField} request
      * @param {HttpMethodsClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.httpMethods.testPatch("id", {
@@ -290,6 +302,9 @@ export class HttpMethodsClient {
      *
      * @param {string} id
      * @param {HttpMethodsClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.httpMethods.testDelete("id")

--- a/seed/ts-sdk/exhaustive/parameter-naming-snake-case/src/api/resources/endpoints/resources/object/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/parameter-naming-snake-case/src/api/resources/endpoints/resources/object/client/Client.ts
@@ -26,6 +26,9 @@ export class ObjectClient {
      * @param {SeedExhaustive.types.ObjectWithOptionalField} request
      * @param {ObjectClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.object.getAndReturnWithOptionalField({
      *         string: "string",
@@ -107,6 +110,9 @@ export class ObjectClient {
      * @param {SeedExhaustive.types.ObjectWithRequiredField} request
      * @param {ObjectClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.object.getAndReturnWithRequiredField({
      *         string: "string"
@@ -173,6 +179,9 @@ export class ObjectClient {
     /**
      * @param {SeedExhaustive.types.ObjectWithMapOfMap} request
      * @param {ObjectClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.object.getAndReturnWithMapOfMap({
@@ -244,6 +253,9 @@ export class ObjectClient {
     /**
      * @param {SeedExhaustive.types.NestedObjectWithOptionalField} request
      * @param {ObjectClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.object.getAndReturnNestedWithOptionalField({
@@ -332,6 +344,9 @@ export class ObjectClient {
      * @param {SeedExhaustive.types.NestedObjectWithRequiredField} request
      * @param {ObjectClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.object.getAndReturnNestedWithRequiredField("string", {
      *         string: "string",
@@ -419,6 +434,9 @@ export class ObjectClient {
     /**
      * @param {SeedExhaustive.types.NestedObjectWithRequiredField[]} request
      * @param {ObjectClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.object.getAndReturnNestedWithRequiredFieldAsList([{
@@ -525,6 +543,9 @@ export class ObjectClient {
      * @param {SeedExhaustive.types.ObjectWithUnknownField} request
      * @param {ObjectClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.object.getAndReturnWithUnknownField({
      *         unknown: {
@@ -593,6 +614,9 @@ export class ObjectClient {
     /**
      * @param {SeedExhaustive.types.ObjectWithDocumentedUnknownType} request
      * @param {ObjectClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.object.getAndReturnWithDocumentedUnknownType({
@@ -664,6 +688,9 @@ export class ObjectClient {
     /**
      * @param {SeedExhaustive.types.MapOfDocumentedUnknownType} request
      * @param {ObjectClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.object.getAndReturnMapOfDocumentedUnknownType({
@@ -738,6 +765,9 @@ export class ObjectClient {
      *
      * @param {SeedExhaustive.types.ObjectWithMixedRequiredAndOptionalFields} request
      * @param {ObjectClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.object.getAndReturnWithMixedRequiredAndOptionalFields({
@@ -816,6 +846,9 @@ export class ObjectClient {
      * @param {SeedExhaustive.types.ObjectWithRequiredNestedObject} request
      * @param {ObjectClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.object.getAndReturnWithRequiredNestedObject({
      *         requiredString: "hello",
@@ -892,6 +925,9 @@ export class ObjectClient {
      *
      * @param {SeedExhaustive.types.ObjectWithDatetimeLikeString} request
      * @param {ObjectClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.object.getAndReturnWithDatetimeLikeString({

--- a/seed/ts-sdk/exhaustive/parameter-naming-snake-case/src/api/resources/endpoints/resources/pagination/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/parameter-naming-snake-case/src/api/resources/endpoints/resources/pagination/client/Client.ts
@@ -27,6 +27,9 @@ export class PaginationClient {
      * @param {SeedExhaustive.endpoints.ListItemsRequest} request
      * @param {PaginationClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.pagination.listItems({
      *         cursor: "cursor",

--- a/seed/ts-sdk/exhaustive/parameter-naming-snake-case/src/api/resources/endpoints/resources/params/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/parameter-naming-snake-case/src/api/resources/endpoints/resources/params/client/Client.ts
@@ -28,6 +28,9 @@ export class ParamsClient {
      * @param {string} param
      * @param {ParamsClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.params.getWithPath("param")
      */
@@ -80,6 +83,9 @@ export class ParamsClient {
      *
      * @param {SeedExhaustive.endpoints.GetWithInlinePath} request
      * @param {ParamsClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.params.getWithInlinePath({
@@ -139,6 +145,9 @@ export class ParamsClient {
      *
      * @param {SeedExhaustive.endpoints.GetWithQuery} request
      * @param {ParamsClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.params.getWithQuery({
@@ -207,6 +216,9 @@ export class ParamsClient {
      *
      * @param {SeedExhaustive.endpoints.GetWithMultipleQuery} request
      * @param {ParamsClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.params.getWithAllowMultipleQuery({
@@ -277,6 +289,9 @@ export class ParamsClient {
      * @param {SeedExhaustive.endpoints.GetWithPathAndQuery} request
      * @param {ParamsClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.params.getWithPathAndQuery("param", {
      *         query: "query"
@@ -344,6 +359,9 @@ export class ParamsClient {
      *
      * @param {SeedExhaustive.endpoints.GetWithInlinePathAndQuery} request
      * @param {ParamsClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.params.getWithInlinePathAndQuery({
@@ -413,6 +431,9 @@ export class ParamsClient {
      * @param {string} request
      * @param {ParamsClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.params.modifyWithPath("param", "string")
      */
@@ -473,6 +494,9 @@ export class ParamsClient {
      *
      * @param {SeedExhaustive.endpoints.ModifyResourceAtInlinedPath} request
      * @param {ParamsClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.params.modifyWithInlinePath({
@@ -537,6 +561,9 @@ export class ParamsClient {
      * @param {core.file.Uploadable} uploadable
      * @param {string} param
      * @param {ParamsClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     import { createReadStream } from "fs";
@@ -604,6 +631,9 @@ export class ParamsClient {
      *
      * @param {SeedExhaustive.endpoints.CreateWithBodyAndQuery} request
      * @param {ParamsClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.params.createWithBodyAndQuery({
@@ -680,6 +710,9 @@ export class ParamsClient {
      * @param {core.file.Uploadable} uploadable
      * @param {SeedExhaustive.endpoints.UploadBytesWithQuery} request
      * @param {ParamsClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      */
     public uploadBytesWithQuery(
         uploadable: core.file.Uploadable,
@@ -751,6 +784,9 @@ export class ParamsClient {
      * @param {boolean} param
      * @param {ParamsClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.params.getWithBooleanPath(true)
      */
@@ -808,6 +844,8 @@ export class ParamsClient {
      * @param {ParamsClient.RequestOptions} requestOptions - Request-specific configuration.
      *
      * @throws {@link SeedExhaustive.BadRequestBody}
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.params.getWithPathAndErrors("param")

--- a/seed/ts-sdk/exhaustive/parameter-naming-snake-case/src/api/resources/endpoints/resources/primitive/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/parameter-naming-snake-case/src/api/resources/endpoints/resources/primitive/client/Client.ts
@@ -25,6 +25,9 @@ export class PrimitiveClient {
      * @param {string} request
      * @param {PrimitiveClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.primitive.getAndReturnString("string")
      */
@@ -81,6 +84,9 @@ export class PrimitiveClient {
     /**
      * @param {number} request
      * @param {PrimitiveClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.primitive.getAndReturnInt(1)
@@ -139,6 +145,9 @@ export class PrimitiveClient {
      * @param {number} request
      * @param {PrimitiveClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.primitive.getAndReturnLong(1000000)
      */
@@ -195,6 +204,9 @@ export class PrimitiveClient {
     /**
      * @param {number} request
      * @param {PrimitiveClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.primitive.getAndReturnDouble(1.1)
@@ -253,6 +265,9 @@ export class PrimitiveClient {
      * @param {boolean} request
      * @param {PrimitiveClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.primitive.getAndReturnBool(true)
      */
@@ -309,6 +324,9 @@ export class PrimitiveClient {
     /**
      * @param {string} request
      * @param {PrimitiveClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.primitive.getAndReturnDatetime("2024-01-15T09:30:00Z")
@@ -367,6 +385,9 @@ export class PrimitiveClient {
      * @param {string} request
      * @param {PrimitiveClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.primitive.getAndReturnDate("2023-01-15")
      */
@@ -424,6 +445,9 @@ export class PrimitiveClient {
      * @param {string} request
      * @param {PrimitiveClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.primitive.getAndReturnUuid("d5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32")
      */
@@ -480,6 +504,9 @@ export class PrimitiveClient {
     /**
      * @param {string} request
      * @param {PrimitiveClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.primitive.getAndReturnBase64("SGVsbG8gd29ybGQh")

--- a/seed/ts-sdk/exhaustive/parameter-naming-snake-case/src/api/resources/endpoints/resources/put/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/parameter-naming-snake-case/src/api/resources/endpoints/resources/put/client/Client.ts
@@ -25,6 +25,9 @@ export class PutClient {
      * @param {SeedExhaustive.endpoints.PutRequest} request
      * @param {PutClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.put.add({
      *         id: "id"

--- a/seed/ts-sdk/exhaustive/parameter-naming-snake-case/src/api/resources/endpoints/resources/union/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/parameter-naming-snake-case/src/api/resources/endpoints/resources/union/client/Client.ts
@@ -26,6 +26,9 @@ export class UnionClient {
      * @param {SeedExhaustive.types.Animal} request
      * @param {UnionClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.union.getAndReturnUnion({
      *         animal: "dog",

--- a/seed/ts-sdk/exhaustive/parameter-naming-snake-case/src/api/resources/endpoints/resources/urls/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/parameter-naming-snake-case/src/api/resources/endpoints/resources/urls/client/Client.ts
@@ -23,6 +23,9 @@ export class UrlsClient {
     /**
      * @param {UrlsClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.urls.withMixedCase()
      */
@@ -69,6 +72,9 @@ export class UrlsClient {
 
     /**
      * @param {UrlsClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.urls.noEndingSlash()
@@ -117,6 +123,9 @@ export class UrlsClient {
     /**
      * @param {UrlsClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.urls.withEndingSlash()
      */
@@ -163,6 +172,9 @@ export class UrlsClient {
 
     /**
      * @param {UrlsClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.urls.withUnderscores()

--- a/seed/ts-sdk/exhaustive/parameter-naming-snake-case/src/api/resources/inlinedRequests/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/parameter-naming-snake-case/src/api/resources/inlinedRequests/client/Client.ts
@@ -29,6 +29,8 @@ export class InlinedRequestsClient {
      * @param {InlinedRequestsClient.RequestOptions} requestOptions - Request-specific configuration.
      *
      * @throws {@link SeedExhaustive.BadRequestBody}
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.inlinedRequests.postWithObjectBodyandResponse({
@@ -114,6 +116,9 @@ export class InlinedRequestsClient {
      *
      * @param {SeedExhaustive.PostWithArrayBodyAndHeaders} request
      * @param {InlinedRequestsClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.inlinedRequests.postWithArrayBodyAndHeaders({

--- a/seed/ts-sdk/exhaustive/parameter-naming-snake-case/src/api/resources/noAuth/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/parameter-naming-snake-case/src/api/resources/noAuth/client/Client.ts
@@ -29,6 +29,8 @@ export class NoAuthClient {
      * @param {NoAuthClient.RequestOptions} requestOptions - Request-specific configuration.
      *
      * @throws {@link SeedExhaustive.BadRequestBody}
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.noAuth.postWithNoAuth({

--- a/seed/ts-sdk/exhaustive/parameter-naming-snake-case/src/api/resources/noReqBody/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/parameter-naming-snake-case/src/api/resources/noReqBody/client/Client.ts
@@ -24,6 +24,9 @@ export class NoReqBodyClient {
     /**
      * @param {NoReqBodyClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.noReqBody.getWithNoRequestBody()
      */
@@ -77,6 +80,9 @@ export class NoReqBodyClient {
 
     /**
      * @param {NoReqBodyClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.noReqBody.postWithNoRequestBody()

--- a/seed/ts-sdk/exhaustive/parameter-naming-snake-case/src/api/resources/reqWithHeaders/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/parameter-naming-snake-case/src/api/resources/reqWithHeaders/client/Client.ts
@@ -26,6 +26,9 @@ export class ReqWithHeadersClient {
      * @param {SeedExhaustive.ReqWithHeaders} request
      * @param {ReqWithHeadersClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.reqWithHeaders.getWithCustomHeader({
      *         x_test_service_header: "X-TEST-SERVICE-HEADER",

--- a/seed/ts-sdk/exhaustive/parameter-naming-wire-value/src/api/resources/endpoints/resources/container/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/parameter-naming-wire-value/src/api/resources/endpoints/resources/container/client/Client.ts
@@ -26,6 +26,9 @@ export class ContainerClient {
      * @param {string[]} request
      * @param {ContainerClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.container.getAndReturnListOfPrimitives(["string", "string"])
      */
@@ -87,6 +90,9 @@ export class ContainerClient {
     /**
      * @param {SeedExhaustive.types.ObjectWithRequiredField[]} request
      * @param {ContainerClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.container.getAndReturnListOfObjects([{
@@ -152,6 +158,9 @@ export class ContainerClient {
      * @param {string[]} request
      * @param {ContainerClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.container.getAndReturnSetOfPrimitives(["string"])
      */
@@ -208,6 +217,9 @@ export class ContainerClient {
     /**
      * @param {SeedExhaustive.types.ObjectWithRequiredField[]} request
      * @param {ContainerClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.container.getAndReturnSetOfObjects([{
@@ -271,6 +283,9 @@ export class ContainerClient {
      * @param {Record<string, string>} request
      * @param {ContainerClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.container.getAndReturnMapPrimToPrim({
      *         "string": "string"
@@ -329,6 +344,9 @@ export class ContainerClient {
     /**
      * @param {Record<string, SeedExhaustive.types.ObjectWithRequiredField>} request
      * @param {ContainerClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.container.getAndReturnMapOfPrimToObject({
@@ -399,6 +417,9 @@ export class ContainerClient {
      * @param {Record<string, SeedExhaustive.types.MixedType>} request
      * @param {ContainerClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.container.getAndReturnMapOfPrimToUndiscriminatedUnion({
      *         "string": 1.1
@@ -462,6 +483,9 @@ export class ContainerClient {
     /**
      * @param {SeedExhaustive.types.ObjectWithRequiredField} request
      * @param {ContainerClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.container.getAndReturnOptional({

--- a/seed/ts-sdk/exhaustive/parameter-naming-wire-value/src/api/resources/endpoints/resources/contentType/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/parameter-naming-wire-value/src/api/resources/endpoints/resources/contentType/client/Client.ts
@@ -26,6 +26,9 @@ export class ContentTypeClient {
      * @param {SeedExhaustive.types.ObjectWithOptionalField} request
      * @param {ContentTypeClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.contentType.postJsonPatchContentType({
      *         string: "string",
@@ -98,6 +101,9 @@ export class ContentTypeClient {
     /**
      * @param {SeedExhaustive.types.ObjectWithOptionalField} request
      * @param {ContentTypeClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.contentType.postJsonPatchContentWithCharsetType({

--- a/seed/ts-sdk/exhaustive/parameter-naming-wire-value/src/api/resources/endpoints/resources/enum/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/parameter-naming-wire-value/src/api/resources/endpoints/resources/enum/client/Client.ts
@@ -26,6 +26,9 @@ export class EnumClient {
      * @param {SeedExhaustive.types.WeatherReport} request
      * @param {EnumClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.enum.getAndReturnEnum("SUNNY")
      */

--- a/seed/ts-sdk/exhaustive/parameter-naming-wire-value/src/api/resources/endpoints/resources/httpMethods/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/parameter-naming-wire-value/src/api/resources/endpoints/resources/httpMethods/client/Client.ts
@@ -26,6 +26,9 @@ export class HttpMethodsClient {
      * @param {string} id
      * @param {HttpMethodsClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.httpMethods.testGet("id")
      */
@@ -78,6 +81,9 @@ export class HttpMethodsClient {
      *
      * @param {SeedExhaustive.types.ObjectWithRequiredField} request
      * @param {HttpMethodsClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.httpMethods.testPost({
@@ -143,6 +149,9 @@ export class HttpMethodsClient {
      * @param {string} id
      * @param {SeedExhaustive.types.ObjectWithRequiredField} request
      * @param {HttpMethodsClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.httpMethods.testPut("id", {
@@ -210,6 +219,9 @@ export class HttpMethodsClient {
      * @param {string} id
      * @param {SeedExhaustive.types.ObjectWithOptionalField} request
      * @param {HttpMethodsClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.httpMethods.testPatch("id", {
@@ -290,6 +302,9 @@ export class HttpMethodsClient {
      *
      * @param {string} id
      * @param {HttpMethodsClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.httpMethods.testDelete("id")

--- a/seed/ts-sdk/exhaustive/parameter-naming-wire-value/src/api/resources/endpoints/resources/object/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/parameter-naming-wire-value/src/api/resources/endpoints/resources/object/client/Client.ts
@@ -26,6 +26,9 @@ export class ObjectClient {
      * @param {SeedExhaustive.types.ObjectWithOptionalField} request
      * @param {ObjectClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.object.getAndReturnWithOptionalField({
      *         string: "string",
@@ -107,6 +110,9 @@ export class ObjectClient {
      * @param {SeedExhaustive.types.ObjectWithRequiredField} request
      * @param {ObjectClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.object.getAndReturnWithRequiredField({
      *         string: "string"
@@ -173,6 +179,9 @@ export class ObjectClient {
     /**
      * @param {SeedExhaustive.types.ObjectWithMapOfMap} request
      * @param {ObjectClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.object.getAndReturnWithMapOfMap({
@@ -244,6 +253,9 @@ export class ObjectClient {
     /**
      * @param {SeedExhaustive.types.NestedObjectWithOptionalField} request
      * @param {ObjectClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.object.getAndReturnNestedWithOptionalField({
@@ -332,6 +344,9 @@ export class ObjectClient {
      * @param {SeedExhaustive.types.NestedObjectWithRequiredField} request
      * @param {ObjectClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.object.getAndReturnNestedWithRequiredField("string", {
      *         string: "string",
@@ -419,6 +434,9 @@ export class ObjectClient {
     /**
      * @param {SeedExhaustive.types.NestedObjectWithRequiredField[]} request
      * @param {ObjectClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.object.getAndReturnNestedWithRequiredFieldAsList([{
@@ -525,6 +543,9 @@ export class ObjectClient {
      * @param {SeedExhaustive.types.ObjectWithUnknownField} request
      * @param {ObjectClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.object.getAndReturnWithUnknownField({
      *         unknown: {
@@ -593,6 +614,9 @@ export class ObjectClient {
     /**
      * @param {SeedExhaustive.types.ObjectWithDocumentedUnknownType} request
      * @param {ObjectClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.object.getAndReturnWithDocumentedUnknownType({
@@ -664,6 +688,9 @@ export class ObjectClient {
     /**
      * @param {SeedExhaustive.types.MapOfDocumentedUnknownType} request
      * @param {ObjectClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.object.getAndReturnMapOfDocumentedUnknownType({
@@ -738,6 +765,9 @@ export class ObjectClient {
      *
      * @param {SeedExhaustive.types.ObjectWithMixedRequiredAndOptionalFields} request
      * @param {ObjectClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.object.getAndReturnWithMixedRequiredAndOptionalFields({
@@ -816,6 +846,9 @@ export class ObjectClient {
      * @param {SeedExhaustive.types.ObjectWithRequiredNestedObject} request
      * @param {ObjectClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.object.getAndReturnWithRequiredNestedObject({
      *         requiredString: "hello",
@@ -892,6 +925,9 @@ export class ObjectClient {
      *
      * @param {SeedExhaustive.types.ObjectWithDatetimeLikeString} request
      * @param {ObjectClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.object.getAndReturnWithDatetimeLikeString({

--- a/seed/ts-sdk/exhaustive/parameter-naming-wire-value/src/api/resources/endpoints/resources/pagination/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/parameter-naming-wire-value/src/api/resources/endpoints/resources/pagination/client/Client.ts
@@ -27,6 +27,9 @@ export class PaginationClient {
      * @param {SeedExhaustive.endpoints.ListItemsRequest} request
      * @param {PaginationClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.pagination.listItems({
      *         cursor: "cursor",

--- a/seed/ts-sdk/exhaustive/parameter-naming-wire-value/src/api/resources/endpoints/resources/params/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/parameter-naming-wire-value/src/api/resources/endpoints/resources/params/client/Client.ts
@@ -28,6 +28,9 @@ export class ParamsClient {
      * @param {string} param
      * @param {ParamsClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.params.getWithPath("param")
      */
@@ -80,6 +83,9 @@ export class ParamsClient {
      *
      * @param {SeedExhaustive.endpoints.GetWithInlinePath} request
      * @param {ParamsClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.params.getWithInlinePath({
@@ -139,6 +145,9 @@ export class ParamsClient {
      *
      * @param {SeedExhaustive.endpoints.GetWithQuery} request
      * @param {ParamsClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.params.getWithQuery({
@@ -207,6 +216,9 @@ export class ParamsClient {
      *
      * @param {SeedExhaustive.endpoints.GetWithMultipleQuery} request
      * @param {ParamsClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.params.getWithAllowMultipleQuery({
@@ -277,6 +289,9 @@ export class ParamsClient {
      * @param {SeedExhaustive.endpoints.GetWithPathAndQuery} request
      * @param {ParamsClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.params.getWithPathAndQuery("param", {
      *         query: "query"
@@ -344,6 +359,9 @@ export class ParamsClient {
      *
      * @param {SeedExhaustive.endpoints.GetWithInlinePathAndQuery} request
      * @param {ParamsClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.params.getWithInlinePathAndQuery({
@@ -413,6 +431,9 @@ export class ParamsClient {
      * @param {string} request
      * @param {ParamsClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.params.modifyWithPath("param", "string")
      */
@@ -473,6 +494,9 @@ export class ParamsClient {
      *
      * @param {SeedExhaustive.endpoints.ModifyResourceAtInlinedPath} request
      * @param {ParamsClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.params.modifyWithInlinePath({
@@ -537,6 +561,9 @@ export class ParamsClient {
      * @param {core.file.Uploadable} uploadable
      * @param {string} param
      * @param {ParamsClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     import { createReadStream } from "fs";
@@ -604,6 +631,9 @@ export class ParamsClient {
      *
      * @param {SeedExhaustive.endpoints.CreateWithBodyAndQuery} request
      * @param {ParamsClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.params.createWithBodyAndQuery({
@@ -680,6 +710,9 @@ export class ParamsClient {
      * @param {core.file.Uploadable} uploadable
      * @param {SeedExhaustive.endpoints.UploadBytesWithQuery} request
      * @param {ParamsClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      */
     public uploadBytesWithQuery(
         uploadable: core.file.Uploadable,
@@ -751,6 +784,9 @@ export class ParamsClient {
      * @param {boolean} param
      * @param {ParamsClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.params.getWithBooleanPath(true)
      */
@@ -808,6 +844,8 @@ export class ParamsClient {
      * @param {ParamsClient.RequestOptions} requestOptions - Request-specific configuration.
      *
      * @throws {@link SeedExhaustive.BadRequestBody}
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.params.getWithPathAndErrors("param")

--- a/seed/ts-sdk/exhaustive/parameter-naming-wire-value/src/api/resources/endpoints/resources/primitive/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/parameter-naming-wire-value/src/api/resources/endpoints/resources/primitive/client/Client.ts
@@ -25,6 +25,9 @@ export class PrimitiveClient {
      * @param {string} request
      * @param {PrimitiveClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.primitive.getAndReturnString("string")
      */
@@ -81,6 +84,9 @@ export class PrimitiveClient {
     /**
      * @param {number} request
      * @param {PrimitiveClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.primitive.getAndReturnInt(1)
@@ -139,6 +145,9 @@ export class PrimitiveClient {
      * @param {number} request
      * @param {PrimitiveClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.primitive.getAndReturnLong(1000000)
      */
@@ -195,6 +204,9 @@ export class PrimitiveClient {
     /**
      * @param {number} request
      * @param {PrimitiveClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.primitive.getAndReturnDouble(1.1)
@@ -253,6 +265,9 @@ export class PrimitiveClient {
      * @param {boolean} request
      * @param {PrimitiveClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.primitive.getAndReturnBool(true)
      */
@@ -309,6 +324,9 @@ export class PrimitiveClient {
     /**
      * @param {string} request
      * @param {PrimitiveClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.primitive.getAndReturnDatetime("2024-01-15T09:30:00Z")
@@ -367,6 +385,9 @@ export class PrimitiveClient {
      * @param {string} request
      * @param {PrimitiveClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.primitive.getAndReturnDate("2023-01-15")
      */
@@ -424,6 +445,9 @@ export class PrimitiveClient {
      * @param {string} request
      * @param {PrimitiveClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.primitive.getAndReturnUuid("d5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32")
      */
@@ -480,6 +504,9 @@ export class PrimitiveClient {
     /**
      * @param {string} request
      * @param {PrimitiveClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.primitive.getAndReturnBase64("SGVsbG8gd29ybGQh")

--- a/seed/ts-sdk/exhaustive/parameter-naming-wire-value/src/api/resources/endpoints/resources/put/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/parameter-naming-wire-value/src/api/resources/endpoints/resources/put/client/Client.ts
@@ -25,6 +25,9 @@ export class PutClient {
      * @param {SeedExhaustive.endpoints.PutRequest} request
      * @param {PutClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.put.add({
      *         id: "id"

--- a/seed/ts-sdk/exhaustive/parameter-naming-wire-value/src/api/resources/endpoints/resources/union/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/parameter-naming-wire-value/src/api/resources/endpoints/resources/union/client/Client.ts
@@ -26,6 +26,9 @@ export class UnionClient {
      * @param {SeedExhaustive.types.Animal} request
      * @param {UnionClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.union.getAndReturnUnion({
      *         animal: "dog",

--- a/seed/ts-sdk/exhaustive/parameter-naming-wire-value/src/api/resources/endpoints/resources/urls/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/parameter-naming-wire-value/src/api/resources/endpoints/resources/urls/client/Client.ts
@@ -23,6 +23,9 @@ export class UrlsClient {
     /**
      * @param {UrlsClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.urls.withMixedCase()
      */
@@ -69,6 +72,9 @@ export class UrlsClient {
 
     /**
      * @param {UrlsClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.urls.noEndingSlash()
@@ -117,6 +123,9 @@ export class UrlsClient {
     /**
      * @param {UrlsClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.urls.withEndingSlash()
      */
@@ -163,6 +172,9 @@ export class UrlsClient {
 
     /**
      * @param {UrlsClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.urls.withUnderscores()

--- a/seed/ts-sdk/exhaustive/parameter-naming-wire-value/src/api/resources/inlinedRequests/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/parameter-naming-wire-value/src/api/resources/inlinedRequests/client/Client.ts
@@ -29,6 +29,8 @@ export class InlinedRequestsClient {
      * @param {InlinedRequestsClient.RequestOptions} requestOptions - Request-specific configuration.
      *
      * @throws {@link SeedExhaustive.BadRequestBody}
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.inlinedRequests.postWithObjectBodyandResponse({
@@ -114,6 +116,9 @@ export class InlinedRequestsClient {
      *
      * @param {SeedExhaustive.PostWithArrayBodyAndHeaders} request
      * @param {InlinedRequestsClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.inlinedRequests.postWithArrayBodyAndHeaders({

--- a/seed/ts-sdk/exhaustive/parameter-naming-wire-value/src/api/resources/noAuth/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/parameter-naming-wire-value/src/api/resources/noAuth/client/Client.ts
@@ -29,6 +29,8 @@ export class NoAuthClient {
      * @param {NoAuthClient.RequestOptions} requestOptions - Request-specific configuration.
      *
      * @throws {@link SeedExhaustive.BadRequestBody}
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.noAuth.postWithNoAuth({

--- a/seed/ts-sdk/exhaustive/parameter-naming-wire-value/src/api/resources/noReqBody/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/parameter-naming-wire-value/src/api/resources/noReqBody/client/Client.ts
@@ -24,6 +24,9 @@ export class NoReqBodyClient {
     /**
      * @param {NoReqBodyClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.noReqBody.getWithNoRequestBody()
      */
@@ -77,6 +80,9 @@ export class NoReqBodyClient {
 
     /**
      * @param {NoReqBodyClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.noReqBody.postWithNoRequestBody()

--- a/seed/ts-sdk/exhaustive/parameter-naming-wire-value/src/api/resources/reqWithHeaders/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/parameter-naming-wire-value/src/api/resources/reqWithHeaders/client/Client.ts
@@ -26,6 +26,9 @@ export class ReqWithHeadersClient {
      * @param {SeedExhaustive.ReqWithHeaders} request
      * @param {ReqWithHeadersClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.reqWithHeaders.getWithCustomHeader({
      *         "X-TEST-SERVICE-HEADER": "X-TEST-SERVICE-HEADER",

--- a/seed/ts-sdk/exhaustive/retain-original-casing/src/api/resources/endpoints/resources/container/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/retain-original-casing/src/api/resources/endpoints/resources/container/client/Client.ts
@@ -26,6 +26,9 @@ export class ContainerClient {
      * @param {string[]} request
      * @param {ContainerClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.container.getAndReturnListOfPrimitives(["string", "string"])
      */
@@ -87,6 +90,9 @@ export class ContainerClient {
     /**
      * @param {SeedExhaustive.types.ObjectWithRequiredField[]} request
      * @param {ContainerClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.container.getAndReturnListOfObjects([{
@@ -152,6 +158,9 @@ export class ContainerClient {
      * @param {string[]} request
      * @param {ContainerClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.container.getAndReturnSetOfPrimitives(["string"])
      */
@@ -208,6 +217,9 @@ export class ContainerClient {
     /**
      * @param {SeedExhaustive.types.ObjectWithRequiredField[]} request
      * @param {ContainerClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.container.getAndReturnSetOfObjects([{
@@ -271,6 +283,9 @@ export class ContainerClient {
      * @param {Record<string, string>} request
      * @param {ContainerClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.container.getAndReturnMapPrimToPrim({
      *         "string": "string"
@@ -329,6 +344,9 @@ export class ContainerClient {
     /**
      * @param {Record<string, SeedExhaustive.types.ObjectWithRequiredField>} request
      * @param {ContainerClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.container.getAndReturnMapOfPrimToObject({
@@ -399,6 +417,9 @@ export class ContainerClient {
      * @param {Record<string, SeedExhaustive.types.MixedType>} request
      * @param {ContainerClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.container.getAndReturnMapOfPrimToUndiscriminatedUnion({
      *         "string": 1.1
@@ -462,6 +483,9 @@ export class ContainerClient {
     /**
      * @param {SeedExhaustive.types.ObjectWithRequiredField} request
      * @param {ContainerClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.container.getAndReturnOptional({

--- a/seed/ts-sdk/exhaustive/retain-original-casing/src/api/resources/endpoints/resources/contentType/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/retain-original-casing/src/api/resources/endpoints/resources/contentType/client/Client.ts
@@ -26,6 +26,9 @@ export class ContentTypeClient {
      * @param {SeedExhaustive.types.ObjectWithOptionalField} request
      * @param {ContentTypeClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.contentType.postJsonPatchContentType({
      *         string: "string",
@@ -98,6 +101,9 @@ export class ContentTypeClient {
     /**
      * @param {SeedExhaustive.types.ObjectWithOptionalField} request
      * @param {ContentTypeClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.contentType.postJsonPatchContentWithCharsetType({

--- a/seed/ts-sdk/exhaustive/retain-original-casing/src/api/resources/endpoints/resources/enum/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/retain-original-casing/src/api/resources/endpoints/resources/enum/client/Client.ts
@@ -26,6 +26,9 @@ export class EnumClient {
      * @param {SeedExhaustive.types.WeatherReport} request
      * @param {EnumClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.enum.getAndReturnEnum("SUNNY")
      */

--- a/seed/ts-sdk/exhaustive/retain-original-casing/src/api/resources/endpoints/resources/httpMethods/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/retain-original-casing/src/api/resources/endpoints/resources/httpMethods/client/Client.ts
@@ -26,6 +26,9 @@ export class HttpMethodsClient {
      * @param {string} id
      * @param {HttpMethodsClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.httpMethods.testGet("id")
      */
@@ -78,6 +81,9 @@ export class HttpMethodsClient {
      *
      * @param {SeedExhaustive.types.ObjectWithRequiredField} request
      * @param {HttpMethodsClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.httpMethods.testPost({
@@ -143,6 +149,9 @@ export class HttpMethodsClient {
      * @param {string} id
      * @param {SeedExhaustive.types.ObjectWithRequiredField} request
      * @param {HttpMethodsClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.httpMethods.testPut("id", {
@@ -210,6 +219,9 @@ export class HttpMethodsClient {
      * @param {string} id
      * @param {SeedExhaustive.types.ObjectWithOptionalField} request
      * @param {HttpMethodsClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.httpMethods.testPatch("id", {
@@ -290,6 +302,9 @@ export class HttpMethodsClient {
      *
      * @param {string} id
      * @param {HttpMethodsClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.httpMethods.testDelete("id")

--- a/seed/ts-sdk/exhaustive/retain-original-casing/src/api/resources/endpoints/resources/object/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/retain-original-casing/src/api/resources/endpoints/resources/object/client/Client.ts
@@ -26,6 +26,9 @@ export class ObjectClient {
      * @param {SeedExhaustive.types.ObjectWithOptionalField} request
      * @param {ObjectClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.object.getAndReturnWithOptionalField({
      *         string: "string",
@@ -107,6 +110,9 @@ export class ObjectClient {
      * @param {SeedExhaustive.types.ObjectWithRequiredField} request
      * @param {ObjectClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.object.getAndReturnWithRequiredField({
      *         string: "string"
@@ -173,6 +179,9 @@ export class ObjectClient {
     /**
      * @param {SeedExhaustive.types.ObjectWithMapOfMap} request
      * @param {ObjectClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.object.getAndReturnWithMapOfMap({
@@ -244,6 +253,9 @@ export class ObjectClient {
     /**
      * @param {SeedExhaustive.types.NestedObjectWithOptionalField} request
      * @param {ObjectClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.object.getAndReturnNestedWithOptionalField({
@@ -332,6 +344,9 @@ export class ObjectClient {
      * @param {SeedExhaustive.types.NestedObjectWithRequiredField} request
      * @param {ObjectClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.object.getAndReturnNestedWithRequiredField("string", {
      *         string: "string",
@@ -419,6 +434,9 @@ export class ObjectClient {
     /**
      * @param {SeedExhaustive.types.NestedObjectWithRequiredField[]} request
      * @param {ObjectClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.object.getAndReturnNestedWithRequiredFieldAsList([{
@@ -525,6 +543,9 @@ export class ObjectClient {
      * @param {SeedExhaustive.types.ObjectWithUnknownField} request
      * @param {ObjectClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.object.getAndReturnWithUnknownField({
      *         unknown: {
@@ -593,6 +614,9 @@ export class ObjectClient {
     /**
      * @param {SeedExhaustive.types.ObjectWithDocumentedUnknownType} request
      * @param {ObjectClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.object.getAndReturnWithDocumentedUnknownType({
@@ -664,6 +688,9 @@ export class ObjectClient {
     /**
      * @param {SeedExhaustive.types.MapOfDocumentedUnknownType} request
      * @param {ObjectClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.object.getAndReturnMapOfDocumentedUnknownType({
@@ -738,6 +765,9 @@ export class ObjectClient {
      *
      * @param {SeedExhaustive.types.ObjectWithMixedRequiredAndOptionalFields} request
      * @param {ObjectClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.object.getAndReturnWithMixedRequiredAndOptionalFields({
@@ -816,6 +846,9 @@ export class ObjectClient {
      * @param {SeedExhaustive.types.ObjectWithRequiredNestedObject} request
      * @param {ObjectClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.object.getAndReturnWithRequiredNestedObject({
      *         requiredString: "hello",
@@ -892,6 +925,9 @@ export class ObjectClient {
      *
      * @param {SeedExhaustive.types.ObjectWithDatetimeLikeString} request
      * @param {ObjectClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.object.getAndReturnWithDatetimeLikeString({

--- a/seed/ts-sdk/exhaustive/retain-original-casing/src/api/resources/endpoints/resources/pagination/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/retain-original-casing/src/api/resources/endpoints/resources/pagination/client/Client.ts
@@ -27,6 +27,9 @@ export class PaginationClient {
      * @param {SeedExhaustive.endpoints.ListItemsRequest} request
      * @param {PaginationClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.pagination.listItems({
      *         cursor: "cursor",

--- a/seed/ts-sdk/exhaustive/retain-original-casing/src/api/resources/endpoints/resources/params/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/retain-original-casing/src/api/resources/endpoints/resources/params/client/Client.ts
@@ -28,6 +28,9 @@ export class ParamsClient {
      * @param {string} param
      * @param {ParamsClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.params.getWithPath("param")
      */
@@ -80,6 +83,9 @@ export class ParamsClient {
      *
      * @param {SeedExhaustive.endpoints.GetWithInlinePath} request
      * @param {ParamsClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.params.getWithInlinePath({
@@ -139,6 +145,9 @@ export class ParamsClient {
      *
      * @param {SeedExhaustive.endpoints.GetWithQuery} request
      * @param {ParamsClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.params.getWithQuery({
@@ -207,6 +216,9 @@ export class ParamsClient {
      *
      * @param {SeedExhaustive.endpoints.GetWithMultipleQuery} request
      * @param {ParamsClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.params.getWithAllowMultipleQuery({
@@ -277,6 +289,9 @@ export class ParamsClient {
      * @param {SeedExhaustive.endpoints.GetWithPathAndQuery} request
      * @param {ParamsClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.params.getWithPathAndQuery("param", {
      *         query: "query"
@@ -344,6 +359,9 @@ export class ParamsClient {
      *
      * @param {SeedExhaustive.endpoints.GetWithInlinePathAndQuery} request
      * @param {ParamsClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.params.getWithInlinePathAndQuery({
@@ -413,6 +431,9 @@ export class ParamsClient {
      * @param {string} request
      * @param {ParamsClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.params.modifyWithPath("param", "string")
      */
@@ -473,6 +494,9 @@ export class ParamsClient {
      *
      * @param {SeedExhaustive.endpoints.ModifyResourceAtInlinedPath} request
      * @param {ParamsClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.params.modifyWithInlinePath({
@@ -537,6 +561,9 @@ export class ParamsClient {
      * @param {core.file.Uploadable} uploadable
      * @param {string} param
      * @param {ParamsClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     import { createReadStream } from "fs";
@@ -604,6 +631,9 @@ export class ParamsClient {
      *
      * @param {SeedExhaustive.endpoints.CreateWithBodyAndQuery} request
      * @param {ParamsClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.params.createWithBodyAndQuery({
@@ -680,6 +710,9 @@ export class ParamsClient {
      * @param {core.file.Uploadable} uploadable
      * @param {SeedExhaustive.endpoints.UploadBytesWithQuery} request
      * @param {ParamsClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      */
     public uploadBytesWithQuery(
         uploadable: core.file.Uploadable,
@@ -751,6 +784,9 @@ export class ParamsClient {
      * @param {boolean} param
      * @param {ParamsClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.params.getWithBooleanPath(true)
      */
@@ -808,6 +844,8 @@ export class ParamsClient {
      * @param {ParamsClient.RequestOptions} requestOptions - Request-specific configuration.
      *
      * @throws {@link SeedExhaustive.BadRequestBody}
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.params.getWithPathAndErrors("param")

--- a/seed/ts-sdk/exhaustive/retain-original-casing/src/api/resources/endpoints/resources/primitive/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/retain-original-casing/src/api/resources/endpoints/resources/primitive/client/Client.ts
@@ -25,6 +25,9 @@ export class PrimitiveClient {
      * @param {string} request
      * @param {PrimitiveClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.primitive.getAndReturnString("string")
      */
@@ -81,6 +84,9 @@ export class PrimitiveClient {
     /**
      * @param {number} request
      * @param {PrimitiveClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.primitive.getAndReturnInt(1)
@@ -139,6 +145,9 @@ export class PrimitiveClient {
      * @param {number} request
      * @param {PrimitiveClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.primitive.getAndReturnLong(1000000)
      */
@@ -195,6 +204,9 @@ export class PrimitiveClient {
     /**
      * @param {number} request
      * @param {PrimitiveClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.primitive.getAndReturnDouble(1.1)
@@ -253,6 +265,9 @@ export class PrimitiveClient {
      * @param {boolean} request
      * @param {PrimitiveClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.primitive.getAndReturnBool(true)
      */
@@ -309,6 +324,9 @@ export class PrimitiveClient {
     /**
      * @param {string} request
      * @param {PrimitiveClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.primitive.getAndReturnDatetime("2024-01-15T09:30:00Z")
@@ -367,6 +385,9 @@ export class PrimitiveClient {
      * @param {string} request
      * @param {PrimitiveClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.primitive.getAndReturnDate("2023-01-15")
      */
@@ -424,6 +445,9 @@ export class PrimitiveClient {
      * @param {string} request
      * @param {PrimitiveClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.primitive.getAndReturnUuid("d5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32")
      */
@@ -480,6 +504,9 @@ export class PrimitiveClient {
     /**
      * @param {string} request
      * @param {PrimitiveClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.primitive.getAndReturnBase64("SGVsbG8gd29ybGQh")

--- a/seed/ts-sdk/exhaustive/retain-original-casing/src/api/resources/endpoints/resources/put/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/retain-original-casing/src/api/resources/endpoints/resources/put/client/Client.ts
@@ -25,6 +25,9 @@ export class PutClient {
      * @param {SeedExhaustive.endpoints.PutRequest} request
      * @param {PutClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.put.add({
      *         id: "id"

--- a/seed/ts-sdk/exhaustive/retain-original-casing/src/api/resources/endpoints/resources/union/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/retain-original-casing/src/api/resources/endpoints/resources/union/client/Client.ts
@@ -26,6 +26,9 @@ export class UnionClient {
      * @param {SeedExhaustive.types.Animal} request
      * @param {UnionClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.union.getAndReturnUnion({
      *         animal: "dog",

--- a/seed/ts-sdk/exhaustive/retain-original-casing/src/api/resources/endpoints/resources/urls/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/retain-original-casing/src/api/resources/endpoints/resources/urls/client/Client.ts
@@ -23,6 +23,9 @@ export class UrlsClient {
     /**
      * @param {UrlsClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.urls.withMixedCase()
      */
@@ -69,6 +72,9 @@ export class UrlsClient {
 
     /**
      * @param {UrlsClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.urls.noEndingSlash()
@@ -117,6 +123,9 @@ export class UrlsClient {
     /**
      * @param {UrlsClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.urls.withEndingSlash()
      */
@@ -163,6 +172,9 @@ export class UrlsClient {
 
     /**
      * @param {UrlsClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.urls.withUnderscores()

--- a/seed/ts-sdk/exhaustive/retain-original-casing/src/api/resources/inlinedRequests/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/retain-original-casing/src/api/resources/inlinedRequests/client/Client.ts
@@ -29,6 +29,8 @@ export class InlinedRequestsClient {
      * @param {InlinedRequestsClient.RequestOptions} requestOptions - Request-specific configuration.
      *
      * @throws {@link SeedExhaustive.BadRequestBody}
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.inlinedRequests.postWithObjectBodyandResponse({
@@ -114,6 +116,9 @@ export class InlinedRequestsClient {
      *
      * @param {SeedExhaustive.PostWithArrayBodyAndHeaders} request
      * @param {InlinedRequestsClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.inlinedRequests.postWithArrayBodyAndHeaders({

--- a/seed/ts-sdk/exhaustive/retain-original-casing/src/api/resources/noAuth/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/retain-original-casing/src/api/resources/noAuth/client/Client.ts
@@ -29,6 +29,8 @@ export class NoAuthClient {
      * @param {NoAuthClient.RequestOptions} requestOptions - Request-specific configuration.
      *
      * @throws {@link SeedExhaustive.BadRequestBody}
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.noAuth.postWithNoAuth({

--- a/seed/ts-sdk/exhaustive/retain-original-casing/src/api/resources/noReqBody/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/retain-original-casing/src/api/resources/noReqBody/client/Client.ts
@@ -24,6 +24,9 @@ export class NoReqBodyClient {
     /**
      * @param {NoReqBodyClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.noReqBody.getWithNoRequestBody()
      */
@@ -77,6 +80,9 @@ export class NoReqBodyClient {
 
     /**
      * @param {NoReqBodyClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.noReqBody.postWithNoRequestBody()

--- a/seed/ts-sdk/exhaustive/retain-original-casing/src/api/resources/reqWithHeaders/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/retain-original-casing/src/api/resources/reqWithHeaders/client/Client.ts
@@ -26,6 +26,9 @@ export class ReqWithHeadersClient {
      * @param {SeedExhaustive.ReqWithHeaders} request
      * @param {ReqWithHeadersClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.reqWithHeaders.getWithCustomHeader({
      *         "X-TEST-SERVICE-HEADER": "X-TEST-SERVICE-HEADER",

--- a/seed/ts-sdk/exhaustive/serde-layer/src/api/resources/endpoints/resources/container/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/serde-layer/src/api/resources/endpoints/resources/container/client/Client.ts
@@ -27,6 +27,9 @@ export class ContainerClient {
      * @param {string[]} request
      * @param {ContainerClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.container.getAndReturnListOfPrimitives(["string", "string"])
      */
@@ -107,6 +110,9 @@ export class ContainerClient {
      * @param {SeedExhaustive.types.ObjectWithRequiredField[]} request
      * @param {ContainerClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.container.getAndReturnListOfObjects([{
      *             string: "string"
@@ -183,6 +189,9 @@ export class ContainerClient {
      * @param {Set<string>} request
      * @param {ContainerClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.container.getAndReturnSetOfPrimitives(new Set(["string"]))
      */
@@ -258,6 +267,9 @@ export class ContainerClient {
      * @param {SeedExhaustive.types.ObjectWithRequiredField[]} request
      * @param {ContainerClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.container.getAndReturnSetOfObjects([{
      *             string: "string"
@@ -332,6 +344,9 @@ export class ContainerClient {
      * @param {Record<string, string>} request
      * @param {ContainerClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.container.getAndReturnMapPrimToPrim({
      *         "string": "string"
@@ -405,6 +420,9 @@ export class ContainerClient {
     /**
      * @param {Record<string, SeedExhaustive.types.ObjectWithRequiredField>} request
      * @param {ContainerClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.container.getAndReturnMapOfPrimToObject({
@@ -490,6 +508,9 @@ export class ContainerClient {
      * @param {Record<string, SeedExhaustive.types.MixedType>} request
      * @param {ContainerClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.container.getAndReturnMapOfPrimToUndiscriminatedUnion({
      *         "string": 1.1
@@ -568,6 +589,9 @@ export class ContainerClient {
     /**
      * @param {SeedExhaustive.types.ObjectWithRequiredField} request
      * @param {ContainerClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.container.getAndReturnOptional({

--- a/seed/ts-sdk/exhaustive/serde-layer/src/api/resources/endpoints/resources/contentType/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/serde-layer/src/api/resources/endpoints/resources/contentType/client/Client.ts
@@ -27,6 +27,9 @@ export class ContentTypeClient {
      * @param {SeedExhaustive.types.ObjectWithOptionalField} request
      * @param {ContentTypeClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.contentType.postJsonPatchContentType({
      *         string: "string",
@@ -105,6 +108,9 @@ export class ContentTypeClient {
     /**
      * @param {SeedExhaustive.types.ObjectWithOptionalField} request
      * @param {ContentTypeClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.contentType.postJsonPatchContentWithCharsetType({

--- a/seed/ts-sdk/exhaustive/serde-layer/src/api/resources/endpoints/resources/enum/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/serde-layer/src/api/resources/endpoints/resources/enum/client/Client.ts
@@ -27,6 +27,9 @@ export class EnumClient {
      * @param {SeedExhaustive.types.WeatherReport} request
      * @param {EnumClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.enum.getAndReturnEnum("SUNNY")
      */

--- a/seed/ts-sdk/exhaustive/serde-layer/src/api/resources/endpoints/resources/httpMethods/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/serde-layer/src/api/resources/endpoints/resources/httpMethods/client/Client.ts
@@ -27,6 +27,9 @@ export class HttpMethodsClient {
      * @param {string} id
      * @param {HttpMethodsClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.httpMethods.testGet("id")
      */
@@ -88,6 +91,9 @@ export class HttpMethodsClient {
      *
      * @param {SeedExhaustive.types.ObjectWithRequiredField} request
      * @param {HttpMethodsClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.httpMethods.testPost({
@@ -165,6 +171,9 @@ export class HttpMethodsClient {
      * @param {string} id
      * @param {SeedExhaustive.types.ObjectWithRequiredField} request
      * @param {HttpMethodsClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.httpMethods.testPut("id", {
@@ -244,6 +253,9 @@ export class HttpMethodsClient {
      * @param {string} id
      * @param {SeedExhaustive.types.ObjectWithOptionalField} request
      * @param {HttpMethodsClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.httpMethods.testPatch("id", {
@@ -336,6 +348,9 @@ export class HttpMethodsClient {
      *
      * @param {string} id
      * @param {HttpMethodsClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.httpMethods.testDelete("id")

--- a/seed/ts-sdk/exhaustive/serde-layer/src/api/resources/endpoints/resources/object/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/serde-layer/src/api/resources/endpoints/resources/object/client/Client.ts
@@ -27,6 +27,9 @@ export class ObjectClient {
      * @param {SeedExhaustive.types.ObjectWithOptionalField} request
      * @param {ObjectClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.object.getAndReturnWithOptionalField({
      *         string: "string",
@@ -120,6 +123,9 @@ export class ObjectClient {
      * @param {SeedExhaustive.types.ObjectWithRequiredField} request
      * @param {ObjectClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.object.getAndReturnWithRequiredField({
      *         string: "string"
@@ -198,6 +204,9 @@ export class ObjectClient {
     /**
      * @param {SeedExhaustive.types.ObjectWithMapOfMap} request
      * @param {ObjectClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.object.getAndReturnWithMapOfMap({
@@ -281,6 +290,9 @@ export class ObjectClient {
     /**
      * @param {SeedExhaustive.types.NestedObjectWithOptionalField} request
      * @param {ObjectClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.object.getAndReturnNestedWithOptionalField({
@@ -381,6 +393,9 @@ export class ObjectClient {
      * @param {SeedExhaustive.types.NestedObjectWithRequiredField} request
      * @param {ObjectClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.object.getAndReturnNestedWithRequiredField("string", {
      *         string: "string",
@@ -480,6 +495,9 @@ export class ObjectClient {
     /**
      * @param {SeedExhaustive.types.NestedObjectWithRequiredField[]} request
      * @param {ObjectClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.object.getAndReturnNestedWithRequiredFieldAsList([{
@@ -598,6 +616,9 @@ export class ObjectClient {
      * @param {SeedExhaustive.types.ObjectWithUnknownField} request
      * @param {ObjectClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.object.getAndReturnWithUnknownField({
      *         unknown: {
@@ -678,6 +699,9 @@ export class ObjectClient {
     /**
      * @param {SeedExhaustive.types.ObjectWithDocumentedUnknownType} request
      * @param {ObjectClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.object.getAndReturnWithDocumentedUnknownType({
@@ -761,6 +785,9 @@ export class ObjectClient {
     /**
      * @param {SeedExhaustive.types.MapOfDocumentedUnknownType} request
      * @param {ObjectClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.object.getAndReturnMapOfDocumentedUnknownType({
@@ -847,6 +874,9 @@ export class ObjectClient {
      *
      * @param {SeedExhaustive.types.ObjectWithMixedRequiredAndOptionalFields} request
      * @param {ObjectClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.object.getAndReturnWithMixedRequiredAndOptionalFields({
@@ -937,6 +967,9 @@ export class ObjectClient {
      * @param {SeedExhaustive.types.ObjectWithRequiredNestedObject} request
      * @param {ObjectClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.object.getAndReturnWithRequiredNestedObject({
      *         requiredString: "hello",
@@ -1025,6 +1058,9 @@ export class ObjectClient {
      *
      * @param {SeedExhaustive.types.ObjectWithDatetimeLikeString} request
      * @param {ObjectClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.object.getAndReturnWithDatetimeLikeString({

--- a/seed/ts-sdk/exhaustive/serde-layer/src/api/resources/endpoints/resources/pagination/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/serde-layer/src/api/resources/endpoints/resources/pagination/client/Client.ts
@@ -28,6 +28,9 @@ export class PaginationClient {
      * @param {SeedExhaustive.endpoints.ListItemsRequest} request
      * @param {PaginationClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.pagination.listItems({
      *         cursor: "cursor",

--- a/seed/ts-sdk/exhaustive/serde-layer/src/api/resources/endpoints/resources/params/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/serde-layer/src/api/resources/endpoints/resources/params/client/Client.ts
@@ -29,6 +29,9 @@ export class ParamsClient {
      * @param {string} param
      * @param {ParamsClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.params.getWithPath("param")
      */
@@ -90,6 +93,9 @@ export class ParamsClient {
      *
      * @param {SeedExhaustive.endpoints.GetWithInlinePath} request
      * @param {ParamsClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.params.getWithInlinePath({
@@ -159,6 +165,9 @@ export class ParamsClient {
      * @param {SeedExhaustive.endpoints.GetWithQuery} request
      * @param {ParamsClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.params.getWithQuery({
      *         query: "query",
@@ -226,6 +235,9 @@ export class ParamsClient {
      *
      * @param {SeedExhaustive.endpoints.GetWithMultipleQuery} request
      * @param {ParamsClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.params.getWithAllowMultipleQuery({
@@ -296,6 +308,9 @@ export class ParamsClient {
      * @param {SeedExhaustive.endpoints.GetWithPathAndQuery} request
      * @param {ParamsClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.params.getWithPathAndQuery("param", {
      *         query: "query"
@@ -364,6 +379,9 @@ export class ParamsClient {
      * @param {SeedExhaustive.endpoints.GetWithInlinePathAndQuery} request
      * @param {ParamsClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.params.getWithInlinePathAndQuery({
      *         param: "param",
@@ -431,6 +449,9 @@ export class ParamsClient {
      * @param {string} param
      * @param {string} request
      * @param {ParamsClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.params.modifyWithPath("param", "string")
@@ -507,6 +528,9 @@ export class ParamsClient {
      *
      * @param {SeedExhaustive.endpoints.ModifyResourceAtInlinedPath} request
      * @param {ParamsClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.params.modifyWithInlinePath({
@@ -587,6 +611,9 @@ export class ParamsClient {
      * @param {string} param
      * @param {ParamsClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     import { createReadStream } from "fs";
      *     await client.endpoints.params.uploadWithPath(createReadStream("path/to/file"), "upload-path")
@@ -659,6 +686,9 @@ export class ParamsClient {
      *
      * @param {SeedExhaustive.endpoints.CreateWithBodyAndQuery} request
      * @param {ParamsClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.params.createWithBodyAndQuery({
@@ -747,6 +777,9 @@ export class ParamsClient {
      * @param {core.file.Uploadable} uploadable
      * @param {SeedExhaustive.endpoints.UploadBytesWithQuery} request
      * @param {ParamsClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      */
     public uploadBytesWithQuery(
         uploadable: core.file.Uploadable,
@@ -824,6 +857,9 @@ export class ParamsClient {
      * @param {boolean} param
      * @param {ParamsClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.params.getWithBooleanPath(true)
      */
@@ -890,6 +926,8 @@ export class ParamsClient {
      * @param {ParamsClient.RequestOptions} requestOptions - Request-specific configuration.
      *
      * @throws {@link SeedExhaustive.BadRequestBody}
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.params.getWithPathAndErrors("param")

--- a/seed/ts-sdk/exhaustive/serde-layer/src/api/resources/endpoints/resources/primitive/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/serde-layer/src/api/resources/endpoints/resources/primitive/client/Client.ts
@@ -26,6 +26,9 @@ export class PrimitiveClient {
      * @param {string} request
      * @param {PrimitiveClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.primitive.getAndReturnString("string")
      */
@@ -97,6 +100,9 @@ export class PrimitiveClient {
     /**
      * @param {number} request
      * @param {PrimitiveClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.primitive.getAndReturnInt(1)
@@ -170,6 +176,9 @@ export class PrimitiveClient {
      * @param {number} request
      * @param {PrimitiveClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.primitive.getAndReturnLong(1000000)
      */
@@ -241,6 +250,9 @@ export class PrimitiveClient {
     /**
      * @param {number} request
      * @param {PrimitiveClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.primitive.getAndReturnDouble(1.1)
@@ -314,6 +326,9 @@ export class PrimitiveClient {
      * @param {boolean} request
      * @param {PrimitiveClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.primitive.getAndReturnBool(true)
      */
@@ -385,6 +400,9 @@ export class PrimitiveClient {
     /**
      * @param {Date} request
      * @param {PrimitiveClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.primitive.getAndReturnDatetime(new Date("2024-01-15T09:30:00.000Z"))
@@ -458,6 +476,9 @@ export class PrimitiveClient {
      * @param {string} request
      * @param {PrimitiveClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.primitive.getAndReturnDate("2023-01-15")
      */
@@ -530,6 +551,9 @@ export class PrimitiveClient {
      * @param {string} request
      * @param {PrimitiveClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.primitive.getAndReturnUuid("d5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32")
      */
@@ -601,6 +625,9 @@ export class PrimitiveClient {
     /**
      * @param {string} request
      * @param {PrimitiveClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.primitive.getAndReturnBase64("SGVsbG8gd29ybGQh")

--- a/seed/ts-sdk/exhaustive/serde-layer/src/api/resources/endpoints/resources/put/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/serde-layer/src/api/resources/endpoints/resources/put/client/Client.ts
@@ -26,6 +26,9 @@ export class PutClient {
      * @param {SeedExhaustive.endpoints.PutRequest} request
      * @param {PutClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.put.add({
      *         id: "id"

--- a/seed/ts-sdk/exhaustive/serde-layer/src/api/resources/endpoints/resources/union/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/serde-layer/src/api/resources/endpoints/resources/union/client/Client.ts
@@ -27,6 +27,9 @@ export class UnionClient {
      * @param {SeedExhaustive.types.Animal} request
      * @param {UnionClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.union.getAndReturnUnion({
      *         animal: "dog",

--- a/seed/ts-sdk/exhaustive/serde-layer/src/api/resources/endpoints/resources/urls/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/serde-layer/src/api/resources/endpoints/resources/urls/client/Client.ts
@@ -24,6 +24,9 @@ export class UrlsClient {
     /**
      * @param {UrlsClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.urls.withMixedCase()
      */
@@ -79,6 +82,9 @@ export class UrlsClient {
 
     /**
      * @param {UrlsClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.urls.noEndingSlash()
@@ -136,6 +142,9 @@ export class UrlsClient {
     /**
      * @param {UrlsClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.urls.withEndingSlash()
      */
@@ -191,6 +200,9 @@ export class UrlsClient {
 
     /**
      * @param {UrlsClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.urls.withUnderscores()

--- a/seed/ts-sdk/exhaustive/serde-layer/src/api/resources/inlinedRequests/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/serde-layer/src/api/resources/inlinedRequests/client/Client.ts
@@ -30,6 +30,8 @@ export class InlinedRequestsClient {
      * @param {InlinedRequestsClient.RequestOptions} requestOptions - Request-specific configuration.
      *
      * @throws {@link SeedExhaustive.BadRequestBody}
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.inlinedRequests.postWithObjectBodyandResponse({
@@ -133,6 +135,9 @@ export class InlinedRequestsClient {
      *
      * @param {SeedExhaustive.PostWithArrayBodyAndHeaders} request
      * @param {InlinedRequestsClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.inlinedRequests.postWithArrayBodyAndHeaders({

--- a/seed/ts-sdk/exhaustive/serde-layer/src/api/resources/noAuth/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/serde-layer/src/api/resources/noAuth/client/Client.ts
@@ -30,6 +30,8 @@ export class NoAuthClient {
      * @param {NoAuthClient.RequestOptions} requestOptions - Request-specific configuration.
      *
      * @throws {@link SeedExhaustive.BadRequestBody}
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.noAuth.postWithNoAuth({

--- a/seed/ts-sdk/exhaustive/serde-layer/src/api/resources/noReqBody/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/serde-layer/src/api/resources/noReqBody/client/Client.ts
@@ -25,6 +25,9 @@ export class NoReqBodyClient {
     /**
      * @param {NoReqBodyClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.noReqBody.getWithNoRequestBody()
      */
@@ -84,6 +87,9 @@ export class NoReqBodyClient {
 
     /**
      * @param {NoReqBodyClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.noReqBody.postWithNoRequestBody()

--- a/seed/ts-sdk/exhaustive/serde-layer/src/api/resources/reqWithHeaders/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/serde-layer/src/api/resources/reqWithHeaders/client/Client.ts
@@ -27,6 +27,9 @@ export class ReqWithHeadersClient {
      * @param {SeedExhaustive.ReqWithHeaders} request
      * @param {ReqWithHeadersClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.reqWithHeaders.getWithCustomHeader({
      *         xTestServiceHeader: "X-TEST-SERVICE-HEADER",

--- a/seed/ts-sdk/exhaustive/use-jest/src/api/resources/endpoints/resources/container/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/use-jest/src/api/resources/endpoints/resources/container/client/Client.ts
@@ -26,6 +26,9 @@ export class ContainerClient {
      * @param {string[]} request
      * @param {ContainerClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.container.getAndReturnListOfPrimitives(["string", "string"])
      */
@@ -87,6 +90,9 @@ export class ContainerClient {
     /**
      * @param {SeedExhaustive.types.ObjectWithRequiredField[]} request
      * @param {ContainerClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.container.getAndReturnListOfObjects([{
@@ -152,6 +158,9 @@ export class ContainerClient {
      * @param {string[]} request
      * @param {ContainerClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.container.getAndReturnSetOfPrimitives(["string"])
      */
@@ -208,6 +217,9 @@ export class ContainerClient {
     /**
      * @param {SeedExhaustive.types.ObjectWithRequiredField[]} request
      * @param {ContainerClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.container.getAndReturnSetOfObjects([{
@@ -271,6 +283,9 @@ export class ContainerClient {
      * @param {Record<string, string>} request
      * @param {ContainerClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.container.getAndReturnMapPrimToPrim({
      *         "string": "string"
@@ -329,6 +344,9 @@ export class ContainerClient {
     /**
      * @param {Record<string, SeedExhaustive.types.ObjectWithRequiredField>} request
      * @param {ContainerClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.container.getAndReturnMapOfPrimToObject({
@@ -399,6 +417,9 @@ export class ContainerClient {
      * @param {Record<string, SeedExhaustive.types.MixedType>} request
      * @param {ContainerClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.container.getAndReturnMapOfPrimToUndiscriminatedUnion({
      *         "string": 1.1
@@ -462,6 +483,9 @@ export class ContainerClient {
     /**
      * @param {SeedExhaustive.types.ObjectWithRequiredField} request
      * @param {ContainerClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.container.getAndReturnOptional({

--- a/seed/ts-sdk/exhaustive/use-jest/src/api/resources/endpoints/resources/contentType/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/use-jest/src/api/resources/endpoints/resources/contentType/client/Client.ts
@@ -26,6 +26,9 @@ export class ContentTypeClient {
      * @param {SeedExhaustive.types.ObjectWithOptionalField} request
      * @param {ContentTypeClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.contentType.postJsonPatchContentType({
      *         string: "string",
@@ -98,6 +101,9 @@ export class ContentTypeClient {
     /**
      * @param {SeedExhaustive.types.ObjectWithOptionalField} request
      * @param {ContentTypeClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.contentType.postJsonPatchContentWithCharsetType({

--- a/seed/ts-sdk/exhaustive/use-jest/src/api/resources/endpoints/resources/enum/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/use-jest/src/api/resources/endpoints/resources/enum/client/Client.ts
@@ -26,6 +26,9 @@ export class EnumClient {
      * @param {SeedExhaustive.types.WeatherReport} request
      * @param {EnumClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.enum.getAndReturnEnum("SUNNY")
      */

--- a/seed/ts-sdk/exhaustive/use-jest/src/api/resources/endpoints/resources/httpMethods/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/use-jest/src/api/resources/endpoints/resources/httpMethods/client/Client.ts
@@ -26,6 +26,9 @@ export class HttpMethodsClient {
      * @param {string} id
      * @param {HttpMethodsClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.httpMethods.testGet("id")
      */
@@ -78,6 +81,9 @@ export class HttpMethodsClient {
      *
      * @param {SeedExhaustive.types.ObjectWithRequiredField} request
      * @param {HttpMethodsClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.httpMethods.testPost({
@@ -143,6 +149,9 @@ export class HttpMethodsClient {
      * @param {string} id
      * @param {SeedExhaustive.types.ObjectWithRequiredField} request
      * @param {HttpMethodsClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.httpMethods.testPut("id", {
@@ -210,6 +219,9 @@ export class HttpMethodsClient {
      * @param {string} id
      * @param {SeedExhaustive.types.ObjectWithOptionalField} request
      * @param {HttpMethodsClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.httpMethods.testPatch("id", {
@@ -290,6 +302,9 @@ export class HttpMethodsClient {
      *
      * @param {string} id
      * @param {HttpMethodsClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.httpMethods.testDelete("id")

--- a/seed/ts-sdk/exhaustive/use-jest/src/api/resources/endpoints/resources/object/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/use-jest/src/api/resources/endpoints/resources/object/client/Client.ts
@@ -26,6 +26,9 @@ export class ObjectClient {
      * @param {SeedExhaustive.types.ObjectWithOptionalField} request
      * @param {ObjectClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.object.getAndReturnWithOptionalField({
      *         string: "string",
@@ -107,6 +110,9 @@ export class ObjectClient {
      * @param {SeedExhaustive.types.ObjectWithRequiredField} request
      * @param {ObjectClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.object.getAndReturnWithRequiredField({
      *         string: "string"
@@ -173,6 +179,9 @@ export class ObjectClient {
     /**
      * @param {SeedExhaustive.types.ObjectWithMapOfMap} request
      * @param {ObjectClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.object.getAndReturnWithMapOfMap({
@@ -244,6 +253,9 @@ export class ObjectClient {
     /**
      * @param {SeedExhaustive.types.NestedObjectWithOptionalField} request
      * @param {ObjectClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.object.getAndReturnNestedWithOptionalField({
@@ -332,6 +344,9 @@ export class ObjectClient {
      * @param {SeedExhaustive.types.NestedObjectWithRequiredField} request
      * @param {ObjectClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.object.getAndReturnNestedWithRequiredField("string", {
      *         string: "string",
@@ -419,6 +434,9 @@ export class ObjectClient {
     /**
      * @param {SeedExhaustive.types.NestedObjectWithRequiredField[]} request
      * @param {ObjectClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.object.getAndReturnNestedWithRequiredFieldAsList([{
@@ -525,6 +543,9 @@ export class ObjectClient {
      * @param {SeedExhaustive.types.ObjectWithUnknownField} request
      * @param {ObjectClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.object.getAndReturnWithUnknownField({
      *         unknown: {
@@ -593,6 +614,9 @@ export class ObjectClient {
     /**
      * @param {SeedExhaustive.types.ObjectWithDocumentedUnknownType} request
      * @param {ObjectClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.object.getAndReturnWithDocumentedUnknownType({
@@ -664,6 +688,9 @@ export class ObjectClient {
     /**
      * @param {SeedExhaustive.types.MapOfDocumentedUnknownType} request
      * @param {ObjectClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.object.getAndReturnMapOfDocumentedUnknownType({
@@ -738,6 +765,9 @@ export class ObjectClient {
      *
      * @param {SeedExhaustive.types.ObjectWithMixedRequiredAndOptionalFields} request
      * @param {ObjectClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.object.getAndReturnWithMixedRequiredAndOptionalFields({
@@ -816,6 +846,9 @@ export class ObjectClient {
      * @param {SeedExhaustive.types.ObjectWithRequiredNestedObject} request
      * @param {ObjectClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.object.getAndReturnWithRequiredNestedObject({
      *         requiredString: "hello",
@@ -892,6 +925,9 @@ export class ObjectClient {
      *
      * @param {SeedExhaustive.types.ObjectWithDatetimeLikeString} request
      * @param {ObjectClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.object.getAndReturnWithDatetimeLikeString({

--- a/seed/ts-sdk/exhaustive/use-jest/src/api/resources/endpoints/resources/pagination/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/use-jest/src/api/resources/endpoints/resources/pagination/client/Client.ts
@@ -27,6 +27,9 @@ export class PaginationClient {
      * @param {SeedExhaustive.endpoints.ListItemsRequest} request
      * @param {PaginationClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.pagination.listItems({
      *         cursor: "cursor",

--- a/seed/ts-sdk/exhaustive/use-jest/src/api/resources/endpoints/resources/params/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/use-jest/src/api/resources/endpoints/resources/params/client/Client.ts
@@ -28,6 +28,9 @@ export class ParamsClient {
      * @param {string} param
      * @param {ParamsClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.params.getWithPath("param")
      */
@@ -80,6 +83,9 @@ export class ParamsClient {
      *
      * @param {SeedExhaustive.endpoints.GetWithInlinePath} request
      * @param {ParamsClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.params.getWithInlinePath({
@@ -139,6 +145,9 @@ export class ParamsClient {
      *
      * @param {SeedExhaustive.endpoints.GetWithQuery} request
      * @param {ParamsClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.params.getWithQuery({
@@ -207,6 +216,9 @@ export class ParamsClient {
      *
      * @param {SeedExhaustive.endpoints.GetWithMultipleQuery} request
      * @param {ParamsClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.params.getWithAllowMultipleQuery({
@@ -277,6 +289,9 @@ export class ParamsClient {
      * @param {SeedExhaustive.endpoints.GetWithPathAndQuery} request
      * @param {ParamsClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.params.getWithPathAndQuery("param", {
      *         query: "query"
@@ -344,6 +359,9 @@ export class ParamsClient {
      *
      * @param {SeedExhaustive.endpoints.GetWithInlinePathAndQuery} request
      * @param {ParamsClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.params.getWithInlinePathAndQuery({
@@ -413,6 +431,9 @@ export class ParamsClient {
      * @param {string} request
      * @param {ParamsClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.params.modifyWithPath("param", "string")
      */
@@ -473,6 +494,9 @@ export class ParamsClient {
      *
      * @param {SeedExhaustive.endpoints.ModifyResourceAtInlinedPath} request
      * @param {ParamsClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.params.modifyWithInlinePath({
@@ -537,6 +561,9 @@ export class ParamsClient {
      * @param {core.file.Uploadable} uploadable
      * @param {string} param
      * @param {ParamsClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     import { createReadStream } from "fs";
@@ -604,6 +631,9 @@ export class ParamsClient {
      *
      * @param {SeedExhaustive.endpoints.CreateWithBodyAndQuery} request
      * @param {ParamsClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.params.createWithBodyAndQuery({
@@ -680,6 +710,9 @@ export class ParamsClient {
      * @param {core.file.Uploadable} uploadable
      * @param {SeedExhaustive.endpoints.UploadBytesWithQuery} request
      * @param {ParamsClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      */
     public uploadBytesWithQuery(
         uploadable: core.file.Uploadable,
@@ -751,6 +784,9 @@ export class ParamsClient {
      * @param {boolean} param
      * @param {ParamsClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.params.getWithBooleanPath(true)
      */
@@ -808,6 +844,8 @@ export class ParamsClient {
      * @param {ParamsClient.RequestOptions} requestOptions - Request-specific configuration.
      *
      * @throws {@link SeedExhaustive.BadRequestBody}
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.params.getWithPathAndErrors("param")

--- a/seed/ts-sdk/exhaustive/use-jest/src/api/resources/endpoints/resources/primitive/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/use-jest/src/api/resources/endpoints/resources/primitive/client/Client.ts
@@ -25,6 +25,9 @@ export class PrimitiveClient {
      * @param {string} request
      * @param {PrimitiveClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.primitive.getAndReturnString("string")
      */
@@ -81,6 +84,9 @@ export class PrimitiveClient {
     /**
      * @param {number} request
      * @param {PrimitiveClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.primitive.getAndReturnInt(1)
@@ -139,6 +145,9 @@ export class PrimitiveClient {
      * @param {number} request
      * @param {PrimitiveClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.primitive.getAndReturnLong(1000000)
      */
@@ -195,6 +204,9 @@ export class PrimitiveClient {
     /**
      * @param {number} request
      * @param {PrimitiveClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.primitive.getAndReturnDouble(1.1)
@@ -253,6 +265,9 @@ export class PrimitiveClient {
      * @param {boolean} request
      * @param {PrimitiveClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.primitive.getAndReturnBool(true)
      */
@@ -309,6 +324,9 @@ export class PrimitiveClient {
     /**
      * @param {string} request
      * @param {PrimitiveClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.primitive.getAndReturnDatetime("2024-01-15T09:30:00Z")
@@ -367,6 +385,9 @@ export class PrimitiveClient {
      * @param {string} request
      * @param {PrimitiveClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.primitive.getAndReturnDate("2023-01-15")
      */
@@ -424,6 +445,9 @@ export class PrimitiveClient {
      * @param {string} request
      * @param {PrimitiveClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.primitive.getAndReturnUuid("d5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32")
      */
@@ -480,6 +504,9 @@ export class PrimitiveClient {
     /**
      * @param {string} request
      * @param {PrimitiveClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.primitive.getAndReturnBase64("SGVsbG8gd29ybGQh")

--- a/seed/ts-sdk/exhaustive/use-jest/src/api/resources/endpoints/resources/put/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/use-jest/src/api/resources/endpoints/resources/put/client/Client.ts
@@ -25,6 +25,9 @@ export class PutClient {
      * @param {SeedExhaustive.endpoints.PutRequest} request
      * @param {PutClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.put.add({
      *         id: "id"

--- a/seed/ts-sdk/exhaustive/use-jest/src/api/resources/endpoints/resources/union/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/use-jest/src/api/resources/endpoints/resources/union/client/Client.ts
@@ -26,6 +26,9 @@ export class UnionClient {
      * @param {SeedExhaustive.types.Animal} request
      * @param {UnionClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.union.getAndReturnUnion({
      *         animal: "dog",

--- a/seed/ts-sdk/exhaustive/use-jest/src/api/resources/endpoints/resources/urls/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/use-jest/src/api/resources/endpoints/resources/urls/client/Client.ts
@@ -23,6 +23,9 @@ export class UrlsClient {
     /**
      * @param {UrlsClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.urls.withMixedCase()
      */
@@ -69,6 +72,9 @@ export class UrlsClient {
 
     /**
      * @param {UrlsClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.urls.noEndingSlash()
@@ -117,6 +123,9 @@ export class UrlsClient {
     /**
      * @param {UrlsClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.urls.withEndingSlash()
      */
@@ -163,6 +172,9 @@ export class UrlsClient {
 
     /**
      * @param {UrlsClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.urls.withUnderscores()

--- a/seed/ts-sdk/exhaustive/use-jest/src/api/resources/inlinedRequests/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/use-jest/src/api/resources/inlinedRequests/client/Client.ts
@@ -29,6 +29,8 @@ export class InlinedRequestsClient {
      * @param {InlinedRequestsClient.RequestOptions} requestOptions - Request-specific configuration.
      *
      * @throws {@link SeedExhaustive.BadRequestBody}
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.inlinedRequests.postWithObjectBodyandResponse({
@@ -114,6 +116,9 @@ export class InlinedRequestsClient {
      *
      * @param {SeedExhaustive.PostWithArrayBodyAndHeaders} request
      * @param {InlinedRequestsClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.inlinedRequests.postWithArrayBodyAndHeaders({

--- a/seed/ts-sdk/exhaustive/use-jest/src/api/resources/noAuth/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/use-jest/src/api/resources/noAuth/client/Client.ts
@@ -29,6 +29,8 @@ export class NoAuthClient {
      * @param {NoAuthClient.RequestOptions} requestOptions - Request-specific configuration.
      *
      * @throws {@link SeedExhaustive.BadRequestBody}
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.noAuth.postWithNoAuth({

--- a/seed/ts-sdk/exhaustive/use-jest/src/api/resources/noReqBody/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/use-jest/src/api/resources/noReqBody/client/Client.ts
@@ -24,6 +24,9 @@ export class NoReqBodyClient {
     /**
      * @param {NoReqBodyClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.noReqBody.getWithNoRequestBody()
      */
@@ -77,6 +80,9 @@ export class NoReqBodyClient {
 
     /**
      * @param {NoReqBodyClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.noReqBody.postWithNoRequestBody()

--- a/seed/ts-sdk/exhaustive/use-jest/src/api/resources/reqWithHeaders/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/use-jest/src/api/resources/reqWithHeaders/client/Client.ts
@@ -26,6 +26,9 @@ export class ReqWithHeadersClient {
      * @param {SeedExhaustive.ReqWithHeaders} request
      * @param {ReqWithHeadersClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.reqWithHeaders.getWithCustomHeader({
      *         "X-TEST-SERVICE-HEADER": "X-TEST-SERVICE-HEADER",

--- a/seed/ts-sdk/exhaustive/web-stream-wrapper/src/api/resources/endpoints/resources/container/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/web-stream-wrapper/src/api/resources/endpoints/resources/container/client/Client.ts
@@ -26,6 +26,9 @@ export class ContainerClient {
      * @param {string[]} request
      * @param {ContainerClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.container.getAndReturnListOfPrimitives(["string", "string"])
      */
@@ -87,6 +90,9 @@ export class ContainerClient {
     /**
      * @param {SeedExhaustive.types.ObjectWithRequiredField[]} request
      * @param {ContainerClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.container.getAndReturnListOfObjects([{
@@ -152,6 +158,9 @@ export class ContainerClient {
      * @param {string[]} request
      * @param {ContainerClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.container.getAndReturnSetOfPrimitives(["string"])
      */
@@ -208,6 +217,9 @@ export class ContainerClient {
     /**
      * @param {SeedExhaustive.types.ObjectWithRequiredField[]} request
      * @param {ContainerClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.container.getAndReturnSetOfObjects([{
@@ -271,6 +283,9 @@ export class ContainerClient {
      * @param {Record<string, string>} request
      * @param {ContainerClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.container.getAndReturnMapPrimToPrim({
      *         "string": "string"
@@ -329,6 +344,9 @@ export class ContainerClient {
     /**
      * @param {Record<string, SeedExhaustive.types.ObjectWithRequiredField>} request
      * @param {ContainerClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.container.getAndReturnMapOfPrimToObject({
@@ -399,6 +417,9 @@ export class ContainerClient {
      * @param {Record<string, SeedExhaustive.types.MixedType>} request
      * @param {ContainerClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.container.getAndReturnMapOfPrimToUndiscriminatedUnion({
      *         "string": 1.1
@@ -462,6 +483,9 @@ export class ContainerClient {
     /**
      * @param {SeedExhaustive.types.ObjectWithRequiredField} request
      * @param {ContainerClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.container.getAndReturnOptional({

--- a/seed/ts-sdk/exhaustive/web-stream-wrapper/src/api/resources/endpoints/resources/contentType/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/web-stream-wrapper/src/api/resources/endpoints/resources/contentType/client/Client.ts
@@ -26,6 +26,9 @@ export class ContentTypeClient {
      * @param {SeedExhaustive.types.ObjectWithOptionalField} request
      * @param {ContentTypeClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.contentType.postJsonPatchContentType({
      *         string: "string",
@@ -98,6 +101,9 @@ export class ContentTypeClient {
     /**
      * @param {SeedExhaustive.types.ObjectWithOptionalField} request
      * @param {ContentTypeClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.contentType.postJsonPatchContentWithCharsetType({

--- a/seed/ts-sdk/exhaustive/web-stream-wrapper/src/api/resources/endpoints/resources/enum/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/web-stream-wrapper/src/api/resources/endpoints/resources/enum/client/Client.ts
@@ -26,6 +26,9 @@ export class EnumClient {
      * @param {SeedExhaustive.types.WeatherReport} request
      * @param {EnumClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.enum.getAndReturnEnum("SUNNY")
      */

--- a/seed/ts-sdk/exhaustive/web-stream-wrapper/src/api/resources/endpoints/resources/httpMethods/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/web-stream-wrapper/src/api/resources/endpoints/resources/httpMethods/client/Client.ts
@@ -26,6 +26,9 @@ export class HttpMethodsClient {
      * @param {string} id
      * @param {HttpMethodsClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.httpMethods.testGet("id")
      */
@@ -78,6 +81,9 @@ export class HttpMethodsClient {
      *
      * @param {SeedExhaustive.types.ObjectWithRequiredField} request
      * @param {HttpMethodsClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.httpMethods.testPost({
@@ -143,6 +149,9 @@ export class HttpMethodsClient {
      * @param {string} id
      * @param {SeedExhaustive.types.ObjectWithRequiredField} request
      * @param {HttpMethodsClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.httpMethods.testPut("id", {
@@ -210,6 +219,9 @@ export class HttpMethodsClient {
      * @param {string} id
      * @param {SeedExhaustive.types.ObjectWithOptionalField} request
      * @param {HttpMethodsClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.httpMethods.testPatch("id", {
@@ -290,6 +302,9 @@ export class HttpMethodsClient {
      *
      * @param {string} id
      * @param {HttpMethodsClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.httpMethods.testDelete("id")

--- a/seed/ts-sdk/exhaustive/web-stream-wrapper/src/api/resources/endpoints/resources/object/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/web-stream-wrapper/src/api/resources/endpoints/resources/object/client/Client.ts
@@ -26,6 +26,9 @@ export class ObjectClient {
      * @param {SeedExhaustive.types.ObjectWithOptionalField} request
      * @param {ObjectClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.object.getAndReturnWithOptionalField({
      *         string: "string",
@@ -107,6 +110,9 @@ export class ObjectClient {
      * @param {SeedExhaustive.types.ObjectWithRequiredField} request
      * @param {ObjectClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.object.getAndReturnWithRequiredField({
      *         string: "string"
@@ -173,6 +179,9 @@ export class ObjectClient {
     /**
      * @param {SeedExhaustive.types.ObjectWithMapOfMap} request
      * @param {ObjectClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.object.getAndReturnWithMapOfMap({
@@ -244,6 +253,9 @@ export class ObjectClient {
     /**
      * @param {SeedExhaustive.types.NestedObjectWithOptionalField} request
      * @param {ObjectClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.object.getAndReturnNestedWithOptionalField({
@@ -332,6 +344,9 @@ export class ObjectClient {
      * @param {SeedExhaustive.types.NestedObjectWithRequiredField} request
      * @param {ObjectClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.object.getAndReturnNestedWithRequiredField("string", {
      *         string: "string",
@@ -419,6 +434,9 @@ export class ObjectClient {
     /**
      * @param {SeedExhaustive.types.NestedObjectWithRequiredField[]} request
      * @param {ObjectClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.object.getAndReturnNestedWithRequiredFieldAsList([{
@@ -525,6 +543,9 @@ export class ObjectClient {
      * @param {SeedExhaustive.types.ObjectWithUnknownField} request
      * @param {ObjectClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.object.getAndReturnWithUnknownField({
      *         unknown: {
@@ -593,6 +614,9 @@ export class ObjectClient {
     /**
      * @param {SeedExhaustive.types.ObjectWithDocumentedUnknownType} request
      * @param {ObjectClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.object.getAndReturnWithDocumentedUnknownType({
@@ -664,6 +688,9 @@ export class ObjectClient {
     /**
      * @param {SeedExhaustive.types.MapOfDocumentedUnknownType} request
      * @param {ObjectClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.object.getAndReturnMapOfDocumentedUnknownType({
@@ -738,6 +765,9 @@ export class ObjectClient {
      *
      * @param {SeedExhaustive.types.ObjectWithMixedRequiredAndOptionalFields} request
      * @param {ObjectClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.object.getAndReturnWithMixedRequiredAndOptionalFields({
@@ -816,6 +846,9 @@ export class ObjectClient {
      * @param {SeedExhaustive.types.ObjectWithRequiredNestedObject} request
      * @param {ObjectClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.object.getAndReturnWithRequiredNestedObject({
      *         requiredString: "hello",
@@ -892,6 +925,9 @@ export class ObjectClient {
      *
      * @param {SeedExhaustive.types.ObjectWithDatetimeLikeString} request
      * @param {ObjectClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.object.getAndReturnWithDatetimeLikeString({

--- a/seed/ts-sdk/exhaustive/web-stream-wrapper/src/api/resources/endpoints/resources/pagination/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/web-stream-wrapper/src/api/resources/endpoints/resources/pagination/client/Client.ts
@@ -27,6 +27,9 @@ export class PaginationClient {
      * @param {SeedExhaustive.endpoints.ListItemsRequest} request
      * @param {PaginationClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.pagination.listItems({
      *         cursor: "cursor",

--- a/seed/ts-sdk/exhaustive/web-stream-wrapper/src/api/resources/endpoints/resources/params/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/web-stream-wrapper/src/api/resources/endpoints/resources/params/client/Client.ts
@@ -28,6 +28,9 @@ export class ParamsClient {
      * @param {string} param
      * @param {ParamsClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.params.getWithPath("param")
      */
@@ -80,6 +83,9 @@ export class ParamsClient {
      *
      * @param {SeedExhaustive.endpoints.GetWithInlinePath} request
      * @param {ParamsClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.params.getWithInlinePath({
@@ -139,6 +145,9 @@ export class ParamsClient {
      *
      * @param {SeedExhaustive.endpoints.GetWithQuery} request
      * @param {ParamsClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.params.getWithQuery({
@@ -207,6 +216,9 @@ export class ParamsClient {
      *
      * @param {SeedExhaustive.endpoints.GetWithMultipleQuery} request
      * @param {ParamsClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.params.getWithAllowMultipleQuery({
@@ -277,6 +289,9 @@ export class ParamsClient {
      * @param {SeedExhaustive.endpoints.GetWithPathAndQuery} request
      * @param {ParamsClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.params.getWithPathAndQuery("param", {
      *         query: "query"
@@ -344,6 +359,9 @@ export class ParamsClient {
      *
      * @param {SeedExhaustive.endpoints.GetWithInlinePathAndQuery} request
      * @param {ParamsClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.params.getWithInlinePathAndQuery({
@@ -413,6 +431,9 @@ export class ParamsClient {
      * @param {string} request
      * @param {ParamsClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.params.modifyWithPath("param", "string")
      */
@@ -473,6 +494,9 @@ export class ParamsClient {
      *
      * @param {SeedExhaustive.endpoints.ModifyResourceAtInlinedPath} request
      * @param {ParamsClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.params.modifyWithInlinePath({
@@ -537,6 +561,9 @@ export class ParamsClient {
      * @param {core.file.Uploadable} uploadable
      * @param {string} param
      * @param {ParamsClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     import { createReadStream } from "fs";
@@ -604,6 +631,9 @@ export class ParamsClient {
      *
      * @param {SeedExhaustive.endpoints.CreateWithBodyAndQuery} request
      * @param {ParamsClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.params.createWithBodyAndQuery({
@@ -680,6 +710,9 @@ export class ParamsClient {
      * @param {core.file.Uploadable} uploadable
      * @param {SeedExhaustive.endpoints.UploadBytesWithQuery} request
      * @param {ParamsClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      */
     public uploadBytesWithQuery(
         uploadable: core.file.Uploadable,
@@ -751,6 +784,9 @@ export class ParamsClient {
      * @param {boolean} param
      * @param {ParamsClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.params.getWithBooleanPath(true)
      */
@@ -808,6 +844,8 @@ export class ParamsClient {
      * @param {ParamsClient.RequestOptions} requestOptions - Request-specific configuration.
      *
      * @throws {@link SeedExhaustive.BadRequestBody}
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.params.getWithPathAndErrors("param")

--- a/seed/ts-sdk/exhaustive/web-stream-wrapper/src/api/resources/endpoints/resources/primitive/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/web-stream-wrapper/src/api/resources/endpoints/resources/primitive/client/Client.ts
@@ -25,6 +25,9 @@ export class PrimitiveClient {
      * @param {string} request
      * @param {PrimitiveClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.primitive.getAndReturnString("string")
      */
@@ -81,6 +84,9 @@ export class PrimitiveClient {
     /**
      * @param {number} request
      * @param {PrimitiveClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.primitive.getAndReturnInt(1)
@@ -139,6 +145,9 @@ export class PrimitiveClient {
      * @param {number} request
      * @param {PrimitiveClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.primitive.getAndReturnLong(1000000)
      */
@@ -195,6 +204,9 @@ export class PrimitiveClient {
     /**
      * @param {number} request
      * @param {PrimitiveClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.primitive.getAndReturnDouble(1.1)
@@ -253,6 +265,9 @@ export class PrimitiveClient {
      * @param {boolean} request
      * @param {PrimitiveClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.primitive.getAndReturnBool(true)
      */
@@ -309,6 +324,9 @@ export class PrimitiveClient {
     /**
      * @param {string} request
      * @param {PrimitiveClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.primitive.getAndReturnDatetime("2024-01-15T09:30:00Z")
@@ -367,6 +385,9 @@ export class PrimitiveClient {
      * @param {string} request
      * @param {PrimitiveClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.primitive.getAndReturnDate("2023-01-15")
      */
@@ -424,6 +445,9 @@ export class PrimitiveClient {
      * @param {string} request
      * @param {PrimitiveClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.primitive.getAndReturnUuid("d5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32")
      */
@@ -480,6 +504,9 @@ export class PrimitiveClient {
     /**
      * @param {string} request
      * @param {PrimitiveClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.primitive.getAndReturnBase64("SGVsbG8gd29ybGQh")

--- a/seed/ts-sdk/exhaustive/web-stream-wrapper/src/api/resources/endpoints/resources/put/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/web-stream-wrapper/src/api/resources/endpoints/resources/put/client/Client.ts
@@ -25,6 +25,9 @@ export class PutClient {
      * @param {SeedExhaustive.endpoints.PutRequest} request
      * @param {PutClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.put.add({
      *         id: "id"

--- a/seed/ts-sdk/exhaustive/web-stream-wrapper/src/api/resources/endpoints/resources/union/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/web-stream-wrapper/src/api/resources/endpoints/resources/union/client/Client.ts
@@ -26,6 +26,9 @@ export class UnionClient {
      * @param {SeedExhaustive.types.Animal} request
      * @param {UnionClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.union.getAndReturnUnion({
      *         animal: "dog",

--- a/seed/ts-sdk/exhaustive/web-stream-wrapper/src/api/resources/endpoints/resources/urls/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/web-stream-wrapper/src/api/resources/endpoints/resources/urls/client/Client.ts
@@ -23,6 +23,9 @@ export class UrlsClient {
     /**
      * @param {UrlsClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.urls.withMixedCase()
      */
@@ -69,6 +72,9 @@ export class UrlsClient {
 
     /**
      * @param {UrlsClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.urls.noEndingSlash()
@@ -117,6 +123,9 @@ export class UrlsClient {
     /**
      * @param {UrlsClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.endpoints.urls.withEndingSlash()
      */
@@ -163,6 +172,9 @@ export class UrlsClient {
 
     /**
      * @param {UrlsClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.endpoints.urls.withUnderscores()

--- a/seed/ts-sdk/exhaustive/web-stream-wrapper/src/api/resources/inlinedRequests/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/web-stream-wrapper/src/api/resources/inlinedRequests/client/Client.ts
@@ -29,6 +29,8 @@ export class InlinedRequestsClient {
      * @param {InlinedRequestsClient.RequestOptions} requestOptions - Request-specific configuration.
      *
      * @throws {@link SeedExhaustive.BadRequestBody}
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.inlinedRequests.postWithObjectBodyandResponse({
@@ -114,6 +116,9 @@ export class InlinedRequestsClient {
      *
      * @param {SeedExhaustive.PostWithArrayBodyAndHeaders} request
      * @param {InlinedRequestsClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.inlinedRequests.postWithArrayBodyAndHeaders({

--- a/seed/ts-sdk/exhaustive/web-stream-wrapper/src/api/resources/noAuth/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/web-stream-wrapper/src/api/resources/noAuth/client/Client.ts
@@ -29,6 +29,8 @@ export class NoAuthClient {
      * @param {NoAuthClient.RequestOptions} requestOptions - Request-specific configuration.
      *
      * @throws {@link SeedExhaustive.BadRequestBody}
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.noAuth.postWithNoAuth({

--- a/seed/ts-sdk/exhaustive/web-stream-wrapper/src/api/resources/noReqBody/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/web-stream-wrapper/src/api/resources/noReqBody/client/Client.ts
@@ -24,6 +24,9 @@ export class NoReqBodyClient {
     /**
      * @param {NoReqBodyClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.noReqBody.getWithNoRequestBody()
      */
@@ -77,6 +80,9 @@ export class NoReqBodyClient {
 
     /**
      * @param {NoReqBodyClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
      *
      * @example
      *     await client.noReqBody.postWithNoRequestBody()

--- a/seed/ts-sdk/exhaustive/web-stream-wrapper/src/api/resources/reqWithHeaders/client/Client.ts
+++ b/seed/ts-sdk/exhaustive/web-stream-wrapper/src/api/resources/reqWithHeaders/client/Client.ts
@@ -26,6 +26,9 @@ export class ReqWithHeadersClient {
      * @param {SeedExhaustive.ReqWithHeaders} request
      * @param {ReqWithHeadersClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExhaustiveError}
+     * @throws {@link errors.SeedExhaustiveTimeoutError}
+     *
      * @example
      *     await client.reqWithHeaders.getWithCustomHeader({
      *         "X-TEST-SERVICE-HEADER": "X-TEST-SERVICE-HEADER",

--- a/seed/ts-sdk/extends/src/Client.ts
+++ b/seed/ts-sdk/extends/src/Client.ts
@@ -26,6 +26,9 @@ export class SeedExtendsClient {
      * @param {SeedExtends.Inlined} request
      * @param {SeedExtendsClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExtendsError}
+     * @throws {@link errors.SeedExtendsTimeoutError}
+     *
      * @example
      *     await client.extendedInlineRequestBody({
      *         unique: "unique",

--- a/seed/ts-sdk/extra-properties/src/api/resources/user/client/Client.ts
+++ b/seed/ts-sdk/extra-properties/src/api/resources/user/client/Client.ts
@@ -26,6 +26,9 @@ export class UserClient {
      * @param {SeedExtraProperties.CreateUserRequest} request
      * @param {UserClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedExtraPropertiesError}
+     * @throws {@link errors.SeedExtraPropertiesTimeoutError}
+     *
      * @example
      *     await client.user.createUser({
      *         name: "Alice",

--- a/seed/ts-sdk/file-download/file-download-response-headers/src/api/resources/service/client/Client.ts
+++ b/seed/ts-sdk/file-download/file-download-response-headers/src/api/resources/service/client/Client.ts
@@ -23,6 +23,9 @@ export class ServiceClient {
     /**
      * @param {ServiceClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedFileDownloadError}
+     * @throws {@link errors.SeedFileDownloadTimeoutError}
+     *
      * @example
      *     await client.service.simple()
      */
@@ -62,6 +65,10 @@ export class ServiceClient {
         return handleNonStatusCodeError(_response.error, _response.rawResponse, "POST", "/snippet");
     }
 
+    /**
+     * @throws {@link errors.SeedFileDownloadError}
+     * @throws {@link errors.SeedFileDownloadTimeoutError}
+     */
     public downloadFile(requestOptions?: ServiceClient.RequestOptions): core.HttpResponsePromise<{
         data: core.BinaryResponse;
         contentLengthInBytes?: number;

--- a/seed/ts-sdk/file-download/no-custom-config/src/api/resources/service/client/Client.ts
+++ b/seed/ts-sdk/file-download/no-custom-config/src/api/resources/service/client/Client.ts
@@ -23,6 +23,9 @@ export class ServiceClient {
     /**
      * @param {ServiceClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedFileDownloadError}
+     * @throws {@link errors.SeedFileDownloadTimeoutError}
+     *
      * @example
      *     await client.service.simple()
      */
@@ -62,6 +65,10 @@ export class ServiceClient {
         return handleNonStatusCodeError(_response.error, _response.rawResponse, "POST", "/snippet");
     }
 
+    /**
+     * @throws {@link errors.SeedFileDownloadError}
+     * @throws {@link errors.SeedFileDownloadTimeoutError}
+     */
     public downloadFile(requestOptions?: ServiceClient.RequestOptions): core.HttpResponsePromise<core.BinaryResponse> {
         return core.HttpResponsePromise.fromPromise(this.__downloadFile(requestOptions));
     }

--- a/seed/ts-sdk/file-download/stream-wrapper/src/api/resources/service/client/Client.ts
+++ b/seed/ts-sdk/file-download/stream-wrapper/src/api/resources/service/client/Client.ts
@@ -24,6 +24,9 @@ export class ServiceClient {
     /**
      * @param {ServiceClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedFileDownloadError}
+     * @throws {@link errors.SeedFileDownloadTimeoutError}
+     *
      * @example
      *     await client.service.simple()
      */
@@ -63,6 +66,10 @@ export class ServiceClient {
         return handleNonStatusCodeError(_response.error, _response.rawResponse, "POST", "/snippet");
     }
 
+    /**
+     * @throws {@link errors.SeedFileDownloadError}
+     * @throws {@link errors.SeedFileDownloadTimeoutError}
+     */
     public downloadFile(requestOptions?: ServiceClient.RequestOptions): core.HttpResponsePromise<stream.Readable> {
         return core.HttpResponsePromise.fromPromise(this.__downloadFile(requestOptions));
     }

--- a/seed/ts-sdk/file-upload-openapi/src/api/resources/fileUploadExample/client/Client.ts
+++ b/seed/ts-sdk/file-upload-openapi/src/api/resources/fileUploadExample/client/Client.ts
@@ -27,6 +27,9 @@ export class FileUploadExampleClient {
      * @param {SeedApi.UploadFileRequest} request
      * @param {FileUploadExampleClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedApiError}
+     * @throws {@link errors.SeedApiTimeoutError}
+     *
      * @example
      *     import { createReadStream } from "fs";
      *     await client.fileUploadExample.uploadFile({

--- a/seed/ts-sdk/file-upload/form-data-node16/src/api/resources/service/client/Client.ts
+++ b/seed/ts-sdk/file-upload/form-data-node16/src/api/resources/service/client/Client.ts
@@ -25,6 +25,9 @@ export class ServiceClient {
     /**
      * @param {SeedFileUpload.MyRequest} request
      * @param {ServiceClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedFileUploadError}
+     * @throws {@link errors.SeedFileUploadTimeoutError}
      */
     public post(
         request: SeedFileUpload.MyRequest,
@@ -137,6 +140,9 @@ export class ServiceClient {
      * @param {SeedFileUpload.JustFileRequest} request
      * @param {ServiceClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedFileUploadError}
+     * @throws {@link errors.SeedFileUploadTimeoutError}
+     *
      * @example
      *     import { createReadStream } from "fs";
      *     await client.service.justFile({
@@ -198,6 +204,9 @@ export class ServiceClient {
     /**
      * @param {SeedFileUpload.JustFileWithQueryParamsRequest} request
      * @param {ServiceClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedFileUploadError}
+     * @throws {@link errors.SeedFileUploadTimeoutError}
      */
     public justFileWithQueryParams(
         request: SeedFileUpload.JustFileWithQueryParamsRequest,
@@ -265,6 +274,9 @@ export class ServiceClient {
     /**
      * @param {SeedFileUpload.JustFileWithOptionalQueryParamsRequest} request
      * @param {ServiceClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedFileUploadError}
+     * @throws {@link errors.SeedFileUploadTimeoutError}
      */
     public justFileWithOptionalQueryParams(
         request: SeedFileUpload.JustFileWithOptionalQueryParamsRequest,
@@ -334,6 +346,9 @@ export class ServiceClient {
     /**
      * @param {SeedFileUpload.WithContentTypeRequest} request
      * @param {ServiceClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedFileUploadError}
+     * @throws {@link errors.SeedFileUploadTimeoutError}
      */
     public withContentType(
         request: SeedFileUpload.WithContentTypeRequest,
@@ -396,6 +411,9 @@ export class ServiceClient {
     /**
      * @param {SeedFileUpload.WithFormEncodingRequest} request
      * @param {ServiceClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedFileUploadError}
+     * @throws {@link errors.SeedFileUploadTimeoutError}
      */
     public withFormEncoding(
         request: SeedFileUpload.WithFormEncodingRequest,
@@ -460,6 +478,9 @@ export class ServiceClient {
     /**
      * @param {SeedFileUpload.MyOtherRequest} request
      * @param {ServiceClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedFileUploadError}
+     * @throws {@link errors.SeedFileUploadTimeoutError}
      */
     public withFormEncodedContainers(
         request: SeedFileUpload.MyOtherRequest,
@@ -609,6 +630,9 @@ export class ServiceClient {
      * @param {SeedFileUpload.OptionalArgsRequest} request
      * @param {ServiceClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedFileUploadError}
+     * @throws {@link errors.SeedFileUploadTimeoutError}
+     *
      * @example
      *     import { createReadStream } from "fs";
      *     await client.service.optionalArgs({})
@@ -675,6 +699,9 @@ export class ServiceClient {
     /**
      * @param {SeedFileUpload.InlineTypeRequest} request
      * @param {ServiceClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedFileUploadError}
+     * @throws {@link errors.SeedFileUploadTimeoutError}
      */
     public withInlineType(
         request: SeedFileUpload.InlineTypeRequest,
@@ -732,6 +759,9 @@ export class ServiceClient {
     /**
      * @param {SeedFileUpload.WithJsonPropertyRequest} request
      * @param {ServiceClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedFileUploadError}
+     * @throws {@link errors.SeedFileUploadTimeoutError}
      */
     public withJsonProperty(
         request: SeedFileUpload.WithJsonPropertyRequest,
@@ -792,6 +822,9 @@ export class ServiceClient {
     /**
      * @param {SeedFileUpload.WithRefBodyRequest} request
      * @param {ServiceClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedFileUploadError}
+     * @throws {@link errors.SeedFileUploadTimeoutError}
      *
      * @example
      *     import { createReadStream } from "fs";
@@ -860,6 +893,9 @@ export class ServiceClient {
     /**
      * @param {ServiceClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedFileUploadError}
+     * @throws {@link errors.SeedFileUploadTimeoutError}
+     *
      * @example
      *     await client.service.simple()
      */
@@ -902,6 +938,9 @@ export class ServiceClient {
     /**
      * @param {SeedFileUpload.LiteralEnumRequest} request
      * @param {ServiceClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedFileUploadError}
+     * @throws {@link errors.SeedFileUploadTimeoutError}
      */
     public withLiteralAndEnumTypes(
         request: SeedFileUpload.LiteralEnumRequest,

--- a/seed/ts-sdk/file-upload/inline/src/api/resources/service/client/Client.ts
+++ b/seed/ts-sdk/file-upload/inline/src/api/resources/service/client/Client.ts
@@ -25,6 +25,9 @@ export class ServiceClient {
     /**
      * @param {SeedFileUpload.MyRequest} request
      * @param {ServiceClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedFileUploadError}
+     * @throws {@link errors.SeedFileUploadTimeoutError}
      */
     public post(
         request: SeedFileUpload.MyRequest,
@@ -137,6 +140,9 @@ export class ServiceClient {
      * @param {SeedFileUpload.JustFileRequest} request
      * @param {ServiceClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedFileUploadError}
+     * @throws {@link errors.SeedFileUploadTimeoutError}
+     *
      * @example
      *     import { createReadStream } from "fs";
      *     await client.service.justFile({
@@ -198,6 +204,9 @@ export class ServiceClient {
     /**
      * @param {SeedFileUpload.JustFileWithQueryParamsRequest} request
      * @param {ServiceClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedFileUploadError}
+     * @throws {@link errors.SeedFileUploadTimeoutError}
      */
     public justFileWithQueryParams(
         request: SeedFileUpload.JustFileWithQueryParamsRequest,
@@ -265,6 +274,9 @@ export class ServiceClient {
     /**
      * @param {SeedFileUpload.JustFileWithOptionalQueryParamsRequest} request
      * @param {ServiceClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedFileUploadError}
+     * @throws {@link errors.SeedFileUploadTimeoutError}
      */
     public justFileWithOptionalQueryParams(
         request: SeedFileUpload.JustFileWithOptionalQueryParamsRequest,
@@ -334,6 +346,9 @@ export class ServiceClient {
     /**
      * @param {SeedFileUpload.WithContentTypeRequest} request
      * @param {ServiceClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedFileUploadError}
+     * @throws {@link errors.SeedFileUploadTimeoutError}
      */
     public withContentType(
         request: SeedFileUpload.WithContentTypeRequest,
@@ -396,6 +411,9 @@ export class ServiceClient {
     /**
      * @param {SeedFileUpload.WithFormEncodingRequest} request
      * @param {ServiceClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedFileUploadError}
+     * @throws {@link errors.SeedFileUploadTimeoutError}
      */
     public withFormEncoding(
         request: SeedFileUpload.WithFormEncodingRequest,
@@ -460,6 +478,9 @@ export class ServiceClient {
     /**
      * @param {SeedFileUpload.MyOtherRequest} request
      * @param {ServiceClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedFileUploadError}
+     * @throws {@link errors.SeedFileUploadTimeoutError}
      */
     public withFormEncodedContainers(
         request: SeedFileUpload.MyOtherRequest,
@@ -609,6 +630,9 @@ export class ServiceClient {
      * @param {SeedFileUpload.OptionalArgsRequest} request
      * @param {ServiceClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedFileUploadError}
+     * @throws {@link errors.SeedFileUploadTimeoutError}
+     *
      * @example
      *     import { createReadStream } from "fs";
      *     await client.service.optionalArgs({})
@@ -675,6 +699,9 @@ export class ServiceClient {
     /**
      * @param {SeedFileUpload.InlineTypeRequest} request
      * @param {ServiceClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedFileUploadError}
+     * @throws {@link errors.SeedFileUploadTimeoutError}
      */
     public withInlineType(
         request: SeedFileUpload.InlineTypeRequest,
@@ -732,6 +759,9 @@ export class ServiceClient {
     /**
      * @param {SeedFileUpload.WithJsonPropertyRequest} request
      * @param {ServiceClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedFileUploadError}
+     * @throws {@link errors.SeedFileUploadTimeoutError}
      */
     public withJsonProperty(
         request: SeedFileUpload.WithJsonPropertyRequest,
@@ -792,6 +822,9 @@ export class ServiceClient {
     /**
      * @param {SeedFileUpload.WithRefBodyRequest} request
      * @param {ServiceClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedFileUploadError}
+     * @throws {@link errors.SeedFileUploadTimeoutError}
      *
      * @example
      *     import { createReadStream } from "fs";
@@ -860,6 +893,9 @@ export class ServiceClient {
     /**
      * @param {ServiceClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedFileUploadError}
+     * @throws {@link errors.SeedFileUploadTimeoutError}
+     *
      * @example
      *     await client.service.simple()
      */
@@ -902,6 +938,9 @@ export class ServiceClient {
     /**
      * @param {SeedFileUpload.LiteralEnumRequest} request
      * @param {ServiceClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedFileUploadError}
+     * @throws {@link errors.SeedFileUploadTimeoutError}
      */
     public withLiteralAndEnumTypes(
         request: SeedFileUpload.LiteralEnumRequest,

--- a/seed/ts-sdk/file-upload/no-custom-config/src/api/resources/service/client/Client.ts
+++ b/seed/ts-sdk/file-upload/no-custom-config/src/api/resources/service/client/Client.ts
@@ -25,6 +25,9 @@ export class ServiceClient {
     /**
      * @param {SeedFileUpload.MyRequest} request
      * @param {ServiceClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedFileUploadError}
+     * @throws {@link errors.SeedFileUploadTimeoutError}
      */
     public post(
         request: SeedFileUpload.MyRequest,
@@ -137,6 +140,9 @@ export class ServiceClient {
      * @param {SeedFileUpload.JustFileRequest} request
      * @param {ServiceClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedFileUploadError}
+     * @throws {@link errors.SeedFileUploadTimeoutError}
+     *
      * @example
      *     import { createReadStream } from "fs";
      *     await client.service.justFile({
@@ -198,6 +204,9 @@ export class ServiceClient {
     /**
      * @param {SeedFileUpload.JustFileWithQueryParamsRequest} request
      * @param {ServiceClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedFileUploadError}
+     * @throws {@link errors.SeedFileUploadTimeoutError}
      */
     public justFileWithQueryParams(
         request: SeedFileUpload.JustFileWithQueryParamsRequest,
@@ -265,6 +274,9 @@ export class ServiceClient {
     /**
      * @param {SeedFileUpload.JustFileWithOptionalQueryParamsRequest} request
      * @param {ServiceClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedFileUploadError}
+     * @throws {@link errors.SeedFileUploadTimeoutError}
      */
     public justFileWithOptionalQueryParams(
         request: SeedFileUpload.JustFileWithOptionalQueryParamsRequest,
@@ -334,6 +346,9 @@ export class ServiceClient {
     /**
      * @param {SeedFileUpload.WithContentTypeRequest} request
      * @param {ServiceClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedFileUploadError}
+     * @throws {@link errors.SeedFileUploadTimeoutError}
      */
     public withContentType(
         request: SeedFileUpload.WithContentTypeRequest,
@@ -396,6 +411,9 @@ export class ServiceClient {
     /**
      * @param {SeedFileUpload.WithFormEncodingRequest} request
      * @param {ServiceClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedFileUploadError}
+     * @throws {@link errors.SeedFileUploadTimeoutError}
      */
     public withFormEncoding(
         request: SeedFileUpload.WithFormEncodingRequest,
@@ -460,6 +478,9 @@ export class ServiceClient {
     /**
      * @param {SeedFileUpload.MyOtherRequest} request
      * @param {ServiceClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedFileUploadError}
+     * @throws {@link errors.SeedFileUploadTimeoutError}
      */
     public withFormEncodedContainers(
         request: SeedFileUpload.MyOtherRequest,
@@ -609,6 +630,9 @@ export class ServiceClient {
      * @param {SeedFileUpload.OptionalArgsRequest} request
      * @param {ServiceClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedFileUploadError}
+     * @throws {@link errors.SeedFileUploadTimeoutError}
+     *
      * @example
      *     import { createReadStream } from "fs";
      *     await client.service.optionalArgs({})
@@ -675,6 +699,9 @@ export class ServiceClient {
     /**
      * @param {SeedFileUpload.InlineTypeRequest} request
      * @param {ServiceClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedFileUploadError}
+     * @throws {@link errors.SeedFileUploadTimeoutError}
      */
     public withInlineType(
         request: SeedFileUpload.InlineTypeRequest,
@@ -732,6 +759,9 @@ export class ServiceClient {
     /**
      * @param {SeedFileUpload.WithJsonPropertyRequest} request
      * @param {ServiceClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedFileUploadError}
+     * @throws {@link errors.SeedFileUploadTimeoutError}
      */
     public withJsonProperty(
         request: SeedFileUpload.WithJsonPropertyRequest,
@@ -792,6 +822,9 @@ export class ServiceClient {
     /**
      * @param {SeedFileUpload.WithRefBodyRequest} request
      * @param {ServiceClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedFileUploadError}
+     * @throws {@link errors.SeedFileUploadTimeoutError}
      *
      * @example
      *     import { createReadStream } from "fs";
@@ -860,6 +893,9 @@ export class ServiceClient {
     /**
      * @param {ServiceClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedFileUploadError}
+     * @throws {@link errors.SeedFileUploadTimeoutError}
+     *
      * @example
      *     await client.service.simple()
      */
@@ -902,6 +938,9 @@ export class ServiceClient {
     /**
      * @param {SeedFileUpload.LiteralEnumRequest} request
      * @param {ServiceClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedFileUploadError}
+     * @throws {@link errors.SeedFileUploadTimeoutError}
      */
     public withLiteralAndEnumTypes(
         request: SeedFileUpload.LiteralEnumRequest,

--- a/seed/ts-sdk/file-upload/serde/src/api/resources/service/client/Client.ts
+++ b/seed/ts-sdk/file-upload/serde/src/api/resources/service/client/Client.ts
@@ -26,6 +26,9 @@ export class ServiceClient {
     /**
      * @param {SeedFileUpload.MyRequest} request
      * @param {ServiceClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedFileUploadError}
+     * @throws {@link errors.SeedFileUploadTimeoutError}
      */
     public post(
         request: SeedFileUpload.MyRequest,
@@ -176,6 +179,9 @@ export class ServiceClient {
      * @param {SeedFileUpload.JustFileRequest} request
      * @param {ServiceClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedFileUploadError}
+     * @throws {@link errors.SeedFileUploadTimeoutError}
+     *
      * @example
      *     import { createReadStream } from "fs";
      *     await client.service.justFile({
@@ -237,6 +243,9 @@ export class ServiceClient {
     /**
      * @param {SeedFileUpload.JustFileWithQueryParamsRequest} request
      * @param {ServiceClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedFileUploadError}
+     * @throws {@link errors.SeedFileUploadTimeoutError}
      */
     public justFileWithQueryParams(
         request: SeedFileUpload.JustFileWithQueryParamsRequest,
@@ -304,6 +313,9 @@ export class ServiceClient {
     /**
      * @param {SeedFileUpload.JustFileWithOptionalQueryParamsRequest} request
      * @param {ServiceClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedFileUploadError}
+     * @throws {@link errors.SeedFileUploadTimeoutError}
      */
     public justFileWithOptionalQueryParams(
         request: SeedFileUpload.JustFileWithOptionalQueryParamsRequest,
@@ -373,6 +385,9 @@ export class ServiceClient {
     /**
      * @param {SeedFileUpload.WithContentTypeRequest} request
      * @param {ServiceClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedFileUploadError}
+     * @throws {@link errors.SeedFileUploadTimeoutError}
      */
     public withContentType(
         request: SeedFileUpload.WithContentTypeRequest,
@@ -435,6 +450,9 @@ export class ServiceClient {
     /**
      * @param {SeedFileUpload.WithFormEncodingRequest} request
      * @param {ServiceClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedFileUploadError}
+     * @throws {@link errors.SeedFileUploadTimeoutError}
      */
     public withFormEncoding(
         request: SeedFileUpload.WithFormEncodingRequest,
@@ -499,6 +517,9 @@ export class ServiceClient {
     /**
      * @param {SeedFileUpload.MyOtherRequest} request
      * @param {ServiceClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedFileUploadError}
+     * @throws {@link errors.SeedFileUploadTimeoutError}
      */
     public withFormEncodedContainers(
         request: SeedFileUpload.MyOtherRequest,
@@ -648,6 +669,9 @@ export class ServiceClient {
      * @param {SeedFileUpload.OptionalArgsRequest} request
      * @param {ServiceClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedFileUploadError}
+     * @throws {@link errors.SeedFileUploadTimeoutError}
+     *
      * @example
      *     import { createReadStream } from "fs";
      *     await client.service.optionalArgs({})
@@ -723,6 +747,9 @@ export class ServiceClient {
     /**
      * @param {SeedFileUpload.InlineTypeRequest} request
      * @param {ServiceClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedFileUploadError}
+     * @throws {@link errors.SeedFileUploadTimeoutError}
      */
     public withInlineType(
         request: SeedFileUpload.InlineTypeRequest,
@@ -797,6 +824,9 @@ export class ServiceClient {
     /**
      * @param {SeedFileUpload.WithJsonPropertyRequest} request
      * @param {ServiceClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedFileUploadError}
+     * @throws {@link errors.SeedFileUploadTimeoutError}
      */
     public withJsonProperty(
         request: SeedFileUpload.WithJsonPropertyRequest,
@@ -875,6 +905,9 @@ export class ServiceClient {
      * @param {SeedFileUpload.WithRefBodyRequest} request
      * @param {ServiceClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedFileUploadError}
+     * @throws {@link errors.SeedFileUploadTimeoutError}
+     *
      * @example
      *     import { createReadStream } from "fs";
      *     await client.service.withRefBody({
@@ -951,6 +984,9 @@ export class ServiceClient {
     /**
      * @param {ServiceClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedFileUploadError}
+     * @throws {@link errors.SeedFileUploadTimeoutError}
+     *
      * @example
      *     await client.service.simple()
      */
@@ -993,6 +1029,9 @@ export class ServiceClient {
     /**
      * @param {SeedFileUpload.LiteralEnumRequest} request
      * @param {ServiceClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedFileUploadError}
+     * @throws {@link errors.SeedFileUploadTimeoutError}
      */
     public withLiteralAndEnumTypes(
         request: SeedFileUpload.LiteralEnumRequest,

--- a/seed/ts-sdk/file-upload/use-jest/src/api/resources/service/client/Client.ts
+++ b/seed/ts-sdk/file-upload/use-jest/src/api/resources/service/client/Client.ts
@@ -25,6 +25,9 @@ export class ServiceClient {
     /**
      * @param {SeedFileUpload.MyRequest} request
      * @param {ServiceClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedFileUploadError}
+     * @throws {@link errors.SeedFileUploadTimeoutError}
      */
     public post(
         request: SeedFileUpload.MyRequest,
@@ -137,6 +140,9 @@ export class ServiceClient {
      * @param {SeedFileUpload.JustFileRequest} request
      * @param {ServiceClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedFileUploadError}
+     * @throws {@link errors.SeedFileUploadTimeoutError}
+     *
      * @example
      *     import { createReadStream } from "fs";
      *     await client.service.justFile({
@@ -198,6 +204,9 @@ export class ServiceClient {
     /**
      * @param {SeedFileUpload.JustFileWithQueryParamsRequest} request
      * @param {ServiceClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedFileUploadError}
+     * @throws {@link errors.SeedFileUploadTimeoutError}
      */
     public justFileWithQueryParams(
         request: SeedFileUpload.JustFileWithQueryParamsRequest,
@@ -265,6 +274,9 @@ export class ServiceClient {
     /**
      * @param {SeedFileUpload.JustFileWithOptionalQueryParamsRequest} request
      * @param {ServiceClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedFileUploadError}
+     * @throws {@link errors.SeedFileUploadTimeoutError}
      */
     public justFileWithOptionalQueryParams(
         request: SeedFileUpload.JustFileWithOptionalQueryParamsRequest,
@@ -334,6 +346,9 @@ export class ServiceClient {
     /**
      * @param {SeedFileUpload.WithContentTypeRequest} request
      * @param {ServiceClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedFileUploadError}
+     * @throws {@link errors.SeedFileUploadTimeoutError}
      */
     public withContentType(
         request: SeedFileUpload.WithContentTypeRequest,
@@ -396,6 +411,9 @@ export class ServiceClient {
     /**
      * @param {SeedFileUpload.WithFormEncodingRequest} request
      * @param {ServiceClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedFileUploadError}
+     * @throws {@link errors.SeedFileUploadTimeoutError}
      */
     public withFormEncoding(
         request: SeedFileUpload.WithFormEncodingRequest,
@@ -460,6 +478,9 @@ export class ServiceClient {
     /**
      * @param {SeedFileUpload.MyOtherRequest} request
      * @param {ServiceClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedFileUploadError}
+     * @throws {@link errors.SeedFileUploadTimeoutError}
      */
     public withFormEncodedContainers(
         request: SeedFileUpload.MyOtherRequest,
@@ -609,6 +630,9 @@ export class ServiceClient {
      * @param {SeedFileUpload.OptionalArgsRequest} request
      * @param {ServiceClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedFileUploadError}
+     * @throws {@link errors.SeedFileUploadTimeoutError}
+     *
      * @example
      *     import { createReadStream } from "fs";
      *     await client.service.optionalArgs({})
@@ -675,6 +699,9 @@ export class ServiceClient {
     /**
      * @param {SeedFileUpload.InlineTypeRequest} request
      * @param {ServiceClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedFileUploadError}
+     * @throws {@link errors.SeedFileUploadTimeoutError}
      */
     public withInlineType(
         request: SeedFileUpload.InlineTypeRequest,
@@ -732,6 +759,9 @@ export class ServiceClient {
     /**
      * @param {SeedFileUpload.WithJsonPropertyRequest} request
      * @param {ServiceClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedFileUploadError}
+     * @throws {@link errors.SeedFileUploadTimeoutError}
      */
     public withJsonProperty(
         request: SeedFileUpload.WithJsonPropertyRequest,
@@ -792,6 +822,9 @@ export class ServiceClient {
     /**
      * @param {SeedFileUpload.WithRefBodyRequest} request
      * @param {ServiceClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedFileUploadError}
+     * @throws {@link errors.SeedFileUploadTimeoutError}
      *
      * @example
      *     import { createReadStream } from "fs";
@@ -860,6 +893,9 @@ export class ServiceClient {
     /**
      * @param {ServiceClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedFileUploadError}
+     * @throws {@link errors.SeedFileUploadTimeoutError}
+     *
      * @example
      *     await client.service.simple()
      */
@@ -902,6 +938,9 @@ export class ServiceClient {
     /**
      * @param {SeedFileUpload.LiteralEnumRequest} request
      * @param {ServiceClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedFileUploadError}
+     * @throws {@link errors.SeedFileUploadTimeoutError}
      */
     public withLiteralAndEnumTypes(
         request: SeedFileUpload.LiteralEnumRequest,

--- a/seed/ts-sdk/file-upload/wrapper/src/api/resources/service/client/Client.ts
+++ b/seed/ts-sdk/file-upload/wrapper/src/api/resources/service/client/Client.ts
@@ -25,6 +25,9 @@ export class ServiceClient {
     /**
      * @param {SeedFileUpload.MyRequest} request
      * @param {ServiceClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedFileUploadError}
+     * @throws {@link errors.SeedFileUploadTimeoutError}
      */
     public post(
         request: SeedFileUpload.MyRequest,
@@ -137,6 +140,9 @@ export class ServiceClient {
      * @param {SeedFileUpload.JustFileRequest} request
      * @param {ServiceClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedFileUploadError}
+     * @throws {@link errors.SeedFileUploadTimeoutError}
+     *
      * @example
      *     import { createReadStream } from "fs";
      *     await client.service.justFile({
@@ -198,6 +204,9 @@ export class ServiceClient {
     /**
      * @param {SeedFileUpload.JustFileWithQueryParamsRequest} request
      * @param {ServiceClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedFileUploadError}
+     * @throws {@link errors.SeedFileUploadTimeoutError}
      */
     public justFileWithQueryParams(
         request: SeedFileUpload.JustFileWithQueryParamsRequest,
@@ -265,6 +274,9 @@ export class ServiceClient {
     /**
      * @param {SeedFileUpload.JustFileWithOptionalQueryParamsRequest} request
      * @param {ServiceClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedFileUploadError}
+     * @throws {@link errors.SeedFileUploadTimeoutError}
      */
     public justFileWithOptionalQueryParams(
         request: SeedFileUpload.JustFileWithOptionalQueryParamsRequest,
@@ -334,6 +346,9 @@ export class ServiceClient {
     /**
      * @param {SeedFileUpload.WithContentTypeRequest} request
      * @param {ServiceClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedFileUploadError}
+     * @throws {@link errors.SeedFileUploadTimeoutError}
      */
     public withContentType(
         request: SeedFileUpload.WithContentTypeRequest,
@@ -396,6 +411,9 @@ export class ServiceClient {
     /**
      * @param {SeedFileUpload.WithFormEncodingRequest} request
      * @param {ServiceClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedFileUploadError}
+     * @throws {@link errors.SeedFileUploadTimeoutError}
      */
     public withFormEncoding(
         request: SeedFileUpload.WithFormEncodingRequest,
@@ -460,6 +478,9 @@ export class ServiceClient {
     /**
      * @param {SeedFileUpload.MyOtherRequest} request
      * @param {ServiceClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedFileUploadError}
+     * @throws {@link errors.SeedFileUploadTimeoutError}
      */
     public withFormEncodedContainers(
         request: SeedFileUpload.MyOtherRequest,
@@ -609,6 +630,9 @@ export class ServiceClient {
      * @param {SeedFileUpload.OptionalArgsRequest} request
      * @param {ServiceClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedFileUploadError}
+     * @throws {@link errors.SeedFileUploadTimeoutError}
+     *
      * @example
      *     import { createReadStream } from "fs";
      *     await client.service.optionalArgs({})
@@ -675,6 +699,9 @@ export class ServiceClient {
     /**
      * @param {SeedFileUpload.InlineTypeRequest} request
      * @param {ServiceClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedFileUploadError}
+     * @throws {@link errors.SeedFileUploadTimeoutError}
      */
     public withInlineType(
         request: SeedFileUpload.InlineTypeRequest,
@@ -732,6 +759,9 @@ export class ServiceClient {
     /**
      * @param {SeedFileUpload.WithJsonPropertyRequest} request
      * @param {ServiceClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedFileUploadError}
+     * @throws {@link errors.SeedFileUploadTimeoutError}
      */
     public withJsonProperty(
         request: SeedFileUpload.WithJsonPropertyRequest,
@@ -792,6 +822,9 @@ export class ServiceClient {
     /**
      * @param {SeedFileUpload.WithRefBodyRequest} request
      * @param {ServiceClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedFileUploadError}
+     * @throws {@link errors.SeedFileUploadTimeoutError}
      *
      * @example
      *     import { createReadStream } from "fs";
@@ -860,6 +893,9 @@ export class ServiceClient {
     /**
      * @param {ServiceClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedFileUploadError}
+     * @throws {@link errors.SeedFileUploadTimeoutError}
+     *
      * @example
      *     await client.service.simple()
      */
@@ -902,6 +938,9 @@ export class ServiceClient {
     /**
      * @param {SeedFileUpload.LiteralEnumRequest} request
      * @param {ServiceClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedFileUploadError}
+     * @throws {@link errors.SeedFileUploadTimeoutError}
      */
     public withLiteralAndEnumTypes(
         request: SeedFileUpload.LiteralEnumRequest,

--- a/seed/ts-sdk/folders/src/Client.ts
+++ b/seed/ts-sdk/folders/src/Client.ts
@@ -35,6 +35,9 @@ export class SeedApiClient {
     /**
      * @param {SeedApiClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedApiError}
+     * @throws {@link errors.SeedApiTimeoutError}
+     *
      * @example
      *     await client.foo()
      */

--- a/seed/ts-sdk/folders/src/api/resources/a/resources/b/client/Client.ts
+++ b/seed/ts-sdk/folders/src/api/resources/a/resources/b/client/Client.ts
@@ -23,6 +23,9 @@ export class BClient {
     /**
      * @param {BClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedApiError}
+     * @throws {@link errors.SeedApiTimeoutError}
+     *
      * @example
      *     await client.a.b.foo()
      */

--- a/seed/ts-sdk/folders/src/api/resources/a/resources/c/client/Client.ts
+++ b/seed/ts-sdk/folders/src/api/resources/a/resources/c/client/Client.ts
@@ -23,6 +23,9 @@ export class CClient {
     /**
      * @param {CClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedApiError}
+     * @throws {@link errors.SeedApiTimeoutError}
+     *
      * @example
      *     await client.a.c.foo()
      */

--- a/seed/ts-sdk/folders/src/api/resources/folder/client/Client.ts
+++ b/seed/ts-sdk/folders/src/api/resources/folder/client/Client.ts
@@ -29,6 +29,9 @@ export class FolderClient {
     /**
      * @param {FolderClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedApiError}
+     * @throws {@link errors.SeedApiTimeoutError}
+     *
      * @example
      *     await client.folder.foo()
      */

--- a/seed/ts-sdk/folders/src/api/resources/folder/resources/service/client/Client.ts
+++ b/seed/ts-sdk/folders/src/api/resources/folder/resources/service/client/Client.ts
@@ -25,6 +25,9 @@ export class ServiceClient {
     /**
      * @param {ServiceClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedApiError}
+     * @throws {@link errors.SeedApiTimeoutError}
+     *
      * @example
      *     await client.folder.service.endpoint()
      */
@@ -69,6 +72,8 @@ export class ServiceClient {
      * @param {ServiceClient.RequestOptions} requestOptions - Request-specific configuration.
      *
      * @throws {@link SeedApi.folder.NotFoundError}
+     * @throws {@link errors.SeedApiError}
+     * @throws {@link errors.SeedApiTimeoutError}
      *
      * @example
      *     await client.folder.service.unknownRequest({

--- a/seed/ts-sdk/header-auth-environment-variable/src/api/resources/service/client/Client.ts
+++ b/seed/ts-sdk/header-auth-environment-variable/src/api/resources/service/client/Client.ts
@@ -25,6 +25,9 @@ export class ServiceClient {
      *
      * @param {ServiceClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedHeaderTokenEnvironmentVariableError}
+     * @throws {@link errors.SeedHeaderTokenEnvironmentVariableTimeoutError}
+     *
      * @example
      *     await client.service.getWithBearerToken()
      */

--- a/seed/ts-sdk/header-auth/src/api/resources/service/client/Client.ts
+++ b/seed/ts-sdk/header-auth/src/api/resources/service/client/Client.ts
@@ -25,6 +25,9 @@ export class ServiceClient {
      *
      * @param {ServiceClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedHeaderTokenError}
+     * @throws {@link errors.SeedHeaderTokenTimeoutError}
+     *
      * @example
      *     await client.service.getWithBearerToken()
      */

--- a/seed/ts-sdk/http-head/src/api/resources/user/client/Client.ts
+++ b/seed/ts-sdk/http-head/src/api/resources/user/client/Client.ts
@@ -24,6 +24,9 @@ export class UserClient {
     /**
      * @param {UserClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedHttpHeadError}
+     * @throws {@link errors.SeedHttpHeadTimeoutError}
+     *
      * @example
      *     await client.user.head()
      */
@@ -66,6 +69,9 @@ export class UserClient {
     /**
      * @param {SeedHttpHead.ListUsersRequest} request
      * @param {UserClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedHttpHeadError}
+     * @throws {@link errors.SeedHttpHeadTimeoutError}
      *
      * @example
      *     await client.user.list({

--- a/seed/ts-sdk/idempotency-headers/auto-generate-idempotency-key/src/api/resources/payment/client/Client.ts
+++ b/seed/ts-sdk/idempotency-headers/auto-generate-idempotency-key/src/api/resources/payment/client/Client.ts
@@ -29,6 +29,9 @@ export class PaymentClient {
      * @param {SeedIdempotencyHeaders.CreatePaymentRequest} request
      * @param {PaymentClient.IdempotentRequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedIdempotencyHeadersError}
+     * @throws {@link errors.SeedIdempotencyHeadersTimeoutError}
+     *
      * @example
      *     await client.payment.create({
      *         amount: 1,
@@ -92,6 +95,9 @@ export class PaymentClient {
     /**
      * @param {string} paymentId
      * @param {PaymentClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedIdempotencyHeadersError}
+     * @throws {@link errors.SeedIdempotencyHeadersTimeoutError}
      *
      * @example
      *     await client.payment.delete("paymentId")

--- a/seed/ts-sdk/idempotency-headers/no-custom-config/src/api/resources/payment/client/Client.ts
+++ b/seed/ts-sdk/idempotency-headers/no-custom-config/src/api/resources/payment/client/Client.ts
@@ -28,6 +28,9 @@ export class PaymentClient {
      * @param {SeedIdempotencyHeaders.CreatePaymentRequest} request
      * @param {PaymentClient.IdempotentRequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedIdempotencyHeadersError}
+     * @throws {@link errors.SeedIdempotencyHeadersTimeoutError}
+     *
      * @example
      *     await client.payment.create({
      *         amount: 1,
@@ -91,6 +94,9 @@ export class PaymentClient {
     /**
      * @param {string} paymentId
      * @param {PaymentClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedIdempotencyHeadersError}
+     * @throws {@link errors.SeedIdempotencyHeadersTimeoutError}
      *
      * @example
      *     await client.payment.delete("paymentId")

--- a/seed/ts-sdk/imdb/branded-string-aliases/src/api/resources/imdb/client/Client.ts
+++ b/seed/ts-sdk/imdb/branded-string-aliases/src/api/resources/imdb/client/Client.ts
@@ -28,6 +28,9 @@ export class ImdbClient {
      * @param {SeedApi.CreateMovieRequest} request
      * @param {ImdbClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedApiError}
+     * @throws {@link errors.SeedApiTimeoutError}
+     *
      * @example
      *     await client.imdb.createMovie({
      *         title: "title",
@@ -86,6 +89,8 @@ export class ImdbClient {
      * @param {ImdbClient.RequestOptions} requestOptions - Request-specific configuration.
      *
      * @throws {@link SeedApi.NotFoundError}
+     * @throws {@link errors.SeedApiError}
+     * @throws {@link errors.SeedApiTimeoutError}
      *
      * @example
      *     await client.imdb.getMovie({

--- a/seed/ts-sdk/imdb/no-custom-config/src/api/resources/imdb/client/Client.ts
+++ b/seed/ts-sdk/imdb/no-custom-config/src/api/resources/imdb/client/Client.ts
@@ -28,6 +28,9 @@ export class ImdbClient {
      * @param {SeedApi.CreateMovieRequest} request
      * @param {ImdbClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedApiError}
+     * @throws {@link errors.SeedApiTimeoutError}
+     *
      * @example
      *     await client.imdb.createMovie({
      *         title: "title",
@@ -86,6 +89,8 @@ export class ImdbClient {
      * @param {ImdbClient.RequestOptions} requestOptions - Request-specific configuration.
      *
      * @throws {@link SeedApi.NotFoundError}
+     * @throws {@link errors.SeedApiError}
+     * @throws {@link errors.SeedApiTimeoutError}
      *
      * @example
      *     await client.imdb.getMovie({

--- a/seed/ts-sdk/imdb/omit-undefined/src/api/resources/imdb/client/Client.ts
+++ b/seed/ts-sdk/imdb/omit-undefined/src/api/resources/imdb/client/Client.ts
@@ -28,6 +28,9 @@ export class ImdbClient {
      * @param {SeedApi.CreateMovieRequest} request
      * @param {ImdbClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedApiError}
+     * @throws {@link errors.SeedApiTimeoutError}
+     *
      * @example
      *     await client.imdb.createMovie({
      *         title: "title",
@@ -86,6 +89,8 @@ export class ImdbClient {
      * @param {ImdbClient.RequestOptions} requestOptions - Request-specific configuration.
      *
      * @throws {@link SeedApi.NotFoundError}
+     * @throws {@link errors.SeedApiError}
+     * @throws {@link errors.SeedApiTimeoutError}
      *
      * @example
      *     await client.imdb.getMovie({

--- a/seed/ts-sdk/inferred-auth-explicit/src/api/resources/auth/client/Client.ts
+++ b/seed/ts-sdk/inferred-auth-explicit/src/api/resources/auth/client/Client.ts
@@ -26,6 +26,9 @@ export class AuthClient {
      * @param {SeedInferredAuthExplicit.GetTokenRequest} request
      * @param {AuthClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedInferredAuthExplicitError}
+     * @throws {@link errors.SeedInferredAuthExplicitTimeoutError}
+     *
      * @example
      *     await client.auth.getTokenWithClientCredentials({
      *         "X-Api-Key": "X-Api-Key",
@@ -93,6 +96,9 @@ export class AuthClient {
     /**
      * @param {SeedInferredAuthExplicit.RefreshTokenRequest} request
      * @param {AuthClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedInferredAuthExplicitError}
+     * @throws {@link errors.SeedInferredAuthExplicitTimeoutError}
      *
      * @example
      *     await client.auth.refreshToken({

--- a/seed/ts-sdk/inferred-auth-explicit/src/api/resources/nested/resources/api/client/Client.ts
+++ b/seed/ts-sdk/inferred-auth-explicit/src/api/resources/nested/resources/api/client/Client.ts
@@ -23,6 +23,9 @@ export class ApiClient {
     /**
      * @param {ApiClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedInferredAuthExplicitError}
+     * @throws {@link errors.SeedInferredAuthExplicitTimeoutError}
+     *
      * @example
      *     await client.nested.api.getSomething()
      */

--- a/seed/ts-sdk/inferred-auth-explicit/src/api/resources/nestedNoAuth/resources/api/client/Client.ts
+++ b/seed/ts-sdk/inferred-auth-explicit/src/api/resources/nestedNoAuth/resources/api/client/Client.ts
@@ -23,6 +23,9 @@ export class ApiClient {
     /**
      * @param {ApiClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedInferredAuthExplicitError}
+     * @throws {@link errors.SeedInferredAuthExplicitTimeoutError}
+     *
      * @example
      *     await client.nestedNoAuth.api.getSomething()
      */

--- a/seed/ts-sdk/inferred-auth-explicit/src/api/resources/simple/client/Client.ts
+++ b/seed/ts-sdk/inferred-auth-explicit/src/api/resources/simple/client/Client.ts
@@ -23,6 +23,9 @@ export class SimpleClient {
     /**
      * @param {SimpleClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedInferredAuthExplicitError}
+     * @throws {@link errors.SeedInferredAuthExplicitTimeoutError}
+     *
      * @example
      *     await client.simple.getSomething()
      */

--- a/seed/ts-sdk/inferred-auth-implicit-api-key/src/api/resources/auth/client/Client.ts
+++ b/seed/ts-sdk/inferred-auth-implicit-api-key/src/api/resources/auth/client/Client.ts
@@ -25,6 +25,9 @@ export class AuthClient {
      * @param {SeedInferredAuthImplicitApiKey.GetTokenRequest} request
      * @param {AuthClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedInferredAuthImplicitApiKeyError}
+     * @throws {@link errors.SeedInferredAuthImplicitApiKeyTimeoutError}
+     *
      * @example
      *     await client.auth.getToken({
      *         "X-Api-Key": "api_key"

--- a/seed/ts-sdk/inferred-auth-implicit-api-key/src/api/resources/nested/resources/api/client/Client.ts
+++ b/seed/ts-sdk/inferred-auth-implicit-api-key/src/api/resources/nested/resources/api/client/Client.ts
@@ -23,6 +23,9 @@ export class ApiClient {
     /**
      * @param {ApiClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedInferredAuthImplicitApiKeyError}
+     * @throws {@link errors.SeedInferredAuthImplicitApiKeyTimeoutError}
+     *
      * @example
      *     await client.nested.api.getSomething()
      */

--- a/seed/ts-sdk/inferred-auth-implicit-api-key/src/api/resources/nestedNoAuth/resources/api/client/Client.ts
+++ b/seed/ts-sdk/inferred-auth-implicit-api-key/src/api/resources/nestedNoAuth/resources/api/client/Client.ts
@@ -23,6 +23,9 @@ export class ApiClient {
     /**
      * @param {ApiClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedInferredAuthImplicitApiKeyError}
+     * @throws {@link errors.SeedInferredAuthImplicitApiKeyTimeoutError}
+     *
      * @example
      *     await client.nestedNoAuth.api.getSomething()
      */

--- a/seed/ts-sdk/inferred-auth-implicit-api-key/src/api/resources/simple/client/Client.ts
+++ b/seed/ts-sdk/inferred-auth-implicit-api-key/src/api/resources/simple/client/Client.ts
@@ -23,6 +23,9 @@ export class SimpleClient {
     /**
      * @param {SimpleClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedInferredAuthImplicitApiKeyError}
+     * @throws {@link errors.SeedInferredAuthImplicitApiKeyTimeoutError}
+     *
      * @example
      *     await client.simple.getSomething()
      */

--- a/seed/ts-sdk/inferred-auth-implicit-no-expiry/src/api/resources/auth/client/Client.ts
+++ b/seed/ts-sdk/inferred-auth-implicit-no-expiry/src/api/resources/auth/client/Client.ts
@@ -26,6 +26,9 @@ export class AuthClient {
      * @param {SeedInferredAuthImplicitNoExpiry.GetTokenRequest} request
      * @param {AuthClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedInferredAuthImplicitNoExpiryError}
+     * @throws {@link errors.SeedInferredAuthImplicitNoExpiryTimeoutError}
+     *
      * @example
      *     await client.auth.getTokenWithClientCredentials({
      *         "X-Api-Key": "X-Api-Key",
@@ -93,6 +96,9 @@ export class AuthClient {
     /**
      * @param {SeedInferredAuthImplicitNoExpiry.RefreshTokenRequest} request
      * @param {AuthClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedInferredAuthImplicitNoExpiryError}
+     * @throws {@link errors.SeedInferredAuthImplicitNoExpiryTimeoutError}
      *
      * @example
      *     await client.auth.refreshToken({

--- a/seed/ts-sdk/inferred-auth-implicit-no-expiry/src/api/resources/nested/resources/api/client/Client.ts
+++ b/seed/ts-sdk/inferred-auth-implicit-no-expiry/src/api/resources/nested/resources/api/client/Client.ts
@@ -23,6 +23,9 @@ export class ApiClient {
     /**
      * @param {ApiClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedInferredAuthImplicitNoExpiryError}
+     * @throws {@link errors.SeedInferredAuthImplicitNoExpiryTimeoutError}
+     *
      * @example
      *     await client.nested.api.getSomething()
      */

--- a/seed/ts-sdk/inferred-auth-implicit-no-expiry/src/api/resources/nestedNoAuth/resources/api/client/Client.ts
+++ b/seed/ts-sdk/inferred-auth-implicit-no-expiry/src/api/resources/nestedNoAuth/resources/api/client/Client.ts
@@ -23,6 +23,9 @@ export class ApiClient {
     /**
      * @param {ApiClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedInferredAuthImplicitNoExpiryError}
+     * @throws {@link errors.SeedInferredAuthImplicitNoExpiryTimeoutError}
+     *
      * @example
      *     await client.nestedNoAuth.api.getSomething()
      */

--- a/seed/ts-sdk/inferred-auth-implicit-no-expiry/src/api/resources/simple/client/Client.ts
+++ b/seed/ts-sdk/inferred-auth-implicit-no-expiry/src/api/resources/simple/client/Client.ts
@@ -23,6 +23,9 @@ export class SimpleClient {
     /**
      * @param {SimpleClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedInferredAuthImplicitNoExpiryError}
+     * @throws {@link errors.SeedInferredAuthImplicitNoExpiryTimeoutError}
+     *
      * @example
      *     await client.simple.getSomething()
      */

--- a/seed/ts-sdk/inferred-auth-implicit-reference/src/api/resources/auth/client/Client.ts
+++ b/seed/ts-sdk/inferred-auth-implicit-reference/src/api/resources/auth/client/Client.ts
@@ -26,6 +26,9 @@ export class AuthClient {
      * @param {SeedInferredAuthImplicit.GetTokenRequest} request
      * @param {AuthClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedInferredAuthImplicitError}
+     * @throws {@link errors.SeedInferredAuthImplicitTimeoutError}
+     *
      * @example
      *     await client.auth.getTokenWithClientCredentials({
      *         client_id: "client_id",
@@ -86,6 +89,9 @@ export class AuthClient {
     /**
      * @param {SeedInferredAuthImplicit.RefreshTokenRequest} request
      * @param {AuthClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedInferredAuthImplicitError}
+     * @throws {@link errors.SeedInferredAuthImplicitTimeoutError}
      *
      * @example
      *     await client.auth.refreshToken({

--- a/seed/ts-sdk/inferred-auth-implicit-reference/src/api/resources/nested/resources/api/client/Client.ts
+++ b/seed/ts-sdk/inferred-auth-implicit-reference/src/api/resources/nested/resources/api/client/Client.ts
@@ -23,6 +23,9 @@ export class ApiClient {
     /**
      * @param {ApiClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedInferredAuthImplicitError}
+     * @throws {@link errors.SeedInferredAuthImplicitTimeoutError}
+     *
      * @example
      *     await client.nested.api.getSomething()
      */

--- a/seed/ts-sdk/inferred-auth-implicit-reference/src/api/resources/nestedNoAuth/resources/api/client/Client.ts
+++ b/seed/ts-sdk/inferred-auth-implicit-reference/src/api/resources/nestedNoAuth/resources/api/client/Client.ts
@@ -23,6 +23,9 @@ export class ApiClient {
     /**
      * @param {ApiClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedInferredAuthImplicitError}
+     * @throws {@link errors.SeedInferredAuthImplicitTimeoutError}
+     *
      * @example
      *     await client.nestedNoAuth.api.getSomething()
      */

--- a/seed/ts-sdk/inferred-auth-implicit-reference/src/api/resources/simple/client/Client.ts
+++ b/seed/ts-sdk/inferred-auth-implicit-reference/src/api/resources/simple/client/Client.ts
@@ -23,6 +23,9 @@ export class SimpleClient {
     /**
      * @param {SimpleClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedInferredAuthImplicitError}
+     * @throws {@link errors.SeedInferredAuthImplicitTimeoutError}
+     *
      * @example
      *     await client.simple.getSomething()
      */

--- a/seed/ts-sdk/inferred-auth-implicit/src/api/resources/auth/client/Client.ts
+++ b/seed/ts-sdk/inferred-auth-implicit/src/api/resources/auth/client/Client.ts
@@ -26,6 +26,9 @@ export class AuthClient {
      * @param {SeedInferredAuthImplicit.GetTokenRequest} request
      * @param {AuthClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedInferredAuthImplicitError}
+     * @throws {@link errors.SeedInferredAuthImplicitTimeoutError}
+     *
      * @example
      *     await client.auth.getTokenWithClientCredentials({
      *         "X-Api-Key": "X-Api-Key",
@@ -93,6 +96,9 @@ export class AuthClient {
     /**
      * @param {SeedInferredAuthImplicit.RefreshTokenRequest} request
      * @param {AuthClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedInferredAuthImplicitError}
+     * @throws {@link errors.SeedInferredAuthImplicitTimeoutError}
      *
      * @example
      *     await client.auth.refreshToken({

--- a/seed/ts-sdk/inferred-auth-implicit/src/api/resources/nested/resources/api/client/Client.ts
+++ b/seed/ts-sdk/inferred-auth-implicit/src/api/resources/nested/resources/api/client/Client.ts
@@ -23,6 +23,9 @@ export class ApiClient {
     /**
      * @param {ApiClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedInferredAuthImplicitError}
+     * @throws {@link errors.SeedInferredAuthImplicitTimeoutError}
+     *
      * @example
      *     await client.nested.api.getSomething()
      */

--- a/seed/ts-sdk/inferred-auth-implicit/src/api/resources/nestedNoAuth/resources/api/client/Client.ts
+++ b/seed/ts-sdk/inferred-auth-implicit/src/api/resources/nestedNoAuth/resources/api/client/Client.ts
@@ -23,6 +23,9 @@ export class ApiClient {
     /**
      * @param {ApiClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedInferredAuthImplicitError}
+     * @throws {@link errors.SeedInferredAuthImplicitTimeoutError}
+     *
      * @example
      *     await client.nestedNoAuth.api.getSomething()
      */

--- a/seed/ts-sdk/inferred-auth-implicit/src/api/resources/simple/client/Client.ts
+++ b/seed/ts-sdk/inferred-auth-implicit/src/api/resources/simple/client/Client.ts
@@ -23,6 +23,9 @@ export class SimpleClient {
     /**
      * @param {SimpleClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedInferredAuthImplicitError}
+     * @throws {@link errors.SeedInferredAuthImplicitTimeoutError}
+     *
      * @example
      *     await client.simple.getSomething()
      */

--- a/seed/ts-sdk/inline-enum-type-name-override/src/api/resources/reporting/client/Client.ts
+++ b/seed/ts-sdk/inline-enum-type-name-override/src/api/resources/reporting/client/Client.ts
@@ -26,6 +26,9 @@ export class ReportingClient {
      * @param {SeedApi.LoadRequest} request
      * @param {ReportingClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedApiError}
+     * @throws {@link errors.SeedApiTimeoutError}
+     *
      * @example
      *     await client.reporting.load()
      */

--- a/seed/ts-sdk/license/src/Client.ts
+++ b/seed/ts-sdk/license/src/Client.ts
@@ -23,6 +23,9 @@ export class SeedLicenseClient {
     /**
      * @param {SeedLicenseClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedLicenseError}
+     * @throws {@link errors.SeedLicenseTimeoutError}
+     *
      * @example
      *     await client.get()
      */

--- a/seed/ts-sdk/literal-user-agent/src/Client.ts
+++ b/seed/ts-sdk/literal-user-agent/src/Client.ts
@@ -23,6 +23,9 @@ export class SeedLiteralUserAgentClient {
     /**
      * @param {SeedLiteralUserAgentClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedLiteralUserAgentError}
+     * @throws {@link errors.SeedLiteralUserAgentTimeoutError}
+     *
      * @example
      *     await client.ping()
      */

--- a/seed/ts-sdk/literal/src/api/resources/headers/client/Client.ts
+++ b/seed/ts-sdk/literal/src/api/resources/headers/client/Client.ts
@@ -26,6 +26,9 @@ export class HeadersClient {
      * @param {SeedLiteral.SendLiteralsInHeadersRequest} request
      * @param {HeadersClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedLiteralError}
+     * @throws {@link errors.SeedLiteralTimeoutError}
+     *
      * @example
      *     await client.headers.send({
      *         query: "What is the weather today"
@@ -83,5 +86,63 @@ export class HeadersClient {
         }
 
         return handleNonStatusCodeError(_response.error, _response.rawResponse, "POST", "/headers");
+    }
+
+    /**
+     * @param {HeadersClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedLiteralError}
+     * @throws {@link errors.SeedLiteralTimeoutError}
+     *
+     * @example
+     *     await client.headers.sendLiteralsOnly()
+     */
+    public sendLiteralsOnly(
+        requestOptions?: HeadersClient.RequestOptions,
+    ): core.HttpResponsePromise<SeedLiteral.SendResponse> {
+        return core.HttpResponsePromise.fromPromise(this.__sendLiteralsOnly(requestOptions));
+    }
+
+    private async __sendLiteralsOnly(
+        requestOptions?: HeadersClient.RequestOptions,
+    ): Promise<core.WithRawResponse<SeedLiteral.SendResponse>> {
+        const _headers: core.Fetcher.Args["headers"] = mergeHeaders(
+            this._options?.headers,
+            mergeOnlyDefinedHeaders({
+                "X-Endpoint-Version": "02-12-2024",
+                "X-Async": "true",
+                "X-API-Version": requestOptions?.version ?? "02-02-2024",
+                "X-API-Enable-Audit-Logging": (requestOptions?.auditLogging ?? true).toString(),
+            }),
+            requestOptions?.headers,
+        );
+        const _response = await core.fetcher({
+            url: core.url.join(
+                (await core.Supplier.get(this._options.baseUrl)) ??
+                    (await core.Supplier.get(this._options.environment)),
+                "headers/literals-only",
+            ),
+            method: "POST",
+            headers: _headers,
+            queryString: core.url.queryBuilder().mergeAdditional(requestOptions?.queryParams).build(),
+            timeoutMs: (requestOptions?.timeoutInSeconds ?? this._options?.timeoutInSeconds ?? 60) * 1000,
+            maxRetries: requestOptions?.maxRetries ?? this._options?.maxRetries,
+            abortSignal: requestOptions?.abortSignal,
+            fetchFn: this._options?.fetch,
+            logging: this._options.logging,
+        });
+        if (_response.ok) {
+            return { data: _response.body as SeedLiteral.SendResponse, rawResponse: _response.rawResponse };
+        }
+
+        if (_response.error.reason === "status-code") {
+            throw new errors.SeedLiteralError({
+                statusCode: _response.error.statusCode,
+                body: _response.error.body,
+                rawResponse: _response.rawResponse,
+            });
+        }
+
+        return handleNonStatusCodeError(_response.error, _response.rawResponse, "POST", "/headers/literals-only");
     }
 }

--- a/seed/ts-sdk/literal/src/api/resources/inlined/client/Client.ts
+++ b/seed/ts-sdk/literal/src/api/resources/inlined/client/Client.ts
@@ -26,6 +26,9 @@ export class InlinedClient {
      * @param {SeedLiteral.SendLiteralsInlinedRequest} request
      * @param {InlinedClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedLiteralError}
+     * @throws {@link errors.SeedLiteralTimeoutError}
+     *
      * @example
      *     await client.inlined.send({
      *         temperature: 10.1,

--- a/seed/ts-sdk/literal/src/api/resources/path/client/Client.ts
+++ b/seed/ts-sdk/literal/src/api/resources/path/client/Client.ts
@@ -25,6 +25,9 @@ export class PathClient {
      * @param {"123"} id
      * @param {PathClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedLiteralError}
+     * @throws {@link errors.SeedLiteralTimeoutError}
+     *
      * @example
      *     await client.path.send("123")
      */

--- a/seed/ts-sdk/literal/src/api/resources/query/client/Client.ts
+++ b/seed/ts-sdk/literal/src/api/resources/query/client/Client.ts
@@ -25,6 +25,9 @@ export class QueryClient {
      * @param {SeedLiteral.SendLiteralsInQueryRequest} request
      * @param {QueryClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedLiteralError}
+     * @throws {@link errors.SeedLiteralTimeoutError}
+     *
      * @example
      *     await client.query.send({
      *         prompt: "You are a helpful assistant",

--- a/seed/ts-sdk/literal/src/api/resources/reference/client/Client.ts
+++ b/seed/ts-sdk/literal/src/api/resources/reference/client/Client.ts
@@ -26,6 +26,9 @@ export class ReferenceClient {
      * @param {SeedLiteral.SendRequest} request
      * @param {ReferenceClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedLiteralError}
+     * @throws {@link errors.SeedLiteralTimeoutError}
+     *
      * @example
      *     await client.reference.send({
      *         prompt: "You are a helpful assistant",

--- a/seed/ts-sdk/mixed-case/no-custom-config/src/api/resources/service/client/Client.ts
+++ b/seed/ts-sdk/mixed-case/no-custom-config/src/api/resources/service/client/Client.ts
@@ -25,6 +25,9 @@ export class ServiceClient {
      * @param {string} ResourceID
      * @param {ServiceClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedMixedCaseError}
+     * @throws {@link errors.SeedMixedCaseTimeoutError}
+     *
      * @example
      *     await client.service.getResource("rsc-xyz")
      */
@@ -73,6 +76,9 @@ export class ServiceClient {
     /**
      * @param {SeedMixedCase.ListResourcesRequest} request
      * @param {ServiceClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedMixedCaseError}
+     * @throws {@link errors.SeedMixedCaseTimeoutError}
      *
      * @example
      *     await client.service.listResources({

--- a/seed/ts-sdk/mixed-case/retain-original-casing/src/api/resources/service/client/Client.ts
+++ b/seed/ts-sdk/mixed-case/retain-original-casing/src/api/resources/service/client/Client.ts
@@ -25,6 +25,9 @@ export class ServiceClient {
      * @param {string} ResourceID
      * @param {ServiceClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedMixedCaseError}
+     * @throws {@link errors.SeedMixedCaseTimeoutError}
+     *
      * @example
      *     await client.service.getResource("rsc-xyz")
      */
@@ -73,6 +76,9 @@ export class ServiceClient {
     /**
      * @param {SeedMixedCase.ListResourcesRequest} request
      * @param {ServiceClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedMixedCaseError}
+     * @throws {@link errors.SeedMixedCaseTimeoutError}
      *
      * @example
      *     await client.service.listResources({

--- a/seed/ts-sdk/mixed-file-directory/src/api/resources/organization/client/Client.ts
+++ b/seed/ts-sdk/mixed-file-directory/src/api/resources/organization/client/Client.ts
@@ -28,6 +28,9 @@ export class OrganizationClient {
      * @param {SeedMixedFileDirectory.CreateOrganizationRequest} request
      * @param {OrganizationClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedMixedFileDirectoryError}
+     * @throws {@link errors.SeedMixedFileDirectoryTimeoutError}
+     *
      * @example
      *     await client.organization.create({
      *         name: "name"

--- a/seed/ts-sdk/mixed-file-directory/src/api/resources/user/client/Client.ts
+++ b/seed/ts-sdk/mixed-file-directory/src/api/resources/user/client/Client.ts
@@ -33,6 +33,9 @@ export class UserClient {
      * @param {SeedMixedFileDirectory.ListUsersRequest} request
      * @param {UserClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedMixedFileDirectoryError}
+     * @throws {@link errors.SeedMixedFileDirectoryTimeoutError}
+     *
      * @example
      *     await client.user.list({
      *         limit: 1

--- a/seed/ts-sdk/mixed-file-directory/src/api/resources/user/resources/events/client/Client.ts
+++ b/seed/ts-sdk/mixed-file-directory/src/api/resources/user/resources/events/client/Client.ts
@@ -33,6 +33,9 @@ export class EventsClient {
      * @param {SeedMixedFileDirectory.user.ListUserEventsRequest} request
      * @param {EventsClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedMixedFileDirectoryError}
+     * @throws {@link errors.SeedMixedFileDirectoryTimeoutError}
+     *
      * @example
      *     await client.user.events.listEvents({
      *         limit: 1

--- a/seed/ts-sdk/mixed-file-directory/src/api/resources/user/resources/events/resources/metadata/client/Client.ts
+++ b/seed/ts-sdk/mixed-file-directory/src/api/resources/user/resources/events/resources/metadata/client/Client.ts
@@ -27,6 +27,9 @@ export class MetadataClient {
      * @param {SeedMixedFileDirectory.user.events.GetEventMetadataRequest} request
      * @param {MetadataClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedMixedFileDirectoryError}
+     * @throws {@link errors.SeedMixedFileDirectoryTimeoutError}
+     *
      * @example
      *     await client.user.events.metadata.getMetadata({
      *         id: "id"

--- a/seed/ts-sdk/multi-content-type-examples/src/api/resources/clients/client/Client.ts
+++ b/seed/ts-sdk/multi-content-type-examples/src/api/resources/clients/client/Client.ts
@@ -26,6 +26,9 @@ export class ClientsClient {
      * @param {SeedApi.ClientRequest} request
      * @param {ClientsClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedApiError}
+     * @throws {@link errors.SeedApiTimeoutError}
+     *
      * @example
      *     await client.clients.create({
      *         client: {

--- a/seed/ts-sdk/multi-line-docs/src/api/resources/user/client/Client.ts
+++ b/seed/ts-sdk/multi-line-docs/src/api/resources/user/client/Client.ts
@@ -30,6 +30,9 @@ export class UserClient {
      *                          This ID is unique to each user.
      * @param {UserClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedMultiLineDocsError}
+     * @throws {@link errors.SeedMultiLineDocsTimeoutError}
+     *
      * @example
      *     await client.user.getUser("userId")
      */
@@ -78,6 +81,9 @@ export class UserClient {
      *
      * @param {SeedMultiLineDocs.CreateUserRequest} request
      * @param {UserClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedMultiLineDocsError}
+     * @throws {@link errors.SeedMultiLineDocsTimeoutError}
      *
      * @example
      *     await client.user.createUser({

--- a/seed/ts-sdk/multi-url-environment-no-default/src/api/resources/ec2/client/Client.ts
+++ b/seed/ts-sdk/multi-url-environment-no-default/src/api/resources/ec2/client/Client.ts
@@ -26,6 +26,9 @@ export class Ec2Client {
      * @param {SeedMultiUrlEnvironmentNoDefault.BootInstanceRequest} request
      * @param {Ec2Client.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedMultiUrlEnvironmentNoDefaultError}
+     * @throws {@link errors.SeedMultiUrlEnvironmentNoDefaultTimeoutError}
+     *
      * @example
      *     await client.ec2.bootInstance({
      *         size: "size"

--- a/seed/ts-sdk/multi-url-environment-no-default/src/api/resources/s3/client/Client.ts
+++ b/seed/ts-sdk/multi-url-environment-no-default/src/api/resources/s3/client/Client.ts
@@ -26,6 +26,9 @@ export class S3Client {
      * @param {SeedMultiUrlEnvironmentNoDefault.GetPresignedUrlRequest} request
      * @param {S3Client.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedMultiUrlEnvironmentNoDefaultError}
+     * @throws {@link errors.SeedMultiUrlEnvironmentNoDefaultTimeoutError}
+     *
      * @example
      *     await client.s3.getPresignedUrl({
      *         s3Key: "s3Key"

--- a/seed/ts-sdk/multi-url-environment-reference/src/api/resources/auth/client/Client.ts
+++ b/seed/ts-sdk/multi-url-environment-reference/src/api/resources/auth/client/Client.ts
@@ -27,6 +27,9 @@ export class AuthClient {
      * @param {SeedApi.AuthGetTokenRequest} request
      * @param {AuthClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedApiError}
+     * @throws {@link errors.SeedApiTimeoutError}
+     *
      * @example
      *     await client.auth.gettoken({
      *         client_id: "client_id",

--- a/seed/ts-sdk/multi-url-environment-reference/src/api/resources/files/client/Client.ts
+++ b/seed/ts-sdk/multi-url-environment-reference/src/api/resources/files/client/Client.ts
@@ -27,6 +27,9 @@ export class FilesClient {
      * @param {SeedApi.FilesUploadRequest} request
      * @param {FilesClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedApiError}
+     * @throws {@link errors.SeedApiTimeoutError}
+     *
      * @example
      *     await client.files.upload({
      *         name: "name",

--- a/seed/ts-sdk/multi-url-environment-reference/src/api/resources/items/client/Client.ts
+++ b/seed/ts-sdk/multi-url-environment-reference/src/api/resources/items/client/Client.ts
@@ -24,6 +24,9 @@ export class ItemsClient {
     /**
      * @param {ItemsClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedApiError}
+     * @throws {@link errors.SeedApiTimeoutError}
+     *
      * @example
      *     await client.items.listItems()
      */

--- a/seed/ts-sdk/multi-url-environment/src/api/resources/ec2/client/Client.ts
+++ b/seed/ts-sdk/multi-url-environment/src/api/resources/ec2/client/Client.ts
@@ -27,6 +27,9 @@ export class Ec2Client {
      * @param {SeedMultiUrlEnvironment.BootInstanceRequest} request
      * @param {Ec2Client.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedMultiUrlEnvironmentError}
+     * @throws {@link errors.SeedMultiUrlEnvironmentTimeoutError}
+     *
      * @example
      *     await client.ec2.bootInstance({
      *         size: "size"

--- a/seed/ts-sdk/multi-url-environment/src/api/resources/s3/client/Client.ts
+++ b/seed/ts-sdk/multi-url-environment/src/api/resources/s3/client/Client.ts
@@ -27,6 +27,9 @@ export class S3Client {
      * @param {SeedMultiUrlEnvironment.GetPresignedUrlRequest} request
      * @param {S3Client.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedMultiUrlEnvironmentError}
+     * @throws {@link errors.SeedMultiUrlEnvironmentTimeoutError}
+     *
      * @example
      *     await client.s3.getPresignedUrl({
      *         s3Key: "s3Key"

--- a/seed/ts-sdk/multiple-request-bodies/src/Client.ts
+++ b/seed/ts-sdk/multiple-request-bodies/src/Client.ts
@@ -27,6 +27,9 @@ export class SeedApiClient {
      * @param {SeedApi.UploadDocumentRequest} request
      * @param {SeedApiClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedApiError}
+     * @throws {@link errors.SeedApiTimeoutError}
+     *
      * @example
      *     await client.uploadJsonDocument()
      */
@@ -84,6 +87,9 @@ export class SeedApiClient {
     /**
      * @param {core.file.Uploadable} uploadable
      * @param {SeedApiClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedApiError}
+     * @throws {@link errors.SeedApiTimeoutError}
      */
     public uploadPdfDocument(
         uploadable: core.file.Uploadable,

--- a/seed/ts-sdk/no-content-response/src/api/resources/contacts/client/Client.ts
+++ b/seed/ts-sdk/no-content-response/src/api/resources/contacts/client/Client.ts
@@ -28,6 +28,9 @@ export class ContactsClient {
      * @param {SeedApi.CreateContactRequest} request
      * @param {ContactsClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedApiError}
+     * @throws {@link errors.SeedApiTimeoutError}
+     *
      * @example
      *     await client.contacts.create({
      *         name: "name"
@@ -83,6 +86,9 @@ export class ContactsClient {
      *
      * @param {SeedApi.GetContactsRequest} request
      * @param {ContactsClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedApiError}
+     * @throws {@link errors.SeedApiTimeoutError}
      *
      * @example
      *     await client.contacts.get({

--- a/seed/ts-sdk/no-environment/src/api/resources/dummy/client/Client.ts
+++ b/seed/ts-sdk/no-environment/src/api/resources/dummy/client/Client.ts
@@ -23,6 +23,9 @@ export class DummyClient {
     /**
      * @param {DummyClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedNoEnvironmentError}
+     * @throws {@link errors.SeedNoEnvironmentTimeoutError}
+     *
      * @example
      *     await client.dummy.getDummy()
      */

--- a/seed/ts-sdk/no-retries/src/api/resources/retries/client/Client.ts
+++ b/seed/ts-sdk/no-retries/src/api/resources/retries/client/Client.ts
@@ -24,6 +24,9 @@ export class RetriesClient {
     /**
      * @param {RetriesClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedNoRetriesError}
+     * @throws {@link errors.SeedNoRetriesTimeoutError}
+     *
      * @example
      *     await client.retries.getUsers()
      */

--- a/seed/ts-sdk/null-type/src/api/resources/conversations/client/Client.ts
+++ b/seed/ts-sdk/null-type/src/api/resources/conversations/client/Client.ts
@@ -28,6 +28,9 @@ export class ConversationsClient {
      * @param {SeedApi.OutboundCallConversationsRequest} request
      * @param {ConversationsClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedApiError}
+     * @throws {@link errors.SeedApiTimeoutError}
+     *
      * @example
      *     await client.conversations.outboundCall({
      *         to_phone_number: "to_phone_number"

--- a/seed/ts-sdk/null-type/src/api/resources/users/client/Client.ts
+++ b/seed/ts-sdk/null-type/src/api/resources/users/client/Client.ts
@@ -27,6 +27,9 @@ export class UsersClient {
      * @param {SeedApi.GetUsersRequest} request
      * @param {UsersClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedApiError}
+     * @throws {@link errors.SeedApiTimeoutError}
+     *
      * @example
      *     await client.users.get({
      *         id: "id"

--- a/seed/ts-sdk/nullable-allof-extends/src/Client.ts
+++ b/seed/ts-sdk/nullable-allof-extends/src/Client.ts
@@ -28,6 +28,9 @@ export class SeedApiClient {
      *
      * @param {SeedApiClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedApiError}
+     * @throws {@link errors.SeedApiTimeoutError}
+     *
      * @example
      *     await client.getTest()
      */
@@ -75,6 +78,9 @@ export class SeedApiClient {
      *
      * @param {SeedApi.RootObject} request
      * @param {SeedApiClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedApiError}
+     * @throws {@link errors.SeedApiTimeoutError}
      *
      * @example
      *     await client.createTest({})

--- a/seed/ts-sdk/nullable-optional/src/api/resources/nullableOptional/client/Client.ts
+++ b/seed/ts-sdk/nullable-optional/src/api/resources/nullableOptional/client/Client.ts
@@ -28,6 +28,9 @@ export class NullableOptionalClient {
      * @param {string} userId
      * @param {NullableOptionalClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedNullableOptionalError}
+     * @throws {@link errors.SeedNullableOptionalTimeoutError}
+     *
      * @example
      *     await client.nullableOptional.getUser("userId")
      */
@@ -78,6 +81,9 @@ export class NullableOptionalClient {
      *
      * @param {SeedNullableOptional.CreateUserRequest} request
      * @param {NullableOptionalClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedNullableOptionalError}
+     * @throws {@link errors.SeedNullableOptionalTimeoutError}
      *
      * @example
      *     await client.nullableOptional.createUser({
@@ -146,6 +152,9 @@ export class NullableOptionalClient {
      * @param {string} userId
      * @param {SeedNullableOptional.UpdateUserRequest} request
      * @param {NullableOptionalClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedNullableOptionalError}
+     * @throws {@link errors.SeedNullableOptionalTimeoutError}
      *
      * @example
      *     await client.nullableOptional.updateUser("userId", {
@@ -216,6 +225,9 @@ export class NullableOptionalClient {
      * @param {SeedNullableOptional.ListUsersRequest} request
      * @param {NullableOptionalClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedNullableOptionalError}
+     * @throws {@link errors.SeedNullableOptionalTimeoutError}
+     *
      * @example
      *     await client.nullableOptional.listUsers({
      *         limit: 1,
@@ -283,6 +295,9 @@ export class NullableOptionalClient {
      * @param {SeedNullableOptional.SearchUsersRequest} request
      * @param {NullableOptionalClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedNullableOptionalError}
+     * @throws {@link errors.SeedNullableOptionalTimeoutError}
+     *
      * @example
      *     await client.nullableOptional.searchUsers({
      *         query: "query",
@@ -349,6 +364,9 @@ export class NullableOptionalClient {
      *
      * @param {SeedNullableOptional.ComplexProfile} request
      * @param {NullableOptionalClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedNullableOptionalError}
+     * @throws {@link errors.SeedNullableOptionalTimeoutError}
      *
      * @example
      *     await client.nullableOptional.createComplexProfile({
@@ -495,6 +513,9 @@ export class NullableOptionalClient {
      * @param {string} profileId
      * @param {NullableOptionalClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedNullableOptionalError}
+     * @throws {@link errors.SeedNullableOptionalTimeoutError}
+     *
      * @example
      *     await client.nullableOptional.getComplexProfile("profileId")
      */
@@ -551,6 +572,9 @@ export class NullableOptionalClient {
      * @param {string} profileId
      * @param {SeedNullableOptional.UpdateComplexProfileRequest} request
      * @param {NullableOptionalClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedNullableOptionalError}
+     * @throws {@link errors.SeedNullableOptionalTimeoutError}
      *
      * @example
      *     await client.nullableOptional.updateComplexProfile("profileId", {
@@ -640,6 +664,9 @@ export class NullableOptionalClient {
      *
      * @param {SeedNullableOptional.DeserializationTestRequest} request
      * @param {NullableOptionalClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedNullableOptionalError}
+     * @throws {@link errors.SeedNullableOptionalTimeoutError}
      *
      * @example
      *     await client.nullableOptional.testDeserialization({
@@ -748,6 +775,9 @@ export class NullableOptionalClient {
      * @param {SeedNullableOptional.FilterByRoleRequest} request
      * @param {NullableOptionalClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedNullableOptionalError}
+     * @throws {@link errors.SeedNullableOptionalTimeoutError}
+     *
      * @example
      *     await client.nullableOptional.filterByRole({
      *         role: "ADMIN",
@@ -813,6 +843,9 @@ export class NullableOptionalClient {
      * @param {string} userId
      * @param {NullableOptionalClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedNullableOptionalError}
+     * @throws {@link errors.SeedNullableOptionalTimeoutError}
+     *
      * @example
      *     await client.nullableOptional.getNotificationSettings("userId")
      */
@@ -873,6 +906,9 @@ export class NullableOptionalClient {
      * @param {SeedNullableOptional.UpdateTagsRequest} request
      * @param {NullableOptionalClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedNullableOptionalError}
+     * @throws {@link errors.SeedNullableOptionalTimeoutError}
+     *
      * @example
      *     await client.nullableOptional.updateTags("userId", {
      *         tags: ["tags", "tags"],
@@ -932,6 +968,9 @@ export class NullableOptionalClient {
      *
      * @param {SeedNullableOptional.SearchRequest} request
      * @param {NullableOptionalClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedNullableOptionalError}
+     * @throws {@link errors.SeedNullableOptionalTimeoutError}
      *
      * @example
      *     await client.nullableOptional.getSearchResults({

--- a/seed/ts-sdk/nullable-request-body/src/api/resources/testGroup/client/Client.ts
+++ b/seed/ts-sdk/nullable-request-body/src/api/resources/testGroup/client/Client.ts
@@ -29,6 +29,8 @@ export class TestGroupClient {
      * @param {TestGroupClient.RequestOptions} requestOptions - Request-specific configuration.
      *
      * @throws {@link SeedApi.UnprocessableEntityError}
+     * @throws {@link errors.SeedApiError}
+     * @throws {@link errors.SeedApiTimeoutError}
      *
      * @example
      *     await client.testGroup.testMethodName({

--- a/seed/ts-sdk/nullable/src/api/resources/nullable/client/Client.ts
+++ b/seed/ts-sdk/nullable/src/api/resources/nullable/client/Client.ts
@@ -26,6 +26,9 @@ export class NullableClient {
      * @param {SeedNullable.GetUsersRequest} request
      * @param {NullableClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedNullableError}
+     * @throws {@link errors.SeedNullableTimeoutError}
+     *
      * @example
      *     await client.nullable.getUsers({
      *         usernames: "usernames",
@@ -92,6 +95,9 @@ export class NullableClient {
     /**
      * @param {SeedNullable.CreateUserRequest} request
      * @param {NullableClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedNullableError}
+     * @throws {@link errors.SeedNullableTimeoutError}
      *
      * @example
      *     await client.nullable.createUser({
@@ -160,6 +166,9 @@ export class NullableClient {
     /**
      * @param {SeedNullable.DeleteUserRequest} request
      * @param {NullableClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedNullableError}
+     * @throws {@link errors.SeedNullableTimeoutError}
      *
      * @example
      *     await client.nullable.deleteUser({

--- a/seed/ts-sdk/oauth-client-credentials-custom/src/api/resources/auth/client/Client.ts
+++ b/seed/ts-sdk/oauth-client-credentials-custom/src/api/resources/auth/client/Client.ts
@@ -26,6 +26,9 @@ export class AuthClient {
      * @param {SeedOauthClientCredentials.GetTokenRequest} request
      * @param {AuthClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedOauthClientCredentialsError}
+     * @throws {@link errors.SeedOauthClientCredentialsTimeoutError}
+     *
      * @example
      *     await client.auth.getTokenWithClientCredentials({
      *         cid: "cid",
@@ -90,6 +93,9 @@ export class AuthClient {
     /**
      * @param {SeedOauthClientCredentials.RefreshTokenRequest} request
      * @param {AuthClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedOauthClientCredentialsError}
+     * @throws {@link errors.SeedOauthClientCredentialsTimeoutError}
      *
      * @example
      *     await client.auth.refreshToken({

--- a/seed/ts-sdk/oauth-client-credentials-custom/src/api/resources/nested/resources/api/client/Client.ts
+++ b/seed/ts-sdk/oauth-client-credentials-custom/src/api/resources/nested/resources/api/client/Client.ts
@@ -23,6 +23,9 @@ export class ApiClient {
     /**
      * @param {ApiClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedOauthClientCredentialsError}
+     * @throws {@link errors.SeedOauthClientCredentialsTimeoutError}
+     *
      * @example
      *     await client.nested.api.getSomething()
      */

--- a/seed/ts-sdk/oauth-client-credentials-custom/src/api/resources/nestedNoAuth/resources/api/client/Client.ts
+++ b/seed/ts-sdk/oauth-client-credentials-custom/src/api/resources/nestedNoAuth/resources/api/client/Client.ts
@@ -23,6 +23,9 @@ export class ApiClient {
     /**
      * @param {ApiClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedOauthClientCredentialsError}
+     * @throws {@link errors.SeedOauthClientCredentialsTimeoutError}
+     *
      * @example
      *     await client.nestedNoAuth.api.getSomething()
      */

--- a/seed/ts-sdk/oauth-client-credentials-custom/src/api/resources/simple/client/Client.ts
+++ b/seed/ts-sdk/oauth-client-credentials-custom/src/api/resources/simple/client/Client.ts
@@ -23,6 +23,9 @@ export class SimpleClient {
     /**
      * @param {SimpleClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedOauthClientCredentialsError}
+     * @throws {@link errors.SeedOauthClientCredentialsTimeoutError}
+     *
      * @example
      *     await client.simple.getSomething()
      */

--- a/seed/ts-sdk/oauth-client-credentials-default/src/api/resources/auth/client/Client.ts
+++ b/seed/ts-sdk/oauth-client-credentials-default/src/api/resources/auth/client/Client.ts
@@ -26,6 +26,9 @@ export class AuthClient {
      * @param {SeedOauthClientCredentialsDefault.GetTokenRequest} request
      * @param {AuthClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedOauthClientCredentialsDefaultError}
+     * @throws {@link errors.SeedOauthClientCredentialsDefaultTimeoutError}
+     *
      * @example
      *     await client.auth.getToken({
      *         client_id: "client_id",

--- a/seed/ts-sdk/oauth-client-credentials-default/src/api/resources/nested/resources/api/client/Client.ts
+++ b/seed/ts-sdk/oauth-client-credentials-default/src/api/resources/nested/resources/api/client/Client.ts
@@ -23,6 +23,9 @@ export class ApiClient {
     /**
      * @param {ApiClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedOauthClientCredentialsDefaultError}
+     * @throws {@link errors.SeedOauthClientCredentialsDefaultTimeoutError}
+     *
      * @example
      *     await client.nested.api.getSomething()
      */

--- a/seed/ts-sdk/oauth-client-credentials-default/src/api/resources/nestedNoAuth/resources/api/client/Client.ts
+++ b/seed/ts-sdk/oauth-client-credentials-default/src/api/resources/nestedNoAuth/resources/api/client/Client.ts
@@ -23,6 +23,9 @@ export class ApiClient {
     /**
      * @param {ApiClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedOauthClientCredentialsDefaultError}
+     * @throws {@link errors.SeedOauthClientCredentialsDefaultTimeoutError}
+     *
      * @example
      *     await client.nestedNoAuth.api.getSomething()
      */

--- a/seed/ts-sdk/oauth-client-credentials-default/src/api/resources/simple/client/Client.ts
+++ b/seed/ts-sdk/oauth-client-credentials-default/src/api/resources/simple/client/Client.ts
@@ -23,6 +23,9 @@ export class SimpleClient {
     /**
      * @param {SimpleClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedOauthClientCredentialsDefaultError}
+     * @throws {@link errors.SeedOauthClientCredentialsDefaultTimeoutError}
+     *
      * @example
      *     await client.simple.getSomething()
      */

--- a/seed/ts-sdk/oauth-client-credentials-environment-variables/no-custom-config/src/api/resources/auth/client/Client.ts
+++ b/seed/ts-sdk/oauth-client-credentials-environment-variables/no-custom-config/src/api/resources/auth/client/Client.ts
@@ -26,6 +26,9 @@ export class AuthClient {
      * @param {SeedOauthClientCredentialsEnvironmentVariables.GetTokenRequest} request
      * @param {AuthClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedOauthClientCredentialsEnvironmentVariablesError}
+     * @throws {@link errors.SeedOauthClientCredentialsEnvironmentVariablesTimeoutError}
+     *
      * @example
      *     await client.auth.getTokenWithClientCredentials({
      *         client_id: "client_id",
@@ -87,6 +90,9 @@ export class AuthClient {
     /**
      * @param {SeedOauthClientCredentialsEnvironmentVariables.RefreshTokenRequest} request
      * @param {AuthClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedOauthClientCredentialsEnvironmentVariablesError}
+     * @throws {@link errors.SeedOauthClientCredentialsEnvironmentVariablesTimeoutError}
      *
      * @example
      *     await client.auth.refreshToken({

--- a/seed/ts-sdk/oauth-client-credentials-environment-variables/no-custom-config/src/api/resources/nested/resources/api/client/Client.ts
+++ b/seed/ts-sdk/oauth-client-credentials-environment-variables/no-custom-config/src/api/resources/nested/resources/api/client/Client.ts
@@ -23,6 +23,9 @@ export class ApiClient {
     /**
      * @param {ApiClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedOauthClientCredentialsEnvironmentVariablesError}
+     * @throws {@link errors.SeedOauthClientCredentialsEnvironmentVariablesTimeoutError}
+     *
      * @example
      *     await client.nested.api.getSomething()
      */

--- a/seed/ts-sdk/oauth-client-credentials-environment-variables/no-custom-config/src/api/resources/nestedNoAuth/resources/api/client/Client.ts
+++ b/seed/ts-sdk/oauth-client-credentials-environment-variables/no-custom-config/src/api/resources/nestedNoAuth/resources/api/client/Client.ts
@@ -23,6 +23,9 @@ export class ApiClient {
     /**
      * @param {ApiClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedOauthClientCredentialsEnvironmentVariablesError}
+     * @throws {@link errors.SeedOauthClientCredentialsEnvironmentVariablesTimeoutError}
+     *
      * @example
      *     await client.nestedNoAuth.api.getSomething()
      */

--- a/seed/ts-sdk/oauth-client-credentials-environment-variables/no-custom-config/src/api/resources/simple/client/Client.ts
+++ b/seed/ts-sdk/oauth-client-credentials-environment-variables/no-custom-config/src/api/resources/simple/client/Client.ts
@@ -23,6 +23,9 @@ export class SimpleClient {
     /**
      * @param {SimpleClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedOauthClientCredentialsEnvironmentVariablesError}
+     * @throws {@link errors.SeedOauthClientCredentialsEnvironmentVariablesTimeoutError}
+     *
      * @example
      *     await client.simple.getSomething()
      */

--- a/seed/ts-sdk/oauth-client-credentials-mandatory-auth/no-custom-config/src/api/resources/auth/client/Client.ts
+++ b/seed/ts-sdk/oauth-client-credentials-mandatory-auth/no-custom-config/src/api/resources/auth/client/Client.ts
@@ -26,6 +26,9 @@ export class AuthClient {
      * @param {SeedOauthClientCredentialsMandatoryAuth.GetTokenRequest} request
      * @param {AuthClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedOauthClientCredentialsMandatoryAuthError}
+     * @throws {@link errors.SeedOauthClientCredentialsMandatoryAuthTimeoutError}
+     *
      * @example
      *     await client.auth.getTokenWithClientCredentials({
      *         client_id: "my_oauth_app_123",
@@ -87,6 +90,9 @@ export class AuthClient {
     /**
      * @param {SeedOauthClientCredentialsMandatoryAuth.RefreshTokenRequest} request
      * @param {AuthClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedOauthClientCredentialsMandatoryAuthError}
+     * @throws {@link errors.SeedOauthClientCredentialsMandatoryAuthTimeoutError}
      *
      * @example
      *     await client.auth.refreshToken({

--- a/seed/ts-sdk/oauth-client-credentials-mandatory-auth/no-custom-config/src/api/resources/nested/resources/api/client/Client.ts
+++ b/seed/ts-sdk/oauth-client-credentials-mandatory-auth/no-custom-config/src/api/resources/nested/resources/api/client/Client.ts
@@ -23,6 +23,9 @@ export class ApiClient {
     /**
      * @param {ApiClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedOauthClientCredentialsMandatoryAuthError}
+     * @throws {@link errors.SeedOauthClientCredentialsMandatoryAuthTimeoutError}
+     *
      * @example
      *     await client.nested.api.getSomething()
      */

--- a/seed/ts-sdk/oauth-client-credentials-mandatory-auth/no-custom-config/src/api/resources/simple/client/Client.ts
+++ b/seed/ts-sdk/oauth-client-credentials-mandatory-auth/no-custom-config/src/api/resources/simple/client/Client.ts
@@ -23,6 +23,9 @@ export class SimpleClient {
     /**
      * @param {SimpleClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedOauthClientCredentialsMandatoryAuthError}
+     * @throws {@link errors.SeedOauthClientCredentialsMandatoryAuthTimeoutError}
+     *
      * @example
      *     await client.simple.getSomething()
      */

--- a/seed/ts-sdk/oauth-client-credentials-nested-root/no-custom-config/src/api/resources/auth/client/Client.ts
+++ b/seed/ts-sdk/oauth-client-credentials-nested-root/no-custom-config/src/api/resources/auth/client/Client.ts
@@ -26,6 +26,9 @@ export class AuthClient {
      * @param {SeedOauthClientCredentials.auth.GetTokenRequest} request
      * @param {AuthClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedOauthClientCredentialsError}
+     * @throws {@link errors.SeedOauthClientCredentialsTimeoutError}
+     *
      * @example
      *     await client.auth.getToken({
      *         client_id: "client_id",

--- a/seed/ts-sdk/oauth-client-credentials-nested-root/no-custom-config/src/api/resources/nested/resources/api/client/Client.ts
+++ b/seed/ts-sdk/oauth-client-credentials-nested-root/no-custom-config/src/api/resources/nested/resources/api/client/Client.ts
@@ -23,6 +23,9 @@ export class ApiClient {
     /**
      * @param {ApiClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedOauthClientCredentialsError}
+     * @throws {@link errors.SeedOauthClientCredentialsTimeoutError}
+     *
      * @example
      *     await client.nested.api.getSomething()
      */

--- a/seed/ts-sdk/oauth-client-credentials-nested-root/no-custom-config/src/api/resources/nestedNoAuth/resources/api/client/Client.ts
+++ b/seed/ts-sdk/oauth-client-credentials-nested-root/no-custom-config/src/api/resources/nestedNoAuth/resources/api/client/Client.ts
@@ -23,6 +23,9 @@ export class ApiClient {
     /**
      * @param {ApiClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedOauthClientCredentialsError}
+     * @throws {@link errors.SeedOauthClientCredentialsTimeoutError}
+     *
      * @example
      *     await client.nestedNoAuth.api.getSomething()
      */

--- a/seed/ts-sdk/oauth-client-credentials-nested-root/no-custom-config/src/api/resources/simple/client/Client.ts
+++ b/seed/ts-sdk/oauth-client-credentials-nested-root/no-custom-config/src/api/resources/simple/client/Client.ts
@@ -23,6 +23,9 @@ export class SimpleClient {
     /**
      * @param {SimpleClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedOauthClientCredentialsError}
+     * @throws {@link errors.SeedOauthClientCredentialsTimeoutError}
+     *
      * @example
      *     await client.simple.getSomething()
      */

--- a/seed/ts-sdk/oauth-client-credentials-openapi/src/api/resources/identity/client/Client.ts
+++ b/seed/ts-sdk/oauth-client-credentials-openapi/src/api/resources/identity/client/Client.ts
@@ -26,6 +26,9 @@ export class IdentityClient {
      * @param {SeedApi.GetTokenIdentityRequest} request
      * @param {IdentityClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedApiError}
+     * @throws {@link errors.SeedApiTimeoutError}
+     *
      * @example
      *     await client.identity.getToken({
      *         username: "username",

--- a/seed/ts-sdk/oauth-client-credentials-openapi/src/api/resources/plants/client/Client.ts
+++ b/seed/ts-sdk/oauth-client-credentials-openapi/src/api/resources/plants/client/Client.ts
@@ -24,6 +24,9 @@ export class PlantsClient {
     /**
      * @param {PlantsClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedApiError}
+     * @throws {@link errors.SeedApiTimeoutError}
+     *
      * @example
      *     await client.plants.list()
      */
@@ -71,6 +74,9 @@ export class PlantsClient {
     /**
      * @param {SeedApi.GetPlantsRequest} request
      * @param {PlantsClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedApiError}
+     * @throws {@link errors.SeedApiTimeoutError}
      *
      * @example
      *     await client.plants.get({

--- a/seed/ts-sdk/oauth-client-credentials-reference/src/api/resources/auth/client/Client.ts
+++ b/seed/ts-sdk/oauth-client-credentials-reference/src/api/resources/auth/client/Client.ts
@@ -26,6 +26,9 @@ export class AuthClient {
      * @param {SeedOauthClientCredentialsReference.GetTokenRequest} request
      * @param {AuthClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedOauthClientCredentialsReferenceError}
+     * @throws {@link errors.SeedOauthClientCredentialsReferenceTimeoutError}
+     *
      * @example
      *     await client.auth.getToken({
      *         client_id: "client_id",

--- a/seed/ts-sdk/oauth-client-credentials-reference/src/api/resources/simple/client/Client.ts
+++ b/seed/ts-sdk/oauth-client-credentials-reference/src/api/resources/simple/client/Client.ts
@@ -23,6 +23,9 @@ export class SimpleClient {
     /**
      * @param {SimpleClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedOauthClientCredentialsReferenceError}
+     * @throws {@link errors.SeedOauthClientCredentialsReferenceTimeoutError}
+     *
      * @example
      *     await client.simple.getSomething()
      */

--- a/seed/ts-sdk/oauth-client-credentials-with-variables/src/api/resources/auth/client/Client.ts
+++ b/seed/ts-sdk/oauth-client-credentials-with-variables/src/api/resources/auth/client/Client.ts
@@ -26,6 +26,9 @@ export class AuthClient {
      * @param {SeedOauthClientCredentialsWithVariables.GetTokenRequest} request
      * @param {AuthClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedOauthClientCredentialsWithVariablesError}
+     * @throws {@link errors.SeedOauthClientCredentialsWithVariablesTimeoutError}
+     *
      * @example
      *     await client.auth.getTokenWithClientCredentials({
      *         client_id: "client_id",
@@ -87,6 +90,9 @@ export class AuthClient {
     /**
      * @param {SeedOauthClientCredentialsWithVariables.RefreshTokenRequest} request
      * @param {AuthClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedOauthClientCredentialsWithVariablesError}
+     * @throws {@link errors.SeedOauthClientCredentialsWithVariablesTimeoutError}
      *
      * @example
      *     await client.auth.refreshToken({

--- a/seed/ts-sdk/oauth-client-credentials-with-variables/src/api/resources/nested/resources/api/client/Client.ts
+++ b/seed/ts-sdk/oauth-client-credentials-with-variables/src/api/resources/nested/resources/api/client/Client.ts
@@ -23,6 +23,9 @@ export class ApiClient {
     /**
      * @param {ApiClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedOauthClientCredentialsWithVariablesError}
+     * @throws {@link errors.SeedOauthClientCredentialsWithVariablesTimeoutError}
+     *
      * @example
      *     await client.nested.api.getSomething()
      */

--- a/seed/ts-sdk/oauth-client-credentials-with-variables/src/api/resources/nestedNoAuth/resources/api/client/Client.ts
+++ b/seed/ts-sdk/oauth-client-credentials-with-variables/src/api/resources/nestedNoAuth/resources/api/client/Client.ts
@@ -23,6 +23,9 @@ export class ApiClient {
     /**
      * @param {ApiClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedOauthClientCredentialsWithVariablesError}
+     * @throws {@link errors.SeedOauthClientCredentialsWithVariablesTimeoutError}
+     *
      * @example
      *     await client.nestedNoAuth.api.getSomething()
      */

--- a/seed/ts-sdk/oauth-client-credentials-with-variables/src/api/resources/service/client/Client.ts
+++ b/seed/ts-sdk/oauth-client-credentials-with-variables/src/api/resources/service/client/Client.ts
@@ -23,6 +23,9 @@ export class ServiceClient {
     /**
      * @param {ServiceClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedOauthClientCredentialsWithVariablesError}
+     * @throws {@link errors.SeedOauthClientCredentialsWithVariablesTimeoutError}
+     *
      * @example
      *     await client.service.post()
      */

--- a/seed/ts-sdk/oauth-client-credentials-with-variables/src/api/resources/simple/client/Client.ts
+++ b/seed/ts-sdk/oauth-client-credentials-with-variables/src/api/resources/simple/client/Client.ts
@@ -23,6 +23,9 @@ export class SimpleClient {
     /**
      * @param {SimpleClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedOauthClientCredentialsWithVariablesError}
+     * @throws {@link errors.SeedOauthClientCredentialsWithVariablesTimeoutError}
+     *
      * @example
      *     await client.simple.getSomething()
      */

--- a/seed/ts-sdk/oauth-client-credentials/no-custom-config/src/api/resources/auth/client/Client.ts
+++ b/seed/ts-sdk/oauth-client-credentials/no-custom-config/src/api/resources/auth/client/Client.ts
@@ -26,6 +26,9 @@ export class AuthClient {
      * @param {SeedOauthClientCredentials.GetTokenRequest} request
      * @param {AuthClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedOauthClientCredentialsError}
+     * @throws {@link errors.SeedOauthClientCredentialsTimeoutError}
+     *
      * @example
      *     await client.auth.getTokenWithClientCredentials({
      *         client_id: "my_oauth_app_123",
@@ -87,6 +90,9 @@ export class AuthClient {
     /**
      * @param {SeedOauthClientCredentials.RefreshTokenRequest} request
      * @param {AuthClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedOauthClientCredentialsError}
+     * @throws {@link errors.SeedOauthClientCredentialsTimeoutError}
      *
      * @example
      *     await client.auth.refreshToken({

--- a/seed/ts-sdk/oauth-client-credentials/no-custom-config/src/api/resources/nested/resources/api/client/Client.ts
+++ b/seed/ts-sdk/oauth-client-credentials/no-custom-config/src/api/resources/nested/resources/api/client/Client.ts
@@ -23,6 +23,9 @@ export class ApiClient {
     /**
      * @param {ApiClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedOauthClientCredentialsError}
+     * @throws {@link errors.SeedOauthClientCredentialsTimeoutError}
+     *
      * @example
      *     await client.nested.api.getSomething()
      */

--- a/seed/ts-sdk/oauth-client-credentials/no-custom-config/src/api/resources/nestedNoAuth/resources/api/client/Client.ts
+++ b/seed/ts-sdk/oauth-client-credentials/no-custom-config/src/api/resources/nestedNoAuth/resources/api/client/Client.ts
@@ -23,6 +23,9 @@ export class ApiClient {
     /**
      * @param {ApiClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedOauthClientCredentialsError}
+     * @throws {@link errors.SeedOauthClientCredentialsTimeoutError}
+     *
      * @example
      *     await client.nestedNoAuth.api.getSomething()
      */

--- a/seed/ts-sdk/oauth-client-credentials/no-custom-config/src/api/resources/simple/client/Client.ts
+++ b/seed/ts-sdk/oauth-client-credentials/no-custom-config/src/api/resources/simple/client/Client.ts
@@ -23,6 +23,9 @@ export class SimpleClient {
     /**
      * @param {SimpleClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedOauthClientCredentialsError}
+     * @throws {@link errors.SeedOauthClientCredentialsTimeoutError}
+     *
      * @example
      *     await client.simple.getSomething()
      */

--- a/seed/ts-sdk/oauth-client-credentials/serde/src/api/resources/auth/client/Client.ts
+++ b/seed/ts-sdk/oauth-client-credentials/serde/src/api/resources/auth/client/Client.ts
@@ -27,6 +27,9 @@ export class AuthClient {
      * @param {SeedOauthClientCredentials.GetTokenRequest} request
      * @param {AuthClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedOauthClientCredentialsError}
+     * @throws {@link errors.SeedOauthClientCredentialsTimeoutError}
+     *
      * @example
      *     await client.auth.getTokenWithClientCredentials({
      *         clientId: "my_oauth_app_123",
@@ -101,6 +104,9 @@ export class AuthClient {
     /**
      * @param {SeedOauthClientCredentials.RefreshTokenRequest} request
      * @param {AuthClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedOauthClientCredentialsError}
+     * @throws {@link errors.SeedOauthClientCredentialsTimeoutError}
      *
      * @example
      *     await client.auth.refreshToken({

--- a/seed/ts-sdk/oauth-client-credentials/serde/src/api/resources/nested/resources/api/client/Client.ts
+++ b/seed/ts-sdk/oauth-client-credentials/serde/src/api/resources/nested/resources/api/client/Client.ts
@@ -23,6 +23,9 @@ export class ApiClient {
     /**
      * @param {ApiClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedOauthClientCredentialsError}
+     * @throws {@link errors.SeedOauthClientCredentialsTimeoutError}
+     *
      * @example
      *     await client.nested.api.getSomething()
      */

--- a/seed/ts-sdk/oauth-client-credentials/serde/src/api/resources/nestedNoAuth/resources/api/client/Client.ts
+++ b/seed/ts-sdk/oauth-client-credentials/serde/src/api/resources/nestedNoAuth/resources/api/client/Client.ts
@@ -23,6 +23,9 @@ export class ApiClient {
     /**
      * @param {ApiClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedOauthClientCredentialsError}
+     * @throws {@link errors.SeedOauthClientCredentialsTimeoutError}
+     *
      * @example
      *     await client.nestedNoAuth.api.getSomething()
      */

--- a/seed/ts-sdk/oauth-client-credentials/serde/src/api/resources/simple/client/Client.ts
+++ b/seed/ts-sdk/oauth-client-credentials/serde/src/api/resources/simple/client/Client.ts
@@ -23,6 +23,9 @@ export class SimpleClient {
     /**
      * @param {SimpleClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedOauthClientCredentialsError}
+     * @throws {@link errors.SeedOauthClientCredentialsTimeoutError}
+     *
      * @example
      *     await client.simple.getSomething()
      */

--- a/seed/ts-sdk/openapi-request-body-ref/no-custom-config/src/api/resources/catalog/client/Client.ts
+++ b/seed/ts-sdk/openapi-request-body-ref/no-custom-config/src/api/resources/catalog/client/Client.ts
@@ -26,6 +26,9 @@ export class CatalogClient {
      * @param {SeedApi.CreateCatalogImageBody} request
      * @param {CatalogClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedApiError}
+     * @throws {@link errors.SeedApiTimeoutError}
+     *
      * @example
      *     import { createReadStream } from "fs";
      *     await client.catalog.createCatalogImage({
@@ -93,6 +96,9 @@ export class CatalogClient {
     /**
      * @param {SeedApi.GetCatalogImageRequest} request
      * @param {CatalogClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedApiError}
+     * @throws {@link errors.SeedApiTimeoutError}
      *
      * @example
      *     await client.catalog.getCatalogImage({

--- a/seed/ts-sdk/openapi-request-body-ref/no-custom-config/src/api/resources/teamMember/client/Client.ts
+++ b/seed/ts-sdk/openapi-request-body-ref/no-custom-config/src/api/resources/teamMember/client/Client.ts
@@ -26,6 +26,9 @@ export class TeamMemberClient {
      * @param {SeedApi.UpdateTeamMemberRequest} request
      * @param {TeamMemberClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedApiError}
+     * @throws {@link errors.SeedApiTimeoutError}
+     *
      * @example
      *     await client.teamMember.updateTeamMember({
      *         team_member_id: "team_member_id"

--- a/seed/ts-sdk/openapi-request-body-ref/no-custom-config/src/api/resources/vendor/client/Client.ts
+++ b/seed/ts-sdk/openapi-request-body-ref/no-custom-config/src/api/resources/vendor/client/Client.ts
@@ -26,6 +26,9 @@ export class VendorClient {
      * @param {SeedApi.UpdateVendorBody} request
      * @param {VendorClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedApiError}
+     * @throws {@link errors.SeedApiTimeoutError}
+     *
      * @example
      *     await client.vendor.updateVendor({
      *         vendor_id: "vendor_id",
@@ -83,6 +86,9 @@ export class VendorClient {
     /**
      * @param {SeedApi.CreateVendorRequest} request
      * @param {VendorClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedApiError}
+     * @throws {@link errors.SeedApiTimeoutError}
      *
      * @example
      *     await client.vendor.createVendor({

--- a/seed/ts-sdk/openapi-subtitle/src/Client.ts
+++ b/seed/ts-sdk/openapi-subtitle/src/Client.ts
@@ -26,6 +26,9 @@ export class SeedApiClient {
      *
      * @param {SeedApiClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedApiError}
+     * @throws {@link errors.SeedApiTimeoutError}
+     *
      * @example
      *     await client.listPlants()
      */
@@ -72,6 +75,9 @@ export class SeedApiClient {
      *
      * @param {SeedApi.GetPlantRequest} request
      * @param {SeedApiClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedApiError}
+     * @throws {@link errors.SeedApiTimeoutError}
      *
      * @example
      *     await client.getPlant({

--- a/seed/ts-sdk/optional/src/api/resources/optional/client/Client.ts
+++ b/seed/ts-sdk/optional/src/api/resources/optional/client/Client.ts
@@ -26,6 +26,9 @@ export class OptionalClient {
      * @param {Record<string, unknown>} request
      * @param {OptionalClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedObjectsWithImportsError}
+     * @throws {@link errors.SeedObjectsWithImportsTimeoutError}
+     *
      * @example
      *     await client.optional.sendOptionalBody({
      *         "string": {
@@ -81,6 +84,9 @@ export class OptionalClient {
     /**
      * @param {SeedObjectsWithImports.SendOptionalBodyRequest} request
      * @param {OptionalClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedObjectsWithImportsError}
+     * @throws {@link errors.SeedObjectsWithImportsTimeoutError}
      *
      * @example
      *     await client.optional.sendOptionalTypedBody({
@@ -140,6 +146,9 @@ export class OptionalClient {
      * @param {string} id
      * @param {SeedObjectsWithImports.DeployParams | null} request
      * @param {OptionalClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedObjectsWithImportsError}
+     * @throws {@link errors.SeedObjectsWithImportsTimeoutError}
      *
      * @example
      *     await client.optional.sendOptionalNullableWithAllOptionalProperties("actionId", "id", {

--- a/seed/ts-sdk/package-yml/src/Client.ts
+++ b/seed/ts-sdk/package-yml/src/Client.ts
@@ -32,6 +32,9 @@ export class SeedPackageYmlClient {
      * @param {SeedPackageYml.EchoRequest} request
      * @param {SeedPackageYmlClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedPackageYmlError}
+     * @throws {@link errors.SeedPackageYmlTimeoutError}
+     *
      * @example
      *     await client.echo({
      *         name: "Hello world!",

--- a/seed/ts-sdk/package-yml/src/api/resources/service/client/Client.ts
+++ b/seed/ts-sdk/package-yml/src/api/resources/service/client/Client.ts
@@ -24,6 +24,9 @@ export class ServiceClient {
      * @param {string} nestedId
      * @param {ServiceClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedPackageYmlError}
+     * @throws {@link errors.SeedPackageYmlTimeoutError}
+     *
      * @example
      *     await client.service.nop("id-219xca8")
      */

--- a/seed/ts-sdk/pagination-custom/src/api/resources/users/client/Client.ts
+++ b/seed/ts-sdk/pagination-custom/src/api/resources/users/client/Client.ts
@@ -25,6 +25,9 @@ export class UsersClient {
      * @param {SeedPagination.ListWithCustomPagerRequest} request
      * @param {UsersClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedPaginationError}
+     * @throws {@link errors.SeedPaginationTimeoutError}
+     *
      * @example
      *     await client.users.listWithCustomPager({
      *         limit: 1,

--- a/seed/ts-sdk/pagination-uri-path/src/api/resources/users/client/Client.ts
+++ b/seed/ts-sdk/pagination-uri-path/src/api/resources/users/client/Client.ts
@@ -24,6 +24,9 @@ export class UsersClient {
     /**
      * @param {UsersClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedPaginationUriPathError}
+     * @throws {@link errors.SeedPaginationUriPathTimeoutError}
+     *
      * @example
      *     await client.users.listWithUriPagination()
      */
@@ -84,6 +87,9 @@ export class UsersClient {
 
     /**
      * @param {UsersClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedPaginationUriPathError}
+     * @throws {@link errors.SeedPaginationUriPathTimeoutError}
      *
      * @example
      *     await client.users.listWithPathPagination()

--- a/seed/ts-sdk/pagination/no-custom-config/src/api/resources/complex/client/Client.ts
+++ b/seed/ts-sdk/pagination/no-custom-config/src/api/resources/complex/client/Client.ts
@@ -27,6 +27,9 @@ export class ComplexClient {
      * @param {SeedPagination.SearchRequest} request
      * @param {ComplexClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedPaginationError}
+     * @throws {@link errors.SeedPaginationTimeoutError}
+     *
      * @example
      *     await client.complex.search("index", {
      *         pagination: {

--- a/seed/ts-sdk/pagination/no-custom-config/src/api/resources/inlineUsers/resources/inlineUsers/client/Client.ts
+++ b/seed/ts-sdk/pagination/no-custom-config/src/api/resources/inlineUsers/resources/inlineUsers/client/Client.ts
@@ -26,6 +26,9 @@ export class InlineUsersClient {
      * @param {SeedPagination.inlineUsers.ListUsersCursorPaginationRequest} request
      * @param {InlineUsersClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedPaginationError}
+     * @throws {@link errors.SeedPaginationTimeoutError}
+     *
      * @example
      *     await client.inlineUsers.inlineUsers.listWithCursorPagination({
      *         page: 1,
@@ -117,6 +120,9 @@ export class InlineUsersClient {
      * @param {SeedPagination.inlineUsers.ListUsersMixedTypeCursorPaginationRequest} request
      * @param {InlineUsersClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedPaginationError}
+     * @throws {@link errors.SeedPaginationTimeoutError}
+     *
      * @example
      *     await client.inlineUsers.inlineUsers.listWithMixedTypeCursorPagination({
      *         cursor: "cursor"
@@ -197,6 +203,9 @@ export class InlineUsersClient {
     /**
      * @param {SeedPagination.inlineUsers.ListUsersBodyCursorPaginationRequest} request
      * @param {InlineUsersClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedPaginationError}
+     * @throws {@link errors.SeedPaginationTimeoutError}
      *
      * @example
      *     await client.inlineUsers.inlineUsers.listWithBodyCursorPagination({
@@ -279,6 +288,9 @@ export class InlineUsersClient {
     /**
      * @param {SeedPagination.inlineUsers.ListUsersOffsetPaginationRequest} request
      * @param {InlineUsersClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedPaginationError}
+     * @throws {@link errors.SeedPaginationTimeoutError}
      *
      * @example
      *     await client.inlineUsers.inlineUsers.listWithOffsetPagination({
@@ -368,6 +380,9 @@ export class InlineUsersClient {
      * @param {SeedPagination.inlineUsers.ListUsersDoubleOffsetPaginationRequest} request
      * @param {InlineUsersClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedPaginationError}
+     * @throws {@link errors.SeedPaginationTimeoutError}
+     *
      * @example
      *     await client.inlineUsers.inlineUsers.listWithDoubleOffsetPagination({
      *         page: 1.1,
@@ -456,6 +471,9 @@ export class InlineUsersClient {
      * @param {SeedPagination.inlineUsers.ListUsersBodyOffsetPaginationRequest} request
      * @param {InlineUsersClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedPaginationError}
+     * @throws {@link errors.SeedPaginationTimeoutError}
+     *
      * @example
      *     await client.inlineUsers.inlineUsers.listWithBodyOffsetPagination({
      *         pagination: {
@@ -534,6 +552,9 @@ export class InlineUsersClient {
     /**
      * @param {SeedPagination.inlineUsers.ListUsersOffsetStepPaginationRequest} request
      * @param {InlineUsersClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedPaginationError}
+     * @throws {@link errors.SeedPaginationTimeoutError}
      *
      * @example
      *     await client.inlineUsers.inlineUsers.listWithOffsetStepPagination({
@@ -622,6 +643,9 @@ export class InlineUsersClient {
     /**
      * @param {SeedPagination.inlineUsers.ListWithOffsetPaginationHasNextPageRequest} request
      * @param {InlineUsersClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedPaginationError}
+     * @throws {@link errors.SeedPaginationTimeoutError}
      *
      * @example
      *     await client.inlineUsers.inlineUsers.listWithOffsetPaginationHasNextPage({
@@ -712,6 +736,9 @@ export class InlineUsersClient {
      * @param {SeedPagination.inlineUsers.ListUsersExtendedRequest} request
      * @param {InlineUsersClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedPaginationError}
+     * @throws {@link errors.SeedPaginationTimeoutError}
+     *
      * @example
      *     await client.inlineUsers.inlineUsers.listWithExtendedResults({
      *         cursor: "d5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32"
@@ -792,6 +819,9 @@ export class InlineUsersClient {
     /**
      * @param {SeedPagination.inlineUsers.ListUsersExtendedRequestForOptionalData} request
      * @param {InlineUsersClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedPaginationError}
+     * @throws {@link errors.SeedPaginationTimeoutError}
      *
      * @example
      *     await client.inlineUsers.inlineUsers.listWithExtendedResultsAndOptionalData({
@@ -874,6 +904,9 @@ export class InlineUsersClient {
      * @param {SeedPagination.inlineUsers.ListUsernamesRequest} request
      * @param {InlineUsersClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedPaginationError}
+     * @throws {@link errors.SeedPaginationTimeoutError}
+     *
      * @example
      *     await client.inlineUsers.inlineUsers.listUsernames({
      *         starting_after: "starting_after"
@@ -947,6 +980,9 @@ export class InlineUsersClient {
     /**
      * @param {SeedPagination.inlineUsers.ListWithGlobalConfigRequest} request
      * @param {InlineUsersClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedPaginationError}
+     * @throws {@link errors.SeedPaginationTimeoutError}
      *
      * @example
      *     await client.inlineUsers.inlineUsers.listWithGlobalConfig({

--- a/seed/ts-sdk/pagination/no-custom-config/src/api/resources/users/client/Client.ts
+++ b/seed/ts-sdk/pagination/no-custom-config/src/api/resources/users/client/Client.ts
@@ -26,6 +26,9 @@ export class UsersClient {
      * @param {SeedPagination.ListUsersCursorPaginationRequest} request
      * @param {UsersClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedPaginationError}
+     * @throws {@link errors.SeedPaginationTimeoutError}
+     *
      * @example
      *     await client.users.listWithCursorPagination({
      *         page: 1,
@@ -109,6 +112,9 @@ export class UsersClient {
      * @param {SeedPagination.ListUsersMixedTypeCursorPaginationRequest} request
      * @param {UsersClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedPaginationError}
+     * @throws {@link errors.SeedPaginationTimeoutError}
+     *
      * @example
      *     await client.users.listWithMixedTypeCursorPagination({
      *         cursor: "cursor"
@@ -181,6 +187,9 @@ export class UsersClient {
     /**
      * @param {SeedPagination.ListUsersBodyCursorPaginationRequest} request
      * @param {UsersClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedPaginationError}
+     * @throws {@link errors.SeedPaginationTimeoutError}
      *
      * @example
      *     await client.users.listWithBodyCursorPagination({
@@ -260,6 +269,9 @@ export class UsersClient {
      * @param {SeedPagination.ListUsersTopLevelBodyCursorPaginationRequest} request
      * @param {UsersClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedPaginationError}
+     * @throws {@link errors.SeedPaginationTimeoutError}
+     *
      * @example
      *     await client.users.listWithTopLevelBodyCursorPagination({
      *         cursor: "initial_cursor",
@@ -334,6 +346,9 @@ export class UsersClient {
     /**
      * @param {SeedPagination.ListUsersOffsetPaginationRequest} request
      * @param {UsersClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedPaginationError}
+     * @throws {@link errors.SeedPaginationTimeoutError}
      *
      * @example
      *     await client.users.listWithOffsetPagination({
@@ -415,6 +430,9 @@ export class UsersClient {
      * @param {SeedPagination.ListUsersDoubleOffsetPaginationRequest} request
      * @param {UsersClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedPaginationError}
+     * @throws {@link errors.SeedPaginationTimeoutError}
+     *
      * @example
      *     await client.users.listWithDoubleOffsetPagination({
      *         page: 1.1,
@@ -495,6 +513,9 @@ export class UsersClient {
      * @param {SeedPagination.ListUsersBodyOffsetPaginationRequest} request
      * @param {UsersClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedPaginationError}
+     * @throws {@link errors.SeedPaginationTimeoutError}
+     *
      * @example
      *     await client.users.listWithBodyOffsetPagination({
      *         pagination: {
@@ -565,6 +586,9 @@ export class UsersClient {
     /**
      * @param {SeedPagination.ListUsersOffsetStepPaginationRequest} request
      * @param {UsersClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedPaginationError}
+     * @throws {@link errors.SeedPaginationTimeoutError}
      *
      * @example
      *     await client.users.listWithOffsetStepPagination({
@@ -645,6 +669,9 @@ export class UsersClient {
     /**
      * @param {SeedPagination.ListWithOffsetPaginationHasNextPageRequest} request
      * @param {UsersClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedPaginationError}
+     * @throws {@link errors.SeedPaginationTimeoutError}
      *
      * @example
      *     await client.users.listWithOffsetPaginationHasNextPage({
@@ -734,6 +761,9 @@ export class UsersClient {
      * @param {SeedPagination.ListUsersExtendedRequest} request
      * @param {UsersClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedPaginationError}
+     * @throws {@link errors.SeedPaginationTimeoutError}
+     *
      * @example
      *     await client.users.listWithExtendedResults({
      *         cursor: "d5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32"
@@ -807,6 +837,9 @@ export class UsersClient {
      * @param {SeedPagination.ListUsersExtendedRequestForOptionalData} request
      * @param {UsersClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedPaginationError}
+     * @throws {@link errors.SeedPaginationTimeoutError}
+     *
      * @example
      *     await client.users.listWithExtendedResultsAndOptionalData({
      *         cursor: "d5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32"
@@ -879,6 +912,9 @@ export class UsersClient {
     /**
      * @param {SeedPagination.ListUsernamesRequest} request
      * @param {UsersClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedPaginationError}
+     * @throws {@link errors.SeedPaginationTimeoutError}
      *
      * @example
      *     await client.users.listUsernames({
@@ -954,6 +990,9 @@ export class UsersClient {
      * @param {SeedPagination.ListUsernamesWithOptionalResponseRequest} request
      * @param {UsersClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedPaginationError}
+     * @throws {@link errors.SeedPaginationTimeoutError}
+     *
      * @example
      *     await client.users.listUsernamesWithOptionalResponse({
      *         starting_after: "starting_after"
@@ -1027,6 +1066,9 @@ export class UsersClient {
     /**
      * @param {SeedPagination.ListWithGlobalConfigRequest} request
      * @param {UsersClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedPaginationError}
+     * @throws {@link errors.SeedPaginationTimeoutError}
      *
      * @example
      *     await client.users.listWithGlobalConfig({
@@ -1102,6 +1144,9 @@ export class UsersClient {
      * @param {SeedPagination.ListUsersOptionalDataRequest} request
      * @param {UsersClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedPaginationError}
+     * @throws {@link errors.SeedPaginationTimeoutError}
+     *
      * @example
      *     await client.users.listWithOptionalData({
      *         page: 1
@@ -1175,6 +1220,9 @@ export class UsersClient {
     /**
      * @param {SeedPagination.ListUsersAliasedDataRequest} request
      * @param {UsersClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedPaginationError}
+     * @throws {@link errors.SeedPaginationTimeoutError}
      *
      * @example
      *     await client.users.listWithAliasedData({

--- a/seed/ts-sdk/pagination/page-index-semantics/src/api/resources/complex/client/Client.ts
+++ b/seed/ts-sdk/pagination/page-index-semantics/src/api/resources/complex/client/Client.ts
@@ -27,6 +27,9 @@ export class ComplexClient {
      * @param {SeedPagination.SearchRequest} request
      * @param {ComplexClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedPaginationError}
+     * @throws {@link errors.SeedPaginationTimeoutError}
+     *
      * @example
      *     await client.complex.search("index", {
      *         pagination: {

--- a/seed/ts-sdk/pagination/page-index-semantics/src/api/resources/inlineUsers/resources/inlineUsers/client/Client.ts
+++ b/seed/ts-sdk/pagination/page-index-semantics/src/api/resources/inlineUsers/resources/inlineUsers/client/Client.ts
@@ -26,6 +26,9 @@ export class InlineUsersClient {
      * @param {SeedPagination.inlineUsers.ListUsersCursorPaginationRequest} request
      * @param {InlineUsersClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedPaginationError}
+     * @throws {@link errors.SeedPaginationTimeoutError}
+     *
      * @example
      *     await client.inlineUsers.inlineUsers.listWithCursorPagination({
      *         page: 1,
@@ -117,6 +120,9 @@ export class InlineUsersClient {
      * @param {SeedPagination.inlineUsers.ListUsersMixedTypeCursorPaginationRequest} request
      * @param {InlineUsersClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedPaginationError}
+     * @throws {@link errors.SeedPaginationTimeoutError}
+     *
      * @example
      *     await client.inlineUsers.inlineUsers.listWithMixedTypeCursorPagination({
      *         cursor: "cursor"
@@ -197,6 +203,9 @@ export class InlineUsersClient {
     /**
      * @param {SeedPagination.inlineUsers.ListUsersBodyCursorPaginationRequest} request
      * @param {InlineUsersClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedPaginationError}
+     * @throws {@link errors.SeedPaginationTimeoutError}
      *
      * @example
      *     await client.inlineUsers.inlineUsers.listWithBodyCursorPagination({
@@ -279,6 +288,9 @@ export class InlineUsersClient {
     /**
      * @param {SeedPagination.inlineUsers.ListUsersOffsetPaginationRequest} request
      * @param {InlineUsersClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedPaginationError}
+     * @throws {@link errors.SeedPaginationTimeoutError}
      *
      * @example
      *     await client.inlineUsers.inlineUsers.listWithOffsetPagination({
@@ -368,6 +380,9 @@ export class InlineUsersClient {
      * @param {SeedPagination.inlineUsers.ListUsersDoubleOffsetPaginationRequest} request
      * @param {InlineUsersClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedPaginationError}
+     * @throws {@link errors.SeedPaginationTimeoutError}
+     *
      * @example
      *     await client.inlineUsers.inlineUsers.listWithDoubleOffsetPagination({
      *         page: 1.1,
@@ -456,6 +471,9 @@ export class InlineUsersClient {
      * @param {SeedPagination.inlineUsers.ListUsersBodyOffsetPaginationRequest} request
      * @param {InlineUsersClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedPaginationError}
+     * @throws {@link errors.SeedPaginationTimeoutError}
+     *
      * @example
      *     await client.inlineUsers.inlineUsers.listWithBodyOffsetPagination({
      *         pagination: {
@@ -534,6 +552,9 @@ export class InlineUsersClient {
     /**
      * @param {SeedPagination.inlineUsers.ListUsersOffsetStepPaginationRequest} request
      * @param {InlineUsersClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedPaginationError}
+     * @throws {@link errors.SeedPaginationTimeoutError}
      *
      * @example
      *     await client.inlineUsers.inlineUsers.listWithOffsetStepPagination({
@@ -622,6 +643,9 @@ export class InlineUsersClient {
     /**
      * @param {SeedPagination.inlineUsers.ListWithOffsetPaginationHasNextPageRequest} request
      * @param {InlineUsersClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedPaginationError}
+     * @throws {@link errors.SeedPaginationTimeoutError}
      *
      * @example
      *     await client.inlineUsers.inlineUsers.listWithOffsetPaginationHasNextPage({
@@ -712,6 +736,9 @@ export class InlineUsersClient {
      * @param {SeedPagination.inlineUsers.ListUsersExtendedRequest} request
      * @param {InlineUsersClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedPaginationError}
+     * @throws {@link errors.SeedPaginationTimeoutError}
+     *
      * @example
      *     await client.inlineUsers.inlineUsers.listWithExtendedResults({
      *         cursor: "d5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32"
@@ -792,6 +819,9 @@ export class InlineUsersClient {
     /**
      * @param {SeedPagination.inlineUsers.ListUsersExtendedRequestForOptionalData} request
      * @param {InlineUsersClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedPaginationError}
+     * @throws {@link errors.SeedPaginationTimeoutError}
      *
      * @example
      *     await client.inlineUsers.inlineUsers.listWithExtendedResultsAndOptionalData({
@@ -874,6 +904,9 @@ export class InlineUsersClient {
      * @param {SeedPagination.inlineUsers.ListUsernamesRequest} request
      * @param {InlineUsersClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedPaginationError}
+     * @throws {@link errors.SeedPaginationTimeoutError}
+     *
      * @example
      *     await client.inlineUsers.inlineUsers.listUsernames({
      *         starting_after: "starting_after"
@@ -947,6 +980,9 @@ export class InlineUsersClient {
     /**
      * @param {SeedPagination.inlineUsers.ListWithGlobalConfigRequest} request
      * @param {InlineUsersClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedPaginationError}
+     * @throws {@link errors.SeedPaginationTimeoutError}
      *
      * @example
      *     await client.inlineUsers.inlineUsers.listWithGlobalConfig({

--- a/seed/ts-sdk/pagination/page-index-semantics/src/api/resources/users/client/Client.ts
+++ b/seed/ts-sdk/pagination/page-index-semantics/src/api/resources/users/client/Client.ts
@@ -26,6 +26,9 @@ export class UsersClient {
      * @param {SeedPagination.ListUsersCursorPaginationRequest} request
      * @param {UsersClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedPaginationError}
+     * @throws {@link errors.SeedPaginationTimeoutError}
+     *
      * @example
      *     await client.users.listWithCursorPagination({
      *         page: 1,
@@ -109,6 +112,9 @@ export class UsersClient {
      * @param {SeedPagination.ListUsersMixedTypeCursorPaginationRequest} request
      * @param {UsersClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedPaginationError}
+     * @throws {@link errors.SeedPaginationTimeoutError}
+     *
      * @example
      *     await client.users.listWithMixedTypeCursorPagination({
      *         cursor: "cursor"
@@ -181,6 +187,9 @@ export class UsersClient {
     /**
      * @param {SeedPagination.ListUsersBodyCursorPaginationRequest} request
      * @param {UsersClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedPaginationError}
+     * @throws {@link errors.SeedPaginationTimeoutError}
      *
      * @example
      *     await client.users.listWithBodyCursorPagination({
@@ -260,6 +269,9 @@ export class UsersClient {
      * @param {SeedPagination.ListUsersTopLevelBodyCursorPaginationRequest} request
      * @param {UsersClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedPaginationError}
+     * @throws {@link errors.SeedPaginationTimeoutError}
+     *
      * @example
      *     await client.users.listWithTopLevelBodyCursorPagination({
      *         cursor: "initial_cursor",
@@ -334,6 +346,9 @@ export class UsersClient {
     /**
      * @param {SeedPagination.ListUsersOffsetPaginationRequest} request
      * @param {UsersClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedPaginationError}
+     * @throws {@link errors.SeedPaginationTimeoutError}
      *
      * @example
      *     await client.users.listWithOffsetPagination({
@@ -415,6 +430,9 @@ export class UsersClient {
      * @param {SeedPagination.ListUsersDoubleOffsetPaginationRequest} request
      * @param {UsersClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedPaginationError}
+     * @throws {@link errors.SeedPaginationTimeoutError}
+     *
      * @example
      *     await client.users.listWithDoubleOffsetPagination({
      *         page: 1.1,
@@ -495,6 +513,9 @@ export class UsersClient {
      * @param {SeedPagination.ListUsersBodyOffsetPaginationRequest} request
      * @param {UsersClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedPaginationError}
+     * @throws {@link errors.SeedPaginationTimeoutError}
+     *
      * @example
      *     await client.users.listWithBodyOffsetPagination({
      *         pagination: {
@@ -565,6 +586,9 @@ export class UsersClient {
     /**
      * @param {SeedPagination.ListUsersOffsetStepPaginationRequest} request
      * @param {UsersClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedPaginationError}
+     * @throws {@link errors.SeedPaginationTimeoutError}
      *
      * @example
      *     await client.users.listWithOffsetStepPagination({
@@ -645,6 +669,9 @@ export class UsersClient {
     /**
      * @param {SeedPagination.ListWithOffsetPaginationHasNextPageRequest} request
      * @param {UsersClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedPaginationError}
+     * @throws {@link errors.SeedPaginationTimeoutError}
      *
      * @example
      *     await client.users.listWithOffsetPaginationHasNextPage({
@@ -734,6 +761,9 @@ export class UsersClient {
      * @param {SeedPagination.ListUsersExtendedRequest} request
      * @param {UsersClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedPaginationError}
+     * @throws {@link errors.SeedPaginationTimeoutError}
+     *
      * @example
      *     await client.users.listWithExtendedResults({
      *         cursor: "d5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32"
@@ -807,6 +837,9 @@ export class UsersClient {
      * @param {SeedPagination.ListUsersExtendedRequestForOptionalData} request
      * @param {UsersClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedPaginationError}
+     * @throws {@link errors.SeedPaginationTimeoutError}
+     *
      * @example
      *     await client.users.listWithExtendedResultsAndOptionalData({
      *         cursor: "d5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32"
@@ -879,6 +912,9 @@ export class UsersClient {
     /**
      * @param {SeedPagination.ListUsernamesRequest} request
      * @param {UsersClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedPaginationError}
+     * @throws {@link errors.SeedPaginationTimeoutError}
      *
      * @example
      *     await client.users.listUsernames({
@@ -954,6 +990,9 @@ export class UsersClient {
      * @param {SeedPagination.ListUsernamesWithOptionalResponseRequest} request
      * @param {UsersClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedPaginationError}
+     * @throws {@link errors.SeedPaginationTimeoutError}
+     *
      * @example
      *     await client.users.listUsernamesWithOptionalResponse({
      *         starting_after: "starting_after"
@@ -1027,6 +1066,9 @@ export class UsersClient {
     /**
      * @param {SeedPagination.ListWithGlobalConfigRequest} request
      * @param {UsersClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedPaginationError}
+     * @throws {@link errors.SeedPaginationTimeoutError}
      *
      * @example
      *     await client.users.listWithGlobalConfig({
@@ -1102,6 +1144,9 @@ export class UsersClient {
      * @param {SeedPagination.ListUsersOptionalDataRequest} request
      * @param {UsersClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedPaginationError}
+     * @throws {@link errors.SeedPaginationTimeoutError}
+     *
      * @example
      *     await client.users.listWithOptionalData({
      *         page: 1
@@ -1175,6 +1220,9 @@ export class UsersClient {
     /**
      * @param {SeedPagination.ListUsersAliasedDataRequest} request
      * @param {UsersClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedPaginationError}
+     * @throws {@link errors.SeedPaginationTimeoutError}
      *
      * @example
      *     await client.users.listWithAliasedData({

--- a/seed/ts-sdk/path-parameters/no-custom-config/src/api/resources/organizations/client/Client.ts
+++ b/seed/ts-sdk/path-parameters/no-custom-config/src/api/resources/organizations/client/Client.ts
@@ -25,6 +25,9 @@ export class OrganizationsClient {
      * @param {string} organization_id
      * @param {OrganizationsClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedPathParametersError}
+     * @throws {@link errors.SeedPathParametersTimeoutError}
+     *
      * @example
      *     await client.organizations.getOrganization("organization_id")
      */
@@ -78,6 +81,9 @@ export class OrganizationsClient {
     /**
      * @param {SeedPathParameters.GetOrganizationUserRequest} request
      * @param {OrganizationsClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedPathParametersError}
+     * @throws {@link errors.SeedPathParametersTimeoutError}
      *
      * @example
      *     await client.organizations.getOrganizationUser({
@@ -137,6 +143,9 @@ export class OrganizationsClient {
      * @param {string} organization_id
      * @param {SeedPathParameters.SearchOrganizationsRequest} request
      * @param {OrganizationsClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedPathParametersError}
+     * @throws {@link errors.SeedPathParametersTimeoutError}
      *
      * @example
      *     await client.organizations.searchOrganizations("organization_id", {

--- a/seed/ts-sdk/path-parameters/no-custom-config/src/api/resources/user/client/Client.ts
+++ b/seed/ts-sdk/path-parameters/no-custom-config/src/api/resources/user/client/Client.ts
@@ -26,6 +26,9 @@ export class UserClient {
      * @param {SeedPathParameters.GetUsersRequest} request
      * @param {UserClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedPathParametersError}
+     * @throws {@link errors.SeedPathParametersTimeoutError}
+     *
      * @example
      *     await client.user.getUser({
      *         user_id: "user_id"
@@ -77,6 +80,9 @@ export class UserClient {
     /**
      * @param {SeedPathParameters.User} request
      * @param {UserClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedPathParametersError}
+     * @throws {@link errors.SeedPathParametersTimeoutError}
      *
      * @example
      *     await client.user.createUser({
@@ -132,6 +138,9 @@ export class UserClient {
     /**
      * @param {SeedPathParameters.UpdateUserRequest} request
      * @param {UserClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedPathParametersError}
+     * @throws {@link errors.SeedPathParametersTimeoutError}
      *
      * @example
      *     await client.user.updateUser({
@@ -191,6 +200,9 @@ export class UserClient {
     /**
      * @param {SeedPathParameters.SearchUsersRequest} request
      * @param {UserClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedPathParametersError}
+     * @throws {@link errors.SeedPathParametersTimeoutError}
      *
      * @example
      *     await client.user.searchUsers({
@@ -259,6 +271,9 @@ export class UserClient {
      * @param {SeedPathParameters.GetUserMetadataRequest} request
      * @param {UserClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedPathParametersError}
+     * @throws {@link errors.SeedPathParametersTimeoutError}
+     *
      * @example
      *     await client.user.getUserMetadata({
      *         user_id: "user_id",
@@ -318,6 +333,9 @@ export class UserClient {
      *
      * @param {SeedPathParameters.GetUserSpecificsRequest} request
      * @param {UserClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedPathParametersError}
+     * @throws {@link errors.SeedPathParametersTimeoutError}
      *
      * @example
      *     await client.user.getUserSpecifics({

--- a/seed/ts-sdk/path-parameters/no-inline-path-parameters-retain-original-casing/src/api/resources/organizations/client/Client.ts
+++ b/seed/ts-sdk/path-parameters/no-inline-path-parameters-retain-original-casing/src/api/resources/organizations/client/Client.ts
@@ -25,6 +25,9 @@ export class OrganizationsClient {
      * @param {string} organization_id
      * @param {OrganizationsClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedPathParametersError}
+     * @throws {@link errors.SeedPathParametersTimeoutError}
+     *
      * @example
      *     await client.organizations.getOrganization("organization_id")
      */
@@ -80,6 +83,9 @@ export class OrganizationsClient {
      * @param {string} user_id
      * @param {SeedPathParameters.GetOrganizationUserRequest} request
      * @param {OrganizationsClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedPathParametersError}
+     * @throws {@link errors.SeedPathParametersTimeoutError}
      *
      * @example
      *     await client.organizations.getOrganizationUser("organization_id", "user_id")
@@ -141,6 +147,9 @@ export class OrganizationsClient {
      * @param {string} organization_id
      * @param {SeedPathParameters.SearchOrganizationsRequest} request
      * @param {OrganizationsClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedPathParametersError}
+     * @throws {@link errors.SeedPathParametersTimeoutError}
      *
      * @example
      *     await client.organizations.searchOrganizations("organization_id", {

--- a/seed/ts-sdk/path-parameters/no-inline-path-parameters-retain-original-casing/src/api/resources/user/client/Client.ts
+++ b/seed/ts-sdk/path-parameters/no-inline-path-parameters-retain-original-casing/src/api/resources/user/client/Client.ts
@@ -27,6 +27,9 @@ export class UserClient {
      * @param {SeedPathParameters.GetUsersRequest} request
      * @param {UserClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedPathParametersError}
+     * @throws {@link errors.SeedPathParametersTimeoutError}
+     *
      * @example
      *     await client.user.getUser("user_id")
      */
@@ -77,6 +80,9 @@ export class UserClient {
     /**
      * @param {SeedPathParameters.User} request
      * @param {UserClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedPathParametersError}
+     * @throws {@link errors.SeedPathParametersTimeoutError}
      *
      * @example
      *     await client.user.createUser({
@@ -133,6 +139,9 @@ export class UserClient {
      * @param {string} user_id
      * @param {SeedPathParameters.UpdateUserRequest} request
      * @param {UserClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedPathParametersError}
+     * @throws {@link errors.SeedPathParametersTimeoutError}
      *
      * @example
      *     await client.user.updateUser("user_id", {
@@ -194,6 +203,9 @@ export class UserClient {
      * @param {string} user_id
      * @param {SeedPathParameters.SearchUsersRequest} request
      * @param {UserClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedPathParametersError}
+     * @throws {@link errors.SeedPathParametersTimeoutError}
      *
      * @example
      *     await client.user.searchUsers("user_id", {
@@ -265,6 +277,9 @@ export class UserClient {
      * @param {SeedPathParameters.GetUserMetadataRequest} request
      * @param {UserClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedPathParametersError}
+     * @throws {@link errors.SeedPathParametersTimeoutError}
+     *
      * @example
      *     await client.user.getUserMetadata("user_id", 1)
      */
@@ -327,6 +342,9 @@ export class UserClient {
      * @param {string} thought
      * @param {SeedPathParameters.GetUserSpecificsRequest} request
      * @param {UserClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedPathParametersError}
+     * @throws {@link errors.SeedPathParametersTimeoutError}
      *
      * @example
      *     await client.user.getUserSpecifics("user_id", 1, "thought")

--- a/seed/ts-sdk/path-parameters/no-inline-path-parameters-serde/src/api/resources/organizations/client/Client.ts
+++ b/seed/ts-sdk/path-parameters/no-inline-path-parameters-serde/src/api/resources/organizations/client/Client.ts
@@ -26,6 +26,9 @@ export class OrganizationsClient {
      * @param {string} organization_id
      * @param {OrganizationsClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedPathParametersError}
+     * @throws {@link errors.SeedPathParametersTimeoutError}
+     *
      * @example
      *     await client.organizations.getOrganization("organization_id")
      */
@@ -90,6 +93,9 @@ export class OrganizationsClient {
      * @param {string} user_id
      * @param {SeedPathParameters.GetOrganizationUserRequest} request
      * @param {OrganizationsClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedPathParametersError}
+     * @throws {@link errors.SeedPathParametersTimeoutError}
      *
      * @example
      *     await client.organizations.getOrganizationUser("organization_id", "user_id")
@@ -160,6 +166,9 @@ export class OrganizationsClient {
      * @param {string} organization_id
      * @param {SeedPathParameters.SearchOrganizationsRequest} request
      * @param {OrganizationsClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedPathParametersError}
+     * @throws {@link errors.SeedPathParametersTimeoutError}
      *
      * @example
      *     await client.organizations.searchOrganizations("organization_id", {

--- a/seed/ts-sdk/path-parameters/no-inline-path-parameters-serde/src/api/resources/user/client/Client.ts
+++ b/seed/ts-sdk/path-parameters/no-inline-path-parameters-serde/src/api/resources/user/client/Client.ts
@@ -28,6 +28,9 @@ export class UserClient {
      * @param {SeedPathParameters.GetUsersRequest} request
      * @param {UserClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedPathParametersError}
+     * @throws {@link errors.SeedPathParametersTimeoutError}
+     *
      * @example
      *     await client.user.getUser("user_id")
      */
@@ -87,6 +90,9 @@ export class UserClient {
     /**
      * @param {SeedPathParameters.User} request
      * @param {UserClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedPathParametersError}
+     * @throws {@link errors.SeedPathParametersTimeoutError}
      *
      * @example
      *     await client.user.createUser({
@@ -155,6 +161,9 @@ export class UserClient {
      * @param {string} user_id
      * @param {SeedPathParameters.UpdateUserRequest} request
      * @param {UserClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedPathParametersError}
+     * @throws {@link errors.SeedPathParametersTimeoutError}
      *
      * @example
      *     await client.user.updateUser("user_id", {
@@ -228,6 +237,9 @@ export class UserClient {
      * @param {string} user_id
      * @param {SeedPathParameters.SearchUsersRequest} request
      * @param {UserClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedPathParametersError}
+     * @throws {@link errors.SeedPathParametersTimeoutError}
      *
      * @example
      *     await client.user.searchUsers("user_id", {
@@ -308,6 +320,9 @@ export class UserClient {
      * @param {SeedPathParameters.GetUserMetadataRequest} request
      * @param {UserClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedPathParametersError}
+     * @throws {@link errors.SeedPathParametersTimeoutError}
+     *
      * @example
      *     await client.user.getUserMetadata("user_id", 1)
      */
@@ -379,6 +394,9 @@ export class UserClient {
      * @param {string} thought
      * @param {SeedPathParameters.GetUserSpecificsRequest} request
      * @param {UserClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedPathParametersError}
+     * @throws {@link errors.SeedPathParametersTimeoutError}
      *
      * @example
      *     await client.user.getUserSpecifics("user_id", 1, "thought")

--- a/seed/ts-sdk/path-parameters/no-inline-path-parameters/src/api/resources/organizations/client/Client.ts
+++ b/seed/ts-sdk/path-parameters/no-inline-path-parameters/src/api/resources/organizations/client/Client.ts
@@ -25,6 +25,9 @@ export class OrganizationsClient {
      * @param {string} organization_id
      * @param {OrganizationsClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedPathParametersError}
+     * @throws {@link errors.SeedPathParametersTimeoutError}
+     *
      * @example
      *     await client.organizations.getOrganization("organization_id")
      */
@@ -80,6 +83,9 @@ export class OrganizationsClient {
      * @param {string} user_id
      * @param {SeedPathParameters.GetOrganizationUserRequest} request
      * @param {OrganizationsClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedPathParametersError}
+     * @throws {@link errors.SeedPathParametersTimeoutError}
      *
      * @example
      *     await client.organizations.getOrganizationUser("organization_id", "user_id")
@@ -141,6 +147,9 @@ export class OrganizationsClient {
      * @param {string} organization_id
      * @param {SeedPathParameters.SearchOrganizationsRequest} request
      * @param {OrganizationsClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedPathParametersError}
+     * @throws {@link errors.SeedPathParametersTimeoutError}
      *
      * @example
      *     await client.organizations.searchOrganizations("organization_id", {

--- a/seed/ts-sdk/path-parameters/no-inline-path-parameters/src/api/resources/user/client/Client.ts
+++ b/seed/ts-sdk/path-parameters/no-inline-path-parameters/src/api/resources/user/client/Client.ts
@@ -27,6 +27,9 @@ export class UserClient {
      * @param {SeedPathParameters.GetUsersRequest} request
      * @param {UserClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedPathParametersError}
+     * @throws {@link errors.SeedPathParametersTimeoutError}
+     *
      * @example
      *     await client.user.getUser("user_id")
      */
@@ -77,6 +80,9 @@ export class UserClient {
     /**
      * @param {SeedPathParameters.User} request
      * @param {UserClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedPathParametersError}
+     * @throws {@link errors.SeedPathParametersTimeoutError}
      *
      * @example
      *     await client.user.createUser({
@@ -133,6 +139,9 @@ export class UserClient {
      * @param {string} user_id
      * @param {SeedPathParameters.UpdateUserRequest} request
      * @param {UserClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedPathParametersError}
+     * @throws {@link errors.SeedPathParametersTimeoutError}
      *
      * @example
      *     await client.user.updateUser("user_id", {
@@ -194,6 +203,9 @@ export class UserClient {
      * @param {string} user_id
      * @param {SeedPathParameters.SearchUsersRequest} request
      * @param {UserClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedPathParametersError}
+     * @throws {@link errors.SeedPathParametersTimeoutError}
      *
      * @example
      *     await client.user.searchUsers("user_id", {
@@ -265,6 +277,9 @@ export class UserClient {
      * @param {SeedPathParameters.GetUserMetadataRequest} request
      * @param {UserClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedPathParametersError}
+     * @throws {@link errors.SeedPathParametersTimeoutError}
+     *
      * @example
      *     await client.user.getUserMetadata("user_id", 1)
      */
@@ -327,6 +342,9 @@ export class UserClient {
      * @param {string} thought
      * @param {SeedPathParameters.GetUserSpecificsRequest} request
      * @param {UserClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedPathParametersError}
+     * @throws {@link errors.SeedPathParametersTimeoutError}
      *
      * @example
      *     await client.user.getUserSpecifics("user_id", 1, "thought")

--- a/seed/ts-sdk/path-parameters/parameter-naming-camel-case/src/api/resources/organizations/client/Client.ts
+++ b/seed/ts-sdk/path-parameters/parameter-naming-camel-case/src/api/resources/organizations/client/Client.ts
@@ -25,6 +25,9 @@ export class OrganizationsClient {
      * @param {string} organizationId
      * @param {OrganizationsClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedPathParametersError}
+     * @throws {@link errors.SeedPathParametersTimeoutError}
+     *
      * @example
      *     await client.organizations.getOrganization("organization_id")
      */
@@ -78,6 +81,9 @@ export class OrganizationsClient {
     /**
      * @param {SeedPathParameters.GetOrganizationUserRequest} request
      * @param {OrganizationsClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedPathParametersError}
+     * @throws {@link errors.SeedPathParametersTimeoutError}
      *
      * @example
      *     await client.organizations.getOrganizationUser({
@@ -137,6 +143,9 @@ export class OrganizationsClient {
      * @param {string} organizationId
      * @param {SeedPathParameters.SearchOrganizationsRequest} request
      * @param {OrganizationsClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedPathParametersError}
+     * @throws {@link errors.SeedPathParametersTimeoutError}
      *
      * @example
      *     await client.organizations.searchOrganizations("organization_id", {

--- a/seed/ts-sdk/path-parameters/parameter-naming-camel-case/src/api/resources/user/client/Client.ts
+++ b/seed/ts-sdk/path-parameters/parameter-naming-camel-case/src/api/resources/user/client/Client.ts
@@ -26,6 +26,9 @@ export class UserClient {
      * @param {SeedPathParameters.GetUsersRequest} request
      * @param {UserClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedPathParametersError}
+     * @throws {@link errors.SeedPathParametersTimeoutError}
+     *
      * @example
      *     await client.user.getUser({
      *         userId: "user_id"
@@ -77,6 +80,9 @@ export class UserClient {
     /**
      * @param {SeedPathParameters.User} request
      * @param {UserClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedPathParametersError}
+     * @throws {@link errors.SeedPathParametersTimeoutError}
      *
      * @example
      *     await client.user.createUser({
@@ -132,6 +138,9 @@ export class UserClient {
     /**
      * @param {SeedPathParameters.UpdateUserRequest} request
      * @param {UserClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedPathParametersError}
+     * @throws {@link errors.SeedPathParametersTimeoutError}
      *
      * @example
      *     await client.user.updateUser({
@@ -191,6 +200,9 @@ export class UserClient {
     /**
      * @param {SeedPathParameters.SearchUsersRequest} request
      * @param {UserClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedPathParametersError}
+     * @throws {@link errors.SeedPathParametersTimeoutError}
      *
      * @example
      *     await client.user.searchUsers({
@@ -259,6 +271,9 @@ export class UserClient {
      * @param {SeedPathParameters.GetUserMetadataRequest} request
      * @param {UserClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedPathParametersError}
+     * @throws {@link errors.SeedPathParametersTimeoutError}
+     *
      * @example
      *     await client.user.getUserMetadata({
      *         userId: "user_id",
@@ -318,6 +333,9 @@ export class UserClient {
      *
      * @param {SeedPathParameters.GetUserSpecificsRequest} request
      * @param {UserClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedPathParametersError}
+     * @throws {@link errors.SeedPathParametersTimeoutError}
      *
      * @example
      *     await client.user.getUserSpecifics({

--- a/seed/ts-sdk/path-parameters/parameter-naming-original-name/src/api/resources/organizations/client/Client.ts
+++ b/seed/ts-sdk/path-parameters/parameter-naming-original-name/src/api/resources/organizations/client/Client.ts
@@ -25,6 +25,9 @@ export class OrganizationsClient {
      * @param {string} organization_id
      * @param {OrganizationsClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedPathParametersError}
+     * @throws {@link errors.SeedPathParametersTimeoutError}
+     *
      * @example
      *     await client.organizations.getOrganization("organization_id")
      */
@@ -78,6 +81,9 @@ export class OrganizationsClient {
     /**
      * @param {SeedPathParameters.GetOrganizationUserRequest} request
      * @param {OrganizationsClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedPathParametersError}
+     * @throws {@link errors.SeedPathParametersTimeoutError}
      *
      * @example
      *     await client.organizations.getOrganizationUser({
@@ -137,6 +143,9 @@ export class OrganizationsClient {
      * @param {string} organization_id
      * @param {SeedPathParameters.SearchOrganizationsRequest} request
      * @param {OrganizationsClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedPathParametersError}
+     * @throws {@link errors.SeedPathParametersTimeoutError}
      *
      * @example
      *     await client.organizations.searchOrganizations("organization_id", {

--- a/seed/ts-sdk/path-parameters/parameter-naming-original-name/src/api/resources/user/client/Client.ts
+++ b/seed/ts-sdk/path-parameters/parameter-naming-original-name/src/api/resources/user/client/Client.ts
@@ -26,6 +26,9 @@ export class UserClient {
      * @param {SeedPathParameters.GetUsersRequest} request
      * @param {UserClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedPathParametersError}
+     * @throws {@link errors.SeedPathParametersTimeoutError}
+     *
      * @example
      *     await client.user.getUser({
      *         user_id: "user_id"
@@ -77,6 +80,9 @@ export class UserClient {
     /**
      * @param {SeedPathParameters.User} request
      * @param {UserClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedPathParametersError}
+     * @throws {@link errors.SeedPathParametersTimeoutError}
      *
      * @example
      *     await client.user.createUser({
@@ -132,6 +138,9 @@ export class UserClient {
     /**
      * @param {SeedPathParameters.UpdateUserRequest} request
      * @param {UserClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedPathParametersError}
+     * @throws {@link errors.SeedPathParametersTimeoutError}
      *
      * @example
      *     await client.user.updateUser({
@@ -191,6 +200,9 @@ export class UserClient {
     /**
      * @param {SeedPathParameters.SearchUsersRequest} request
      * @param {UserClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedPathParametersError}
+     * @throws {@link errors.SeedPathParametersTimeoutError}
      *
      * @example
      *     await client.user.searchUsers({
@@ -259,6 +271,9 @@ export class UserClient {
      * @param {SeedPathParameters.GetUserMetadataRequest} request
      * @param {UserClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedPathParametersError}
+     * @throws {@link errors.SeedPathParametersTimeoutError}
+     *
      * @example
      *     await client.user.getUserMetadata({
      *         user_id: "user_id",
@@ -318,6 +333,9 @@ export class UserClient {
      *
      * @param {SeedPathParameters.GetUserSpecificsRequest} request
      * @param {UserClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedPathParametersError}
+     * @throws {@link errors.SeedPathParametersTimeoutError}
      *
      * @example
      *     await client.user.getUserSpecifics({

--- a/seed/ts-sdk/path-parameters/parameter-naming-snake-case/src/api/resources/organizations/client/Client.ts
+++ b/seed/ts-sdk/path-parameters/parameter-naming-snake-case/src/api/resources/organizations/client/Client.ts
@@ -25,6 +25,9 @@ export class OrganizationsClient {
      * @param {string} organization_id
      * @param {OrganizationsClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedPathParametersError}
+     * @throws {@link errors.SeedPathParametersTimeoutError}
+     *
      * @example
      *     await client.organizations.getOrganization("organization_id")
      */
@@ -78,6 +81,9 @@ export class OrganizationsClient {
     /**
      * @param {SeedPathParameters.GetOrganizationUserRequest} request
      * @param {OrganizationsClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedPathParametersError}
+     * @throws {@link errors.SeedPathParametersTimeoutError}
      *
      * @example
      *     await client.organizations.getOrganizationUser({
@@ -137,6 +143,9 @@ export class OrganizationsClient {
      * @param {string} organization_id
      * @param {SeedPathParameters.SearchOrganizationsRequest} request
      * @param {OrganizationsClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedPathParametersError}
+     * @throws {@link errors.SeedPathParametersTimeoutError}
      *
      * @example
      *     await client.organizations.searchOrganizations("organization_id", {

--- a/seed/ts-sdk/path-parameters/parameter-naming-snake-case/src/api/resources/user/client/Client.ts
+++ b/seed/ts-sdk/path-parameters/parameter-naming-snake-case/src/api/resources/user/client/Client.ts
@@ -26,6 +26,9 @@ export class UserClient {
      * @param {SeedPathParameters.GetUsersRequest} request
      * @param {UserClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedPathParametersError}
+     * @throws {@link errors.SeedPathParametersTimeoutError}
+     *
      * @example
      *     await client.user.getUser({
      *         user_id: "user_id"
@@ -77,6 +80,9 @@ export class UserClient {
     /**
      * @param {SeedPathParameters.User} request
      * @param {UserClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedPathParametersError}
+     * @throws {@link errors.SeedPathParametersTimeoutError}
      *
      * @example
      *     await client.user.createUser({
@@ -132,6 +138,9 @@ export class UserClient {
     /**
      * @param {SeedPathParameters.UpdateUserRequest} request
      * @param {UserClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedPathParametersError}
+     * @throws {@link errors.SeedPathParametersTimeoutError}
      *
      * @example
      *     await client.user.updateUser({
@@ -191,6 +200,9 @@ export class UserClient {
     /**
      * @param {SeedPathParameters.SearchUsersRequest} request
      * @param {UserClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedPathParametersError}
+     * @throws {@link errors.SeedPathParametersTimeoutError}
      *
      * @example
      *     await client.user.searchUsers({
@@ -259,6 +271,9 @@ export class UserClient {
      * @param {SeedPathParameters.GetUserMetadataRequest} request
      * @param {UserClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedPathParametersError}
+     * @throws {@link errors.SeedPathParametersTimeoutError}
+     *
      * @example
      *     await client.user.getUserMetadata({
      *         user_id: "user_id",
@@ -318,6 +333,9 @@ export class UserClient {
      *
      * @param {SeedPathParameters.GetUserSpecificsRequest} request
      * @param {UserClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedPathParametersError}
+     * @throws {@link errors.SeedPathParametersTimeoutError}
      *
      * @example
      *     await client.user.getUserSpecifics({

--- a/seed/ts-sdk/path-parameters/parameter-naming-wire-value/src/api/resources/organizations/client/Client.ts
+++ b/seed/ts-sdk/path-parameters/parameter-naming-wire-value/src/api/resources/organizations/client/Client.ts
@@ -25,6 +25,9 @@ export class OrganizationsClient {
      * @param {string} organization_id
      * @param {OrganizationsClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedPathParametersError}
+     * @throws {@link errors.SeedPathParametersTimeoutError}
+     *
      * @example
      *     await client.organizations.getOrganization("organization_id")
      */
@@ -78,6 +81,9 @@ export class OrganizationsClient {
     /**
      * @param {SeedPathParameters.GetOrganizationUserRequest} request
      * @param {OrganizationsClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedPathParametersError}
+     * @throws {@link errors.SeedPathParametersTimeoutError}
      *
      * @example
      *     await client.organizations.getOrganizationUser({
@@ -137,6 +143,9 @@ export class OrganizationsClient {
      * @param {string} organization_id
      * @param {SeedPathParameters.SearchOrganizationsRequest} request
      * @param {OrganizationsClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedPathParametersError}
+     * @throws {@link errors.SeedPathParametersTimeoutError}
      *
      * @example
      *     await client.organizations.searchOrganizations("organization_id", {

--- a/seed/ts-sdk/path-parameters/parameter-naming-wire-value/src/api/resources/user/client/Client.ts
+++ b/seed/ts-sdk/path-parameters/parameter-naming-wire-value/src/api/resources/user/client/Client.ts
@@ -26,6 +26,9 @@ export class UserClient {
      * @param {SeedPathParameters.GetUsersRequest} request
      * @param {UserClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedPathParametersError}
+     * @throws {@link errors.SeedPathParametersTimeoutError}
+     *
      * @example
      *     await client.user.getUser({
      *         user_id: "user_id"
@@ -77,6 +80,9 @@ export class UserClient {
     /**
      * @param {SeedPathParameters.User} request
      * @param {UserClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedPathParametersError}
+     * @throws {@link errors.SeedPathParametersTimeoutError}
      *
      * @example
      *     await client.user.createUser({
@@ -132,6 +138,9 @@ export class UserClient {
     /**
      * @param {SeedPathParameters.UpdateUserRequest} request
      * @param {UserClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedPathParametersError}
+     * @throws {@link errors.SeedPathParametersTimeoutError}
      *
      * @example
      *     await client.user.updateUser({
@@ -191,6 +200,9 @@ export class UserClient {
     /**
      * @param {SeedPathParameters.SearchUsersRequest} request
      * @param {UserClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedPathParametersError}
+     * @throws {@link errors.SeedPathParametersTimeoutError}
      *
      * @example
      *     await client.user.searchUsers({
@@ -259,6 +271,9 @@ export class UserClient {
      * @param {SeedPathParameters.GetUserMetadataRequest} request
      * @param {UserClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedPathParametersError}
+     * @throws {@link errors.SeedPathParametersTimeoutError}
+     *
      * @example
      *     await client.user.getUserMetadata({
      *         user_id: "user_id",
@@ -318,6 +333,9 @@ export class UserClient {
      *
      * @param {SeedPathParameters.GetUserSpecificsRequest} request
      * @param {UserClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedPathParametersError}
+     * @throws {@link errors.SeedPathParametersTimeoutError}
      *
      * @example
      *     await client.user.getUserSpecifics({

--- a/seed/ts-sdk/path-parameters/retain-original-casing/src/api/resources/organizations/client/Client.ts
+++ b/seed/ts-sdk/path-parameters/retain-original-casing/src/api/resources/organizations/client/Client.ts
@@ -25,6 +25,9 @@ export class OrganizationsClient {
      * @param {string} organization_id
      * @param {OrganizationsClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedPathParametersError}
+     * @throws {@link errors.SeedPathParametersTimeoutError}
+     *
      * @example
      *     await client.organizations.getOrganization("organization_id")
      */
@@ -78,6 +81,9 @@ export class OrganizationsClient {
     /**
      * @param {SeedPathParameters.GetOrganizationUserRequest} request
      * @param {OrganizationsClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedPathParametersError}
+     * @throws {@link errors.SeedPathParametersTimeoutError}
      *
      * @example
      *     await client.organizations.getOrganizationUser({
@@ -137,6 +143,9 @@ export class OrganizationsClient {
      * @param {string} organization_id
      * @param {SeedPathParameters.SearchOrganizationsRequest} request
      * @param {OrganizationsClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedPathParametersError}
+     * @throws {@link errors.SeedPathParametersTimeoutError}
      *
      * @example
      *     await client.organizations.searchOrganizations("organization_id", {

--- a/seed/ts-sdk/path-parameters/retain-original-casing/src/api/resources/user/client/Client.ts
+++ b/seed/ts-sdk/path-parameters/retain-original-casing/src/api/resources/user/client/Client.ts
@@ -26,6 +26,9 @@ export class UserClient {
      * @param {SeedPathParameters.GetUsersRequest} request
      * @param {UserClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedPathParametersError}
+     * @throws {@link errors.SeedPathParametersTimeoutError}
+     *
      * @example
      *     await client.user.getUser({
      *         user_id: "user_id"
@@ -77,6 +80,9 @@ export class UserClient {
     /**
      * @param {SeedPathParameters.User} request
      * @param {UserClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedPathParametersError}
+     * @throws {@link errors.SeedPathParametersTimeoutError}
      *
      * @example
      *     await client.user.createUser({
@@ -132,6 +138,9 @@ export class UserClient {
     /**
      * @param {SeedPathParameters.UpdateUserRequest} request
      * @param {UserClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedPathParametersError}
+     * @throws {@link errors.SeedPathParametersTimeoutError}
      *
      * @example
      *     await client.user.updateUser({
@@ -191,6 +200,9 @@ export class UserClient {
     /**
      * @param {SeedPathParameters.SearchUsersRequest} request
      * @param {UserClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedPathParametersError}
+     * @throws {@link errors.SeedPathParametersTimeoutError}
      *
      * @example
      *     await client.user.searchUsers({
@@ -259,6 +271,9 @@ export class UserClient {
      * @param {SeedPathParameters.GetUserMetadataRequest} request
      * @param {UserClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedPathParametersError}
+     * @throws {@link errors.SeedPathParametersTimeoutError}
+     *
      * @example
      *     await client.user.getUserMetadata({
      *         user_id: "user_id",
@@ -318,6 +333,9 @@ export class UserClient {
      *
      * @param {SeedPathParameters.GetUserSpecificsRequest} request
      * @param {UserClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedPathParametersError}
+     * @throws {@link errors.SeedPathParametersTimeoutError}
      *
      * @example
      *     await client.user.getUserSpecifics({

--- a/seed/ts-sdk/plain-text/src/api/resources/service/client/Client.ts
+++ b/seed/ts-sdk/plain-text/src/api/resources/service/client/Client.ts
@@ -23,6 +23,9 @@ export class ServiceClient {
     /**
      * @param {ServiceClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedPlainTextError}
+     * @throws {@link errors.SeedPlainTextTimeoutError}
+     *
      * @example
      *     await client.service.getText()
      */
@@ -66,6 +69,9 @@ export class ServiceClient {
     /**
      * @param {ServiceClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedPlainTextError}
+     * @throws {@link errors.SeedPlainTextTimeoutError}
+     *
      * @example
      *     await client.service.getCsv()
      */
@@ -108,6 +114,9 @@ export class ServiceClient {
 
     /**
      * @param {ServiceClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedPlainTextError}
+     * @throws {@link errors.SeedPlainTextTimeoutError}
      *
      * @example
      *     await client.service.getXml()

--- a/seed/ts-sdk/property-access/generate-read-write-only-types/src/Client.ts
+++ b/seed/ts-sdk/property-access/generate-read-write-only-types/src/Client.ts
@@ -26,6 +26,9 @@ export class SeedPropertyAccessClient {
      * @param {SeedPropertyAccess.User.Request} request
      * @param {SeedPropertyAccessClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedPropertyAccessError}
+     * @throws {@link errors.SeedPropertyAccessTimeoutError}
+     *
      * @example
      *     await client.createUser({
      *         password: "password",

--- a/seed/ts-sdk/property-access/no-custom-config/src/Client.ts
+++ b/seed/ts-sdk/property-access/no-custom-config/src/Client.ts
@@ -26,6 +26,9 @@ export class SeedPropertyAccessClient {
      * @param {SeedPropertyAccess.User} request
      * @param {SeedPropertyAccessClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedPropertyAccessError}
+     * @throws {@link errors.SeedPropertyAccessTimeoutError}
+     *
      * @example
      *     await client.createUser({
      *         id: "id",

--- a/seed/ts-sdk/public-object/src/api/resources/service/client/Client.ts
+++ b/seed/ts-sdk/public-object/src/api/resources/service/client/Client.ts
@@ -20,6 +20,10 @@ export class ServiceClient {
         this._options = normalizeClientOptions(options);
     }
 
+    /**
+     * @throws {@link errors.SeedPublicObjectError}
+     * @throws {@link errors.SeedPublicObjectTimeoutError}
+     */
     public get(requestOptions?: ServiceClient.RequestOptions): core.HttpResponsePromise<core.BinaryResponse> {
         return core.HttpResponsePromise.fromPromise(this.__get(requestOptions));
     }

--- a/seed/ts-sdk/query-param-name-conflict/src/Client.ts
+++ b/seed/ts-sdk/query-param-name-conflict/src/Client.ts
@@ -26,6 +26,9 @@ export class SeedApiClient {
      * @param {SeedApi.BulkUpdateTasksRequest} request
      * @param {SeedApiClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedApiError}
+     * @throws {@link errors.SeedApiTimeoutError}
+     *
      * @example
      *     await client.bulkUpdateTasks()
      */

--- a/seed/ts-sdk/query-parameters-openapi-as-objects/src/Client.ts
+++ b/seed/ts-sdk/query-parameters-openapi-as-objects/src/Client.ts
@@ -26,6 +26,9 @@ export class SeedApiClient {
      * @param {SeedApi.SearchRequest} request
      * @param {SeedApiClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedApiError}
+     * @throws {@link errors.SeedApiTimeoutError}
+     *
      * @example
      *     await client.search({
      *         limit: 1,

--- a/seed/ts-sdk/query-parameters-openapi/src/Client.ts
+++ b/seed/ts-sdk/query-parameters-openapi/src/Client.ts
@@ -26,6 +26,9 @@ export class SeedApiClient {
      * @param {SeedApi.SearchRequest} request
      * @param {SeedApiClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedApiError}
+     * @throws {@link errors.SeedApiTimeoutError}
+     *
      * @example
      *     await client.search({
      *         limit: 1,

--- a/seed/ts-sdk/query-parameters/no-custom-config/src/api/resources/user/client/Client.ts
+++ b/seed/ts-sdk/query-parameters/no-custom-config/src/api/resources/user/client/Client.ts
@@ -26,6 +26,9 @@ export class UserClient {
      * @param {SeedQueryParameters.GetUsersRequest} request
      * @param {UserClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedQueryParametersError}
+     * @throws {@link errors.SeedQueryParametersTimeoutError}
+     *
      * @example
      *     await client.user.getUsername({
      *         limit: 1,

--- a/seed/ts-sdk/query-parameters/parameter-naming-camel-case/src/api/resources/user/client/Client.ts
+++ b/seed/ts-sdk/query-parameters/parameter-naming-camel-case/src/api/resources/user/client/Client.ts
@@ -26,6 +26,9 @@ export class UserClient {
      * @param {SeedQueryParameters.GetUsersRequest} request
      * @param {UserClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedQueryParametersError}
+     * @throws {@link errors.SeedQueryParametersTimeoutError}
+     *
      * @example
      *     await client.user.getUsername({
      *         limit: 1,

--- a/seed/ts-sdk/query-parameters/parameter-naming-original-name/src/api/resources/user/client/Client.ts
+++ b/seed/ts-sdk/query-parameters/parameter-naming-original-name/src/api/resources/user/client/Client.ts
@@ -26,6 +26,9 @@ export class UserClient {
      * @param {SeedQueryParameters.GetUsersRequest} request
      * @param {UserClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedQueryParametersError}
+     * @throws {@link errors.SeedQueryParametersTimeoutError}
+     *
      * @example
      *     await client.user.getUsername({
      *         limit: 1,

--- a/seed/ts-sdk/query-parameters/parameter-naming-snake-case/src/api/resources/user/client/Client.ts
+++ b/seed/ts-sdk/query-parameters/parameter-naming-snake-case/src/api/resources/user/client/Client.ts
@@ -26,6 +26,9 @@ export class UserClient {
      * @param {SeedQueryParameters.GetUsersRequest} request
      * @param {UserClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedQueryParametersError}
+     * @throws {@link errors.SeedQueryParametersTimeoutError}
+     *
      * @example
      *     await client.user.getUsername({
      *         limit: 1,

--- a/seed/ts-sdk/query-parameters/parameter-naming-wire-value/src/api/resources/user/client/Client.ts
+++ b/seed/ts-sdk/query-parameters/parameter-naming-wire-value/src/api/resources/user/client/Client.ts
@@ -26,6 +26,9 @@ export class UserClient {
      * @param {SeedQueryParameters.GetUsersRequest} request
      * @param {UserClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedQueryParametersError}
+     * @throws {@link errors.SeedQueryParametersTimeoutError}
+     *
      * @example
      *     await client.user.getUsername({
      *         limit: 1,

--- a/seed/ts-sdk/query-parameters/serde/src/api/resources/user/client/Client.ts
+++ b/seed/ts-sdk/query-parameters/serde/src/api/resources/user/client/Client.ts
@@ -27,6 +27,9 @@ export class UserClient {
      * @param {SeedQueryParameters.GetUsersRequest} request
      * @param {UserClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedQueryParametersError}
+     * @throws {@link errors.SeedQueryParametersTimeoutError}
+     *
      * @example
      *     await client.user.getUsername({
      *         limit: 1,

--- a/seed/ts-sdk/request-parameters/flatten-request-parameters/src/api/resources/user/client/Client.ts
+++ b/seed/ts-sdk/request-parameters/flatten-request-parameters/src/api/resources/user/client/Client.ts
@@ -27,6 +27,9 @@ export class UserClient {
      * @param {SeedRequestParameters.CreateUsernameRequest} request
      * @param {UserClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedRequestParametersError}
+     * @throws {@link errors.SeedRequestParametersTimeoutError}
+     *
      * @example
      *     await client.user.createUsername({
      *         tags: ["tags", "tags"],
@@ -91,6 +94,9 @@ export class UserClient {
     /**
      * @param {SeedRequestParameters.CreateUsernameReferencedRequest} request
      * @param {UserClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedRequestParametersError}
+     * @throws {@link errors.SeedRequestParametersTimeoutError}
      *
      * @example
      *     await client.user.createUsernameWithReferencedType({
@@ -157,6 +163,9 @@ export class UserClient {
      * @param {SeedRequestParameters.CreateUsernameBodyOptionalProperties | null} request
      * @param {UserClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedRequestParametersError}
+     * @throws {@link errors.SeedRequestParametersTimeoutError}
+     *
      * @example
      *     await client.user.createUsernameOptional()
      */
@@ -208,6 +217,9 @@ export class UserClient {
     /**
      * @param {SeedRequestParameters.GetUsersRequest} request
      * @param {UserClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedRequestParametersError}
+     * @throws {@link errors.SeedRequestParametersTimeoutError}
      *
      * @example
      *     await client.user.getUsername({

--- a/seed/ts-sdk/request-parameters/no-custom-config/src/api/resources/user/client/Client.ts
+++ b/seed/ts-sdk/request-parameters/no-custom-config/src/api/resources/user/client/Client.ts
@@ -27,6 +27,9 @@ export class UserClient {
      * @param {SeedRequestParameters.CreateUsernameRequest} request
      * @param {UserClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedRequestParametersError}
+     * @throws {@link errors.SeedRequestParametersTimeoutError}
+     *
      * @example
      *     await client.user.createUsername({
      *         tags: ["tags", "tags"],
@@ -91,6 +94,9 @@ export class UserClient {
     /**
      * @param {SeedRequestParameters.CreateUsernameReferencedRequest} request
      * @param {UserClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedRequestParametersError}
+     * @throws {@link errors.SeedRequestParametersTimeoutError}
      *
      * @example
      *     await client.user.createUsernameWithReferencedType({
@@ -159,6 +165,9 @@ export class UserClient {
      * @param {SeedRequestParameters.CreateUsernameBodyOptionalProperties | null} request
      * @param {UserClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedRequestParametersError}
+     * @throws {@link errors.SeedRequestParametersTimeoutError}
+     *
      * @example
      *     await client.user.createUsernameOptional()
      */
@@ -210,6 +219,9 @@ export class UserClient {
     /**
      * @param {SeedRequestParameters.GetUsersRequest} request
      * @param {UserClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedRequestParametersError}
+     * @throws {@link errors.SeedRequestParametersTimeoutError}
      *
      * @example
      *     await client.user.getUsername({

--- a/seed/ts-sdk/request-parameters/use-big-int-and-default-request-parameter-values/src/api/resources/user/client/Client.ts
+++ b/seed/ts-sdk/request-parameters/use-big-int-and-default-request-parameter-values/src/api/resources/user/client/Client.ts
@@ -27,6 +27,9 @@ export class UserClient {
      * @param {SeedRequestParameters.CreateUsernameRequest} request
      * @param {UserClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedRequestParametersError}
+     * @throws {@link errors.SeedRequestParametersTimeoutError}
+     *
      * @example
      *     await client.user.createUsername({
      *         tags: ["tags", "tags"],
@@ -91,6 +94,9 @@ export class UserClient {
     /**
      * @param {SeedRequestParameters.CreateUsernameReferencedRequest} request
      * @param {UserClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedRequestParametersError}
+     * @throws {@link errors.SeedRequestParametersTimeoutError}
      *
      * @example
      *     await client.user.createUsernameWithReferencedType({
@@ -159,6 +165,9 @@ export class UserClient {
      * @param {SeedRequestParameters.CreateUsernameBodyOptionalProperties | null} request
      * @param {UserClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedRequestParametersError}
+     * @throws {@link errors.SeedRequestParametersTimeoutError}
+     *
      * @example
      *     await client.user.createUsernameOptional()
      */
@@ -210,6 +219,9 @@ export class UserClient {
     /**
      * @param {SeedRequestParameters.GetUsersRequest} request
      * @param {UserClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedRequestParametersError}
+     * @throws {@link errors.SeedRequestParametersTimeoutError}
      *
      * @example
      *     await client.user.getUsername({

--- a/seed/ts-sdk/request-parameters/use-default-request-parameter-values/src/api/resources/user/client/Client.ts
+++ b/seed/ts-sdk/request-parameters/use-default-request-parameter-values/src/api/resources/user/client/Client.ts
@@ -27,6 +27,9 @@ export class UserClient {
      * @param {SeedRequestParameters.CreateUsernameRequest} request
      * @param {UserClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedRequestParametersError}
+     * @throws {@link errors.SeedRequestParametersTimeoutError}
+     *
      * @example
      *     await client.user.createUsername({
      *         tags: ["tags", "tags"],
@@ -91,6 +94,9 @@ export class UserClient {
     /**
      * @param {SeedRequestParameters.CreateUsernameReferencedRequest} request
      * @param {UserClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedRequestParametersError}
+     * @throws {@link errors.SeedRequestParametersTimeoutError}
      *
      * @example
      *     await client.user.createUsernameWithReferencedType({
@@ -159,6 +165,9 @@ export class UserClient {
      * @param {SeedRequestParameters.CreateUsernameBodyOptionalProperties | null} request
      * @param {UserClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedRequestParametersError}
+     * @throws {@link errors.SeedRequestParametersTimeoutError}
+     *
      * @example
      *     await client.user.createUsernameOptional()
      */
@@ -210,6 +219,9 @@ export class UserClient {
     /**
      * @param {SeedRequestParameters.GetUsersRequest} request
      * @param {UserClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedRequestParametersError}
+     * @throws {@link errors.SeedRequestParametersTimeoutError}
      *
      * @example
      *     await client.user.getUsername({

--- a/seed/ts-sdk/required-nullable/src/Client.ts
+++ b/seed/ts-sdk/required-nullable/src/Client.ts
@@ -26,6 +26,9 @@ export class SeedApiClient {
      * @param {SeedApi.GetFooRequest} request
      * @param {SeedApiClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedApiError}
+     * @throws {@link errors.SeedApiTimeoutError}
+     *
      * @example
      *     await client.getFoo({
      *         required_baz: "required_baz",
@@ -94,6 +97,9 @@ export class SeedApiClient {
      * @param {string} id
      * @param {SeedApi.UpdateFooRequest} request
      * @param {SeedApiClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedApiError}
+     * @throws {@link errors.SeedApiTimeoutError}
      *
      * @example
      *     await client.updateFoo("id", {

--- a/seed/ts-sdk/reserved-keywords/src/api/resources/package/client/Client.ts
+++ b/seed/ts-sdk/reserved-keywords/src/api/resources/package/client/Client.ts
@@ -25,6 +25,9 @@ export class PackageClient {
      * @param {SeedNurseryApi.TestRequest} request
      * @param {PackageClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedNurseryApiError}
+     * @throws {@link errors.SeedNurseryApiTimeoutError}
+     *
      * @example
      *     await client.package.test({
      *         "for": "for"

--- a/seed/ts-sdk/response-property/src/api/resources/service/client/Client.ts
+++ b/seed/ts-sdk/response-property/src/api/resources/service/client/Client.ts
@@ -26,6 +26,9 @@ export class ServiceClient {
      * @param {string} request
      * @param {ServiceClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedResponsePropertyError}
+     * @throws {@link errors.SeedResponsePropertyTimeoutError}
+     *
      * @example
      *     await client.service.getMovie("string")
      */
@@ -77,6 +80,9 @@ export class ServiceClient {
     /**
      * @param {string} request
      * @param {ServiceClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedResponsePropertyError}
+     * @throws {@link errors.SeedResponsePropertyTimeoutError}
      *
      * @example
      *     await client.service.getMovieDocs("string")
@@ -130,6 +136,9 @@ export class ServiceClient {
      * @param {string} request
      * @param {ServiceClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedResponsePropertyError}
+     * @throws {@link errors.SeedResponsePropertyTimeoutError}
+     *
      * @example
      *     await client.service.getMovieName("string")
      */
@@ -182,6 +191,9 @@ export class ServiceClient {
      * @param {string} request
      * @param {ServiceClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedResponsePropertyError}
+     * @throws {@link errors.SeedResponsePropertyTimeoutError}
+     *
      * @example
      *     await client.service.getMovieMetadata("string")
      */
@@ -233,6 +245,9 @@ export class ServiceClient {
     /**
      * @param {string} request
      * @param {ServiceClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedResponsePropertyError}
+     * @throws {@link errors.SeedResponsePropertyTimeoutError}
      *
      * @example
      *     await client.service.getOptionalMovie("string")
@@ -289,6 +304,9 @@ export class ServiceClient {
      * @param {string} request
      * @param {ServiceClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedResponsePropertyError}
+     * @throws {@link errors.SeedResponsePropertyTimeoutError}
+     *
      * @example
      *     await client.service.getOptionalMovieDocs("string")
      */
@@ -343,6 +361,9 @@ export class ServiceClient {
     /**
      * @param {string} request
      * @param {ServiceClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedResponsePropertyError}
+     * @throws {@link errors.SeedResponsePropertyTimeoutError}
      *
      * @example
      *     await client.service.getOptionalMovieName("string")

--- a/seed/ts-sdk/schemaless-request-body-examples/src/Client.ts
+++ b/seed/ts-sdk/schemaless-request-body-examples/src/Client.ts
@@ -28,6 +28,9 @@ export class SeedApiClient {
      * @param {unknown} request
      * @param {SeedApiClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedApiError}
+     * @throws {@link errors.SeedApiTimeoutError}
+     *
      * @example
      *     await client.createPlant({
      *         "name": "Venus Flytrap",
@@ -94,6 +97,9 @@ export class SeedApiClient {
      * @param {SeedApi.UpdatePlantRequest} request
      * @param {SeedApiClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedApiError}
+     * @throws {@link errors.SeedApiTimeoutError}
+     *
      * @example
      *     await client.updatePlant({
      *         plantId: "plantId",
@@ -156,6 +162,9 @@ export class SeedApiClient {
      *
      * @param {SeedApi.CreatePlantWithSchemaRequest} request
      * @param {SeedApiClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedApiError}
+     * @throws {@link errors.SeedApiTimeoutError}
      *
      * @example
      *     await client.createPlantWithSchema({

--- a/seed/ts-sdk/server-sent-events-openapi/no-custom-config/src/Client.ts
+++ b/seed/ts-sdk/server-sent-events-openapi/no-custom-config/src/Client.ts
@@ -528,6 +528,9 @@ export class SeedApiClient {
      * @param {SeedApi.StreamXFernStreamingConditionRequest} request
      * @param {SeedApiClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedApiError}
+     * @throws {@link errors.SeedApiTimeoutError}
+     *
      * @example
      *     await client.streamXFernStreamingCondition({
      *         query: "query"
@@ -659,6 +662,9 @@ export class SeedApiClient {
      * @param {SeedApi.StreamXFernStreamingSharedSchemaRequest} request
      * @param {SeedApiClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedApiError}
+     * @throws {@link errors.SeedApiTimeoutError}
+     *
      * @example
      *     await client.streamXFernStreamingSharedSchema({
      *         prompt: "prompt",
@@ -723,6 +729,9 @@ export class SeedApiClient {
      *
      * @param {SeedApi.SharedCompletionRequest} request
      * @param {SeedApiClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedApiError}
+     * @throws {@link errors.SeedApiTimeoutError}
      *
      * @example
      *     await client.validateCompletion({
@@ -846,6 +855,9 @@ export class SeedApiClient {
      * @param {SeedApi.StreamXFernStreamingUnionRequest} request
      * @param {SeedApiClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedApiError}
+     * @throws {@link errors.SeedApiTimeoutError}
+     *
      * @example
      *     await client.streamXFernStreamingUnion({
      *         type: "message",
@@ -910,6 +922,9 @@ export class SeedApiClient {
      *
      * @param {SeedApi.UnionStreamRequestBase} request
      * @param {SeedApiClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedApiError}
+     * @throws {@link errors.SeedApiTimeoutError}
      *
      * @example
      *     await client.validateUnionRequest({
@@ -1033,6 +1048,9 @@ export class SeedApiClient {
      *
      * @param {SeedApi.StreamXFernStreamingNullableConditionRequest} request
      * @param {SeedApiClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedApiError}
+     * @throws {@link errors.SeedApiTimeoutError}
      *
      * @example
      *     await client.streamXFernStreamingNullableCondition({

--- a/seed/ts-sdk/server-url-templating-single-url/no-custom-config/src/Client.ts
+++ b/seed/ts-sdk/server-url-templating-single-url/no-custom-config/src/Client.ts
@@ -25,6 +25,9 @@ export class SeedApiClient {
     /**
      * @param {SeedApiClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedApiError}
+     * @throws {@link errors.SeedApiTimeoutError}
+     *
      * @example
      *     await client.getUsers()
      */
@@ -70,6 +73,9 @@ export class SeedApiClient {
     /**
      * @param {SeedApi.GetUserRequest} request
      * @param {SeedApiClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedApiError}
+     * @throws {@link errors.SeedApiTimeoutError}
      *
      * @example
      *     await client.getUser({

--- a/seed/ts-sdk/server-url-templating/no-custom-config/src/Client.ts
+++ b/seed/ts-sdk/server-url-templating/no-custom-config/src/Client.ts
@@ -26,6 +26,9 @@ export class SeedApiClient {
     /**
      * @param {SeedApiClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedApiError}
+     * @throws {@link errors.SeedApiTimeoutError}
+     *
      * @example
      *     await client.getUsers()
      */
@@ -73,6 +76,9 @@ export class SeedApiClient {
     /**
      * @param {SeedApi.GetUserRequest} request
      * @param {SeedApiClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedApiError}
+     * @throws {@link errors.SeedApiTimeoutError}
      *
      * @example
      *     await client.getUser({
@@ -128,6 +134,9 @@ export class SeedApiClient {
     /**
      * @param {SeedApi.TokenRequest} request
      * @param {SeedApiClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedApiError}
+     * @throws {@link errors.SeedApiTimeoutError}
      *
      * @example
      *     await client.getToken({

--- a/seed/ts-sdk/simple-api/allow-custom-fetcher/src/api/resources/user/client/Client.ts
+++ b/seed/ts-sdk/simple-api/allow-custom-fetcher/src/api/resources/user/client/Client.ts
@@ -25,6 +25,9 @@ export class UserClient {
      * @param {string} id
      * @param {UserClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedSimpleApiError}
+     * @throws {@link errors.SeedSimpleApiTimeoutError}
+     *
      * @example
      *     await client.user.get("id")
      */

--- a/seed/ts-sdk/simple-api/allow-extra-fields/src/api/resources/user/client/Client.ts
+++ b/seed/ts-sdk/simple-api/allow-extra-fields/src/api/resources/user/client/Client.ts
@@ -25,6 +25,9 @@ export class UserClient {
      * @param {string} id
      * @param {UserClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedSimpleApiError}
+     * @throws {@link errors.SeedSimpleApiTimeoutError}
+     *
      * @example
      *     await client.user.get("id")
      */

--- a/seed/ts-sdk/simple-api/bundle/src/api/resources/user/client/Client.ts
+++ b/seed/ts-sdk/simple-api/bundle/src/api/resources/user/client/Client.ts
@@ -25,6 +25,9 @@ export class UserClient {
      * @param {string} id
      * @param {UserClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedSimpleApiError}
+     * @throws {@link errors.SeedSimpleApiTimeoutError}
+     *
      * @example
      *     await client.user.get("id")
      */

--- a/seed/ts-sdk/simple-api/custom-package-json/src/api/resources/user/client/Client.ts
+++ b/seed/ts-sdk/simple-api/custom-package-json/src/api/resources/user/client/Client.ts
@@ -25,6 +25,9 @@ export class UserClient {
      * @param {string} id
      * @param {UserClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedSimpleApiError}
+     * @throws {@link errors.SeedSimpleApiTimeoutError}
+     *
      * @example
      *     await client.user.get("id")
      */

--- a/seed/ts-sdk/simple-api/include-platform-headers/src/api/resources/user/client/Client.ts
+++ b/seed/ts-sdk/simple-api/include-platform-headers/src/api/resources/user/client/Client.ts
@@ -25,6 +25,9 @@ export class UserClient {
      * @param {string} id
      * @param {UserClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedSimpleApiError}
+     * @throws {@link errors.SeedSimpleApiTimeoutError}
+     *
      * @example
      *     await client.user.get("id")
      */

--- a/seed/ts-sdk/simple-api/jsr/src/api/resources/user/client/Client.ts
+++ b/seed/ts-sdk/simple-api/jsr/src/api/resources/user/client/Client.ts
@@ -25,6 +25,9 @@ export class UserClient {
      * @param {string} id
      * @param {UserClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedSimpleApiError}
+     * @throws {@link errors.SeedSimpleApiTimeoutError}
+     *
      * @example
      *     await client.user.get("id")
      */

--- a/seed/ts-sdk/simple-api/legacy-exports/src/api/resources/user/client/Client.ts
+++ b/seed/ts-sdk/simple-api/legacy-exports/src/api/resources/user/client/Client.ts
@@ -25,6 +25,9 @@ export class UserClient {
      * @param {string} id
      * @param {UserClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedSimpleApiError}
+     * @throws {@link errors.SeedSimpleApiTimeoutError}
+     *
      * @example
      *     await client.user.get("id")
      */

--- a/seed/ts-sdk/simple-api/naming-shorthand/src/api/resources/user/client/Client.ts
+++ b/seed/ts-sdk/simple-api/naming-shorthand/src/api/resources/user/client/Client.ts
@@ -25,6 +25,9 @@ export class UserClient {
      * @param {string} id
      * @param {UserClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.AcmeError}
+     * @throws {@link errors.AcmeTimeoutError}
+     *
      * @example
      *     await client.user.get("id")
      */

--- a/seed/ts-sdk/simple-api/naming/src/api/resources/user/client/Client.ts
+++ b/seed/ts-sdk/simple-api/naming/src/api/resources/user/client/Client.ts
@@ -25,6 +25,9 @@ export class UserClient {
      * @param {string} id
      * @param {UserClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.AcmeApiError}
+     * @throws {@link errors.AcmeRequestTimeoutError}
+     *
      * @example
      *     await client.user.get("id")
      */

--- a/seed/ts-sdk/simple-api/no-custom-config/src/api/resources/user/client/Client.ts
+++ b/seed/ts-sdk/simple-api/no-custom-config/src/api/resources/user/client/Client.ts
@@ -25,6 +25,9 @@ export class UserClient {
      * @param {string} id
      * @param {UserClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedSimpleApiError}
+     * @throws {@link errors.SeedSimpleApiTimeoutError}
+     *
      * @example
      *     await client.user.get("id")
      */

--- a/seed/ts-sdk/simple-api/no-linter-and-formatter/src/api/resources/user/client/Client.ts
+++ b/seed/ts-sdk/simple-api/no-linter-and-formatter/src/api/resources/user/client/Client.ts
@@ -28,6 +28,9 @@ export class UserClient {
      * @param {string} id
      * @param {UserClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedSimpleApiError}
+     * @throws {@link errors.SeedSimpleApiTimeoutError}
+     *
      * @example
      *     await client.user.get("id")
      */

--- a/seed/ts-sdk/simple-api/no-scripts/src/api/resources/user/client/Client.ts
+++ b/seed/ts-sdk/simple-api/no-scripts/src/api/resources/user/client/Client.ts
@@ -28,6 +28,9 @@ export class UserClient {
      * @param {string} id
      * @param {UserClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedSimpleApiError}
+     * @throws {@link errors.SeedSimpleApiTimeoutError}
+     *
      * @example
      *     await client.user.get("id")
      */

--- a/seed/ts-sdk/simple-api/oidc-token/src/api/resources/user/client/Client.ts
+++ b/seed/ts-sdk/simple-api/oidc-token/src/api/resources/user/client/Client.ts
@@ -25,6 +25,9 @@ export class UserClient {
      * @param {string} id
      * @param {UserClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedSimpleApiError}
+     * @throws {@link errors.SeedSimpleApiTimeoutError}
+     *
      * @example
      *     await client.user.get("id")
      */

--- a/seed/ts-sdk/simple-api/omit-fern-headers/src/api/resources/user/client/Client.ts
+++ b/seed/ts-sdk/simple-api/omit-fern-headers/src/api/resources/user/client/Client.ts
@@ -25,6 +25,9 @@ export class UserClient {
      * @param {string} id
      * @param {UserClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedSimpleApiError}
+     * @throws {@link errors.SeedSimpleApiTimeoutError}
+     *
      * @example
      *     await client.user.get("id")
      */

--- a/seed/ts-sdk/simple-api/use-oxc/src/api/resources/user/client/Client.ts
+++ b/seed/ts-sdk/simple-api/use-oxc/src/api/resources/user/client/Client.ts
@@ -26,6 +26,9 @@ export class UserClient {
      * @param {string} id
      * @param {UserClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedSimpleApiError}
+     * @throws {@link errors.SeedSimpleApiTimeoutError}
+     *
      * @example
      *     await client.user.get("id")
      */

--- a/seed/ts-sdk/simple-api/use-oxfmt/src/api/resources/user/client/Client.ts
+++ b/seed/ts-sdk/simple-api/use-oxfmt/src/api/resources/user/client/Client.ts
@@ -25,6 +25,9 @@ export class UserClient {
      * @param {string} id
      * @param {UserClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedSimpleApiError}
+     * @throws {@link errors.SeedSimpleApiTimeoutError}
+     *
      * @example
      *     await client.user.get("id")
      */

--- a/seed/ts-sdk/simple-api/use-oxlint/src/api/resources/user/client/Client.ts
+++ b/seed/ts-sdk/simple-api/use-oxlint/src/api/resources/user/client/Client.ts
@@ -26,6 +26,9 @@ export class UserClient {
      * @param {string} id
      * @param {UserClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedSimpleApiError}
+     * @throws {@link errors.SeedSimpleApiTimeoutError}
+     *
      * @example
      *     await client.user.get("id")
      */

--- a/seed/ts-sdk/simple-api/use-prettier-no-linter/src/api/resources/user/client/Client.ts
+++ b/seed/ts-sdk/simple-api/use-prettier-no-linter/src/api/resources/user/client/Client.ts
@@ -26,6 +26,9 @@ export class UserClient {
      * @param {string} id
      * @param {UserClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedSimpleApiError}
+     * @throws {@link errors.SeedSimpleApiTimeoutError}
+     *
      * @example
      *     await client.user.get("id")
      */

--- a/seed/ts-sdk/simple-api/use-prettier/src/api/resources/user/client/Client.ts
+++ b/seed/ts-sdk/simple-api/use-prettier/src/api/resources/user/client/Client.ts
@@ -25,6 +25,9 @@ export class UserClient {
      * @param {string} id
      * @param {UserClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedSimpleApiError}
+     * @throws {@link errors.SeedSimpleApiTimeoutError}
+     *
      * @example
      *     await client.user.get("id")
      */

--- a/seed/ts-sdk/simple-api/use-yarn/src/api/resources/user/client/Client.ts
+++ b/seed/ts-sdk/simple-api/use-yarn/src/api/resources/user/client/Client.ts
@@ -25,6 +25,9 @@ export class UserClient {
      * @param {string} id
      * @param {UserClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedSimpleApiError}
+     * @throws {@link errors.SeedSimpleApiTimeoutError}
+     *
      * @example
      *     await client.user.get("id")
      */

--- a/seed/ts-sdk/simple-fhir/src/Client.ts
+++ b/seed/ts-sdk/simple-fhir/src/Client.ts
@@ -25,6 +25,9 @@ export class SeedApiClient {
      * @param {string} account_id
      * @param {SeedApiClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedApiError}
+     * @throws {@link errors.SeedApiTimeoutError}
+     *
      * @example
      *     await client.getAccount("account_id")
      */

--- a/seed/ts-sdk/single-url-environment-default/src/api/resources/dummy/client/Client.ts
+++ b/seed/ts-sdk/single-url-environment-default/src/api/resources/dummy/client/Client.ts
@@ -24,6 +24,9 @@ export class DummyClient {
     /**
      * @param {DummyClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedSingleUrlEnvironmentDefaultError}
+     * @throws {@link errors.SeedSingleUrlEnvironmentDefaultTimeoutError}
+     *
      * @example
      *     await client.dummy.getDummy()
      */

--- a/seed/ts-sdk/single-url-environment-no-default/src/api/resources/dummy/client/Client.ts
+++ b/seed/ts-sdk/single-url-environment-no-default/src/api/resources/dummy/client/Client.ts
@@ -23,6 +23,9 @@ export class DummyClient {
     /**
      * @param {DummyClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedSingleUrlEnvironmentNoDefaultError}
+     * @throws {@link errors.SeedSingleUrlEnvironmentNoDefaultTimeoutError}
+     *
      * @example
      *     await client.dummy.getDummy()
      */

--- a/seed/ts-sdk/streaming/no-custom-config/src/api/resources/dummy/client/Client.ts
+++ b/seed/ts-sdk/streaming/no-custom-config/src/api/resources/dummy/client/Client.ts
@@ -83,6 +83,9 @@ export class DummyClient {
      * @param {SeedStreaming.Generateequest} request
      * @param {DummyClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedStreamingError}
+     * @throws {@link errors.SeedStreamingTimeoutError}
+     *
      * @example
      *     await client.dummy.generate({
      *         num_events: 5

--- a/seed/ts-sdk/streaming/serde-layer/src/api/resources/dummy/client/Client.ts
+++ b/seed/ts-sdk/streaming/serde-layer/src/api/resources/dummy/client/Client.ts
@@ -101,6 +101,9 @@ export class DummyClient {
      * @param {SeedStreaming.Generateequest} request
      * @param {DummyClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedStreamingError}
+     * @throws {@link errors.SeedStreamingTimeoutError}
+     *
      * @example
      *     await client.dummy.generate({
      *         numEvents: 5

--- a/seed/ts-sdk/streaming/wrapper/src/api/resources/dummy/client/Client.ts
+++ b/seed/ts-sdk/streaming/wrapper/src/api/resources/dummy/client/Client.ts
@@ -84,6 +84,9 @@ export class DummyClient {
      * @param {SeedStreaming.Generateequest} request
      * @param {DummyClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedStreamingError}
+     * @throws {@link errors.SeedStreamingTimeoutError}
+     *
      * @example
      *     await client.dummy.generate({
      *         num_events: 5

--- a/seed/ts-sdk/trace/no-custom-config/src/api/resources/admin/client/Client.ts
+++ b/seed/ts-sdk/trace/no-custom-config/src/api/resources/admin/client/Client.ts
@@ -28,6 +28,9 @@ export class AdminClient {
      * @param {SeedTrace.TestSubmissionStatus} request
      * @param {AdminClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedTraceError}
+     * @throws {@link errors.SeedTraceTimeoutError}
+     *
      * @example
      *     await client.admin.updateTestSubmissionStatus("d5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32", {
      *         type: "stopped"
@@ -98,6 +101,9 @@ export class AdminClient {
      * @param {SeedTrace.SubmissionId} submissionId
      * @param {SeedTrace.TestSubmissionUpdate} request
      * @param {AdminClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedTraceError}
+     * @throws {@link errors.SeedTraceTimeoutError}
      *
      * @example
      *     await client.admin.sendTestSubmissionUpdate("d5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32", {
@@ -174,6 +180,9 @@ export class AdminClient {
      * @param {SeedTrace.WorkspaceSubmissionStatus} request
      * @param {AdminClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedTraceError}
+     * @throws {@link errors.SeedTraceTimeoutError}
+     *
      * @example
      *     await client.admin.updateWorkspaceSubmissionStatus("d5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32", {
      *         type: "stopped"
@@ -244,6 +253,9 @@ export class AdminClient {
      * @param {SeedTrace.SubmissionId} submissionId
      * @param {SeedTrace.WorkspaceSubmissionUpdate} request
      * @param {AdminClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedTraceError}
+     * @throws {@link errors.SeedTraceTimeoutError}
      *
      * @example
      *     await client.admin.sendWorkspaceSubmissionUpdate("d5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32", {
@@ -320,6 +332,9 @@ export class AdminClient {
      * @param {string} testCaseId
      * @param {SeedTrace.StoreTracedTestCaseRequest} request
      * @param {AdminClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedTraceError}
+     * @throws {@link errors.SeedTraceTimeoutError}
      *
      * @example
      *     await client.admin.storeTracedTestCase("d5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32", "testCaseId", {
@@ -480,6 +495,9 @@ export class AdminClient {
      * @param {SeedTrace.TraceResponseV2[]} request
      * @param {AdminClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedTraceError}
+     * @throws {@link errors.SeedTraceTimeoutError}
+     *
      * @example
      *     await client.admin.storeTracedTestCaseV2("d5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32", "testCaseId", [{
      *             submissionId: "d5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32",
@@ -626,6 +644,9 @@ export class AdminClient {
      * @param {SeedTrace.SubmissionId} submissionId
      * @param {SeedTrace.StoreTracedWorkspaceRequest} request
      * @param {AdminClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedTraceError}
+     * @throws {@link errors.SeedTraceTimeoutError}
      *
      * @example
      *     await client.admin.storeTracedWorkspace("d5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32", {
@@ -777,6 +798,9 @@ export class AdminClient {
      * @param {SeedTrace.SubmissionId} submissionId
      * @param {SeedTrace.TraceResponseV2[]} request
      * @param {AdminClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedTraceError}
+     * @throws {@link errors.SeedTraceTimeoutError}
      *
      * @example
      *     await client.admin.storeTracedWorkspaceV2("d5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32", [{

--- a/seed/ts-sdk/trace/no-custom-config/src/api/resources/homepage/client/Client.ts
+++ b/seed/ts-sdk/trace/no-custom-config/src/api/resources/homepage/client/Client.ts
@@ -26,6 +26,9 @@ export class HomepageClient {
     /**
      * @param {HomepageClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedTraceError}
+     * @throws {@link errors.SeedTraceTimeoutError}
+     *
      * @example
      *     await client.homepage.getHomepageProblems()
      */
@@ -79,6 +82,9 @@ export class HomepageClient {
     /**
      * @param {SeedTrace.ProblemId[]} request
      * @param {HomepageClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedTraceError}
+     * @throws {@link errors.SeedTraceTimeoutError}
      *
      * @example
      *     await client.homepage.setHomepageProblems(["string", "string"])

--- a/seed/ts-sdk/trace/no-custom-config/src/api/resources/migration/client/Client.ts
+++ b/seed/ts-sdk/trace/no-custom-config/src/api/resources/migration/client/Client.ts
@@ -26,6 +26,9 @@ export class MigrationClient {
      * @param {SeedTrace.GetAttemptedMigrationsRequest} request
      * @param {MigrationClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedTraceError}
+     * @throws {@link errors.SeedTraceTimeoutError}
+     *
      * @example
      *     await client.migration.getAttemptedMigrations({
      *         "admin-key-header": "admin-key-header"

--- a/seed/ts-sdk/trace/no-custom-config/src/api/resources/playlist/client/Client.ts
+++ b/seed/ts-sdk/trace/no-custom-config/src/api/resources/playlist/client/Client.ts
@@ -30,6 +30,9 @@ export class PlaylistClient {
      * @param {SeedTrace.CreatePlaylistRequest} request
      * @param {PlaylistClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedTraceError}
+     * @throws {@link errors.SeedTraceTimeoutError}
+     *
      * @example
      *     await client.playlist.createPlaylist(1, {
      *         datetime: "2024-01-15T09:30:00Z",
@@ -116,6 +119,9 @@ export class PlaylistClient {
      * @param {number} serviceParam
      * @param {SeedTrace.GetPlaylistsRequest} request
      * @param {PlaylistClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedTraceError}
+     * @throws {@link errors.SeedTraceTimeoutError}
      *
      * @example
      *     await client.playlist.getPlaylists(1, {
@@ -205,6 +211,8 @@ export class PlaylistClient {
      *
      * @throws {@link SeedTrace.PlaylistIdNotFoundError}
      * @throws {@link SeedTrace.UnauthorizedError}
+     * @throws {@link errors.SeedTraceError}
+     * @throws {@link errors.SeedTraceTimeoutError}
      *
      * @example
      *     await client.playlist.getPlaylist(1, "playlistId")
@@ -284,6 +292,8 @@ export class PlaylistClient {
      * @param {PlaylistClient.RequestOptions} requestOptions - Request-specific configuration.
      *
      * @throws {@link SeedTrace.PlaylistIdNotFoundError}
+     * @throws {@link errors.SeedTraceError}
+     * @throws {@link errors.SeedTraceTimeoutError}
      *
      * @example
      *     await client.playlist.updatePlaylist(1, "playlistId", {
@@ -370,6 +380,9 @@ export class PlaylistClient {
      * @param {number} serviceParam
      * @param {SeedTrace.PlaylistId} playlist_id
      * @param {PlaylistClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedTraceError}
+     * @throws {@link errors.SeedTraceTimeoutError}
      *
      * @example
      *     await client.playlist.deletePlaylist(1, "playlist_id")

--- a/seed/ts-sdk/trace/no-custom-config/src/api/resources/problem/client/Client.ts
+++ b/seed/ts-sdk/trace/no-custom-config/src/api/resources/problem/client/Client.ts
@@ -29,6 +29,9 @@ export class ProblemClient {
      * @param {SeedTrace.CreateProblemRequest} request
      * @param {ProblemClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedTraceError}
+     * @throws {@link errors.SeedTraceTimeoutError}
+     *
      * @example
      *     await client.problem.createProblem({
      *         problemName: "problemName",
@@ -162,6 +165,9 @@ export class ProblemClient {
      * @param {SeedTrace.ProblemId} problemId
      * @param {SeedTrace.CreateProblemRequest} request
      * @param {ProblemClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedTraceError}
+     * @throws {@link errors.SeedTraceTimeoutError}
      *
      * @example
      *     await client.problem.updateProblem("problemId", {
@@ -303,6 +309,9 @@ export class ProblemClient {
      * @param {SeedTrace.ProblemId} problemId
      * @param {ProblemClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedTraceError}
+     * @throws {@link errors.SeedTraceTimeoutError}
+     *
      * @example
      *     await client.problem.deleteProblem("problemId")
      */
@@ -365,6 +374,9 @@ export class ProblemClient {
      *
      * @param {SeedTrace.GetDefaultStarterFilesRequest} request
      * @param {ProblemClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedTraceError}
+     * @throws {@link errors.SeedTraceTimeoutError}
      *
      * @example
      *     await client.problem.getDefaultStarterFiles({

--- a/seed/ts-sdk/trace/no-custom-config/src/api/resources/submission/client/Client.ts
+++ b/seed/ts-sdk/trace/no-custom-config/src/api/resources/submission/client/Client.ts
@@ -31,6 +31,9 @@ export class SubmissionClient {
      * @param {SeedTrace.Language} language
      * @param {SubmissionClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedTraceError}
+     * @throws {@link errors.SeedTraceTimeoutError}
+     *
      * @example
      *     await client.submission.createExecutionSession("JAVA")
      */
@@ -94,6 +97,9 @@ export class SubmissionClient {
      * @param {string} sessionId
      * @param {SubmissionClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedTraceError}
+     * @throws {@link errors.SeedTraceTimeoutError}
+     *
      * @example
      *     await client.submission.getExecutionSession("sessionId")
      */
@@ -155,6 +161,9 @@ export class SubmissionClient {
      * @param {string} sessionId
      * @param {SubmissionClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedTraceError}
+     * @throws {@link errors.SeedTraceTimeoutError}
+     *
      * @example
      *     await client.submission.stopExecutionSession("sessionId")
      */
@@ -209,6 +218,9 @@ export class SubmissionClient {
 
     /**
      * @param {SubmissionClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedTraceError}
+     * @throws {@link errors.SeedTraceTimeoutError}
      *
      * @example
      *     await client.submission.getExecutionSessionsState()

--- a/seed/ts-sdk/trace/no-custom-config/src/api/resources/sysprop/client/Client.ts
+++ b/seed/ts-sdk/trace/no-custom-config/src/api/resources/sysprop/client/Client.ts
@@ -27,6 +27,9 @@ export class SyspropClient {
      * @param {number} numWarmInstances
      * @param {SyspropClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedTraceError}
+     * @throws {@link errors.SeedTraceTimeoutError}
+     *
      * @example
      *     await client.sysprop.setNumWarmInstances("JAVA", 1)
      */
@@ -90,6 +93,9 @@ export class SyspropClient {
 
     /**
      * @param {SyspropClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedTraceError}
+     * @throws {@link errors.SeedTraceTimeoutError}
      *
      * @example
      *     await client.sysprop.getNumWarmInstances()

--- a/seed/ts-sdk/trace/no-custom-config/src/api/resources/v2/client/Client.ts
+++ b/seed/ts-sdk/trace/no-custom-config/src/api/resources/v2/client/Client.ts
@@ -36,6 +36,9 @@ export class V2Client {
     /**
      * @param {V2Client.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedTraceError}
+     * @throws {@link errors.SeedTraceTimeoutError}
+     *
      * @example
      *     await client.v2.test()
      */

--- a/seed/ts-sdk/trace/no-custom-config/src/api/resources/v2/resources/problem/client/Client.ts
+++ b/seed/ts-sdk/trace/no-custom-config/src/api/resources/v2/resources/problem/client/Client.ts
@@ -27,6 +27,9 @@ export class ProblemClient {
      *
      * @param {ProblemClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedTraceError}
+     * @throws {@link errors.SeedTraceTimeoutError}
+     *
      * @example
      *     await client.v2.problem.getLightweightProblems()
      */
@@ -90,6 +93,9 @@ export class ProblemClient {
      *
      * @param {ProblemClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedTraceError}
+     * @throws {@link errors.SeedTraceTimeoutError}
+     *
      * @example
      *     await client.v2.problem.getProblems()
      */
@@ -145,6 +151,9 @@ export class ProblemClient {
      *
      * @param {SeedTrace.ProblemId} problemId
      * @param {ProblemClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedTraceError}
+     * @throws {@link errors.SeedTraceTimeoutError}
      *
      * @example
      *     await client.v2.problem.getLatestProblem("problemId")
@@ -209,6 +218,9 @@ export class ProblemClient {
      * @param {SeedTrace.ProblemId} problemId
      * @param {number} problemVersion
      * @param {ProblemClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedTraceError}
+     * @throws {@link errors.SeedTraceTimeoutError}
      *
      * @example
      *     await client.v2.problem.getProblemVersion("problemId", 1)

--- a/seed/ts-sdk/trace/no-custom-config/src/api/resources/v2/resources/v3/resources/problem/client/Client.ts
+++ b/seed/ts-sdk/trace/no-custom-config/src/api/resources/v2/resources/v3/resources/problem/client/Client.ts
@@ -27,6 +27,9 @@ export class ProblemClient {
      *
      * @param {ProblemClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedTraceError}
+     * @throws {@link errors.SeedTraceTimeoutError}
+     *
      * @example
      *     await client.v2.v3.problem.getLightweightProblems()
      */
@@ -90,6 +93,9 @@ export class ProblemClient {
      *
      * @param {ProblemClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedTraceError}
+     * @throws {@link errors.SeedTraceTimeoutError}
+     *
      * @example
      *     await client.v2.v3.problem.getProblems()
      */
@@ -145,6 +151,9 @@ export class ProblemClient {
      *
      * @param {SeedTrace.ProblemId} problemId
      * @param {ProblemClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedTraceError}
+     * @throws {@link errors.SeedTraceTimeoutError}
      *
      * @example
      *     await client.v2.v3.problem.getLatestProblem("problemId")
@@ -209,6 +218,9 @@ export class ProblemClient {
      * @param {SeedTrace.ProblemId} problemId
      * @param {number} problemVersion
      * @param {ProblemClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedTraceError}
+     * @throws {@link errors.SeedTraceTimeoutError}
      *
      * @example
      *     await client.v2.v3.problem.getProblemVersion("problemId", 1)

--- a/seed/ts-sdk/trace/serde/src/api/resources/admin/client/Client.ts
+++ b/seed/ts-sdk/trace/serde/src/api/resources/admin/client/Client.ts
@@ -29,6 +29,9 @@ export class AdminClient {
      * @param {SeedTrace.TestSubmissionStatus} request
      * @param {AdminClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedTraceError}
+     * @throws {@link errors.SeedTraceTimeoutError}
+     *
      * @example
      *     await client.admin.updateTestSubmissionStatus("d5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32", {
      *         type: "stopped"
@@ -105,6 +108,9 @@ export class AdminClient {
      * @param {SeedTrace.SubmissionId} submissionId
      * @param {SeedTrace.TestSubmissionUpdate} request
      * @param {AdminClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedTraceError}
+     * @throws {@link errors.SeedTraceTimeoutError}
      *
      * @example
      *     await client.admin.sendTestSubmissionUpdate("d5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32", {
@@ -187,6 +193,9 @@ export class AdminClient {
      * @param {SeedTrace.WorkspaceSubmissionStatus} request
      * @param {AdminClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedTraceError}
+     * @throws {@link errors.SeedTraceTimeoutError}
+     *
      * @example
      *     await client.admin.updateWorkspaceSubmissionStatus("d5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32", {
      *         type: "stopped"
@@ -263,6 +272,9 @@ export class AdminClient {
      * @param {SeedTrace.SubmissionId} submissionId
      * @param {SeedTrace.WorkspaceSubmissionUpdate} request
      * @param {AdminClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedTraceError}
+     * @throws {@link errors.SeedTraceTimeoutError}
      *
      * @example
      *     await client.admin.sendWorkspaceSubmissionUpdate("d5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32", {
@@ -345,6 +357,9 @@ export class AdminClient {
      * @param {string} testCaseId
      * @param {SeedTrace.StoreTracedTestCaseRequest} request
      * @param {AdminClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedTraceError}
+     * @throws {@link errors.SeedTraceTimeoutError}
      *
      * @example
      *     await client.admin.storeTracedTestCase("d5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32", "testCaseId", {
@@ -511,6 +526,9 @@ export class AdminClient {
      * @param {SeedTrace.TraceResponseV2[]} request
      * @param {AdminClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedTraceError}
+     * @throws {@link errors.SeedTraceTimeoutError}
+     *
      * @example
      *     await client.admin.storeTracedTestCaseV2("d5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32", "testCaseId", [{
      *             submissionId: "d5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32",
@@ -663,6 +681,9 @@ export class AdminClient {
      * @param {SeedTrace.SubmissionId} submissionId
      * @param {SeedTrace.StoreTracedWorkspaceRequest} request
      * @param {AdminClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedTraceError}
+     * @throws {@link errors.SeedTraceTimeoutError}
      *
      * @example
      *     await client.admin.storeTracedWorkspace("d5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32", {
@@ -820,6 +841,9 @@ export class AdminClient {
      * @param {SeedTrace.SubmissionId} submissionId
      * @param {SeedTrace.TraceResponseV2[]} request
      * @param {AdminClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedTraceError}
+     * @throws {@link errors.SeedTraceTimeoutError}
      *
      * @example
      *     await client.admin.storeTracedWorkspaceV2("d5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32", [{

--- a/seed/ts-sdk/trace/serde/src/api/resources/homepage/client/Client.ts
+++ b/seed/ts-sdk/trace/serde/src/api/resources/homepage/client/Client.ts
@@ -27,6 +27,9 @@ export class HomepageClient {
     /**
      * @param {HomepageClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedTraceError}
+     * @throws {@link errors.SeedTraceTimeoutError}
+     *
      * @example
      *     await client.homepage.getHomepageProblems()
      */
@@ -89,6 +92,9 @@ export class HomepageClient {
     /**
      * @param {SeedTrace.ProblemId[]} request
      * @param {HomepageClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedTraceError}
+     * @throws {@link errors.SeedTraceTimeoutError}
      *
      * @example
      *     await client.homepage.setHomepageProblems(["string", "string"])

--- a/seed/ts-sdk/trace/serde/src/api/resources/migration/client/Client.ts
+++ b/seed/ts-sdk/trace/serde/src/api/resources/migration/client/Client.ts
@@ -27,6 +27,9 @@ export class MigrationClient {
      * @param {SeedTrace.GetAttemptedMigrationsRequest} request
      * @param {MigrationClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedTraceError}
+     * @throws {@link errors.SeedTraceTimeoutError}
+     *
      * @example
      *     await client.migration.getAttemptedMigrations({
      *         adminKeyHeader: "admin-key-header"

--- a/seed/ts-sdk/trace/serde/src/api/resources/playlist/client/Client.ts
+++ b/seed/ts-sdk/trace/serde/src/api/resources/playlist/client/Client.ts
@@ -31,6 +31,9 @@ export class PlaylistClient {
      * @param {SeedTrace.CreatePlaylistRequest} request
      * @param {PlaylistClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedTraceError}
+     * @throws {@link errors.SeedTraceTimeoutError}
+     *
      * @example
      *     await client.playlist.createPlaylist(1, {
      *         datetime: new Date("2024-01-15T09:30:00.000Z"),
@@ -133,6 +136,9 @@ export class PlaylistClient {
      * @param {SeedTrace.GetPlaylistsRequest} request
      * @param {PlaylistClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedTraceError}
+     * @throws {@link errors.SeedTraceTimeoutError}
+     *
      * @example
      *     await client.playlist.getPlaylists(1, {
      *         limit: 1,
@@ -230,6 +236,8 @@ export class PlaylistClient {
      *
      * @throws {@link SeedTrace.PlaylistIdNotFoundError}
      * @throws {@link SeedTrace.UnauthorizedError}
+     * @throws {@link errors.SeedTraceError}
+     * @throws {@link errors.SeedTraceTimeoutError}
      *
      * @example
      *     await client.playlist.getPlaylist(1, "playlistId")
@@ -324,6 +332,8 @@ export class PlaylistClient {
      * @param {PlaylistClient.RequestOptions} requestOptions - Request-specific configuration.
      *
      * @throws {@link SeedTrace.PlaylistIdNotFoundError}
+     * @throws {@link errors.SeedTraceError}
+     * @throws {@link errors.SeedTraceTimeoutError}
      *
      * @example
      *     await client.playlist.updatePlaylist(1, "playlistId", {
@@ -431,6 +441,9 @@ export class PlaylistClient {
      * @param {number} serviceParam
      * @param {SeedTrace.PlaylistId} playlist_id
      * @param {PlaylistClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedTraceError}
+     * @throws {@link errors.SeedTraceTimeoutError}
      *
      * @example
      *     await client.playlist.deletePlaylist(1, "playlist_id")

--- a/seed/ts-sdk/trace/serde/src/api/resources/problem/client/Client.ts
+++ b/seed/ts-sdk/trace/serde/src/api/resources/problem/client/Client.ts
@@ -30,6 +30,9 @@ export class ProblemClient {
      * @param {SeedTrace.CreateProblemRequest} request
      * @param {ProblemClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedTraceError}
+     * @throws {@link errors.SeedTraceTimeoutError}
+     *
      * @example
      *     await client.problem.createProblem({
      *         problemName: "problemName",
@@ -178,6 +181,9 @@ export class ProblemClient {
      * @param {SeedTrace.ProblemId} problemId
      * @param {SeedTrace.CreateProblemRequest} request
      * @param {ProblemClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedTraceError}
+     * @throws {@link errors.SeedTraceTimeoutError}
      *
      * @example
      *     await client.problem.updateProblem("problemId", {
@@ -334,6 +340,9 @@ export class ProblemClient {
      * @param {SeedTrace.ProblemId} problemId
      * @param {ProblemClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedTraceError}
+     * @throws {@link errors.SeedTraceTimeoutError}
+     *
      * @example
      *     await client.problem.deleteProblem("problemId")
      */
@@ -396,6 +405,9 @@ export class ProblemClient {
      *
      * @param {SeedTrace.GetDefaultStarterFilesRequest} request
      * @param {ProblemClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedTraceError}
+     * @throws {@link errors.SeedTraceTimeoutError}
      *
      * @example
      *     await client.problem.getDefaultStarterFiles({

--- a/seed/ts-sdk/trace/serde/src/api/resources/submission/client/Client.ts
+++ b/seed/ts-sdk/trace/serde/src/api/resources/submission/client/Client.ts
@@ -32,6 +32,9 @@ export class SubmissionClient {
      * @param {SeedTrace.Language} language
      * @param {SubmissionClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedTraceError}
+     * @throws {@link errors.SeedTraceTimeoutError}
+     *
      * @example
      *     await client.submission.createExecutionSession("JAVA")
      */
@@ -104,6 +107,9 @@ export class SubmissionClient {
      * @param {string} sessionId
      * @param {SubmissionClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedTraceError}
+     * @throws {@link errors.SeedTraceTimeoutError}
+     *
      * @example
      *     await client.submission.getExecutionSession("sessionId")
      */
@@ -171,6 +177,9 @@ export class SubmissionClient {
      * @param {string} sessionId
      * @param {SubmissionClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedTraceError}
+     * @throws {@link errors.SeedTraceTimeoutError}
+     *
      * @example
      *     await client.submission.stopExecutionSession("sessionId")
      */
@@ -225,6 +234,9 @@ export class SubmissionClient {
 
     /**
      * @param {SubmissionClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedTraceError}
+     * @throws {@link errors.SeedTraceTimeoutError}
      *
      * @example
      *     await client.submission.getExecutionSessionsState()

--- a/seed/ts-sdk/trace/serde/src/api/resources/sysprop/client/Client.ts
+++ b/seed/ts-sdk/trace/serde/src/api/resources/sysprop/client/Client.ts
@@ -28,6 +28,9 @@ export class SyspropClient {
      * @param {number} numWarmInstances
      * @param {SyspropClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedTraceError}
+     * @throws {@link errors.SeedTraceTimeoutError}
+     *
      * @example
      *     await client.sysprop.setNumWarmInstances("JAVA", 1)
      */
@@ -91,6 +94,9 @@ export class SyspropClient {
 
     /**
      * @param {SyspropClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedTraceError}
+     * @throws {@link errors.SeedTraceTimeoutError}
      *
      * @example
      *     await client.sysprop.getNumWarmInstances()

--- a/seed/ts-sdk/trace/serde/src/api/resources/v2/client/Client.ts
+++ b/seed/ts-sdk/trace/serde/src/api/resources/v2/client/Client.ts
@@ -36,6 +36,9 @@ export class V2Client {
     /**
      * @param {V2Client.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedTraceError}
+     * @throws {@link errors.SeedTraceTimeoutError}
+     *
      * @example
      *     await client.v2.test()
      */

--- a/seed/ts-sdk/trace/serde/src/api/resources/v2/resources/problem/client/Client.ts
+++ b/seed/ts-sdk/trace/serde/src/api/resources/v2/resources/problem/client/Client.ts
@@ -28,6 +28,9 @@ export class ProblemClient {
      *
      * @param {ProblemClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedTraceError}
+     * @throws {@link errors.SeedTraceTimeoutError}
+     *
      * @example
      *     await client.v2.problem.getLightweightProblems()
      */
@@ -97,6 +100,9 @@ export class ProblemClient {
      *
      * @param {ProblemClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedTraceError}
+     * @throws {@link errors.SeedTraceTimeoutError}
+     *
      * @example
      *     await client.v2.problem.getProblems()
      */
@@ -161,6 +167,9 @@ export class ProblemClient {
      *
      * @param {SeedTrace.ProblemId} problemId
      * @param {ProblemClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedTraceError}
+     * @throws {@link errors.SeedTraceTimeoutError}
      *
      * @example
      *     await client.v2.problem.getLatestProblem("problemId")
@@ -234,6 +243,9 @@ export class ProblemClient {
      * @param {SeedTrace.ProblemId} problemId
      * @param {number} problemVersion
      * @param {ProblemClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedTraceError}
+     * @throws {@link errors.SeedTraceTimeoutError}
      *
      * @example
      *     await client.v2.problem.getProblemVersion("problemId", 1)

--- a/seed/ts-sdk/trace/serde/src/api/resources/v2/resources/v3/resources/problem/client/Client.ts
+++ b/seed/ts-sdk/trace/serde/src/api/resources/v2/resources/v3/resources/problem/client/Client.ts
@@ -28,6 +28,9 @@ export class ProblemClient {
      *
      * @param {ProblemClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedTraceError}
+     * @throws {@link errors.SeedTraceTimeoutError}
+     *
      * @example
      *     await client.v2.v3.problem.getLightweightProblems()
      */
@@ -97,6 +100,9 @@ export class ProblemClient {
      *
      * @param {ProblemClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedTraceError}
+     * @throws {@link errors.SeedTraceTimeoutError}
+     *
      * @example
      *     await client.v2.v3.problem.getProblems()
      */
@@ -161,6 +167,9 @@ export class ProblemClient {
      *
      * @param {SeedTrace.ProblemId} problemId
      * @param {ProblemClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedTraceError}
+     * @throws {@link errors.SeedTraceTimeoutError}
      *
      * @example
      *     await client.v2.v3.problem.getLatestProblem("problemId")
@@ -234,6 +243,9 @@ export class ProblemClient {
      * @param {SeedTrace.ProblemId} problemId
      * @param {number} problemVersion
      * @param {ProblemClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedTraceError}
+     * @throws {@link errors.SeedTraceTimeoutError}
      *
      * @example
      *     await client.v2.v3.problem.getProblemVersion("problemId", 1)

--- a/seed/ts-sdk/ts-error-name-collision/src/api/resources/simple/client/Client.ts
+++ b/seed/ts-sdk/ts-error-name-collision/src/api/resources/simple/client/Client.ts
@@ -29,6 +29,8 @@ export class SimpleClient {
      * @throws {@link SeedErrors.NotFoundError}
      * @throws {@link SeedErrors.BadRequestError}
      * @throws {@link SeedErrors.InternalServerError}
+     * @throws {@link errors.SeedErrorsError}
+     * @throws {@link errors.SeedErrorsTimeoutError}
      *
      * @example
      *     await client.simple.fooWithoutEndpointError({
@@ -107,6 +109,8 @@ export class SimpleClient {
      * @throws {@link SeedErrors.NotFoundError}
      * @throws {@link SeedErrors.BadRequestError}
      * @throws {@link SeedErrors.InternalServerError}
+     * @throws {@link errors.SeedErrorsError}
+     * @throws {@link errors.SeedErrorsTimeoutError}
      *
      * @example
      *     await client.simple.foo({
@@ -190,6 +194,8 @@ export class SimpleClient {
      * @throws {@link SeedErrors.NotFoundError}
      * @throws {@link SeedErrors.BadRequestError}
      * @throws {@link SeedErrors.InternalServerError}
+     * @throws {@link errors.SeedErrorsError}
+     * @throws {@link errors.SeedErrorsTimeoutError}
      *
      * @example
      *     await client.simple.fooWithExamples({

--- a/seed/ts-sdk/ts-express-casing/src/api/resources/imdb/client/Client.ts
+++ b/seed/ts-sdk/ts-express-casing/src/api/resources/imdb/client/Client.ts
@@ -28,6 +28,9 @@ export class ImdbClient {
      * @param {SeedApi.CreateMovieRequest} request
      * @param {ImdbClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedApiError}
+     * @throws {@link errors.SeedApiTimeoutError}
+     *
      * @example
      *     await client.imdb.createMovie({
      *         id: "id",
@@ -85,6 +88,8 @@ export class ImdbClient {
      * @param {ImdbClient.RequestOptions} requestOptions - Request-specific configuration.
      *
      * @throws {@link SeedApi.MovieDoesNotExistError}
+     * @throws {@link errors.SeedApiError}
+     * @throws {@link errors.SeedApiTimeoutError}
      *
      * @example
      *     await client.imdb.getMovie("movie_id")

--- a/seed/ts-sdk/ts-extra-properties/src/Client.ts
+++ b/seed/ts-sdk/ts-extra-properties/src/Client.ts
@@ -26,6 +26,9 @@ export class SeedApiClient {
     /**
      * @param {SeedApiClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedApiError}
+     * @throws {@link errors.SeedApiTimeoutError}
+     *
      * @example
      *     await client.getUser()
      */
@@ -79,6 +82,9 @@ export class SeedApiClient {
     /**
      * @param {SeedApi.CreateUserRequest} request
      * @param {SeedApiClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedApiError}
+     * @throws {@link errors.SeedApiTimeoutError}
      *
      * @example
      *     await client.createUser({

--- a/seed/ts-sdk/ts-inline-types/inline/src/Client.ts
+++ b/seed/ts-sdk/ts-inline-types/inline/src/Client.ts
@@ -26,6 +26,9 @@ export class SeedObjectClient {
      * @param {SeedObject.PostRootRequest} request
      * @param {SeedObjectClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedObjectError}
+     * @throws {@link errors.SeedObjectTimeoutError}
+     *
      * @example
      *     await client.getRoot({
      *         bar: {
@@ -82,6 +85,9 @@ export class SeedObjectClient {
     /**
      * @param {SeedObject.GetDiscriminatedUnionRequest} request
      * @param {SeedObjectClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedObjectError}
+     * @throws {@link errors.SeedObjectTimeoutError}
      *
      * @example
      *     await client.getDiscriminatedUnion({
@@ -149,6 +155,9 @@ export class SeedObjectClient {
     /**
      * @param {SeedObject.GetUndiscriminatedUnionRequest} request
      * @param {SeedObjectClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedObjectError}
+     * @throws {@link errors.SeedObjectTimeoutError}
      *
      * @example
      *     await client.getUndiscriminatedUnion({

--- a/seed/ts-sdk/ts-inline-types/no-inline/src/Client.ts
+++ b/seed/ts-sdk/ts-inline-types/no-inline/src/Client.ts
@@ -26,6 +26,9 @@ export class SeedObjectClient {
      * @param {SeedObject.PostRootRequest} request
      * @param {SeedObjectClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedObjectError}
+     * @throws {@link errors.SeedObjectTimeoutError}
+     *
      * @example
      *     await client.getRoot({
      *         bar: {
@@ -82,6 +85,9 @@ export class SeedObjectClient {
     /**
      * @param {SeedObject.GetDiscriminatedUnionRequest} request
      * @param {SeedObjectClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedObjectError}
+     * @throws {@link errors.SeedObjectTimeoutError}
      *
      * @example
      *     await client.getDiscriminatedUnion({
@@ -149,6 +155,9 @@ export class SeedObjectClient {
     /**
      * @param {SeedObject.GetUndiscriminatedUnionRequest} request
      * @param {SeedObjectClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedObjectError}
+     * @throws {@link errors.SeedObjectTimeoutError}
      *
      * @example
      *     await client.getUndiscriminatedUnion({

--- a/seed/ts-sdk/ts-oauth-token-optional/no-custom-config/src/api/resources/auth/client/Client.ts
+++ b/seed/ts-sdk/ts-oauth-token-optional/no-custom-config/src/api/resources/auth/client/Client.ts
@@ -26,6 +26,9 @@ export class AuthClient {
      * @param {SeedTsOauthTokenOptional.CreateOauth2TokenRequest} request
      * @param {AuthClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedTsOauthTokenOptionalError}
+     * @throws {@link errors.SeedTsOauthTokenOptionalTimeoutError}
+     *
      * @example
      *     await client.auth.createOauth2Token({
      *         client_id: "my_oauth_app_123",

--- a/seed/ts-sdk/ts-react-query/src/Client.ts
+++ b/seed/ts-sdk/ts-react-query/src/Client.ts
@@ -37,6 +37,9 @@ export class SeedApiClient {
      *
      * @param {SeedApiClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedApiError}
+     * @throws {@link errors.SeedApiTimeoutError}
+     *
      * @example
      *     await client.status()
      */
@@ -80,6 +83,9 @@ export class SeedApiClient {
      * Root-level endpoint named invalidate to test collision handling
      *
      * @param {SeedApiClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedApiError}
+     * @throws {@link errors.SeedApiTimeoutError}
      *
      * @example
      *     await client.invalidate()

--- a/seed/ts-sdk/ts-react-query/src/api/resources/health/client/Client.ts
+++ b/seed/ts-sdk/ts-react-query/src/api/resources/health/client/Client.ts
@@ -25,6 +25,9 @@ export class HealthClient {
      *
      * @param {HealthClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedApiError}
+     * @throws {@link errors.SeedApiTimeoutError}
+     *
      * @example
      *     await client.health.check()
      */
@@ -68,6 +71,9 @@ export class HealthClient {
      * Get health details
      *
      * @param {HealthClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedApiError}
+     * @throws {@link errors.SeedApiTimeoutError}
      *
      * @example
      *     await client.health.details()

--- a/seed/ts-sdk/ts-react-query/src/api/resources/user/client/Client.ts
+++ b/seed/ts-sdk/ts-react-query/src/api/resources/user/client/Client.ts
@@ -27,6 +27,9 @@ export class UserClient {
      *
      * @param {UserClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedApiError}
+     * @throws {@link errors.SeedApiTimeoutError}
+     *
      * @example
      *     await client.user.list()
      */
@@ -71,6 +74,9 @@ export class UserClient {
      *
      * @param {string} userId
      * @param {UserClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedApiError}
+     * @throws {@link errors.SeedApiTimeoutError}
      *
      * @example
      *     await client.user.get("userId")
@@ -119,6 +125,9 @@ export class UserClient {
      *
      * @param {SeedApi.CreateUserRequest} request
      * @param {UserClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedApiError}
+     * @throws {@link errors.SeedApiTimeoutError}
      *
      * @example
      *     await client.user.create({
@@ -177,6 +186,9 @@ export class UserClient {
      * @param {string} userId
      * @param {SeedApi.UpdateUserRequest} request
      * @param {UserClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedApiError}
+     * @throws {@link errors.SeedApiTimeoutError}
      *
      * @example
      *     await client.user.update("userId", {
@@ -238,6 +250,9 @@ export class UserClient {
      * @param {SeedApi.UpdateUserRequest} request
      * @param {UserClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedApiError}
+     * @throws {@link errors.SeedApiTimeoutError}
+     *
      * @example
      *     await client.user.patch("userId", {
      *         name: "name",
@@ -296,6 +311,9 @@ export class UserClient {
      *
      * @param {string} userId
      * @param {UserClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedApiError}
+     * @throws {@link errors.SeedApiTimeoutError}
      *
      * @example
      *     await client.user.delete("userId")

--- a/seed/ts-sdk/undiscriminated-union-with-response-property/src/Client.ts
+++ b/seed/ts-sdk/undiscriminated-union-with-response-property/src/Client.ts
@@ -24,6 +24,9 @@ export class SeedUndiscriminatedUnionWithResponsePropertyClient {
     /**
      * @param {SeedUndiscriminatedUnionWithResponsePropertyClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedUndiscriminatedUnionWithResponsePropertyError}
+     * @throws {@link errors.SeedUndiscriminatedUnionWithResponsePropertyTimeoutError}
+     *
      * @example
      *     await client.getUnion()
      */
@@ -72,6 +75,9 @@ export class SeedUndiscriminatedUnionWithResponsePropertyClient {
 
     /**
      * @param {SeedUndiscriminatedUnionWithResponsePropertyClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedUndiscriminatedUnionWithResponsePropertyError}
+     * @throws {@link errors.SeedUndiscriminatedUnionWithResponsePropertyTimeoutError}
      *
      * @example
      *     await client.listUnions()

--- a/seed/ts-sdk/undiscriminated-unions/no-custom-config/src/api/resources/union/client/Client.ts
+++ b/seed/ts-sdk/undiscriminated-unions/no-custom-config/src/api/resources/union/client/Client.ts
@@ -26,6 +26,9 @@ export class UnionClient {
      * @param {SeedUndiscriminatedUnions.MyUnion} request
      * @param {UnionClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedUndiscriminatedUnionsError}
+     * @throws {@link errors.SeedUndiscriminatedUnionsTimeoutError}
+     *
      * @example
      *     await client.union.get("string")
      */
@@ -75,6 +78,9 @@ export class UnionClient {
     /**
      * @param {UnionClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedUndiscriminatedUnionsError}
+     * @throws {@link errors.SeedUndiscriminatedUnionsTimeoutError}
+     *
      * @example
      *     await client.union.getMetadata()
      */
@@ -121,6 +127,9 @@ export class UnionClient {
     /**
      * @param {SeedUndiscriminatedUnions.MetadataUnion} request
      * @param {UnionClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedUndiscriminatedUnionsError}
+     * @throws {@link errors.SeedUndiscriminatedUnionsTimeoutError}
      *
      * @example
      *     await client.union.updateMetadata({
@@ -177,6 +186,9 @@ export class UnionClient {
     /**
      * @param {SeedUndiscriminatedUnions.Request} request
      * @param {UnionClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedUndiscriminatedUnionsError}
+     * @throws {@link errors.SeedUndiscriminatedUnionsTimeoutError}
      *
      * @example
      *     await client.union.call({
@@ -236,6 +248,9 @@ export class UnionClient {
      * @param {SeedUndiscriminatedUnions.UnionWithDuplicateTypes} request
      * @param {UnionClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedUndiscriminatedUnionsError}
+     * @throws {@link errors.SeedUndiscriminatedUnionsTimeoutError}
+     *
      * @example
      *     await client.union.duplicateTypesUnion("string")
      */
@@ -291,6 +306,9 @@ export class UnionClient {
      * @param {SeedUndiscriminatedUnions.NestedUnionRoot} request
      * @param {UnionClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedUndiscriminatedUnionsError}
+     * @throws {@link errors.SeedUndiscriminatedUnionsTimeoutError}
+     *
      * @example
      *     await client.union.nestedUnions("string")
      */
@@ -343,6 +361,9 @@ export class UnionClient {
      * @param {SeedUndiscriminatedUnions.OuterNestedUnion} request
      * @param {UnionClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedUndiscriminatedUnionsError}
+     * @throws {@link errors.SeedUndiscriminatedUnionsTimeoutError}
+     *
      * @example
      *     await client.union.nestedObjectUnions("string")
      */
@@ -394,6 +415,9 @@ export class UnionClient {
     /**
      * @param {SeedUndiscriminatedUnions.AliasedObjectUnion} request
      * @param {UnionClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedUndiscriminatedUnionsError}
+     * @throws {@link errors.SeedUndiscriminatedUnionsTimeoutError}
      *
      * @example
      *     await client.union.aliasedObjectUnion({
@@ -449,6 +473,9 @@ export class UnionClient {
     /**
      * @param {SeedUndiscriminatedUnions.UnionWithBaseProperties} request
      * @param {UnionClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedUndiscriminatedUnionsError}
+     * @throws {@link errors.SeedUndiscriminatedUnionsTimeoutError}
      *
      * @example
      *     await client.union.getWithBaseProperties({
@@ -511,6 +538,9 @@ export class UnionClient {
     /**
      * @param {SeedUndiscriminatedUnions.PaymentRequest} request
      * @param {UnionClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedUndiscriminatedUnionsError}
+     * @throws {@link errors.SeedUndiscriminatedUnionsTimeoutError}
      *
      * @example
      *     await client.union.testCamelCaseProperties({

--- a/seed/ts-sdk/undiscriminated-unions/skip-response-validation/src/api/resources/union/client/Client.ts
+++ b/seed/ts-sdk/undiscriminated-unions/skip-response-validation/src/api/resources/union/client/Client.ts
@@ -26,6 +26,9 @@ export class UnionClient {
      * @param {SeedUndiscriminatedUnions.MyUnion} request
      * @param {UnionClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedUndiscriminatedUnionsError}
+     * @throws {@link errors.SeedUndiscriminatedUnionsTimeoutError}
+     *
      * @example
      *     await client.union.get("string")
      */
@@ -75,6 +78,9 @@ export class UnionClient {
     /**
      * @param {UnionClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedUndiscriminatedUnionsError}
+     * @throws {@link errors.SeedUndiscriminatedUnionsTimeoutError}
+     *
      * @example
      *     await client.union.getMetadata()
      */
@@ -121,6 +127,9 @@ export class UnionClient {
     /**
      * @param {SeedUndiscriminatedUnions.MetadataUnion} request
      * @param {UnionClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedUndiscriminatedUnionsError}
+     * @throws {@link errors.SeedUndiscriminatedUnionsTimeoutError}
      *
      * @example
      *     await client.union.updateMetadata({
@@ -177,6 +186,9 @@ export class UnionClient {
     /**
      * @param {SeedUndiscriminatedUnions.Request} request
      * @param {UnionClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedUndiscriminatedUnionsError}
+     * @throws {@link errors.SeedUndiscriminatedUnionsTimeoutError}
      *
      * @example
      *     await client.union.call({
@@ -236,6 +248,9 @@ export class UnionClient {
      * @param {SeedUndiscriminatedUnions.UnionWithDuplicateTypes} request
      * @param {UnionClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedUndiscriminatedUnionsError}
+     * @throws {@link errors.SeedUndiscriminatedUnionsTimeoutError}
+     *
      * @example
      *     await client.union.duplicateTypesUnion("string")
      */
@@ -291,6 +306,9 @@ export class UnionClient {
      * @param {SeedUndiscriminatedUnions.NestedUnionRoot} request
      * @param {UnionClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedUndiscriminatedUnionsError}
+     * @throws {@link errors.SeedUndiscriminatedUnionsTimeoutError}
+     *
      * @example
      *     await client.union.nestedUnions("string")
      */
@@ -343,6 +361,9 @@ export class UnionClient {
      * @param {SeedUndiscriminatedUnions.OuterNestedUnion} request
      * @param {UnionClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedUndiscriminatedUnionsError}
+     * @throws {@link errors.SeedUndiscriminatedUnionsTimeoutError}
+     *
      * @example
      *     await client.union.nestedObjectUnions("string")
      */
@@ -394,6 +415,9 @@ export class UnionClient {
     /**
      * @param {SeedUndiscriminatedUnions.AliasedObjectUnion} request
      * @param {UnionClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedUndiscriminatedUnionsError}
+     * @throws {@link errors.SeedUndiscriminatedUnionsTimeoutError}
      *
      * @example
      *     await client.union.aliasedObjectUnion({
@@ -449,6 +473,9 @@ export class UnionClient {
     /**
      * @param {SeedUndiscriminatedUnions.UnionWithBaseProperties} request
      * @param {UnionClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedUndiscriminatedUnionsError}
+     * @throws {@link errors.SeedUndiscriminatedUnionsTimeoutError}
      *
      * @example
      *     await client.union.getWithBaseProperties({
@@ -511,6 +538,9 @@ export class UnionClient {
     /**
      * @param {SeedUndiscriminatedUnions.PaymentRequest} request
      * @param {UnionClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedUndiscriminatedUnionsError}
+     * @throws {@link errors.SeedUndiscriminatedUnionsTimeoutError}
      *
      * @example
      *     await client.union.testCamelCaseProperties({

--- a/seed/ts-sdk/union-query-parameters/no-custom-config/src/api/resources/events/client/Client.ts
+++ b/seed/ts-sdk/union-query-parameters/no-custom-config/src/api/resources/events/client/Client.ts
@@ -29,6 +29,9 @@ export class EventsClient {
      * @param {SeedUnionQueryParameters.SubscribeEventsRequest} request
      * @param {EventsClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedUnionQueryParametersError}
+     * @throws {@link errors.SeedUnionQueryParametersTimeoutError}
+     *
      * @example
      *     await client.events.subscribe({
      *         event_type: "group.created",

--- a/seed/ts-sdk/unions-with-local-date/src/api/resources/bigunion/client/Client.ts
+++ b/seed/ts-sdk/unions-with-local-date/src/api/resources/bigunion/client/Client.ts
@@ -26,6 +26,9 @@ export class BigunionClient {
      * @param {string} id
      * @param {BigunionClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedUnionsError}
+     * @throws {@link errors.SeedUnionsTimeoutError}
+     *
      * @example
      *     await client.bigunion.get("id")
      */
@@ -74,6 +77,9 @@ export class BigunionClient {
     /**
      * @param {SeedUnions.BigUnion} request
      * @param {BigunionClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedUnionsError}
+     * @throws {@link errors.SeedUnionsTimeoutError}
      *
      * @example
      *     await client.bigunion.update({
@@ -130,6 +136,9 @@ export class BigunionClient {
     /**
      * @param {SeedUnions.BigUnion[]} request
      * @param {BigunionClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedUnionsError}
+     * @throws {@link errors.SeedUnionsTimeoutError}
      *
      * @example
      *     await client.bigunion.updateMany([{

--- a/seed/ts-sdk/unions-with-local-date/src/api/resources/types/client/Client.ts
+++ b/seed/ts-sdk/unions-with-local-date/src/api/resources/types/client/Client.ts
@@ -26,6 +26,9 @@ export class TypesClient {
      * @param {string} id
      * @param {TypesClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedUnionsError}
+     * @throws {@link errors.SeedUnionsTimeoutError}
+     *
      * @example
      *     await client.types.get("date-example")
      *
@@ -77,6 +80,9 @@ export class TypesClient {
     /**
      * @param {SeedUnions.UnionWithTime} request
      * @param {TypesClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedUnionsError}
+     * @throws {@link errors.SeedUnionsTimeoutError}
      *
      * @example
      *     await client.types.update({

--- a/seed/ts-sdk/unions-with-local-date/src/api/resources/union/client/Client.ts
+++ b/seed/ts-sdk/unions-with-local-date/src/api/resources/union/client/Client.ts
@@ -26,6 +26,9 @@ export class UnionClient {
      * @param {string} id
      * @param {UnionClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedUnionsError}
+     * @throws {@link errors.SeedUnionsTimeoutError}
+     *
      * @example
      *     await client.union.get("id")
      */
@@ -71,6 +74,9 @@ export class UnionClient {
     /**
      * @param {SeedUnions.Shape} request
      * @param {UnionClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedUnionsError}
+     * @throws {@link errors.SeedUnionsTimeoutError}
      *
      * @example
      *     await client.union.update({

--- a/seed/ts-sdk/unions/no-custom-config/src/api/resources/bigunion/client/Client.ts
+++ b/seed/ts-sdk/unions/no-custom-config/src/api/resources/bigunion/client/Client.ts
@@ -26,6 +26,9 @@ export class BigunionClient {
      * @param {string} id
      * @param {BigunionClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedUnionsError}
+     * @throws {@link errors.SeedUnionsTimeoutError}
+     *
      * @example
      *     await client.bigunion.get("id")
      */
@@ -74,6 +77,9 @@ export class BigunionClient {
     /**
      * @param {SeedUnions.BigUnion} request
      * @param {BigunionClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedUnionsError}
+     * @throws {@link errors.SeedUnionsTimeoutError}
      *
      * @example
      *     await client.bigunion.update({
@@ -132,6 +138,9 @@ export class BigunionClient {
     /**
      * @param {SeedUnions.BigUnion[]} request
      * @param {BigunionClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedUnionsError}
+     * @throws {@link errors.SeedUnionsTimeoutError}
      *
      * @example
      *     await client.bigunion.updateMany([{

--- a/seed/ts-sdk/unions/no-custom-config/src/api/resources/union/client/Client.ts
+++ b/seed/ts-sdk/unions/no-custom-config/src/api/resources/union/client/Client.ts
@@ -26,6 +26,9 @@ export class UnionClient {
      * @param {string} id
      * @param {UnionClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedUnionsError}
+     * @throws {@link errors.SeedUnionsTimeoutError}
+     *
      * @example
      *     await client.union.get("id")
      */
@@ -71,6 +74,9 @@ export class UnionClient {
     /**
      * @param {SeedUnions.Shape} request
      * @param {UnionClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedUnionsError}
+     * @throws {@link errors.SeedUnionsTimeoutError}
      *
      * @example
      *     await client.union.update({

--- a/seed/ts-sdk/unions/serde-layer/src/api/resources/bigunion/client/Client.ts
+++ b/seed/ts-sdk/unions/serde-layer/src/api/resources/bigunion/client/Client.ts
@@ -27,6 +27,9 @@ export class BigunionClient {
      * @param {string} id
      * @param {BigunionClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedUnionsError}
+     * @throws {@link errors.SeedUnionsTimeoutError}
+     *
      * @example
      *     await client.bigunion.get("id")
      */
@@ -84,6 +87,9 @@ export class BigunionClient {
     /**
      * @param {SeedUnions.BigUnion} request
      * @param {BigunionClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedUnionsError}
+     * @throws {@link errors.SeedUnionsTimeoutError}
      *
      * @example
      *     await client.bigunion.update({
@@ -154,6 +160,9 @@ export class BigunionClient {
     /**
      * @param {SeedUnions.BigUnion[]} request
      * @param {BigunionClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedUnionsError}
+     * @throws {@link errors.SeedUnionsTimeoutError}
      *
      * @example
      *     await client.bigunion.updateMany([{

--- a/seed/ts-sdk/unions/serde-layer/src/api/resources/union/client/Client.ts
+++ b/seed/ts-sdk/unions/serde-layer/src/api/resources/union/client/Client.ts
@@ -27,6 +27,9 @@ export class UnionClient {
      * @param {string} id
      * @param {UnionClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedUnionsError}
+     * @throws {@link errors.SeedUnionsTimeoutError}
+     *
      * @example
      *     await client.union.get("id")
      */
@@ -81,6 +84,9 @@ export class UnionClient {
     /**
      * @param {SeedUnions.Shape} request
      * @param {UnionClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedUnionsError}
+     * @throws {@link errors.SeedUnionsTimeoutError}
      *
      * @example
      *     await client.union.update({

--- a/seed/ts-sdk/unknown/no-custom-config/src/api/resources/unknown/client/Client.ts
+++ b/seed/ts-sdk/unknown/no-custom-config/src/api/resources/unknown/client/Client.ts
@@ -26,6 +26,9 @@ export class UnknownClient {
      * @param {unknown} request
      * @param {UnknownClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedUnknownAsAnyError}
+     * @throws {@link errors.SeedUnknownAsAnyTimeoutError}
+     *
      * @example
      *     await client.unknown.post({
      *         "key": "value"
@@ -74,6 +77,9 @@ export class UnknownClient {
     /**
      * @param {SeedUnknownAsAny.MyObject} request
      * @param {UnknownClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedUnknownAsAnyError}
+     * @throws {@link errors.SeedUnknownAsAnyTimeoutError}
      *
      * @example
      *     await client.unknown.postObject({

--- a/seed/ts-sdk/unknown/unknown-as-any/src/api/resources/unknown/client/Client.ts
+++ b/seed/ts-sdk/unknown/unknown-as-any/src/api/resources/unknown/client/Client.ts
@@ -26,6 +26,9 @@ export class UnknownClient {
      * @param {any} request
      * @param {UnknownClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedUnknownAsAnyError}
+     * @throws {@link errors.SeedUnknownAsAnyTimeoutError}
+     *
      * @example
      *     await client.unknown.post({
      *         "key": "value"
@@ -74,6 +77,9 @@ export class UnknownClient {
     /**
      * @param {SeedUnknownAsAny.MyObject} request
      * @param {UnknownClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedUnknownAsAnyError}
+     * @throws {@link errors.SeedUnknownAsAnyTimeoutError}
      *
      * @example
      *     await client.unknown.postObject({

--- a/seed/ts-sdk/url-form-encoded/src/Client.ts
+++ b/seed/ts-sdk/url-form-encoded/src/Client.ts
@@ -26,6 +26,9 @@ export class SeedApiClient {
      * @param {SeedApi.PostSubmitRequest} request
      * @param {SeedApiClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedApiError}
+     * @throws {@link errors.SeedApiTimeoutError}
+     *
      * @example
      *     await client.submitFormData({
      *         username: "johndoe",
@@ -80,6 +83,9 @@ export class SeedApiClient {
     /**
      * @param {SeedApi.TokenRequest} request
      * @param {SeedApiClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedApiError}
+     * @throws {@link errors.SeedApiTimeoutError}
      *
      * @example
      *     await client.getToken({

--- a/seed/ts-sdk/validation/src/Client.ts
+++ b/seed/ts-sdk/validation/src/Client.ts
@@ -26,6 +26,9 @@ export class SeedValidationClient {
      * @param {SeedValidation.CreateRequest} request
      * @param {SeedValidationClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedValidationError}
+     * @throws {@link errors.SeedValidationTimeoutError}
+     *
      * @example
      *     await client.create({
      *         decimal: 2.2,
@@ -82,6 +85,9 @@ export class SeedValidationClient {
     /**
      * @param {SeedValidation.GetRequest} request
      * @param {SeedValidationClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedValidationError}
+     * @throws {@link errors.SeedValidationTimeoutError}
      *
      * @example
      *     await client.get({

--- a/seed/ts-sdk/variables/src/api/resources/service/client/Client.ts
+++ b/seed/ts-sdk/variables/src/api/resources/service/client/Client.ts
@@ -23,6 +23,9 @@ export class ServiceClient {
     /**
      * @param {ServiceClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedVariablesError}
+     * @throws {@link errors.SeedVariablesTimeoutError}
+     *
      * @example
      *     await client.service.post()
      */

--- a/seed/ts-sdk/version-no-default/src/api/resources/user/client/Client.ts
+++ b/seed/ts-sdk/version-no-default/src/api/resources/user/client/Client.ts
@@ -25,6 +25,9 @@ export class UserClient {
      * @param {SeedVersion.UserId} userId
      * @param {UserClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedVersionError}
+     * @throws {@link errors.SeedVersionTimeoutError}
+     *
      * @example
      *     await client.user.getUser("userId")
      */

--- a/seed/ts-sdk/version/src/api/resources/user/client/Client.ts
+++ b/seed/ts-sdk/version/src/api/resources/user/client/Client.ts
@@ -25,6 +25,9 @@ export class UserClient {
      * @param {SeedVersion.UserId} userId
      * @param {UserClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedVersionError}
+     * @throws {@link errors.SeedVersionTimeoutError}
+     *
      * @example
      *     await client.user.getUser("userId")
      */

--- a/seed/ts-sdk/websocket-inferred-auth/websockets/src/api/resources/auth/client/Client.ts
+++ b/seed/ts-sdk/websocket-inferred-auth/websockets/src/api/resources/auth/client/Client.ts
@@ -26,6 +26,9 @@ export class AuthClient {
      * @param {SeedWebsocketAuth.GetTokenRequest} request
      * @param {AuthClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedWebsocketAuthError}
+     * @throws {@link errors.SeedWebsocketAuthTimeoutError}
+     *
      * @example
      *     await client.auth.getTokenWithClientCredentials({
      *         "X-Api-Key": "X-Api-Key",
@@ -90,6 +93,9 @@ export class AuthClient {
     /**
      * @param {SeedWebsocketAuth.RefreshTokenRequest} request
      * @param {AuthClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedWebsocketAuthError}
+     * @throws {@link errors.SeedWebsocketAuthTimeoutError}
      *
      * @example
      *     await client.auth.refreshToken({

--- a/seed/ts-sdk/websocket/no-serde/src/api/resources/status/client/Client.ts
+++ b/seed/ts-sdk/websocket/no-serde/src/api/resources/status/client/Client.ts
@@ -24,6 +24,9 @@ export class StatusClient {
     /**
      * @param {StatusClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedWebsocketError}
+     * @throws {@link errors.SeedWebsocketTimeoutError}
+     *
      * @example
      *     await client.status.getStatus()
      */

--- a/seed/ts-sdk/websocket/no-websocket-clients/src/api/resources/status/client/Client.ts
+++ b/seed/ts-sdk/websocket/no-websocket-clients/src/api/resources/status/client/Client.ts
@@ -24,6 +24,9 @@ export class StatusClient {
     /**
      * @param {StatusClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedWebsocketError}
+     * @throws {@link errors.SeedWebsocketTimeoutError}
+     *
      * @example
      *     await client.status.getStatus()
      */

--- a/seed/ts-sdk/websocket/serde/src/api/resources/status/client/Client.ts
+++ b/seed/ts-sdk/websocket/serde/src/api/resources/status/client/Client.ts
@@ -25,6 +25,9 @@ export class StatusClient {
     /**
      * @param {StatusClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedWebsocketError}
+     * @throws {@link errors.SeedWebsocketTimeoutError}
+     *
      * @example
      *     await client.status.getStatus()
      */

--- a/seed/ts-sdk/x-fern-default/src/Client.ts
+++ b/seed/ts-sdk/x-fern-default/src/Client.ts
@@ -25,6 +25,9 @@ export class SeedApiClient {
      * @param {SeedApi.TestGetRequest} request
      * @param {SeedApiClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedApiError}
+     * @throws {@link errors.SeedApiTimeoutError}
+     *
      * @example
      *     await client.testGet({
      *         region: "region"

--- a/seed/ts-sdk/x-fern-global-parameters/src/api/resources/products/client/Client.ts
+++ b/seed/ts-sdk/x-fern-global-parameters/src/api/resources/products/client/Client.ts
@@ -26,6 +26,9 @@ export class ProductsClient {
      * @param {SeedApi.SearchProductsRequest} request
      * @param {ProductsClient.RequestOptions} requestOptions - Request-specific configuration.
      *
+     * @throws {@link errors.SeedApiError}
+     * @throws {@link errors.SeedApiTimeoutError}
+     *
      * @example
      *     await client.products.search({
      *         regionId: "regionId"
@@ -85,6 +88,9 @@ export class ProductsClient {
     /**
      * @param {SeedApi.GetProductsRequest} request
      * @param {ProductsClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link errors.SeedApiError}
+     * @throws {@link errors.SeedApiTimeoutError}
      *
      * @example
      *     await client.products.get({


### PR DESCRIPTION
## Description
Linear ticket: N/A (customer report — Twilio Core SDK)

Every generated client method has a `default:` branch that throws the base API error (`<Org>Error`) for undeclared HTTP status codes, and delegates to `handleNonStatusCodeError` which throws `<Org>TimeoutError` on request timeout. Neither throw path was documented — the `@throws` JSDoc listed only the errors declared in the API definition, so callers had no way to know from the method signature that they must handle those paths.

`GeneratedThrowingEndpointResponse.getNamesOfThrownExceptions` now appends the base API error and timeout error references after the declared errors:

```ts
// before
* @throws {@link SeedApi.NotFoundError}

// after
* @throws {@link SeedApi.NotFoundError}
* @throws {@link errors.SeedApiError}
* @throws {@link errors.SeedApiTimeoutError}
```

This applies to both default and file-download endpoint implementations (both derive `@throws` docs from `getNamesOfThrownExceptions`). `neverThrowErrors` mode is unaffected (`GeneratedNonThrowingEndpointResponse` still returns `[]`).

## Changes Made
- `GeneratedThrowingEndpointResponse.getNamesOfThrownExceptions`: append `genericAPISdkError` and `timeoutSdkError` references
- Updated unit tests + mock context in `GeneratedEndpointResponse.test.ts`
- Regenerated ts-sdk seed fixtures (`seed test --generator ts-sdk --local --skip-scripts`, 231/231 passed)
- Added unreleased changelog entry
- [ ] Updated README.md generator (if applicable)

## Testing
- [x] Unit tests added/updated (`pnpm vitest run` in client-class-generator: 573 passed)
- [x] Manual testing completed (seed regen — verified generated JSDoc in `seed/ts-sdk/imdb`)

Link to Devin session: https://app.devin.ai/sessions/0ad16296cebd474fbbcaf77355363c88
Requested by: @iamnamananand996
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/17114" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->