### PR TITLE
feat(typescript): generate SDKs across worker shards

### DIFF
--- a/generators/typescript/sdk/cli/package.json
+++ b/generators/typescript/sdk/cli/package.json
@@ -27,6 +27,8 @@
     "compile:debug": "tsc --sourceMap",
     "depcheck": "knip --config ../../../../knip.json --no-config-hints",
     "dist:cli": "node build.mjs",
+    "test": "vitest --run",
+    "test:debug": "pnpm run test --inspect --no-file-parallelism",
     "dockerTagLatest": "docker build -f ./Dockerfile -t fernapi/fern-typescript-node-sdk:latest -t fernapi/fern-typescript-sdk:latest ../../../..",
     "podmanTagLatest": "podman build -f ./Dockerfile -t fernapi/fern-typescript-node-sdk:latest -t fernapi/fern-typescript-sdk:latest ../../../.."
   },
@@ -45,6 +47,8 @@
     "@fern-typescript/contexts": "workspace:*",
     "@fern-typescript/sdk-generator": "workspace:*",
     "@types/node": "catalog:",
-    "typescript": "catalog:"
+    "ts-morph": "catalog:",
+    "typescript": "catalog:",
+    "vitest": "catalog:"
   }
 }

--- a/generators/typescript/sdk/cli/src/SdkGeneratorCli.ts
+++ b/generators/typescript/sdk/cli/src/SdkGeneratorCli.ts
@@ -15,7 +15,7 @@ import {
     writeTemplateFiles
 } from "@fern-typescript/commons";
 import { GeneratorContext } from "@fern-typescript/contexts";
-import { SdkGenerator } from "@fern-typescript/sdk-generator";
+import { GenerationShard, SdkGenerator } from "@fern-typescript/sdk-generator";
 import { copyFile } from "fs/promises";
 import path from "path";
 import { SdkCustomConfig } from "./custom-config/SdkCustomConfig.js";
@@ -23,15 +23,18 @@ import { SdkCustomConfigSchema } from "./custom-config/schema/SdkCustomConfigSch
 export declare namespace SdkGeneratorCli {
     export interface Init {
         configOverrides?: Partial<SdkCustomConfig>;
+        generationShard?: GenerationShard;
     }
 }
 
 export class SdkGeneratorCli extends AbstractGeneratorCli<SdkCustomConfig> {
     private configOverrides: Partial<SdkCustomConfig>;
+    private generationShard: GenerationShard | undefined;
 
-    constructor({ configOverrides }: SdkGeneratorCli.Init = {}) {
+    constructor({ configOverrides, generationShard }: SdkGeneratorCli.Init = {}) {
         super();
         this.configOverrides = configOverrides ?? {};
+        this.generationShard = generationShard;
     }
 
     protected parseCustomConfig(customConfig: unknown, logger: Logger): SdkCustomConfig {
@@ -274,7 +277,8 @@ export class SdkGeneratorCli extends AbstractGeneratorCli<SdkCustomConfig> {
                 maxRetries: customConfig.maxRetries,
                 alwaysSendAuth: customConfig.alwaysSendAuth,
                 generateReactQueryHooks: customConfig.generateReactQueryHooks
-            }
+            },
+            generationShard: this.generationShard
         });
         const typescriptProject = await sdkGenerator.generate();
         const persistedTypescriptProject = await typescriptProject.persist();
