### PR TITLE
fix(cli): consistent per-API url keys in multi-api environment grouping

### DIFF
--- a/packages/cli/api-importers/openapi/openapi-ir-parser/src/parse.ts
+++ b/packages/cli/api-importers/openapi/openapi-ir-parser/src/parse.ts
@@ -211,9 +211,15 @@ interface MultiApiEndpoint extends Endpoint {
 
 type TypedEndpoint = StandardEndpoint | MultiApiEndpoint;
 
-function getEnvironmentName(server: SingleServerInput): string {
-    const rawName = String(server.description || server.name || server["x-fern-server-name"] || "default").trim();
+function getRawEnvironmentName(server: SingleServerInput): string {
+    return String(server.description || server.name || server["x-fern-server-name"] || "default").trim();
+}
 
+function getEnvironmentName(server: SingleServerInput): string {
+    return normalizeEnvironmentName(getRawEnvironmentName(server));
+}
+
+function normalizeEnvironmentName(rawName: string): string {
     const normalized = rawName.toUpperCase();
 
     // Map common variations to standard names
@@ -468,12 +474,22 @@ function merge(
         const api2Name = extractApiNameFromServers(ir2.servers);
 
         const environmentMap = new Map<string, Record<string, ApiServerConfig>>();
+        // Preserve the first user-facing name seen for each normalized environment
+        // (e.g. keep "Production" instead of the normalized "PRD" matching key)
+        const environmentDisplayNames = new Map<string, string>();
 
         // Process servers from first API - handle already-grouped servers from previous merges
+        // The API name must be constant across all of the first API's servers (each server is
+        // the same API in a different environment), so derive it once from the first server.
+        const api1Name = extractApiNameFromServers(ir1.servers);
         for (const server of ir1.servers as AnyServerInput[]) {
             if (server.type === "grouped") {
                 // Preserve existing grouped URLs from previous merges
-                const envName = server.name ?? "default";
+                const rawEnvName = server.name ?? "default";
+                const envName = normalizeEnvironmentName(rawEnvName);
+                if (!environmentDisplayNames.has(envName)) {
+                    environmentDisplayNames.set(envName, rawEnvName);
+                }
                 if (!environmentMap.has(envName)) {
                     environmentMap.set(envName, {});
                 }
@@ -486,8 +502,10 @@ function merge(
                 }
             } else {
                 // Handle single server (first merge case)
-                const api1Name = extractApiNameFromUrl(getPreferredUrlForNameExtraction(server));
                 const envName = getEnvironmentName(server);
+                if (!environmentDisplayNames.has(envName)) {
+                    environmentDisplayNames.set(envName, getRawEnvironmentName(server));
+                }
                 if (!environmentMap.has(envName)) {
                     environmentMap.set(envName, {});
                 }
@@ -507,6 +525,9 @@ function merge(
         // Process servers from second API (always single servers from fresh IR)
         for (const server of ir2.servers) {
             const envName = getEnvironmentName(server);
+            if (!environmentDisplayNames.has(envName)) {
+                environmentDisplayNames.set(envName, getRawEnvironmentName(server));
+            }
             if (!environmentMap.has(envName)) {
                 environmentMap.set(envName, {});
             }
@@ -523,10 +544,11 @@ function merge(
         }
 
         for (const [envName, urls] of environmentMap.entries()) {
+            const displayName = environmentDisplayNames.get(envName) ?? envName;
             const groupedServer: GroupedServerInput = {
                 type: "grouped",
-                name: envName,
-                description: `${envName} environment`,
+                name: displayName,
+                description: `${displayName} environment`,
                 urls: urls
             };
             mergedServers.push(groupedServer);
@@ -546,11 +568,6 @@ function merge(
                 };
             }
             // First merge - derive API name from the first server
-            const firstServer = ir1.servers[0] as AnyServerInput | undefined;
-            const api1Name =
-                firstServer != null && firstServer.type !== "grouped"
-                    ? extractApiNameFromUrl(getPreferredUrlForNameExtraction(firstServer))
-                    : "api";
             return {
                 ...endpoint,
                 type: "multi-api" as const,

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir/multi-api-duplicate-servers.json
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir/multi-api-duplicate-servers.json
@@ -4,8 +4,8 @@
   "servers": [
     {
       "type": "grouped",
-      "name": "STG",
-      "description": "STG environment",
+      "name": "Staging",
+      "description": "Staging environment",
       "urls": {
         "stage": {
           "url": "https://api.stage.example.com"

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir/multi-api-environment-grouping-multi-host.json
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir/multi-api-environment-grouping-multi-host.json
@@ -1,0 +1,337 @@
+{
+  "specVersion": "1.0.0",
+  "title": "Core API",
+  "servers": [
+    {
+      "type": "grouped",
+      "name": "Production",
+      "description": "Production environment",
+      "urls": {
+        "acme": {
+          "url": "https://api.us1.acme.com",
+          "defaultUrl": "https://api.acme.com",
+          "urlTemplate": "https://api.{region}.acme.com",
+          "variables": [
+            {
+              "id": "region",
+              "default": "us1"
+            }
+          ]
+        },
+        "oauth": {
+          "url": "https://oauth.us1.acme.com",
+          "defaultUrl": "https://oauth.acme.com",
+          "urlTemplate": "https://oauth.{region}.acme.com",
+          "variables": [
+            {
+              "id": "region",
+              "default": "us1"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "type": "grouped",
+      "name": "Staging",
+      "description": "Staging environment",
+      "urls": {
+        "acme": {
+          "url": "https://api.stage.us1.acme.com",
+          "defaultUrl": "https://api.stage.acme.com",
+          "urlTemplate": "https://api.stage.{region}.acme.com",
+          "variables": [
+            {
+              "id": "region",
+              "default": "us1"
+            }
+          ]
+        },
+        "oauth": {
+          "url": "https://oauth.stage.us1.acme.com",
+          "defaultUrl": "https://oauth.stage.acme.com",
+          "urlTemplate": "https://oauth.stage.{region}.acme.com",
+          "variables": [
+            {
+              "id": "region",
+              "default": "us1"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "type": "grouped",
+      "name": "Development",
+      "description": "Development environment",
+      "urls": {
+        "acme": {
+          "url": "https://api.dev.us1.acme.com",
+          "defaultUrl": "https://api.dev.acme.com",
+          "urlTemplate": "https://api.dev.{region}.acme.com",
+          "variables": [
+            {
+              "id": "region",
+              "default": "us1"
+            }
+          ]
+        },
+        "oauth": {
+          "url": "https://oauth.dev.us1.acme.com",
+          "defaultUrl": "https://oauth.dev.acme.com",
+          "urlTemplate": "https://oauth.dev.{region}.acme.com",
+          "variables": [
+            {
+              "id": "region",
+              "default": "us1"
+            }
+          ]
+        }
+      }
+    }
+  ],
+  "websocketServers": [],
+  "tags": {
+    "tagsById": {}
+  },
+  "hasEndpointsMarkedInternal": false,
+  "endpoints": [
+    {
+      "audiences": [],
+      "operationId": "listThings",
+      "tags": [
+        "core"
+      ],
+      "namespace": "core",
+      "pathParameters": [],
+      "queryParameters": [],
+      "headers": [],
+      "generatedRequestName": "ListThingsRequest",
+      "response": {
+        "description": "Success",
+        "schema": {
+          "allOf": [],
+          "properties": [
+            {
+              "conflict": {},
+              "generatedName": "listThingsResponseId",
+              "key": "id",
+              "schema": {
+                "generatedName": "ListThingsResponseId",
+                "value": {
+                  "schema": {
+                    "type": "string"
+                  },
+                  "generatedName": "ListThingsResponseId",
+                  "namespace": "core",
+                  "groupName": [
+                    {
+                      "type": "namespace",
+                      "name": "core"
+                    }
+                  ],
+                  "type": "primitive"
+                },
+                "namespace": "core",
+                "groupName": [
+                  {
+                    "type": "namespace",
+                    "name": "core"
+                  }
+                ],
+                "type": "optional"
+              },
+              "audiences": []
+            }
+          ],
+          "allOfPropertyConflicts": [],
+          "generatedName": "ListThingsResponse",
+          "namespace": "core",
+          "groupName": [
+            {
+              "type": "namespace",
+              "name": "core"
+            }
+          ],
+          "additionalProperties": false,
+          "source": {
+            "file": "../core-api.yml",
+            "type": "openapi"
+          },
+          "type": "object"
+        },
+        "fullExamples": [],
+        "source": {
+          "file": "../core-api.yml",
+          "type": "openapi"
+        },
+        "statusCode": 200,
+        "type": "json"
+      },
+      "errors": {},
+      "authed": false,
+      "method": "GET",
+      "path": "/things",
+      "examples": [
+        {
+          "pathParameters": [],
+          "queryParameters": [],
+          "headers": [],
+          "response": {
+            "value": {
+              "properties": {
+                "id": {
+                  "value": {
+                    "value": "id",
+                    "type": "string"
+                  },
+                  "type": "primitive"
+                }
+              },
+              "type": "object"
+            },
+            "type": "withoutStreaming"
+          },
+          "codeSamples": [],
+          "type": "full"
+        }
+      ],
+      "source": {
+        "file": "../core-api.yml",
+        "type": "openapi"
+      },
+      "__apiName": "acme",
+      "servers": [
+        {
+          "name": "acme"
+        }
+      ]
+    },
+    {
+      "audiences": [],
+      "operationId": "getToken",
+      "tags": [
+        "auth"
+      ],
+      "namespace": "auth",
+      "pathParameters": [],
+      "queryParameters": [],
+      "headers": [],
+      "generatedRequestName": "GetTokenRequest",
+      "response": {
+        "description": "Success",
+        "schema": {
+          "allOf": [],
+          "properties": [
+            {
+              "conflict": {},
+              "generatedName": "getTokenResponseAccessToken",
+              "key": "access_token",
+              "schema": {
+                "generatedName": "GetTokenResponseAccessToken",
+                "value": {
+                  "schema": {
+                    "type": "string"
+                  },
+                  "generatedName": "GetTokenResponseAccessToken",
+                  "namespace": "auth",
+                  "groupName": [
+                    {
+                      "type": "namespace",
+                      "name": "auth"
+                    }
+                  ],
+                  "type": "primitive"
+                },
+                "namespace": "auth",
+                "groupName": [
+                  {
+                    "type": "namespace",
+                    "name": "auth"
+                  }
+                ],
+                "type": "optional"
+              },
+              "audiences": []
+            }
+          ],
+          "allOfPropertyConflicts": [],
+          "generatedName": "GetTokenResponse",
+          "namespace": "auth",
+          "groupName": [
+            {
+              "type": "namespace",
+              "name": "auth"
+            }
+          ],
+          "additionalProperties": false,
+          "source": {
+            "file": "../auth-api.yml",
+            "type": "openapi"
+          },
+          "type": "object"
+        },
+        "fullExamples": [],
+        "source": {
+          "file": "../auth-api.yml",
+          "type": "openapi"
+        },
+        "statusCode": 200,
+        "type": "json"
+      },
+      "errors": {},
+      "authed": false,
+      "method": "POST",
+      "path": "/token",
+      "examples": [
+        {
+          "pathParameters": [],
+          "queryParameters": [],
+          "headers": [],
+          "response": {
+            "value": {
+              "properties": {
+                "access_token": {
+                  "value": {
+                    "value": "access_token",
+                    "type": "string"
+                  },
+                  "type": "primitive"
+                }
+              },
+              "type": "object"
+            },
+            "type": "withoutStreaming"
+          },
+          "codeSamples": [],
+          "type": "full"
+        }
+      ],
+      "source": {
+        "file": "../auth-api.yml",
+        "type": "openapi"
+      },
+      "__apiName": "oauth",
+      "servers": [
+        {
+          "name": "oauth"
+        }
+      ]
+    }
+  ],
+  "webhooks": [],
+  "channels": {},
+  "groupedSchemas": {
+    "rootSchemas": {},
+    "namespacedSchemas": {
+      "core": {},
+      "auth": {}
+    }
+  },
+  "variables": {},
+  "nonRequestReferencedSchemas": {},
+  "securitySchemes": {},
+  "globalHeaders": [],
+  "idempotencyHeaders": [],
+  "groups": {}
+}

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi/multi-api-duplicate-servers.json
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi/multi-api-duplicate-servers.json
@@ -183,11 +183,11 @@
   "packageMarkers": {},
   "rootApiFile": {
     "contents": {
-      "default-environment": "STG",
+      "default-environment": "Staging",
       "default-url": "stage",
       "display-name": "Messages API",
       "environments": {
-        "STG": {
+        "Staging": {
           "urls": {
             "oauth": "https://oauth.stage.example.com",
             "stage": "https://api.stage.example.com",
@@ -205,11 +205,11 @@ error-discrimination:
   strategy: status-code
 display-name: Messages API
 environments:
-  STG:
+  Staging:
     urls:
       stage: https://api.stage.example.com
       oauth: https://oauth.stage.example.com
-default-environment: STG
+default-environment: Staging
 default-url: stage
 ",
   },

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi/multi-api-environment-grouping-multi-host.json
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi/multi-api-environment-grouping-multi-host.json
@@ -1,0 +1,333 @@
+{
+  "absoluteFilePath": "/DUMMY_PATH",
+  "importedDefinitions": {},
+  "namedDefinitionFiles": {
+    "__package__.yml": {
+      "absoluteFilepath": "/DUMMY_PATH",
+      "contents": {},
+      "rawContents": "{}
+",
+    },
+    "auth/__package__.yml": {
+      "absoluteFilepath": "/DUMMY_PATH",
+      "contents": {
+        "service": {
+          "auth": false,
+          "base-path": "",
+          "endpoints": {
+            "getToken": {
+              "auth": undefined,
+              "docs": undefined,
+              "examples": [
+                {
+                  "response": {
+                    "body": {
+                      "access_token": "access_token",
+                    },
+                  },
+                },
+              ],
+              "method": "POST",
+              "pagination": undefined,
+              "path": "/token",
+              "response": {
+                "docs": "Success",
+                "status-code": 200,
+                "type": "GetTokenResponse",
+              },
+              "source": {
+                "openapi": "../auth-api.yml",
+              },
+              "url": "oauth",
+            },
+          },
+          "source": {
+            "openapi": "../auth-api.yml",
+          },
+        },
+        "types": {
+          "GetTokenResponse": {
+            "docs": undefined,
+            "inline": undefined,
+            "properties": {
+              "access_token": "optional<string>",
+            },
+            "source": {
+              "openapi": "../auth-api.yml",
+            },
+          },
+        },
+      },
+      "rawContents": "types:
+  GetTokenResponse:
+    properties:
+      access_token: optional<string>
+    source:
+      openapi: ../auth-api.yml
+service:
+  auth: false
+  base-path: ''
+  endpoints:
+    getToken:
+      path: /token
+      method: POST
+      source:
+        openapi: ../auth-api.yml
+      response:
+        docs: Success
+        type: GetTokenResponse
+        status-code: 200
+      url: oauth
+      examples:
+        - response:
+            body:
+              access_token: access_token
+  source:
+    openapi: ../auth-api.yml
+",
+    },
+    "core/__package__.yml": {
+      "absoluteFilepath": "/DUMMY_PATH",
+      "contents": {
+        "service": {
+          "auth": false,
+          "base-path": "",
+          "endpoints": {
+            "listThings": {
+              "auth": undefined,
+              "docs": undefined,
+              "examples": [
+                {
+                  "response": {
+                    "body": {
+                      "id": "id",
+                    },
+                  },
+                },
+              ],
+              "method": "GET",
+              "pagination": undefined,
+              "path": "/things",
+              "response": {
+                "docs": "Success",
+                "status-code": 200,
+                "type": "ListThingsResponse",
+              },
+              "source": {
+                "openapi": "../core-api.yml",
+              },
+              "url": "acme",
+            },
+          },
+          "source": {
+            "openapi": "../core-api.yml",
+          },
+        },
+        "types": {
+          "ListThingsResponse": {
+            "docs": undefined,
+            "inline": undefined,
+            "properties": {
+              "id": "optional<string>",
+            },
+            "source": {
+              "openapi": "../core-api.yml",
+            },
+          },
+        },
+      },
+      "rawContents": "types:
+  ListThingsResponse:
+    properties:
+      id: optional<string>
+    source:
+      openapi: ../core-api.yml
+service:
+  auth: false
+  base-path: ''
+  endpoints:
+    listThings:
+      path: /things
+      method: GET
+      source:
+        openapi: ../core-api.yml
+      response:
+        docs: Success
+        type: ListThingsResponse
+        status-code: 200
+      url: acme
+      examples:
+        - response:
+            body:
+              id: id
+  source:
+    openapi: ../core-api.yml
+",
+    },
+  },
+  "packageMarkers": {},
+  "rootApiFile": {
+    "contents": {
+      "default-environment": "Production",
+      "default-url": "acme",
+      "display-name": "Core API",
+      "environments": {
+        "Development": {
+          "default-urls": {
+            "acme": "https://api.dev.acme.com",
+            "oauth": "https://oauth.dev.acme.com",
+          },
+          "url-templates": {
+            "acme": "https://api.dev.{region}.acme.com",
+            "oauth": "https://oauth.dev.{region}.acme.com",
+          },
+          "urls": {
+            "acme": "https://api.dev.acme.com",
+            "oauth": "https://oauth.dev.acme.com",
+          },
+          "variables": {
+            "acme": [
+              {
+                "default": "us1",
+                "id": "region",
+                "values": undefined,
+              },
+            ],
+            "oauth": [
+              {
+                "default": "us1",
+                "id": "region",
+                "values": undefined,
+              },
+            ],
+          },
+        },
+        "Production": {
+          "default-urls": {
+            "acme": "https://api.acme.com",
+            "oauth": "https://oauth.acme.com",
+          },
+          "url-templates": {
+            "acme": "https://api.{region}.acme.com",
+            "oauth": "https://oauth.{region}.acme.com",
+          },
+          "urls": {
+            "acme": "https://api.acme.com",
+            "oauth": "https://oauth.acme.com",
+          },
+          "variables": {
+            "acme": [
+              {
+                "default": "us1",
+                "id": "region",
+                "values": undefined,
+              },
+            ],
+            "oauth": [
+              {
+                "default": "us1",
+                "id": "region",
+                "values": undefined,
+              },
+            ],
+          },
+        },
+        "Staging": {
+          "default-urls": {
+            "acme": "https://api.stage.acme.com",
+            "oauth": "https://oauth.stage.acme.com",
+          },
+          "url-templates": {
+            "acme": "https://api.stage.{region}.acme.com",
+            "oauth": "https://oauth.stage.{region}.acme.com",
+          },
+          "urls": {
+            "acme": "https://api.stage.acme.com",
+            "oauth": "https://oauth.stage.acme.com",
+          },
+          "variables": {
+            "acme": [
+              {
+                "default": "us1",
+                "id": "region",
+                "values": undefined,
+              },
+            ],
+            "oauth": [
+              {
+                "default": "us1",
+                "id": "region",
+                "values": undefined,
+              },
+            ],
+          },
+        },
+      },
+      "error-discrimination": {
+        "strategy": "status-code",
+      },
+      "name": "api",
+    },
+    "defaultUrl": "acme",
+    "rawContents": "name: api
+error-discrimination:
+  strategy: status-code
+display-name: Core API
+environments:
+  Production:
+    urls:
+      acme: https://api.acme.com
+      oauth: https://oauth.acme.com
+    url-templates:
+      acme: https://api.{region}.acme.com
+      oauth: https://oauth.{region}.acme.com
+    default-urls:
+      acme: https://api.acme.com
+      oauth: https://oauth.acme.com
+    variables:
+      acme:
+        - id: region
+          default: us1
+      oauth:
+        - id: region
+          default: us1
+  Staging:
+    urls:
+      acme: https://api.stage.acme.com
+      oauth: https://oauth.stage.acme.com
+    url-templates:
+      acme: https://api.stage.{region}.acme.com
+      oauth: https://oauth.stage.{region}.acme.com
+    default-urls:
+      acme: https://api.stage.acme.com
+      oauth: https://oauth.stage.acme.com
+    variables:
+      acme:
+        - id: region
+          default: us1
+      oauth:
+        - id: region
+          default: us1
+  Development:
+    urls:
+      acme: https://api.dev.acme.com
+      oauth: https://oauth.dev.acme.com
+    url-templates:
+      acme: https://api.dev.{region}.acme.com
+      oauth: https://oauth.dev.{region}.acme.com
+    default-urls:
+      acme: https://api.dev.acme.com
+      oauth: https://oauth.dev.acme.com
+    variables:
+      acme:
+        - id: region
+          default: us1
+      oauth:
+        - id: region
+          default: us1
+default-environment: Production
+default-url: acme
+",
+  },
+  "specVersion": "1.0.0",
+}

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/fixtures/multi-api-environment-grouping-multi-host/auth-api.yml
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/fixtures/multi-api-environment-grouping-multi-host/auth-api.yml
@@ -1,0 +1,37 @@
+openapi: 3.0.3
+info:
+  title: Auth API
+  version: 1.0.0
+servers:
+  - url: https://oauth.{region}.acme.com
+    x-fern-server-name: Production
+    x-fern-default-url: https://oauth.acme.com
+    variables:
+      region:
+        default: us1
+  - url: https://oauth.stage.{region}.acme.com
+    x-fern-server-name: Staging
+    x-fern-default-url: https://oauth.stage.acme.com
+    variables:
+      region:
+        default: us1
+  - url: https://oauth.dev.{region}.acme.com
+    x-fern-server-name: Development
+    x-fern-default-url: https://oauth.dev.acme.com
+    variables:
+      region:
+        default: us1
+paths:
+  /token:
+    post:
+      operationId: getToken
+      responses:
+        "200":
+          description: Success
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  access_token:
+                    type: string

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/fixtures/multi-api-environment-grouping-multi-host/core-api.yml
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/fixtures/multi-api-environment-grouping-multi-host/core-api.yml
@@ -1,0 +1,37 @@
+openapi: 3.0.3
+info:
+  title: Core API
+  version: 1.0.0
+servers:
+  - url: https://api.{region}.acme.com
+    x-fern-server-name: Production
+    x-fern-default-url: https://api.acme.com
+    variables:
+      region:
+        default: us1
+  - url: https://api.stage.{region}.acme.com
+    x-fern-server-name: Staging
+    x-fern-default-url: https://api.stage.acme.com
+    variables:
+      region:
+        default: us1
+  - url: https://api.dev.{region}.acme.com
+    x-fern-server-name: Development
+    x-fern-default-url: https://api.dev.acme.com
+    variables:
+      region:
+        default: us1
+paths:
+  /things:
+    get:
+      operationId: listThings
+      responses:
+        "200":
+          description: Success
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  id:
+                    type: string

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/fixtures/multi-api-environment-grouping-multi-host/fern.config.json
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/fixtures/multi-api-environment-grouping-multi-host/fern.config.json
@@ -1,0 +1,4 @@
+{
+  "organization": "seed",
+  "version": "0.0.0"
+}

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/fixtures/multi-api-environment-grouping-multi-host/fern/generators.yml
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/fixtures/multi-api-environment-grouping-multi-host/fern/generators.yml
@@ -1,0 +1,8 @@
+api:
+  specs:
+    - openapi: ../core-api.yml
+      namespace: core
+    - openapi: ../auth-api.yml
+      namespace: auth
+  settings:
+    group-multi-api-environments: true

--- a/packages/cli/cli/changes/unreleased/fix-multi-api-environment-grouping-api-name.yml
+++ b/packages/cli/cli/changes/unreleased/fix-multi-api-environment-grouping-api-name.yml
@@ -1,0 +1,8 @@
+- summary: |
+    Fix multi-API environment grouping (`group-multi-api-environments`) when a spec's
+    environment URLs differ by a dot-separated host segment (e.g. `api.stage.acme.com`):
+    the per-API URL key is now derived once per spec instead of per server, so all
+    environments share a consistent set of URL keys. Grouped environments also keep
+    their original user-facing names (e.g. `Production`) instead of normalized
+    matching keys (e.g. `PRD`).
+  type: fix


### PR DESCRIPTION
## Description

With `group-multi-api-environments: true`, merging two specs whose environments live on hosts that differ by a dot-separated env segment (e.g. `api.twilio.com` / `api.stage.twilio.com` / `api.dev.twilio.com` grouped with `oauth.twilio.com` / `oauth.stage.twilio.com` / `oauth.dev.twilio.com`) failed validation with errors like:

```
Environment Development is missing URL for twilio
Environment PRD is missing URL for stage
```

Root cause in `merge()` (`openapi-ir-parser/src/parse.ts`): the per-API url key was computed **per server** via `extractApiNameFromUrl`, so each environment's server of the *same* API got a different key (`twilio`, `stage`, `dev` — the env segment leaks into the key). Endpoints, meanwhile, were tagged with the key derived from the *first* server only, so the url keys per environment were inconsistent and validation rejected the workspace.

## Changes Made
- Derive `api1Name` once per merged IR (from the first server, same as endpoint tagging) instead of per server:
  ```diff
  + const api1Name = extractApiNameFromServers(ir1.servers);
    for (const server of ir1.servers) {
        ...
  -     const api1Name = extractApiNameFromUrl(getPreferredUrlForNameExtraction(server));
        envUrls[api1Name] = {...}
  ```
- Preserve user-facing environment names: grouping still matches environments via normalized keys (`PRD`, `STG`, ...) but the emitted environment keeps the first raw name seen (`Production`, `Staging`), so generated SDK environment enums keep the names from `x-fern-server-name`. (Affected the `multi-api-duplicate-servers` snapshot: `STG` → `Staging`.)
- New fixture `multi-api-environment-grouping-multi-host` covering two APIs on different hosts with dot-separated env segments, region-templated urls (`{region}` variables + `x-fern-default-url`) across Production/Staging/Development.
- CLI changelog entry under `packages/cli/cli/changes/unreleased/`.

## Testing
- [x] Unit tests added/updated — `openapi-ir-to-fern-tests` snapshot for the new fixture shows all three environments carrying both url keys with templates/variables; existing multi-api fixtures pass.
- [x] Manual testing completed — ran the dev CLI against `fern-demo/twilio-core-fern-config` with a fully templated oauth override: `fern check` goes from 6 errors → 0, and the IR emits `multipleBaseUrls` environments (`twilio` + `oauth` in every environment, all region-templated).

Link to Devin session: https://app.devin.ai/sessions/80e4bd943e4f4b4a827242cc5114264a
Requested by: @iamnamananand996
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/17144" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->