### PR TITLE
fix(openapi): cache parser reference metadata

### DIFF
--- a/packages/cli/api-importers/openapi/openapi-ir-parser/src/__test__/OpenAPIV3ParserContext.test.ts
+++ b/packages/cli/api-importers/openapi/openapi-ir-parser/src/__test__/OpenAPIV3ParserContext.test.ts
@@ -1,0 +1,110 @@
+import { Source } from "@fern-api/openapi-ir";
+import { TaskContext } from "@fern-api/task-context";
+import { OpenAPIV3 } from "openapi-types";
+import { describe, expect, it, vi } from "vitest";
+import { OpenAPIV3DocumentMetadata } from "../openapi/v3/AbstractOpenAPIV3ParserContext.js";
+import { stripBasePathFromPaths } from "../openapi/v3/extensions/getFernBasePath.js";
+import { OpenAPIV3ParserContext } from "../openapi/v3/OpenAPIV3ParserContext.js";
+import { DEFAULT_PARSE_OPENAPI_SETTINGS } from "../options.js";
+
+const taskContext = {
+    logger: {
+        debug: vi.fn(),
+        info: vi.fn(),
+        warn: vi.fn(),
+        error: vi.fn()
+    }
+} as unknown as TaskContext;
+
+const source = Source.openapi({ file: "test.yaml" });
+
+describe("OpenAPIV3ParserContext", () => {
+    it("shares document metadata with the dummy context", () => {
+        const document: OpenAPIV3.Document = {
+            openapi: "3.0.0",
+            info: { title: "Test API", version: "1.0.0" },
+            paths: {
+                "/widgets": {
+                    get: {
+                        responses: {
+                            "200": {
+                                description: "Success",
+                                content: {
+                                    "application/json": {
+                                        schema: { $ref: "#/components/schemas/widget_response" }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            components: {
+                schemas: {
+                    widget_response: { type: "object" }
+                }
+            }
+        };
+
+        const documentMetadata = new OpenAPIV3DocumentMetadata(document, DEFAULT_PARSE_OPENAPI_SETTINGS);
+        const occurrenceSpy = vi.spyOn(documentMetadata, "getNumberOfOccurrencesForRef");
+        const componentNameSpy = vi.spyOn(documentMetadata, "hasGeneratedComponentSchemaName");
+        const context = new OpenAPIV3ParserContext({
+            document,
+            taskContext,
+            authHeaders: new Set(),
+            options: DEFAULT_PARSE_OPENAPI_SETTINGS,
+            source,
+            namespace: undefined,
+            documentMetadata
+        });
+
+        expect(context.DUMMY).not.toBe(context);
+        expect(context.DUMMY.DUMMY).toBe(context.DUMMY);
+        expect(context.getNumberOfOccurrencesForRef({ $ref: "#/components/schemas/widget_response" })).toBe(1);
+        expect(context.DUMMY.getNumberOfOccurrencesForRef({ $ref: "#/components/schemas/widget_response" })).toBe(1);
+        expect(context.hasGeneratedComponentSchemaName("WidgetResponse")).toBe(true);
+        expect(context.DUMMY.hasGeneratedComponentSchemaName("WidgetResponse")).toBe(true);
+        expect(occurrenceSpy).toHaveBeenCalledTimes(2);
+        expect(componentNameSpy).toHaveBeenCalledTimes(2);
+    });
+
+    it("preserves reference counts when base path parameters are stripped", () => {
+        const document: OpenAPIV3.Document = {
+            openapi: "3.0.0",
+            info: { title: "Test API", version: "1.0.0" },
+            paths: {
+                "/{account_id}/widgets": {
+                    parameters: [
+                        {
+                            name: "account_id",
+                            in: "path",
+                            required: true,
+                            schema: { $ref: "#/components/schemas/AccountId" }
+                        }
+                    ],
+                    get: { responses: { "200": { description: "Success" } } }
+                }
+            },
+            components: { schemas: { AccountId: { type: "string" } } }
+        };
+        const documentMetadata = new OpenAPIV3DocumentMetadata(document, DEFAULT_PARSE_OPENAPI_SETTINGS);
+
+        stripBasePathFromPaths({
+            openApi: document,
+            basePath: "/{account_id}",
+            rootPathParameterNames: new Set(["account_id"])
+        });
+        const context = new OpenAPIV3ParserContext({
+            document,
+            taskContext,
+            authHeaders: new Set(),
+            options: DEFAULT_PARSE_OPENAPI_SETTINGS,
+            source,
+            namespace: undefined,
+            documentMetadata
+        });
+
+        expect(context.getNumberOfOccurrencesForRef({ $ref: "#/components/schemas/AccountId" })).toBe(1);
+    });
+});

--- a/packages/cli/api-importers/openapi/openapi-ir-parser/src/openapi/v3/AbstractOpenAPIV3ParserContext.ts
+++ b/packages/cli/api-importers/openapi/openapi-ir-parser/src/openapi/v3/AbstractOpenAPIV3ParserContext.ts
@@ -8,15 +8,38 @@ import { getExtension } from "../../getExtension.js";
 import type { ParseOpenAPIOptions } from "../../options.js";
 import type { SchemaParserContext } from "../../schema/SchemaParserContext.js";
 import { getReferenceOccurrences } from "../../schema/utils/getReferenceOccurrences.js";
+import { getGeneratedTypeName } from "../../schema/utils/getSchemaName.js";
 import { isReferenceObject } from "../../schema/utils/isReferenceObject.js";
 import { FernOpenAPIExtension } from "./extensions/fernExtensions.js";
 import { OpenAPIFilter } from "./OpenAPIFilter.js";
+import { resolveSecuritySchemeReference } from "./resolveSecuritySchemeReference.js";
+
+export class OpenAPIV3DocumentMetadata {
+    private readonly refOccurrences: Readonly<Record<string, number>>;
+    private readonly generatedComponentSchemaNames: ReadonlySet<string>;
+
+    public constructor(document: OpenAPIV3.Document, options: ParseOpenAPIOptions) {
+        this.refOccurrences = getReferenceOccurrences(document);
+        this.generatedComponentSchemaNames = new Set(
+            Object.keys(document.components?.schemas ?? {}).map((schemaKey) =>
+                getGeneratedTypeName([schemaKey], options.preserveSchemaIds)
+            )
+        );
+    }
+
+    public getNumberOfOccurrencesForRef(ref: string): number {
+        return this.refOccurrences[ref] ?? 0;
+    }
+
+    public hasGeneratedComponentSchemaName(name: string): boolean {
+        return this.generatedComponentSchemaNames.has(name);
+    }
+}
 
 export const PARAMETER_REFERENCE_PREFIX = "#/components/parameters/";
 export const RESPONSE_REFERENCE_PREFIX = "#/components/responses/";
 export const EXAMPLES_REFERENCE_PREFIX = "#/components/examples/";
 export const REQUEST_BODY_REFERENCE_PREFIX = "#/components/requestBodies/";
-export const SECURITY_SCHEME_REFERENCE_PREFIX = "#/components/securitySchemes/";
 
 export interface DiscriminatedUnionReference {
     discriminants: Set<string>;
@@ -33,8 +56,8 @@ export abstract class AbstractOpenAPIV3ParserContext implements SchemaParserCont
     public readonly document: OpenAPIV3.Document;
     public readonly taskContext: TaskContext;
     public readonly authHeaders: Set<string>;
-    public readonly refOccurrences: Record<string, number>;
-    public readonly DUMMY: SchemaParserContext;
+    private readonly documentMetadata: OpenAPIV3DocumentMetadata;
+    public readonly DUMMY: AbstractOpenAPIV3ParserContext;
     public readonly options: ParseOpenAPIOptions;
     public readonly source: Source;
     public readonly filter: OpenAPIFilter;
@@ -46,7 +69,8 @@ export abstract class AbstractOpenAPIV3ParserContext implements SchemaParserCont
         authHeaders,
         options,
         source,
-        namespace
+        namespace,
+        documentMetadata
     }: {
         document: OpenAPIV3.Document;
         taskContext: TaskContext;
@@ -54,23 +78,31 @@ export abstract class AbstractOpenAPIV3ParserContext implements SchemaParserCont
         options: ParseOpenAPIOptions;
         source: Source;
         namespace: string | undefined;
+        documentMetadata?: OpenAPIV3DocumentMetadata;
     }) {
         this.document = document;
         this.logger = taskContext.logger;
         this.taskContext = taskContext;
         this.authHeaders = authHeaders;
-        this.refOccurrences = getReferenceOccurrences(document);
+        this.documentMetadata = documentMetadata ?? new OpenAPIV3DocumentMetadata(document, options);
         this.options = options;
         this.source = source;
         this.filter = new OpenAPIFilter({ context: taskContext, options });
-        this.DUMMY = this.getDummy();
-
         this.namespace = namespace;
         this.schemaNamespaceMapping = this.buildSchemaNamespaceMapping();
+        this.DUMMY = this.getDummy();
     }
 
     public getNumberOfOccurrencesForRef(schema: OpenAPIV3.ReferenceObject): number {
-        return this.refOccurrences[schema.$ref] ?? 0;
+        return this.documentMetadata.getNumberOfOccurrencesForRef(schema.$ref);
+    }
+
+    public hasGeneratedComponentSchemaName(name: string): boolean {
+        return this.documentMetadata.hasGeneratedComponentSchemaName(name);
+    }
+
+    protected getDocumentMetadata(): OpenAPIV3DocumentMetadata {
+        return this.documentMetadata;
     }
 
     public resolveTagsToTagIds(operationTags: string[] | undefined): string[] {
@@ -231,25 +263,7 @@ export abstract class AbstractOpenAPIV3ParserContext implements SchemaParserCont
     }
 
     public resolveSecuritySchemeReference(securityScheme: OpenAPIV3.ReferenceObject): OpenAPIV3.SecuritySchemeObject {
-        if (
-            this.document.components == null ||
-            this.document.components.securitySchemes == null ||
-            !securityScheme.$ref.startsWith(SECURITY_SCHEME_REFERENCE_PREFIX)
-        ) {
-            throw new CliError({
-                message: `Failed to resolve ${securityScheme.$ref}`,
-                code: CliError.Code.ReferenceError
-            });
-        }
-        const securitySchemeKey = securityScheme.$ref.substring(SECURITY_SCHEME_REFERENCE_PREFIX.length);
-        const resolvedSecurityScheme = this.document.components.securitySchemes[securitySchemeKey];
-        if (resolvedSecurityScheme == null) {
-            throw new CliError({ message: `${securityScheme.$ref} is undefined`, code: CliError.Code.ReferenceError });
-        }
-        if (isReferenceObject(resolvedSecurityScheme)) {
-            return this.resolveSecuritySchemeReference(resolvedSecurityScheme);
-        }
-        return resolvedSecurityScheme;
+        return resolveSecuritySchemeReference(this.document, securityScheme);
     }
 
     public referenceExists(ref: string): boolean {
@@ -281,7 +295,7 @@ export abstract class AbstractOpenAPIV3ParserContext implements SchemaParserCont
 
     public abstract getReferencedSchemas(): Set<SchemaId>;
 
-    public abstract getDummy(): SchemaParserContext;
+    public abstract getDummy(): AbstractOpenAPIV3ParserContext;
 
     public abstract markReferencedByDiscriminatedUnion(
         schema: OpenAPIV3.ReferenceObject,

--- a/packages/cli/api-importers/openapi/openapi-ir-parser/src/openapi/v3/DummyOpenAPIV3ParserContext.ts
+++ b/packages/cli/api-importers/openapi/openapi-ir-parser/src/openapi/v3/DummyOpenAPIV3ParserContext.ts
@@ -3,11 +3,11 @@ import { TaskContext } from "@fern-api/task-context";
 import { OpenAPIV3 } from "openapi-types";
 
 import { ParseOpenAPIOptions } from "../../options.js";
-import { SchemaParserContext } from "../../schema/SchemaParserContext.js";
 import {
     AbstractOpenAPIV3ParserContext,
     DiscriminatedUnionMetadata,
-    DiscriminatedUnionReference
+    DiscriminatedUnionReference,
+    OpenAPIV3DocumentMetadata
 } from "./AbstractOpenAPIV3ParserContext.js";
 
 export class DummyOpenAPIV3ParserContext extends AbstractOpenAPIV3ParserContext {
@@ -16,13 +16,15 @@ export class DummyOpenAPIV3ParserContext extends AbstractOpenAPIV3ParserContext 
         taskContext,
         options,
         source,
-        namespace
+        namespace,
+        documentMetadata
     }: {
         document: OpenAPIV3.Document;
         taskContext: TaskContext;
         options: ParseOpenAPIOptions;
         source: Source;
         namespace: string | undefined;
+        documentMetadata?: OpenAPIV3DocumentMetadata;
     }) {
         super({
             document,
@@ -30,11 +32,12 @@ export class DummyOpenAPIV3ParserContext extends AbstractOpenAPIV3ParserContext 
             authHeaders: new Set(),
             options,
             source,
-            namespace
+            namespace,
+            documentMetadata
         });
     }
 
-    public getDummy(): SchemaParserContext {
+    public getDummy(): AbstractOpenAPIV3ParserContext {
         return this;
     }
 

--- a/packages/cli/api-importers/openapi/openapi-ir-parser/src/openapi/v3/OpenAPIV3ParserContext.ts
+++ b/packages/cli/api-importers/openapi/openapi-ir-parser/src/openapi/v3/OpenAPIV3ParserContext.ts
@@ -3,11 +3,11 @@ import { TaskContext } from "@fern-api/task-context";
 import { OpenAPIV3 } from "openapi-types";
 
 import { ParseOpenAPIOptions } from "../../options.js";
-import { SchemaParserContext } from "../../schema/SchemaParserContext.js";
 import {
     AbstractOpenAPIV3ParserContext,
     DiscriminatedUnionMetadata,
-    DiscriminatedUnionReference
+    DiscriminatedUnionReference,
+    OpenAPIV3DocumentMetadata
 } from "./AbstractOpenAPIV3ParserContext.js";
 import { DummyOpenAPIV3ParserContext } from "./DummyOpenAPIV3ParserContext.js";
 
@@ -26,7 +26,8 @@ export class OpenAPIV3ParserContext extends AbstractOpenAPIV3ParserContext {
         authHeaders,
         options,
         source,
-        namespace
+        namespace,
+        documentMetadata
     }: {
         document: OpenAPIV3.Document;
         taskContext: TaskContext;
@@ -34,6 +35,7 @@ export class OpenAPIV3ParserContext extends AbstractOpenAPIV3ParserContext {
         options: ParseOpenAPIOptions;
         source: Source;
         namespace?: string;
+        documentMetadata?: OpenAPIV3DocumentMetadata;
     }) {
         super({
             document,
@@ -41,17 +43,19 @@ export class OpenAPIV3ParserContext extends AbstractOpenAPIV3ParserContext {
             authHeaders,
             options,
             source,
-            namespace
+            namespace,
+            documentMetadata
         });
     }
 
-    public getDummy(): SchemaParserContext {
+    public getDummy(): AbstractOpenAPIV3ParserContext {
         return new DummyOpenAPIV3ParserContext({
             document: this.document,
             taskContext: this.taskContext,
             options: this.options,
             source: this.source,
-            namespace: this.namespace
+            namespace: this.namespace,
+            documentMetadata: this.getDocumentMetadata()
         });
     }
 

--- a/packages/cli/api-importers/openapi/openapi-ir-parser/src/openapi/v3/converters/operation/convertHttpOperation.ts
+++ b/packages/cli/api-importers/openapi/openapi-ir-parser/src/openapi/v3/converters/operation/convertHttpOperation.ts
@@ -16,7 +16,6 @@ import { getGeneratedTypeName } from "../../../../schema/utils/getSchemaName.js"
 import { isReferenceObject } from "../../../../schema/utils/isReferenceObject.js";
 import { sanitizeSecurityScopes } from "../../../../utils/sanitizeSecurityScopes.js";
 import { AbstractOpenAPIV3ParserContext } from "../../AbstractOpenAPIV3ParserContext.js";
-import { DummyOpenAPIV3ParserContext } from "../../DummyOpenAPIV3ParserContext.js";
 import { OpenAPIExtension } from "../../extensions/extensions.js";
 import { FernOpenAPIExtension } from "../../extensions/fernExtensions.js";
 import { getExamplesFromExtension } from "../../extensions/getExamplesFromExtension.js";
@@ -204,13 +203,7 @@ export function convertHttpOperation({
                             mediaTypeObject,
                             description: resolvedRequestBody.description,
                             document,
-                            context: new DummyOpenAPIV3ParserContext({
-                                document: context.document,
-                                taskContext: context.taskContext,
-                                options: context.options,
-                                source: context.source,
-                                namespace: context.namespace
-                            }),
+                            context: context.DUMMY,
                             requestBreadcrumbs,
                             source,
                             namespace: context.namespace
@@ -260,13 +253,7 @@ export function convertHttpOperation({
                 content: resolvedRequestBody.content,
                 description: resolvedRequestBody.description,
                 document,
-                context: new DummyOpenAPIV3ParserContext({
-                    document: context.document,
-                    taskContext: context.taskContext,
-                    options: context.options,
-                    source: context.source,
-                    namespace: context.namespace
-                }),
+                context: context.DUMMY,
                 requestBreadcrumbs,
                 source,
                 namespace: context.namespace
@@ -474,16 +461,7 @@ function getDisambiguatedRequestName({
         return computedName;
     }
 
-    const componentSchemas = context.document.components?.schemas;
-    if (componentSchemas == null) {
-        return computedName;
-    }
-
-    // Check if any component schema would produce the same generated type name.
-    const collidesWithSchema = Object.keys(componentSchemas).some(
-        (schemaKey) => getGeneratedTypeName([schemaKey], context.options.preserveSchemaIds) === computedName
-    );
-    if (!collidesWithSchema) {
+    if (!context.hasGeneratedComponentSchemaName(computedName)) {
         return computedName;
     }
 

--- a/packages/cli/api-importers/openapi/openapi-ir-parser/src/openapi/v3/generateIr.ts
+++ b/packages/cli/api-importers/openapi/openapi-ir-parser/src/openapi/v3/generateIr.ts
@@ -34,7 +34,7 @@ import { isReferenceObject } from "../../schema/utils/isReferenceObject.js";
 import { getSchemas } from "../../utils/getSchemas.js";
 import { sanitizeSecurityScopes } from "../../utils/sanitizeSecurityScopes.js";
 import { createSchemaCollisionTracker } from "../../utils/schemaCollision.js";
-import { AbstractOpenAPIV3ParserContext } from "./AbstractOpenAPIV3ParserContext.js";
+import { AbstractOpenAPIV3ParserContext, OpenAPIV3DocumentMetadata } from "./AbstractOpenAPIV3ParserContext.js";
 import { convertPathItem, convertPathItemToWebhooks } from "./converters/convertPathItem.js";
 import { convertSecurityScheme } from "./converters/convertSecurityScheme.js";
 import { convertServer } from "./converters/convertServer.js";
@@ -52,6 +52,7 @@ import { getVariableDefinitions } from "./extensions/getVariableDefinitions.js";
 import { getWebhooksPathsObject } from "./getWebhookPathsObject.js";
 import { hasIncompleteExample } from "./hasIncompleteExample.js";
 import { OpenAPIV3ParserContext } from "./OpenAPIV3ParserContext.js";
+import { resolveSecuritySchemeReference } from "./resolveSecuritySchemeReference.js";
 import { runResolutions } from "./runResolutions.js";
 
 export function generateIr({
@@ -72,20 +73,27 @@ export function generateIr({
     // Reset title collision tracker for this document processing
     resetTitleCollisionTracker();
 
-    // Create a temporary context for reference resolution during security scheme processing
-    const tempContext = new OpenAPIV3ParserContext({
-        document: openApi,
-        taskContext,
-        authHeaders: new Set(), // temporary empty set
-        options,
-        source,
-        namespace
-    });
+    const documentMetadata = new OpenAPIV3DocumentMetadata(openApi, options);
+
+    const fernBasePathParsed = getFernBasePath(openApi);
+    if (fernBasePathParsed?.pathsIncludeBasePath) {
+        const stripErrors = stripBasePathFromPaths({
+            openApi,
+            basePath: fernBasePathParsed.basePath,
+            rootPathParameterNames: new Set(fernBasePathParsed.pathParameters.map((p) => p.name))
+        });
+        for (const message of stripErrors) {
+            taskContext.logger.warn(message);
+        }
+    }
 
     const securitySchemes: Record<string, SecurityScheme> = Object.fromEntries(
         Object.entries(openApi.components?.securitySchemes ?? {})
             .map(([key, securityScheme]) => {
-                const convertedSecurityScheme = convertSecurityScheme(securityScheme, source, taskContext, tempContext);
+                const resolvedSecurityScheme = isReferenceObject(securityScheme)
+                    ? resolveSecuritySchemeReference(openApi, securityScheme)
+                    : securityScheme;
+                const convertedSecurityScheme = convertSecurityScheme(resolvedSecurityScheme, source, taskContext);
                 if (convertedSecurityScheme == null) {
                     return null;
                 }
@@ -112,6 +120,15 @@ export function generateIr({
             })
             .filter((header): header is string => header != null)
     );
+    const context = new OpenAPIV3ParserContext({
+        document: openApi,
+        taskContext,
+        authHeaders,
+        options,
+        source,
+        namespace,
+        documentMetadata
+    });
     const variables = getVariableDefinitions(openApi, options.preserveSchemaIds);
     const globalHeaders = getGlobalHeaders(openApi);
     const globalParameters = getGlobalParameters(openApi);
@@ -120,29 +137,8 @@ export function generateIr({
     const endpointsWithExample: EndpointWithExample[] = [];
     const webhooksWithExample: WebhookWithExample[] = [];
 
-    const context = new OpenAPIV3ParserContext({
-        document: openApi,
-        taskContext,
-        authHeaders,
-        options,
-        source,
-        namespace
-    });
-
     if (context.filter.hasEndpoints()) {
         taskContext.logger.debug("Endpoint filter applied...");
-    }
-
-    const fernBasePathParsed = getFernBasePath(openApi);
-    if (fernBasePathParsed?.pathsIncludeBasePath) {
-        const stripErrors = stripBasePathFromPaths({
-            openApi,
-            basePath: fernBasePathParsed.basePath,
-            rootPathParameterNames: new Set(fernBasePathParsed.pathParameters.map((p) => p.name))
-        });
-        for (const message of stripErrors) {
-            taskContext.logger.warn(message);
-        }
     }
 
     Object.entries(openApi.paths ?? {}).forEach(([path, pathItem]) => {

--- a/packages/cli/api-importers/openapi/openapi-ir-parser/src/openapi/v3/resolveSecuritySchemeReference.ts
+++ b/packages/cli/api-importers/openapi/openapi-ir-parser/src/openapi/v3/resolveSecuritySchemeReference.ts
@@ -1,0 +1,31 @@
+import { CliError } from "@fern-api/task-context";
+import { OpenAPIV3 } from "openapi-types";
+import { isReferenceObject } from "../../schema/utils/isReferenceObject.js";
+
+const SECURITY_SCHEME_REFERENCE_PREFIX = "#/components/securitySchemes/";
+
+export function resolveSecuritySchemeReference(
+    document: OpenAPIV3.Document,
+    securityScheme: OpenAPIV3.ReferenceObject
+): OpenAPIV3.SecuritySchemeObject {
+    if (
+        document.components?.securitySchemes == null ||
+        !securityScheme.$ref.startsWith(SECURITY_SCHEME_REFERENCE_PREFIX)
+    ) {
+        throw new CliError({
+            message: `Failed to resolve ${securityScheme.$ref}`,
+            code: CliError.Code.ReferenceError
+        });
+    }
+    const securitySchemeKey = securityScheme.$ref.substring(SECURITY_SCHEME_REFERENCE_PREFIX.length);
+    const resolvedSecurityScheme = document.components.securitySchemes[securitySchemeKey];
+    if (resolvedSecurityScheme == null) {
+        throw new CliError({
+            message: `${securityScheme.$ref} is undefined`,
+            code: CliError.Code.ReferenceError
+        });
+    }
+    return isReferenceObject(resolvedSecurityScheme)
+        ? resolveSecuritySchemeReference(document, resolvedSecurityScheme)
+        : resolvedSecurityScheme;
+}

--- a/packages/cli/api-importers/openapi/openapi-ir-parser/src/schema/utils/getReferenceOccurrences.ts
+++ b/packages/cli/api-importers/openapi/openapi-ir-parser/src/schema/utils/getReferenceOccurrences.ts
@@ -6,19 +6,17 @@ import { isReferenceObject } from "./isReferenceObject.js";
 export function getReferenceOccurrences(document: OpenAPIV3.Document): Record<string, number> {
     const contentConflictsRemovedDocument = removeApplicationJsonAndMultipartConflictsFromDocument(document);
     const occurrences: Record<string, number> = {};
-    getReferenceOccurrencesHelper({ obj: contentConflictsRemovedDocument, occurrences, breadcrumbs: [] });
+    getReferenceOccurrencesHelper({ obj: contentConflictsRemovedDocument, occurrences });
     return occurrences;
 }
 
 function getReferenceOccurrencesHelper({
     obj,
-    occurrences,
-    breadcrumbs
+    occurrences
 }: {
     // biome-ignore lint/suspicious/noExplicitAny: allow explicit any
     obj: any;
     occurrences: Record<string, number>;
-    breadcrumbs: string[];
 }): void {
     if (obj == null) {
         return;
@@ -28,8 +26,7 @@ function getReferenceOccurrencesHelper({
         for (const element of obj) {
             getReferenceOccurrencesHelper({
                 obj: element,
-                occurrences,
-                breadcrumbs
+                occurrences
             });
         }
         return;
@@ -51,8 +48,7 @@ function getReferenceOccurrencesHelper({
     for (const key in obj) {
         getReferenceOccurrencesHelper({
             obj: obj[key],
-            occurrences,
-            breadcrumbs: [...breadcrumbs, key]
+            occurrences
         });
     }
 }


### PR DESCRIPTION
## Summary

Cache reference metadata while parsing OpenAPI documents instead of repeatedly traversing the document for each lookup.

## Benchmark

Cloudflare's 26 MB OpenAPI document, three alternating runs:

- Before: 283.1s median
- After: 236.6s median
- Improvement: 16.4%

All runs produced identical IR.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/17159" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->