@@ -346,7 +350,7 @@ export class SdkGeneratorCli extends AbstractGeneratorCli<SdkCustomConfig> {
         _customConfig: SdkCustomConfig
     ): Promise<void> {
         const customConfig = this.customConfigWithOverrides(_customConfig);
-        if (customConfig.useLegacyExports === false) {
+        if (customConfig.useLegacyExports === false && (this.generationShard?.count ?? 1) <= 1) {
             await fixImportsForEsm(persistedTypescriptProject.getRootDirectory());
         }
         if (customConfig.testFramework === "vitest") {

--- a/generators/typescript/sdk/cli/src/cli.ts
+++ b/generators/typescript/sdk/cli/src/cli.ts
@@ -1,3 +1,43 @@
 import { SdkGeneratorCli } from "./SdkGeneratorCli.js";
+import { mergeShardOutputs } from "./sharding/mergeShardOutputs.js";
+import { runShardedGeneration } from "./sharding/runShardedGeneration.js";
 
-void new SdkGeneratorCli().runCli();
+async function main(): Promise<void> {
+    if (process.argv[2] === "--internal-sharded-generation") {
+        const [configPath, countValue, heapValue] = process.argv.slice(3);
+        if (configPath == null || countValue == null) {
+            throw new Error("--internal-sharded-generation requires a config path and shard count");
+        }
+        await runShardedGeneration({
+            configPath,
+            shardCount: Number(countValue),
+            maxOldSpaceSizeMb: heapValue == null ? undefined : Number(heapValue)
+        });
+    } else if (process.argv[2] === "--internal-shard-worker") {
+        const [configPath, countValue, indexValue] = process.argv.slice(3);
+        if (configPath == null || countValue == null || indexValue == null) {
+            throw new Error("--internal-shard-worker requires a config path, shard count, and shard index");
+        }
+        await new SdkGeneratorCli({ generationShard: { count: Number(countValue), index: Number(indexValue) } }).run(
+            configPath,
+            {
+                disableNotifications: true,
+                unzipOutput: true
+            }
+        );
+    } else if (process.argv[2] === "--internal-merge-shards") {
+        const [outputDirectory, ...shardDirectories] = process.argv.slice(3);
+        if (outputDirectory == null || shardDirectories.length === 0) {
+            throw new Error("--internal-merge-shards requires an output directory and at least one shard directory");
+        }
+        await mergeShardOutputs({ outputDirectory, shardDirectories });
+    } else {
+        await new SdkGeneratorCli().runCli();
+    }
+}
+
+void main().catch((error) => {
+    // biome-ignore lint/suspicious/noConsole: report fatal CLI errors
+    console.error(error);
+    process.exitCode = 1;
+});

--- a/generators/typescript/sdk/cli/src/sharding/__test__/mergeShardOutputs.test.ts
+++ b/generators/typescript/sdk/cli/src/sharding/__test__/mergeShardOutputs.test.ts
@@ -1,0 +1,230 @@
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { mergeShardOutputs } from "../mergeShardOutputs.js";
+
+const temporaryDirectories: string[] = [];
+
+afterEach(async () => {
+    await Promise.all(
+        temporaryDirectories.splice(0).map((directory) => rm(directory, { recursive: true, force: true }))
+    );
+});
+
+describe("mergeShardOutputs", () => {
+    it("merges distributed aggregate barrels and fixes ESM imports", async () => {
+        const { output, shards, write } = await createFixture();
+        for (const shard of shards) {
+            await write(shard, "api/resources/index.ts", "");
+        }
+        await write(shards[0], "api/index.ts", 'export * from "./errors/index";\n');
+        await write(shards[1], "api/index.ts", 'export * from "./types/index";\n');
+        await write(shards[0], "api/errors/index.ts", "");
+        await write(shards[0], "api/types/index.ts", 'export * from "./Account";\n');
+        await write(shards[1], "api/types/index.ts", 'export * from "./Zone";\n');
+        await write(shards[0], "api/types/Account.ts", "export interface Account {}\n");
+        await write(shards[1], "api/types/Zone.ts", "export interface Zone {}\n");
+        await write(
+            shards[0],
+            "Client.ts",
+            'export { Account } from "./api/types/Account";\nimport "./api/errors";\nexport const account = import("./api/types/Account.ts");\n'
+        );
+
+        const result = await mergeShardOutputs({
+            outputDirectory: output,
+            shardDirectories: shards
+        });
+
+        expect(result.fileCount).toBe(7);
+        await expect(readFile(join(output, "api/index.ts"), "utf8")).resolves.toBe(
+            'export * from "./errors/index.js";\nexport * from "./types/index.js";\n'
+        );
+        await expect(readFile(join(output, "api/types/index.ts"), "utf8")).resolves.toBe(
+            'export * from "./Account.js";\nexport * from "./Zone.js";\n'
+        );
+        await expect(readFile(join(output, "Client.ts"), "utf8")).resolves.toBe(
+            'export { Account } from "./api/types/Account.js";\nimport "./api/errors/index.js";\nexport const account = import("./api/types/Account.js");\n'
+        );
+        await expect(readFile(join(shards[0], "Client.ts"), "utf8")).resolves.toBe(
+            'export { Account } from "./api/types/Account";\nimport "./api/errors";\nexport const account = import("./api/types/Account.ts");\n'
+        );
+    });
+
+    it("rejects case-only path collisions", async () => {
+        const { output, shards, write } = await createFixture();
+        await write(shards[0], "api/resources/oAuthClients/exports.ts", "");
+        await write(shards[1], "api/resources/oauthClients/exports.ts", "");
+
+        await expect(mergeShardOutputs({ outputDirectory: output, shardDirectories: shards })).rejects.toThrow(
+            "Case-only shard path collision"
+        );
+    });
+
+    it("rejects conflicting non-aggregate files", async () => {
+        const { output, shards, write } = await createFixture();
+        await write(shards[0], "Client.ts", "export const shard = 0;\n");
+        await write(shards[1], "Client.ts", "export const shard = 1;\n");
+
+        await expect(mergeShardOutputs({ outputDirectory: output, shardDirectories: shards })).rejects.toThrow(
+            "Conflicting shard file: Client.ts"
+        );
+    });
+
+    it("rejects conflicting nested core implementation barrels", async () => {
+        const { output, shards, write } = await createFixture();
+        await write(shards[0], "core/logging/exports.ts", "export const shard = 0;\n");
+        await write(shards[1], "core/logging/exports.ts", "export const shard = 1;\n");
+
+        await expect(mergeShardOutputs({ outputDirectory: output, shardDirectories: shards })).rejects.toThrow(
+            "Conflicting shard file: core/logging/exports.ts"
+        );
+    });
+
+    it("merges top-level core aggregate barrels", async () => {
+        const { output, shards, write } = await createFixture();
+        await write(shards[0], "core/exports.ts", 'export * from "./auth/index.js";\n');
+        await write(shards[1], "core/exports.ts", 'export * from "./logging/index.js";\n');
+        await write(shards[0], "core/auth/index.ts", "");
+        await write(shards[1], "core/logging/index.ts", "");
+
+        await mergeShardOutputs({ outputDirectory: output, shardDirectories: shards });
+
+        await expect(readFile(join(output, "core/exports.ts"), "utf8")).resolves.toBe(
+            'export * from "./auth/index.js";\nexport * from "./logging/index.js";\n'
+        );
+    });
+
+    it("accepts byte-identical shared files", async () => {
+        const { output, shards, write } = await createFixture();
+        await write(shards[0], "package.json", '{"name":"example"}\n');
+        await write(shards[1], "package.json", '{"name":"example"}\n');
+
+        await expect(mergeShardOutputs({ outputDirectory: output, shardDirectories: shards })).resolves.toEqual({
+            fileCount: 1
+        });
+    });
+
+    it("produces deterministic aggregate ordering regardless of shard order", async () => {
+        const { output, shards, write } = await createFixture();
+        await write(shards[0], "api/resources/index.ts", 'export * as zones from "./zones/index.js";\n');
+        await write(shards[1], "api/resources/index.ts", 'export * as accounts from "./accounts/index.js";\n');
+        await write(shards[0], "api/resources/zones/index.ts", "");
+        await write(shards[1], "api/resources/accounts/index.ts", "");
+
+        await mergeShardOutputs({
+            outputDirectory: output,
+            shardDirectories: [...shards].reverse()
+        });
+
+        await expect(readFile(join(output, "api/resources/index.ts"), "utf8")).resolves.toBe(
+            'export * as accounts from "./accounts/index.js";\nexport * as zones from "./zones/index.js";\n'
+        );
+    });
+
+    it("does not rewrite import-like text in strings or comments", async () => {
+        const { output, shards, write } = await createFixture();
+        const source = 'const example = \'import "./Missing"\';\n// export * from "./Missing";\n';
+        await write(shards[0], "example.ts", source);
+
+        await mergeShardOutputs({
+            outputDirectory: output,
+            shardDirectories: shards
+        });
+
+        await expect(readFile(join(output, "example.ts"), "utf8")).resolves.toBe(source);
+    });
+
+    it("rejects declarations in distributed barrels", async () => {
+        const { output, shards, write } = await createFixture();
+        await write(shards[0], "api/types/index.ts", "export const shard = 0;\n");
+        await write(shards[1], "api/types/index.ts", "export const shard = 1;\n");
+
+        await expect(mergeShardOutputs({ outputDirectory: output, shardDirectories: shards })).rejects.toThrow(
+            "Non-export content in shard barrel"
+        );
+    });
+
+    it("validates and normalizes a barrel from one shard", async () => {
+        const { output, shards, write } = await createFixture();
+        await write(shards[0], "api/types/index.ts", 'export * from "./Account";\r\n\r\n');
+        await write(shards[0], "api/types/Account.ts", "export interface Account {}\n");
+
+        await mergeShardOutputs({ outputDirectory: output, shardDirectories: shards });
+
+        await expect(readFile(join(output, "api/types/index.ts"), "utf8")).resolves.toBe(
+            'export * from "./Account.js";\n'
+        );
+    });
+
+    it("rejects declarations in byte-identical barrels", async () => {
+        const { output, shards, write } = await createFixture();
+        for (const shard of shards) {
+            await write(shard, "api/types/index.ts", "export const invalid = true;\n");
+        }
+
+        await expect(mergeShardOutputs({ outputDirectory: output, shardDirectories: shards })).rejects.toThrow(
+            "Non-export content in shard barrel"
+        );
+    });
+
+    it("rejects declarations in a resource barrel from one shard", async () => {
+        const { output, shards, write } = await createFixture();
+        await write(shards[0], "api/resources/index.ts", "export const invalid = true;\n");
+
+        await expect(mergeShardOutputs({ outputDirectory: output, shardDirectories: shards })).rejects.toThrow(
+            "Non-export content in shard barrel"
+        );
+    });
+
+    it("rejects unresolved relative imports", async () => {
+        const { output, shards, write } = await createFixture();
+        await write(shards[0], "Client.ts", 'export { Missing } from "./Missing.js";\n');
+
+        await expect(mergeShardOutputs({ outputDirectory: output, shardDirectories: shards })).rejects.toThrow(
+            /Unresolved Fern ESM specifiers.*Client\.ts: \.\/Missing\.js/s
+        );
+    });
+
+    it("preserves existing output when merge validation fails", async () => {
+        const { output, shards, write } = await createFixture();
+        await mkdir(output, { recursive: true });
+        await writeFile(join(output, "existing.txt"), "previous output\n");
+        await write(shards[0], "Client.ts", "export const shard = 0;\n");
+        await write(shards[1], "Client.ts", "export const shard = 1;\n");
+
+        await expect(mergeShardOutputs({ outputDirectory: output, shardDirectories: shards })).rejects.toThrow();
+        await expect(readFile(join(output, "existing.txt"), "utf8")).resolves.toBe("previous output\n");
+    });
+
+    it("rejects overlapping output and shard paths", async () => {
+        const { shards } = await createFixture();
+
+        await expect(
+            mergeShardOutputs({
+                outputDirectory: join(shards[0], "output"),
+                shardDirectories: shards
+            })
+        ).rejects.toThrow("must not overlap");
+    });
+});
+
+async function createFixture(): Promise<{
+    output: string;
+    shards: [string, string];
+    write: (shard: string, path: string, content: string) => Promise<void>;
+}> {
+    const root = await mkdtemp(join(tmpdir(), "fern-shards-"));
+    temporaryDirectories.push(root);
+    const shards: [string, string] = [join(root, "shard-0"), join(root, "shard-1")];
+    await Promise.all(shards.map((shard) => mkdir(shard, { recursive: true })));
+    return {
+        output: join(root, "output"),
+        shards,
+        write: async (shard, path, content) => {
+            const destination = join(shard, path);
+            await mkdir(dirname(destination), { recursive: true });
+            await writeFile(destination, content);
+        }
+    };
+}

--- a/generators/typescript/sdk/cli/src/sharding/__test__/shardedGeneration.test.ts
+++ b/generators/typescript/sdk/cli/src/sharding/__test__/shardedGeneration.test.ts
@@ -1,0 +1,153 @@
+import { mkdir, mkdtemp, readdir, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { dirname, join, relative, resolve, sep } from "node:path";
+import { AsIsManager, CoreUtilitiesManager } from "@fern-typescript/commons";
+import { afterEach, describe, expect, it } from "vitest";
+import { SdkGeneratorCli } from "../../SdkGeneratorCli.js";
+import { mergeShardOutputs } from "../mergeShardOutputs.js";
+import { runShardedGeneration } from "../runShardedGeneration.js";
+
+const temporaryDirectories: string[] = [];
+
+afterEach(async () => {
+    await Promise.all(
+        temporaryDirectories.splice(0).map((directory) => rm(directory, { recursive: true, force: true }))
+    );
+});
+
+describe("sharded generation", () => {
+    it.each([false, "true"])("rejects non-source output configuration %j", async (outputSourceFiles) => {
+        const root = await mkdtemp(join(tmpdir(), "fern-sharded-generation-"));
+        temporaryDirectories.push(root);
+        const configPath = await writeConfig(root, "invalid", "unused-ir.json", join(root, "output"), {
+            outputSourceFiles,
+            outputSrcOnly: false
+        });
+
+        await expect(runShardedGeneration({ configPath, shardCount: 2 })).rejects.toThrow(
+            "Sharded generation requires source output"
+        );
+    });
+
+    it("matches unsharded source output", async () => {
+        const addToTsProject = AsIsManager.prototype.addToTsProject;
+        const copyCoreUtilities = CoreUtilitiesManager.prototype.copyCoreUtilities;
+        AsIsManager.prototype.addToTsProject = async ({ project }) => {
+            for (const path of ["/src/core/headers.ts", "/src/core/requestBody.ts", "/src/core/json.ts"]) {
+                project.createSourceFile(path, "export {};\n", { overwrite: true });
+            }
+        };
+        CoreUtilitiesManager.prototype.copyCoreUtilities = async ({ pathToSrc }) => {
+            for (const path of [
+                "auth/index.ts",
+                "base64.ts",
+                "fetcher/index.ts",
+                "logging/index.ts",
+                "runtime/index.ts",
+                "url/index.ts"
+            ]) {
+                const destination = join(pathToSrc, "core", path);
+                await mkdir(dirname(destination), { recursive: true });
+                await writeFile(destination, "export {};\n");
+            }
+        };
+        const root = await mkdtemp(join(tmpdir(), "fern-sharded-generation-"));
+        temporaryDirectories.push(root);
+        const irFilepath = resolve(
+            import.meta.dirname,
+            "../../../../../../../packages/commons/mock-utils/test/fixtures/imdb/ir.json"
+        );
+        const unshardedOutput = join(root, "unsharded");
+        const mergedOutput = join(root, "merged");
+        const unshardedConfig = await writeConfig(root, "unsharded", irFilepath, unshardedOutput);
+
+        try {
+            await new SdkGeneratorCli().run(unshardedConfig, {
+                disableNotifications: true,
+                unzipOutput: true
+            });
+
+            const shardDirectories = await Promise.all(
+                [0, 1].map(async (index) => {
+                    const output = join(root, "shards", String(index));
+                    const config = await writeConfig(root, `shard-${index}`, irFilepath, output);
+                    await new SdkGeneratorCli({ generationShard: { count: 2, index } }).run(config, {
+                        disableNotifications: true,
+                        unzipOutput: true
+                    });
+                    return output;
+                })
+            );
+
+            await mergeShardOutputs({ outputDirectory: mergedOutput, shardDirectories });
+
+            expect(normalizeAggregateOrder(await readTree(mergedOutput))).toEqual(
+                normalizeAggregateOrder(await readTree(unshardedOutput))
+            );
+        } finally {
+            AsIsManager.prototype.addToTsProject = addToTsProject;
+            CoreUtilitiesManager.prototype.copyCoreUtilities = copyCoreUtilities;
+        }
+    }, 60_000);
+});
+
+async function writeConfig(
+    root: string,
+    name: string,
+    irFilepath: string,
+    outputPath: string,
+    customConfig: Record<string, unknown> = {
+        outputSrcOnly: true,
+        noScripts: true,
+        formatter: "none",
+        linter: "none",
+        writeUnitTests: false,
+        generateWireTests: false
+    }
+): Promise<string> {
+    const directory = join(root, "configs", name);
+    const configPath = join(directory, "config.json");
+    await mkdir(directory, { recursive: true });
+    await writeFile(
+        configPath,
+        JSON.stringify({
+            irFilepath,
+            output: { mode: { type: "downloadFiles" }, path: outputPath },
+            customConfig,
+            workspaceName: "imdb",
+            organization: "fern",
+            environment: { _type: "local" },
+            dryRun: false,
+            whitelabel: false,
+            writeUnitTests: false,
+            generateOauthClients: false
+        })
+    );
+    return configPath;
+}
+
+async function readTree(root: string, current = root): Promise<Record<string, string>> {
+    const files: Record<string, string> = {};
+    const entries = await readdir(current, { withFileTypes: true });
+    entries.sort((left, right) => left.name.localeCompare(right.name));
+    for (const entry of entries) {
+        const path = join(current, entry.name);
+        if (entry.isDirectory()) {
+            Object.assign(files, await readTree(root, path));
+        } else if (entry.isFile()) {
+            files[relative(root, path).split(sep).join("/")] = await readFile(path, "utf8");
+        }
+    }
+    return files;
+}
+
+function normalizeAggregateOrder(files: Record<string, string>): Record<string, string> {
+    return Object.fromEntries(
+        Object.entries(files).map(([path, source]) => [
+            path,
+            /(?:^|\/)(?:index|exports)\.ts$/.test(path)
+                ? `${source.replaceAll("\r\n", "\n").trim().split("\n").filter(Boolean).sort().join("\n")}\n`
+                : source
+        ])
+    );
+}

--- a/generators/typescript/sdk/cli/src/sharding/mergeShardOutputs.ts
+++ b/generators/typescript/sdk/cli/src/sharding/mergeShardOutputs.ts
@@ -1,0 +1,386 @@
+import { copyFile, mkdir, mkdtemp, readdir, readFile, realpath, rename, rm, writeFile } from "node:fs/promises";
+import { basename, dirname, isAbsolute, join, parse, relative, resolve, sep } from "node:path";
+import { ts } from "ts-morph";
+
+const FILE_CONCURRENCY = 64;
+const RESOURCE_INDEX_PATH = "api/resources/index.ts";
+const RE_EXPORT =
+    /^(?:export \{\};|export (?:type \{[^}]+\}|\{[^}]+\}|\*|\* as [A-Za-z_$][\w$]*) from ["']\.\.?\/[^"']+["'];)$/;
+
+interface FileEntry {
+    absolutePath: string;
+    relativePath: string;
+}
+
+export interface MergeShardOutputsArgs {
+    outputDirectory: string;
+    shardDirectories: readonly string[];
+}
+
+export interface MergeShardOutputsResult {
+    fileCount: number;
+}
+
+export async function mergeShardOutputs({
+    outputDirectory,
+    shardDirectories
+}: MergeShardOutputsArgs): Promise<MergeShardOutputsResult> {
+    if (shardDirectories.length === 0) {
+        throw new Error("At least one shard directory is required");
+    }
+
+    const resolvedOutput = await canonicalizePath(outputDirectory);
+    const resolvedShards = await Promise.all(shardDirectories.map((directory) => realpath(resolve(directory))));
+    validatePaths(resolvedOutput, resolvedShards);
+
+    await mkdir(dirname(resolvedOutput), { recursive: true });
+    const stagingDirectory = await mkdtemp(join(dirname(resolvedOutput), `.${basename(resolvedOutput)}-merge-`));
+    try {
+        const result = await mergeIntoDirectory(stagingDirectory, resolvedShards);
+        await replaceDirectory({ stagingDirectory, outputDirectory: resolvedOutput });
+        return result;
+    } catch (error) {
+        await rm(stagingDirectory, { recursive: true, force: true });
+        throw error;
+    }
+}
+
+async function mergeIntoDirectory(
+    outputDirectory: string,
+    shardDirectories: readonly string[]
+): Promise<MergeShardOutputsResult> {
+    const seen = new Set<string>();
+    const caseInsensitivePaths = new Map<string, string>();
+    const aggregateVariants = new Map<string, string[]>();
+
+    await mapConcurrent([outputDirectory], (directory) => mkdir(directory, { recursive: true }));
+
+    for (const shardDirectory of shardDirectories) {
+        const files = await filesUnder(shardDirectory);
+        const directories = new Set<string>();
+        const tasks = files.map(({ absolutePath, relativePath }) => {
+            const normalizedPath = relativePath.toLowerCase();
+            const previousPath = caseInsensitivePaths.get(normalizedPath);
+            if (previousPath != null && previousPath !== relativePath) {
+                throw new Error(`Case-only shard path collision: ${previousPath} and ${relativePath}`);
+            }
+            caseInsensitivePaths.set(normalizedPath, relativePath);
+
+            const previous = seen.has(relativePath);
+            if (!previous) {
+                seen.add(relativePath);
+                directories.add(dirname(join(outputDirectory, relativePath)));
+            }
+            return { absolutePath, relativePath, previous, aggregate: isAggregatePath(relativePath) };
+        });
+
+        await mapConcurrent([...directories], (directory) => mkdir(directory, { recursive: true }));
+        const sources = await mapConcurrent(tasks, async ({ absolutePath, relativePath, previous, aggregate }) => {
+            const source = aggregate ? await readFile(absolutePath, "utf8") : undefined;
+            const destination = join(outputDirectory, relativePath);
+            if (!previous) {
+                await copyFile(absolutePath, destination);
+            } else if (!aggregate) {
+                const [current, existing] = await Promise.all([readFile(absolutePath), readFile(destination)]);
+                if (!current.equals(existing)) {
+                    throw new Error(`Conflicting shard file: ${relativePath}`);
+                }
+            }
+            return source;
+        });
+
+        for (let index = 0; index < tasks.length; index++) {
+            const source = sources[index];
+            if (source == null) {
+                continue;
+            }
+            const relativePath = tasks[index]?.relativePath;
+            if (relativePath == null) {
+                continue;
+            }
+            const variants = aggregateVariants.get(relativePath) ?? [];
+            variants.push(source);
+            aggregateVariants.set(relativePath, variants);
+        }
+    }
+
+    await rebuildAggregateFiles(outputDirectory, aggregateVariants);
+    await fixAndValidateRelativeSpecifiers(outputDirectory);
+
+    return { fileCount: seen.size };
+}
+
+async function rebuildAggregateFiles(outputDirectory: string, aggregateVariants: Map<string, string[]>): Promise<void> {
+    const resourceVariants = aggregateVariants.get(RESOURCE_INDEX_PATH);
+    if (resourceVariants != null) {
+        const resources = new Map<string, Set<string>>();
+        for (const source of resourceVariants) {
+            for (const line of aggregateLines(RESOURCE_INDEX_PATH, source)) {
+                const resource = line.match(/from\s+["']\.\/([^/"']+)/)?.[1];
+                if (resource == null) {
+                    throw new Error(`Invalid resource export: ${line}`);
+                }
+                const lines = resources.get(resource) ?? new Set<string>();
+                lines.add(line);
+                resources.set(resource, lines);
+            }
+        }
+        const resourceLines: string[] = [];
+        for (const resource of [...resources.keys()].sort(compareStrings)) {
+            resourceLines.push(
+                ...[...(resources.get(resource) ?? [])].sort(
+                    (a, b) => rankResourceExport(a) - rankResourceExport(b) || compareStrings(a, b)
+                )
+            );
+        }
+        await writeFile(join(outputDirectory, RESOURCE_INDEX_PATH), `${resourceLines.join("\n")}\n`);
+    }
+
+    for (const [aggregatePath, variants] of aggregateVariants) {
+        if (aggregatePath === RESOURCE_INDEX_PATH) {
+            continue;
+        }
+        const lines = new Set<string>();
+        for (const source of variants) {
+            for (const line of aggregateLines(aggregatePath, source)) {
+                lines.add(line);
+            }
+        }
+        await writeFile(join(outputDirectory, aggregatePath), `${[...lines].sort(compareStrings).join("\n")}\n`);
+    }
+}
+
+async function fixAndValidateRelativeSpecifiers(outputDirectory: string): Promise<void> {
+    const files = await filesUnder(outputDirectory);
+    const filePaths = new Set(files.map(({ absolutePath }) => absolutePath));
+    const unresolvedByFile = await mapConcurrent(
+        files.filter(({ relativePath }) => relativePath.endsWith(".ts")),
+        async ({ absolutePath, relativePath }) => {
+            const source = await readFile(absolutePath, "utf8");
+            if (!source.includes('".') && !source.includes("'.")) {
+                return [];
+            }
+
+            const sourceFile = ts.createSourceFile(
+                absolutePath,
+                source,
+                ts.ScriptTarget.Latest,
+                false,
+                ts.ScriptKind.TS
+            );
+            const replacements: Array<{ start: number; end: number; value: string }> = [];
+            const unresolved: string[] = [];
+            const visit = (node: ts.Node): void => {
+                const specifier = getModuleSpecifier(node);
+                if (specifier != null && specifier.text.startsWith(".")) {
+                    const replacement = resolveRelativeSpecifier(absolutePath, specifier.text, filePaths);
+                    if (replacement == null) {
+                        unresolved.push(`${relativePath}: ${specifier.text}`);
+                    } else if (replacement !== specifier.text) {
+                        replacements.push({
+                            start: specifier.getStart(sourceFile) + 1,
+                            end: specifier.getEnd() - 1,
+                            value: replacement
+                        });
+                    }
+                }
+                ts.forEachChild(node, visit);
+            };
+            visit(sourceFile);
+
+            if (replacements.length > 0) {
+                let rewritten = source;
+                for (const replacement of replacements.sort((left, right) => right.start - left.start)) {
+                    rewritten =
+                        rewritten.slice(0, replacement.start) + replacement.value + rewritten.slice(replacement.end);
+                }
+                await writeFile(absolutePath, rewritten);
+            }
+            return unresolved;
+        }
+    );
+    const unresolvedSpecifiers = unresolvedByFile.flat().sort(compareStrings);
+    if (unresolvedSpecifiers.length > 0) {
+        throw new Error(
+            `Unresolved Fern ESM specifiers (showing up to 20):\n${unresolvedSpecifiers.slice(0, 20).join("\n")}`
+        );
+    }
+}
+
+function getModuleSpecifier(node: ts.Node): ts.StringLiteral | undefined {
+    if (
+        (ts.isImportDeclaration(node) || ts.isExportDeclaration(node)) &&
+        node.moduleSpecifier != null &&
+        ts.isStringLiteral(node.moduleSpecifier)
+    ) {
+        return node.moduleSpecifier;
+    }
+    if (ts.isCallExpression(node) && node.expression.kind === ts.SyntaxKind.ImportKeyword) {
+        const argument = node.arguments[0];
+        return argument != null && ts.isStringLiteral(argument) ? argument : undefined;
+    }
+    return undefined;
+}
+
+function resolveRelativeSpecifier(sourceFile: string, specifier: string, filePaths: Set<string>): string | undefined {
+    const target = resolve(dirname(sourceFile), specifier);
+    if (specifier.endsWith(".js")) {
+        return filePaths.has(target) || filePaths.has(`${target.slice(0, -3)}.ts`) ? specifier : undefined;
+    }
+    if (/\.(?:json|node)$/.test(specifier)) {
+        return filePaths.has(target) ? specifier : undefined;
+    }
+    if (specifier.endsWith(".ts")) {
+        return filePaths.has(target) ? `${specifier.slice(0, -3)}.js` : undefined;
+    }
+    if (filePaths.has(`${target}.ts`)) {
+        return `${specifier}.js`;
+    }
+    if (filePaths.has(join(target, "index.ts"))) {
+        return `${specifier}/index.js`;
+    }
+    return undefined;
+}
+
+async function filesUnder(root: string, current = root): Promise<FileEntry[]> {
+    const files: FileEntry[] = [];
+    const entries = await readdir(current, { withFileTypes: true });
+    entries.sort((a, b) => compareStrings(a.name, b.name));
+    for (const entry of entries) {
+        const absolutePath = join(current, entry.name);
+        if (entry.isDirectory()) {
+            files.push(...(await filesUnder(root, absolutePath)));
+        } else if (entry.isFile()) {
+            files.push({ absolutePath, relativePath: relative(root, absolutePath).split(sep).join("/") });
+        } else {
+            throw new Error(`Unsupported shard entry: ${absolutePath}`);
+        }
+    }
+    return files;
+}
+
+async function mapConcurrent<Input, Output>(
+    items: readonly Input[],
+    callback: (item: Input) => Promise<Output>
+): Promise<Output[]> {
+    const results = new Array<Output>(items.length);
+    let next = 0;
+    const workers = Array.from({ length: Math.min(FILE_CONCURRENCY, items.length) }, async () => {
+        while (next < items.length) {
+            const index = next++;
+            const item = items[index];
+            if (item != null) {
+                results[index] = await callback(item);
+            }
+        }
+    });
+    await Promise.all(workers);
+    return results;
+}
+
+function isAggregatePath(path: string): boolean {
+    const normalized = path.replace(/\\/g, "/").replace(/^src\//, "");
+    if (normalized.startsWith("core/")) {
+        return normalized === "core/index.ts" || normalized === "core/exports.ts";
+    }
+    return /(?:^|\/)(?:index|exports)\.ts$/.test(normalized);
+}
+
+function aggregateLines(path: string, source: string): string[] {
+    return source
+        .replaceAll("\r\n", "\n")
+        .trim()
+        .split("\n")
+        .filter(Boolean)
+        .map((line) => {
+            if (line.trimStart().startsWith("//") || RE_EXPORT.test(line)) {
+                return line;
+            }
+            throw new Error(`Non-export content in shard barrel ${path}: ${line}`);
+        });
+}
+
+function validatePaths(outputDirectory: string, shardDirectories: readonly string[]): void {
+    if (outputDirectory === parse(outputDirectory).root) {
+        throw new Error("Shard output cannot be a filesystem root");
+    }
+    for (const shardDirectory of shardDirectories) {
+        if (pathsOverlap(outputDirectory, shardDirectory)) {
+            throw new Error(
+                `Fern shard output and input directories must not overlap: ${outputDirectory}, ${shardDirectory}`
+            );
+        }
+    }
+}
+
+async function canonicalizePath(path: string): Promise<string> {
+    const resolvedPath = resolve(path);
+    try {
+        return await realpath(resolvedPath);
+    } catch (error) {
+        if ((error as NodeJS.ErrnoException).code !== "ENOENT") {
+            throw error;
+        }
+        const parent = dirname(resolvedPath);
+        if (parent === resolvedPath) {
+            throw error;
+        }
+        return join(await canonicalizePath(parent), basename(resolvedPath));
+    }
+}
+
+function pathsOverlap(left: string, right: string): boolean {
+    return left === right || isWithin(left, right) || isWithin(right, left);
+}
+
+function isWithin(parent: string, child: string): boolean {
+    const path = relative(parent, child);
+    return path !== "" && !path.startsWith(`..${sep}`) && path !== ".." && !isAbsolute(path);
+}
+
+async function replaceDirectory({
+    stagingDirectory,
+    outputDirectory
+}: {
+    stagingDirectory: string;
+    outputDirectory: string;
+}): Promise<void> {
+    const backupDirectory = `${outputDirectory}.backup-${process.pid}-${Date.now()}`;
+    let hasBackup = false;
+    try {
+        await rename(outputDirectory, backupDirectory);
+        hasBackup = true;
+    } catch (error) {
+        if ((error as NodeJS.ErrnoException).code !== "ENOENT") {
+            throw error;
+        }
+    }
+    try {
+        await rename(stagingDirectory, outputDirectory);
+        if (hasBackup) {
+            await rm(backupDirectory, { recursive: true, force: true }).catch(() => undefined);
+        }
+    } catch (error) {
+        if (hasBackup) {
+            await rename(backupDirectory, outputDirectory);
+        }
+        throw error;
+    }
+}
+
+function compareStrings(left: string, right: string): number {
+    return left < right ? -1 : left > right ? 1 : 0;
+}
+
+function rankResourceExport(line: string): number {
+    if (line.startsWith("export * as ")) {
+        return 0;
+    }
+    if (line.includes("/client/requests")) {
+        return 1;
+    }
+    if (line.includes("/types")) {
+        return 2;
+    }
+    return 3;
+}

--- a/generators/typescript/sdk/cli/src/sharding/runShardedGeneration.ts
+++ b/generators/typescript/sdk/cli/src/sharding/runShardedGeneration.ts
@@ -1,0 +1,154 @@
+import { spawn } from "node:child_process";
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { parseGeneratorConfig } from "@fern-api/base-generator";
+import { mergeShardOutputs } from "./mergeShardOutputs.js";
+
+export interface RunShardedGenerationArgs {
+    configPath: string;
+    shardCount: number;
+    maxOldSpaceSizeMb?: number;
+    cliPath?: string;
+}
+
+export async function runShardedGeneration({
+    configPath,
+    shardCount,
+    maxOldSpaceSizeMb,
+    cliPath = process.argv[1]
+}: RunShardedGenerationArgs): Promise<void> {
+    if (!Number.isSafeInteger(shardCount) || shardCount < 1) {
+        throw new Error("Shard count must be a positive integer");
+    }
+    if (maxOldSpaceSizeMb != null && (!Number.isSafeInteger(maxOldSpaceSizeMb) || maxOldSpaceSizeMb < 1)) {
+        throw new Error("Maximum old space size must be a positive integer");
+    }
+    if (cliPath == null) {
+        throw new Error("Unable to determine the generator CLI path");
+    }
+
+    const resolvedConfigPath = resolve(configPath);
+    const config = await parseGeneratorConfig(resolvedConfigPath);
+    if (config.output.mode.type !== "downloadFiles") {
+        throw new Error("Sharded generation requires downloadFiles output");
+    }
+    const customConfig = config.customConfig as { outputSourceFiles?: unknown; outputSrcOnly?: unknown } | undefined;
+    const outputSourceFiles = customConfig?.outputSourceFiles ?? true;
+    const outputSrcOnly = customConfig?.outputSrcOnly ?? false;
+    if (outputSourceFiles !== true && outputSrcOnly !== true) {
+        throw new Error("Sharded generation requires source output");
+    }
+
+    const outputDirectory = resolve(config.output.path);
+    const workDirectory = await mkdtemp(join(tmpdir(), "fern-typescript-shards-"));
+    const controllers = Array.from({ length: shardCount }, () => new AbortController());
+    const abortWorkers = () => {
+        for (const controller of controllers) {
+            controller.abort();
+        }
+    };
+    process.once("SIGINT", abortWorkers);
+    process.once("SIGTERM", abortWorkers);
+    try {
+        const sourceConfig = JSON.parse(await readFile(resolvedConfigPath, "utf8")) as Record<string, unknown>;
+        const shardDirectories = await Promise.all(
+            Array.from({ length: shardCount }, async (_, index) => {
+                const shardDirectory = join(workDirectory, "output", String(index));
+                const workerDirectory = join(workDirectory, "input", String(index));
+                const workerConfigPath = join(workerDirectory, "config.json");
+                await mkdir(workerDirectory, { recursive: true });
+                await writeFile(
+                    workerConfigPath,
+                    JSON.stringify({
+                        ...sourceConfig,
+                        irFilepath: resolve(dirname(resolvedConfigPath), config.irFilepath),
+                        output: { ...(sourceConfig.output as Record<string, unknown>), path: shardDirectory }
+                    })
+                );
+                return { index, shardDirectory, workerConfigPath };
+            })
+        );
+
+        const workers = shardDirectories.map(({ index, workerConfigPath }) =>
+            runWorker({
+                cliPath,
+                configPath: workerConfigPath,
+                shardCount,
+                shardIndex: index,
+                maxOldSpaceSizeMb,
+                signal: controllers[index]?.signal
+            })
+        );
+        try {
+            await Promise.all(workers);
+        } catch (error) {
+            abortWorkers();
+            await Promise.allSettled(workers);
+            throw error;
+        }
+
+        await mergeShardOutputs({
+            outputDirectory,
+            shardDirectories: shardDirectories.map(({ shardDirectory }) => shardDirectory)
+        });
+    } finally {
+        process.removeListener("SIGINT", abortWorkers);
+        process.removeListener("SIGTERM", abortWorkers);
+        await rm(workDirectory, { recursive: true, force: true });
+    }
+}
+
+async function runWorker({
+    cliPath,
+    configPath,
+    shardCount,
+    shardIndex,
+    maxOldSpaceSizeMb,
+    signal
+}: {
+    cliPath: string;
+    configPath: string;
+    shardCount: number;
+    shardIndex: number;
+    maxOldSpaceSizeMb: number | undefined;
+    signal: AbortSignal | undefined;
+}): Promise<void> {
+    const nodeOptions = withMaxOldSpaceSize(process.env.NODE_OPTIONS, maxOldSpaceSizeMb);
+    await new Promise<void>((resolvePromise, reject) => {
+        const child = spawn(
+            process.execPath,
+            [
+                "--stack-size=8192",
+                cliPath,
+                "--internal-shard-worker",
+                configPath,
+                String(shardCount),
+                String(shardIndex)
+            ],
+            {
+                env: { ...process.env, NODE_OPTIONS: nodeOptions },
+                stdio: "inherit",
+                signal
+            }
+        );
+        child.once("error", reject);
+        child.once("exit", (code, childSignal) => {
+            if (code === 0) {
+                resolvePromise();
+            } else {
+                reject(new Error(`TypeScript shard ${shardIndex + 1}/${shardCount} failed (${childSignal ?? code})`));
+            }
+        });
+    });
+}
+
+function withMaxOldSpaceSize(
+    nodeOptions: string | undefined,
+    maxOldSpaceSizeMb: number | undefined
+): string | undefined {
+    if (maxOldSpaceSizeMb == null) {
+        return nodeOptions;
+    }
+    return [nodeOptions, `--max-old-space-size=${maxOldSpaceSizeMb}`].filter(Boolean).join(" ");
+}

--- a/generators/typescript/sdk/generator/src/SdkGenerator.ts
+++ b/generators/typescript/sdk/generator/src/SdkGenerator.ts
@@ -65,6 +65,7 @@ import { VersionDeclarationReferencer } from "./declaration-referencers/VersionD
 import { WebhooksHelperDeclarationReferencer } from "./declaration-referencers/WebhooksHelperDeclarationReferencer.js";
 import { WebsocketSocketDeclarationReferencer } from "./declaration-referencers/WebsocketSocketDeclarationReferencer.js";
 import { WebsocketTypeSchemaDeclarationReferencer } from "./declaration-referencers/WebsocketTypeSchemaDeclarationReferencer.js";
+import { GenerationShard, shardOwnsFile, validateGenerationShard } from "./generationShard.js";
 import { NonStatusCodeErrorHandlerGenerator } from "./non-status-code-error-handler/NonStatusCodeErrorHandlerGenerator.js";
 import { ReactQueryGenerator } from "./react-query/ReactQueryGenerator.js";
 import { ReadmeConfigBuilder } from "./readme/ReadmeConfigBuilder.js";
@@ -105,6 +106,7 @@ export declare namespace SdkGenerator {
         generateJestTests: boolean;
         rawConfig: FernGeneratorExec.GeneratorConfig;
         config: Config;
+        generationShard?: GenerationShard;
     }
 
     export interface Config {
@@ -187,6 +189,7 @@ export class SdkGenerator {
     private intermediateRepresentation: FernIr.IntermediateRepresentation;
     private rawConfig: FernGeneratorExec.GeneratorConfig;
     private config: SdkGenerator.Config;
+    private generationShard: GenerationShard;
     private npmPackage: NpmPackage | undefined;
     private generateOAuthClients: boolean;
     private generateJestTests: boolean;
@@ -277,7 +280,8 @@ export class SdkGenerator {
         npmPackage,
         rawConfig,
         config,
-        generateJestTests
+        generateJestTests,
+        generationShard
     }: SdkGenerator.Init) {
         this.rootDirectoryPath = "/";
         this.defaultSrcDirectory = "src";
@@ -300,6 +304,7 @@ export class SdkGenerator {
             config.generateEndpointMetadata = true;
         }
         this.config = config;
+        this.generationShard = validateGenerationShard(generationShard ?? { count: 1, index: 0 });
 
         this.npmPackage = npmPackage;
         this.rawConfig = rawConfig;
@@ -1907,6 +1912,10 @@ export class SdkGenerator {
     }) {
         filepath.rootDir = packagePath;
         const filepathStr = this.exportsManager.convertExportedFilePathToFilePath(filepath);
+        const shard = this.generationShard;
+        if (!shardOwnsFile(filepathStr, shard.count, shard.index)) {
+            return;
+        }
         this.context.logger.debug(`Generating ${filepathStr}`);
 
         const sourceFile = this.rootDirectory.createSourceFile(filepathStr, undefined, { overwrite: true });

--- a/generators/typescript/sdk/generator/src/__test__/generationShard.test.ts
+++ b/generators/typescript/sdk/generator/src/__test__/generationShard.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from "vitest";
+
+import { shardOwnsFile, validateGenerationShard } from "../generationShard.js";
+
+describe("shardOwnsFile", () => {
+    const paths = [
+        "/src/Client.ts",
+        "/src/api/types/Widget.ts",
+        "/src/api/resources/users/types/User.ts",
+        "/src/api/resources/users/client/UsersClient.ts",
+        "/src/api/resources/users/client/requests/GetUserRequest.ts",
+        "/src/serialization/resources/users/types/User.ts"
+    ];
+
+    it("assigns every file to exactly one shard", () => {
+        for (const path of paths) {
+            expect([0, 1, 2].filter((index) => shardOwnsFile(path, 3, index))).toHaveLength(1);
+        }
+    });
+
+    it("keeps resource clients and requests together", () => {
+        const client = "/src/api/resources/users/client/UsersClient.ts";
+        const request = "/src/api/resources/users/client/requests/GetUserRequest.ts";
+        for (let index = 0; index < 3; index++) {
+            expect(shardOwnsFile(client, 3, index)).toBe(shardOwnsFile(request, 3, index));
+        }
+    });
+
+    it("supports custom source directory names", () => {
+        const path = "/generated/api/resources/users/types/User.ts";
+        expect([0, 1, 2].filter((index) => shardOwnsFile(path, 3, index))).toHaveLength(1);
+    });
+
+    it("assigns shared files to shard zero", () => {
+        expect(shardOwnsFile("/src/Client.ts", 3, 0)).toBe(true);
+        expect(shardOwnsFile("/src/Client.ts", 3, 1)).toBe(false);
+    });
+
+    it("does not shard when count is one", () => {
+        expect(shardOwnsFile("/src/Client.ts", 1, 0)).toBe(true);
+    });
+
+    it("validates shard values", () => {
+        expect(validateGenerationShard({ count: 3, index: 1 })).toEqual({ count: 3, index: 1 });
+        expect(() => validateGenerationShard({ count: 0, index: 0 })).toThrow(
+            "Shard count must be a positive integer."
+        );
+        expect(() => validateGenerationShard({ count: 2, index: 2 })).toThrow("Shard index must be in [0, count).");
+        expect(() => validateGenerationShard({ count: 1.5, index: 0 })).toThrow(
+            "Shard count must be a positive integer."
+        );
+        expect(() => validateGenerationShard({ count: 2, index: 1.5 })).toThrow("Shard index must be in [0, count).");
+    });
+});

--- a/generators/typescript/sdk/generator/src/generationShard.ts
+++ b/generators/typescript/sdk/generator/src/generationShard.ts
@@ -1,0 +1,50 @@
+// Shard assignment is a stable protocol: changing this hash reshuffles files across generator versions.
+function hash(value: string): number {
+    let result = 2166136261;
+    for (const character of value) {
+        result ^= character.charCodeAt(0);
+        result = Math.imul(result, 16777619);
+    }
+    return result >>> 0;
+}
+
+export function shardOwnsFile(filepath: string, count: number, index: number): boolean {
+    if (count <= 1) {
+        return true;
+    }
+    if (index < 0 || index >= count) {
+        return false;
+    }
+    const sourcePath = filepath.replace(/^\/[^/]+(?=\/api\/|\/serialization\/)/, "/src");
+    const isApiLeaf =
+        /^\/src\/api\/(?:types|errors)\/[^/]+\.ts$/.test(sourcePath) ||
+        /^\/src\/api\/resources\/.+\/(?:types|errors)\/[^/]+\.ts$/.test(sourcePath);
+    const isSharedApiLeaf = isApiLeaf && !filepath.endsWith("/index.ts") && !filepath.endsWith("/exports.ts");
+    const isSerdeLeaf =
+        /^\/src\/serialization\/.+\.ts$/.test(sourcePath) &&
+        !filepath.endsWith("/index.ts") &&
+        !filepath.endsWith("/exports.ts");
+    if (isSharedApiLeaf || isSerdeLeaf) {
+        return hash(`leaf:${sourcePath}`) % count === index;
+    }
+    const resource = sourcePath.match(/^\/src\/api\/resources\/([^/]+)\//)?.[1];
+    if (resource != null) {
+        return hash(`resource:${resource}`) % count === index;
+    }
+    return index === 0;
+}
+
+export interface GenerationShard {
+    count: number;
+    index: number;
+}
+
+export function validateGenerationShard({ count, index }: GenerationShard): GenerationShard {
+    if (!Number.isSafeInteger(count) || count < 1) {
+        throw new Error("Shard count must be a positive integer.");
+    }
+    if (!Number.isSafeInteger(index) || index < 0 || index >= count) {
+        throw new Error("Shard index must be in [0, count).");
+    }
+    return { count, index };
+}

--- a/generators/typescript/sdk/generator/src/index.ts
+++ b/generators/typescript/sdk/generator/src/index.ts
@@ -1,1 +1,2 @@
+export { type GenerationShard, shardOwnsFile, validateGenerationShard } from "./generationShard.js";
 export { SdkGenerator } from "./SdkGenerator.js";

--- a/generators/typescript/sdk/versions.yml
+++ b/generators/typescript/sdk/versions.yml
@@ -1,4 +1,11 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+- version: 3.83.0
+  changelogEntry:
+    - summary: |
+        Support generating TypeScript SDKs across worker shards and merging their output.
+      type: feat
+  createdAt: "2026-07-21"
+  irVersion: 67
 - version: 3.82.3
   changelogEntry:
     - summary: |

--- a/generators/typescript/utils/abstract-generator-cli/src/AbstractGeneratorCli.ts
+++ b/generators/typescript/utils/abstract-generator-cli/src/AbstractGeneratorCli.ts
@@ -233,6 +233,7 @@ export abstract class AbstractGeneratorCli<CustomConfig> {
                     } else if (!(await typescriptProject.areCheckFixToolsAvailable(logger))) {
                         await typescriptProject.installCheckFixDependencies(logger);
                     }
+
                     await typescriptProject.checkFix(logger);
 
                     if (this.outputSrcOnly(customConfig)) {

--- a/generators/typescript/utils/commons/src/typescript-project/PersistedTypescriptProject.ts
+++ b/generators/typescript/utils/commons/src/typescript-project/PersistedTypescriptProject.ts
@@ -434,6 +434,11 @@ export class PersistedTypescriptProject {
             unzipOutput
         }: { destinationPath: AbsoluteFilePath; zipFilename: string; logger: Logger; unzipOutput?: boolean }
     ) {
+        if (unzipOutput) {
+            await cp(directoryToZip, destinationPath, { recursive: true });
+            return;
+        }
+
         const zip = createLoggingExecutable("zip", {
             cwd: directoryToZip,
             logger,

--- a/generators/typescript/utils/commons/src/typescript-project/__test__/PersistedTypescriptProject.test.ts
+++ b/generators/typescript/utils/commons/src/typescript-project/__test__/PersistedTypescriptProject.test.ts
@@ -1,6 +1,8 @@
 import { AbsoluteFilePath, RelativeFilePath } from "@fern-api/fs-utils";
 import { createLogger } from "@fern-api/logger";
-import { readFile, rm } from "fs/promises";
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { PersistedTypescriptProject } from "../PersistedTypescriptProject.js";
@@ -40,6 +42,32 @@ function collectLogs(): { lines: string[]; logger: ReturnType<typeof createLogge
 describe("PersistedTypescriptProject", () => {
     beforeEach(() => {
         vi.clearAllMocks();
+    });
+
+    it("copies unzipped output without invoking zip", async () => {
+        const source = await mkdtemp(join(tmpdir(), "fern-project-"));
+        const destination = await mkdtemp(join(tmpdir(), "fern-output-"));
+        await mkdir(join(source, "src"));
+        await writeFile(join(source, "src", "index.ts"), "export {};\n");
+        const project = makeProject({ directory: AbsoluteFilePath.of(source) });
+        const { logger } = collectLogs();
+
+        try {
+            await project.copyProjectTo({
+                destinationPath: AbsoluteFilePath.of(destination),
+                zipFilename: "output.zip",
+                unzipOutput: true,
+                logger
+            });
+
+            await expect(readFile(join(destination, "src", "index.ts"), "utf8")).resolves.toBe("export {};\n");
+            expect(mockedCreateLoggingExecutable).not.toHaveBeenCalled();
+        } finally {
+            await Promise.all([
+                rm(source, { recursive: true, force: true }),
+                rm(destination, { recursive: true, force: true })
+            ]);
+        }
     });
 
     describe("format", () => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2925,9 +2925,15 @@ importers:
       '@types/node':
         specifier: 'catalog:'
         version: 22.19.17
+      ts-morph:
+        specifier: 'catalog:'
+        version: 27.0.2
       typescript:
         specifier: 'catalog:'
         version: 5.9.3
+      vitest:
+        specifier: 'catalog:'
+        version: 4.1.4(@opentelemetry/api@1.9.1)(@types/node@22.19.17)(@vitest/coverage-v8@4.1.4)(vite@7.3.5(@types/node@22.19.17)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
 
   generators/typescript/sdk/client-class-generator:
     dependencies:


### PR DESCRIPTION
## Summary

Add internal worker sharding for TypeScript SDK generation and merge each worker's output into one SDK.

## Benchmark

Cloudflare's canonical TypeScript IR, three alternating runs:

- Single worker: 188.1s median
- Three workers: 41.9s median
- Improvement: 77.7%

Both modes generated 22,573 files. After the workflow's formatting step, there were zero normalized content differences.

## Testing

- Added shard assignment and output merge coverage
- Added sharded/unsharded generation parity coverage
- TypeScript generator and CLI tests pass
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/17161" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->