### PR TITLE
fix(internal): cache definition file lookup

### DIFF
--- a/packages/commons/api-workspace-commons/src/AbstractAPIWorkspace.ts
+++ b/packages/commons/api-workspace-commons/src/AbstractAPIWorkspace.ts
@@ -8,13 +8,13 @@ import { ParsedFernFile } from "./FernFile.js";
 import { FernWorkspace } from "./FernWorkspace.js";
 
 export interface FernDefinition {
-    absoluteFilePath: AbsoluteFilePath;
-    rootApiFile: ParsedFernFile<RootApiFileSchema>;
-    namedDefinitionFiles: Record<RelativeFilePath, OnDiskNamedDefinitionFile>;
-    packageMarkers: Record<RelativeFilePath, ParsedFernFile<PackageMarkerFileSchema>>;
-    importedDefinitions: Record<RelativeFilePath, ImportedDefinition>;
+    readonly absoluteFilePath: AbsoluteFilePath;
+    readonly rootApiFile: ParsedFernFile<RootApiFileSchema>;
+    readonly namedDefinitionFiles: Readonly<Record<RelativeFilePath, OnDiskNamedDefinitionFile>>;
+    readonly packageMarkers: Readonly<Record<RelativeFilePath, ParsedFernFile<PackageMarkerFileSchema>>>;
+    readonly importedDefinitions: Readonly<Record<RelativeFilePath, ImportedDefinition>>;
     /** The document version from OpenAPI `info.version`, preserved as-is. */
-    specVersion?: string;
+    readonly specVersion?: string;
 }
 
 export interface OnDiskNamedDefinitionFile extends ParsedFernFile<DefinitionFileSchema> {
@@ -22,8 +22,8 @@ export interface OnDiskNamedDefinitionFile extends ParsedFernFile<DefinitionFile
 }
 
 export interface ImportedDefinition {
-    url: string | undefined;
-    definition: FernDefinition;
+    readonly url: string | undefined;
+    readonly definition: FernDefinition;
 }
 
 export declare namespace AbstractAPIWorkspace {

--- a/packages/commons/api-workspace-commons/src/FernWorkspace.ts
+++ b/packages/commons/api-workspace-commons/src/FernWorkspace.ts
@@ -14,7 +14,7 @@ export declare namespace FernWorkspace {
 }
 
 export class FernWorkspace extends AbstractAPIWorkspace<void> {
-    public definition: FernDefinition;
+    public readonly definition: FernDefinition;
     public sources: IdentifiableSource[];
 
     public type: string = "fern";

--- a/packages/commons/api-workspace-commons/src/__test__/getDefinitionFile.test.ts
+++ b/packages/commons/api-workspace-commons/src/__test__/getDefinitionFile.test.ts
@@ -1,0 +1,90 @@
+import { AbsoluteFilePath, RelativeFilePath } from "@fern-api/path-utils";
+import { describe, expect, it } from "vitest";
+import { FernDefinition } from "../AbstractAPIWorkspace.js";
+import { FernWorkspace } from "../FernWorkspace.js";
+import { getDefinitionFile } from "../utils/getDefinitionFile.js";
+
+describe("getDefinitionFile", () => {
+    it("resolves local and imported files", () => {
+        const localContents = { types: {} };
+        const importedContents = { types: {} };
+        const importPath = RelativeFilePath.of("dependencies/widgets");
+        const importedDefinition = createDefinition({
+            "types/imported.yml": importedContents
+        });
+        const definition = createDefinition(
+            { "types/local.yml": localContents },
+            {
+                [importPath]: {
+                    url: undefined,
+                    definition: importedDefinition
+                }
+            }
+        );
+        const workspace = createWorkspace(definition);
+
+        expect(getDefinitionFile(workspace, RelativeFilePath.of("types/local.yml"))).toBe(localContents);
+        expect(getDefinitionFile(workspace, RelativeFilePath.of("dependencies/widgets/types/imported.yml"))).toBe(
+            importedContents
+        );
+        expect(getDefinitionFile(workspace, RelativeFilePath.of("types/missing.yml"))).toBeUndefined();
+    });
+
+    it("caches files per workspace", () => {
+        const originalContents = { types: {} };
+        const replacementContents = { types: {} };
+        const relativeFilepath = RelativeFilePath.of("types/widget.yml");
+        const definition = createDefinition({ [relativeFilepath]: originalContents });
+        const firstWorkspace = createWorkspace(definition);
+
+        expect(getDefinitionFile(firstWorkspace, relativeFilepath)).toBe(originalContents);
+
+        const replacementDefinition = createDefinition({ [relativeFilepath]: replacementContents });
+        const secondWorkspace = createWorkspace(replacementDefinition);
+
+        expect(getDefinitionFile(firstWorkspace, relativeFilepath)).toBe(originalContents);
+        expect(getDefinitionFile(secondWorkspace, relativeFilepath)).toBe(replacementContents);
+    });
+});
+
+function createWorkspace(definition: FernDefinition): FernWorkspace {
+    return new FernWorkspace({
+        absoluteFilePath: definition.absoluteFilePath,
+        changelog: undefined,
+        cliVersion: "0.0.0",
+        definition,
+        dependenciesConfiguration: { dependencies: {} },
+        generatorsConfiguration: undefined,
+        workspaceName: undefined
+    });
+}
+
+function createDefinition(
+    files: Record<string, { types: Record<string, never> }>,
+    importedDefinitions: FernDefinition["importedDefinitions"] = {}
+): FernDefinition {
+    return {
+        absoluteFilePath: AbsoluteFilePath.of("/fern/api"),
+        rootApiFile: {
+            rawContents: "",
+            contents: { name: "Test API" },
+            defaultUrl: undefined
+        },
+        namedDefinitionFiles: Object.fromEntries(
+            Object.entries(files).map(([relativeFilepath, contents]) => {
+                const path = RelativeFilePath.of(relativeFilepath);
+                return [
+                    path,
+                    {
+                        absoluteFilePath: AbsoluteFilePath.of(`/fern/api/${relativeFilepath}`),
+                        rawContents: "",
+                        contents,
+                        defaultUrl: undefined
+                    }
+                ];
+            })
+        ) as FernDefinition["namedDefinitionFiles"],
+        packageMarkers: {},
+        importedDefinitions
+    };
+}

--- a/packages/commons/api-workspace-commons/src/utils/getDefinitionFile.ts
+++ b/packages/commons/api-workspace-commons/src/utils/getDefinitionFile.ts
@@ -4,9 +4,17 @@ import { RelativeFilePath } from "@fern-api/path-utils";
 import { FernWorkspace } from "../FernWorkspace.js";
 import { getAllDefinitionFiles } from "./getAllDefinitionFiles.js";
 
+const definitionFilesByWorkspace = new WeakMap<FernWorkspace, ReturnType<typeof getAllDefinitionFiles>>();
+
 export function getDefinitionFile(
     workspace: FernWorkspace,
     relativeFilepath: RelativeFilePath
 ): DefinitionFileSchema | undefined {
-    return getAllDefinitionFiles(workspace.definition)[relativeFilepath]?.contents;
+    // FernWorkspace.definition is readonly, so this cache is stable for the workspace lifetime.
+    let definitionFiles = definitionFilesByWorkspace.get(workspace);
+    if (definitionFiles == null) {
+        definitionFiles = getAllDefinitionFiles(workspace.definition);
+        definitionFilesByWorkspace.set(workspace, definitionFiles);
+    }
+    return definitionFiles[relativeFilepath]?.contents;
 }


### PR DESCRIPTION
## Summary

Cache definition-file lookup results within an API workspace instead of repeatedly scanning the workspace.

## Benchmark

Cloudflare's 26 MB OpenAPI workspace, three alternating runs:

- Before: 280.4s median
- After: 81.0s median
- Improvement: 71.1%

All runs produced identical IR.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/17162" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->