### PR TITLE
fix(typescript): use property names for multipart files

### DIFF
--- a/generators/typescript/sdk/client-class-generator/src/__test__/EndpointRequests.test.ts
+++ b/generators/typescript/sdk/client-class-generator/src/__test__/EndpointRequests.test.ts
@@ -295,6 +295,11 @@ function createMockGeneratedRequestWrapper() {
             propertyName: caseConverter.camelUnsafe(h.name),
             safeName: caseConverter.camelUnsafe(h.name)
         }),
+        getPropertyNameOfFileParameter: (property: FernIr.FileProperty) => ({
+            propertyName: caseConverter.camelSafe(property.key),
+            safeName: caseConverter.camelSafe(property.key),
+            originalParameter: property
+        }),
         getInlinedRequestBodyPropertyKey: (p: FernIr.InlinedRequestBodyProperty) => ({
             propertyName: caseConverter.camelUnsafe(p.name),
             safeName: caseConverter.camelUnsafe(p.name)
@@ -344,10 +349,10 @@ function createFileUploadRequestBody(opts?: {
 
 function createFileProperty(
     name: string,
-    opts?: { isOptional?: boolean; type?: "file" | "fileArray" }
+    opts?: { isOptional?: boolean; type?: "file" | "fileArray"; wireValue?: string }
 ): FernIr.FileUploadRequestProperty {
     const base = {
-        key: createNameAndWireValue(name),
+        key: createNameAndWireValue(name, opts?.wireValue),
         isOptional: opts?.isOptional ?? false,
         contentType: undefined,
         docs: undefined
@@ -758,6 +763,35 @@ describe("GeneratedDefaultEndpointRequest", () => {
     });
 
     describe("getBuildRequestStatements", () => {
+        it("uses the generated property name and wire form-data key for inline files", () => {
+            const fileProperty = createFileProperty("fileName", { wireValue: "file-name" });
+            const fileBody = createFileUploadRequestBody({ properties: [fileProperty] });
+            const request = new GeneratedFileUploadEndpointRequest({
+                ir: createMinimalIR(),
+                packageId: { isRoot: true },
+                service: createHttpService(),
+                endpoint: createHttpEndpoint({
+                    requestBody: fileBody,
+                    sdkRequest: createSdkRequestWrapper()
+                }),
+                requestBody: fileBody,
+                generatedSdkClientClass: createMockSdkClientClass(),
+                retainOriginalCasing: true,
+                inlineFileProperties: true,
+                includeSerdeLayer: true,
+                allowExtraFields: false,
+                omitUndefined: false,
+                formDataSupport: "Node18",
+                parameterNaming: "wireValue",
+                caseConverter
+            });
+            const context = createEndpointRequestMockContext();
+            context.inlineFileProperties = true;
+            context.retainOriginalCasing = true;
+            const serialized = serializeStatements(request.getBuildRequestStatements(context));
+            expect(serialized).toContain('_body.appendFile("file-name", request.fileName);');
+        });
+
         it("generates header initialization for endpoint with no request body", () => {
             const request = new GeneratedDefaultEndpointRequest({
                 ir: createMinimalIR(),

--- a/generators/typescript/sdk/client-class-generator/src/__test__/appendPropertyToFormData.test.ts
+++ b/generators/typescript/sdk/client-class-generator/src/__test__/appendPropertyToFormData.test.ts
@@ -1,3 +1,4 @@
+import { getWireValue } from "@fern-api/base-generator";
 import { FernIr } from "@fern-fern/ir-sdk";
 import { getTextOfTsNode } from "@fern-typescript/commons";
 import {
@@ -99,10 +100,10 @@ function createMockContext(): any {
 
 function createFileProperty(
     name: string,
-    opts?: { isOptional?: boolean; type?: "file" | "fileArray" }
+    opts?: { isOptional?: boolean; type?: "file" | "fileArray"; wireValue?: string }
 ): FernIr.FileUploadRequestProperty {
     const base = {
-        key: createNameAndWireValue(name),
+        key: createNameAndWireValue(name, opts?.wireValue),
         isOptional: opts?.isOptional ?? false,
         contentType: undefined,
         docs: undefined
@@ -127,6 +128,15 @@ function createBodyProperty(
 // biome-ignore lint/suspicious/noExplicitAny: test mock
 function createMockRequestParameter(): any {
     return {
+        getReferenceToFileProperty: (property: FernIr.FileProperty) => {
+            const propertyName = getWireValue(property.key);
+            return /^[A-Za-z_$][A-Za-z0-9_$]*$/.test(propertyName)
+                ? ts.factory.createPropertyAccessExpression(ts.factory.createIdentifier("request"), propertyName)
+                : ts.factory.createElementAccessExpression(
+                      ts.factory.createIdentifier("request"),
+                      ts.factory.createStringLiteral(propertyName)
+                  );
+        },
         getReferenceToBodyProperty: (property: FernIr.InlinedRequestBodyProperty) =>
             ts.factory.createPropertyAccessExpression(
                 ts.factory.createIdentifier("request"),
@@ -153,6 +163,61 @@ describe("appendPropertyToFormData", () => {
                 omitUndefined: false
             });
             expect(getTextOfTsNode(stmt)).toMatchSnapshot();
+        });
+
+        it("uses property access for an inlined file with a valid identifier", () => {
+            const property = createFileProperty("avatar");
+            const context = createMockContext();
+            context.inlineFileProperties = true;
+            const stmt = appendPropertyToFormData({
+                property,
+                context,
+                referenceToFormData,
+                wrapperName: "request",
+                requestParameter: createMockRequestParameter(),
+                includeSerdeLayer: true,
+                allowExtraFields: false,
+                omitUndefined: false
+            });
+            expect(getTextOfTsNode(stmt)).toBe('_body.appendFile("avatar", request.avatar);');
+        });
+
+        it("uses element access for an inlined file with a non-identifier name", () => {
+            const property = createFileProperty("fileName", { wireValue: "file-name" });
+            const context = createMockContext();
+            context.inlineFileProperties = true;
+            context.retainOriginalCasing = true;
+            const stmt = appendPropertyToFormData({
+                property,
+                context,
+                referenceToFormData,
+                wrapperName: "request",
+                requestParameter: createMockRequestParameter(),
+                includeSerdeLayer: true,
+                allowExtraFields: false,
+                omitUndefined: false
+            });
+            expect(getTextOfTsNode(stmt)).toBe('_body.appendFile("file-name", request["file-name"]);');
+        });
+
+        it("uses element access for optional inline file arrays", () => {
+            const property = createFileProperty("file-name", { isOptional: true, type: "fileArray" });
+            const context = createMockContext();
+            context.inlineFileProperties = true;
+            context.retainOriginalCasing = true;
+            const stmt = appendPropertyToFormData({
+                property,
+                context,
+                referenceToFormData,
+                wrapperName: "request",
+                requestParameter: createMockRequestParameter(),
+                includeSerdeLayer: true,
+                allowExtraFields: false,
+                omitUndefined: false
+            });
+            const text = getTextOfTsNode(stmt);
+            expect(text).toContain('if (request["file-name"] != null)');
+            expect(text).toContain('for (const _file of request["file-name"])');
         });
 
         it("generates for-of loop for fileArray", () => {

--- a/generators/typescript/sdk/client-class-generator/src/endpoints/utils/appendPropertyToFormData.ts
+++ b/generators/typescript/sdk/client-class-generator/src/endpoints/utils/appendPropertyToFormData.ts
@@ -28,20 +28,32 @@ export function appendPropertyToFormData({
     return FernIr.FileUploadRequestProperty._visit(property, {
         file: (property) => {
             const FOR_LOOP_ITEM_VARIABLE_NAME = "_file";
-
+            const referenceToFile = context.inlineFileProperties
+                ? (requestParameter?.getReferenceToFileProperty(property, context) ??
+                  ts.factory.createIdentifier(
+                      getParameterNameForFile({
+                          property,
+                          wrapperName,
+                          includeSerdeLayer: context.includeSerdeLayer,
+                          retainOriginalCasing: context.retainOriginalCasing,
+                          inlineFileProperties: true,
+                          caseConverter: context.case
+                      })
+                  ))
+                : ts.factory.createIdentifier(
+                      getParameterNameForFile({
+                          property,
+                          wrapperName,
+                          includeSerdeLayer: context.includeSerdeLayer,
+                          retainOriginalCasing: context.retainOriginalCasing,
+                          inlineFileProperties: false,
+                          caseConverter: context.case
+                      })
+                  );
             let statement = context.coreUtilities.formDataUtils.appendFile({
                 referenceToFormData,
                 key: getWireValue(property.key),
-                value: ts.factory.createIdentifier(
-                    getParameterNameForFile({
-                        property,
-                        wrapperName,
-                        includeSerdeLayer: context.includeSerdeLayer,
-                        retainOriginalCasing: context.retainOriginalCasing,
-                        inlineFileProperties: context.inlineFileProperties,
-                        caseConverter: context.case
-                    })
-                )
+                value: referenceToFile
             });
 
             if (property.type === "fileArray") {
@@ -58,16 +70,7 @@ export function appendPropertyToFormData({
                         ],
                         ts.NodeFlags.Const
                     ),
-                    ts.factory.createIdentifier(
-                        getParameterNameForFile({
-                            property,
-                            wrapperName,
-                            includeSerdeLayer: context.includeSerdeLayer,
-                            retainOriginalCasing: context.retainOriginalCasing,
-                            inlineFileProperties: context.inlineFileProperties,
-                            caseConverter: context.case
-                        })
-                    ),
+                    referenceToFile,
                     ts.factory.createBlock(
                         [
                             context.coreUtilities.formDataUtils.appendFile({
@@ -84,16 +87,7 @@ export function appendPropertyToFormData({
             if (property.isOptional) {
                 statement = ts.factory.createIfStatement(
                     ts.factory.createBinaryExpression(
-                        ts.factory.createIdentifier(
-                            getParameterNameForFile({
-                                property,
-                                wrapperName,
-                                includeSerdeLayer: context.includeSerdeLayer,
-                                retainOriginalCasing: context.retainOriginalCasing,
-                                inlineFileProperties: context.inlineFileProperties,
-                                caseConverter: context.case
-                            })
-                        ),
+                        referenceToFile,
                         ts.factory.createToken(ts.SyntaxKind.ExclamationEqualsToken),
                         ts.factory.createNull()
                     ),

--- a/generators/typescript/sdk/client-class-generator/src/request-parameter/FileUploadRequestParameter.ts
+++ b/generators/typescript/sdk/client-class-generator/src/request-parameter/FileUploadRequestParameter.ts
@@ -110,13 +110,17 @@ export class FileUploadRequestParameter extends AbstractRequestParameter {
         );
     }
 
+    public getReferenceToFileProperty(property: FernIr.FileProperty, context: FileContext): ts.Expression {
+        return this.getReferenceToProperty(
+            this.getGeneratedRequestWrapper(context).getPropertyNameOfFileParameter(property).propertyName
+        );
+    }
+
     private getGeneratedRequestWrapper(context: FileContext): GeneratedRequestWrapper {
         return context.requestWrapper.getGeneratedRequestWrapper(this.packageId, this.endpoint.name);
     }
 
     private getReferenceToProperty(propertyName: string): ts.Expression {
-        // Check if property name is a valid JavaScript identifier
-        // Valid identifiers: start with letter, _, or $, followed by letters, numbers, _, or $
         const isValidIdentifier = /^[a-zA-Z_$][a-zA-Z0-9_$]*$/.test(propertyName);
 
         if (isValidIdentifier) {
@@ -124,12 +128,10 @@ export class FileUploadRequestParameter extends AbstractRequestParameter {
                 ts.factory.createIdentifier(this.getRequestParameterName()),
                 propertyName
             );
-        } else {
-            // Use bracket notation for property names with hyphens or other invalid characters
-            return ts.factory.createElementAccessExpression(
-                ts.factory.createIdentifier(this.getRequestParameterName()),
-                ts.factory.createStringLiteral(propertyName)
-            );
         }
+        return ts.factory.createElementAccessExpression(
+            ts.factory.createIdentifier(this.getRequestParameterName()),
+            ts.factory.createStringLiteral(propertyName)
+        );
     }
 }

--- a/generators/typescript/sdk/versions.yml
+++ b/generators/typescript/sdk/versions.yml
@@ -1,4 +1,12 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+- version: 3.82.4
+  changelogEntry:
+    - summary: |
+        Reference inline multipart files by their generated request property names while
+        preserving the original wire names in form-data fields.
+      type: fix
+  createdAt: "2026-07-21"
+  irVersion: 67
 - version: 3.82.3
   changelogEntry:
     - summary: |


### PR DESCRIPTION
## Summary

Use the generated property name when reading multipart file values while preserving the wire name for the form-data field.

This fixes inline file properties whose generated TypeScript property name differs from their wire name.

## Testing

- Added multipart property-name coverage
- TypeScript SDK generator tests pass
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/17160" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->