### PR TITLE
feat(cli): support native local generators

### DIFF
--- a/fern/apis/generators-yml/definition/group.yml
+++ b/fern/apis/generators-yml/definition/group.yml
@@ -58,6 +58,10 @@ types:
           When smart casing is enabled, preserves the word boundary after a digit run in
           snake_case names (e.g., ConversationsV2Configuration → conversations_v2_configuration).
           Defaults to false, which keeps the digit run fused to the following word.
+      local-command:
+        type: optional<list<string>>
+        docs: |
+          Host command for local generation. Fern appends the config path. No shell expansion.
       api:
         type: optional<GeneratorAPISettingsSchema>
         docs: Override API import settings (this is applied across all specs)

--- a/generators-yml.schema.json
+++ b/generators-yml.schema.json
@@ -4640,6 +4640,20 @@
           ],
           "description": "When smart casing is enabled, preserves the word boundary after a digit run in\nsnake_case names (e.g., ConversationsV2Configuration → conversations_v2_configuration).\nDefaults to false, which keeps the digit run fused to the following word."
         },
+        "local-command": {
+          "oneOf": [
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Host command for local generation. Fern appends the config path. No shell expansion."
+        },
         "api": {
           "oneOf": [
             {
@@ -4836,6 +4850,20 @@
             }
           ],
           "description": "When smart casing is enabled, preserves the word boundary after a digit run in\nsnake_case names (e.g., ConversationsV2Configuration → conversations_v2_configuration).\nDefaults to false, which keeps the digit run fused to the following word."
+        },
+        "local-command": {
+          "oneOf": [
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Host command for local generation. Fern appends the config path. No shell expansion."
         },
         "api": {
           "oneOf": [

--- a/generators/go-v2/base/src/project/GoProject.ts
+++ b/generators/go-v2/base/src/project/GoProject.ts
@@ -242,9 +242,8 @@ export class GoProject extends AbstractProject<AbstractGoGeneratorContext<BaseGo
             return;
         }
 
-        // In Docker execution environment (local generation), the license file is mounted at /tmp/LICENSE
-        // For remote generation, Fiddle handles writing the LICENSE file after generation
-        const dockerLicensePath = "/tmp/LICENSE";
+        // Local generators read custom licenses from FERN_LICENSE_PATH.
+        const dockerLicensePath = process.env.FERN_LICENSE_PATH ?? "/tmp/LICENSE";
         const licenseFileName = licenseConfig.filename ?? "LICENSE";
         const destinationPath = path.join(this.absolutePathToOutputDirectory, licenseFileName);
 

--- a/generators/go/model/versions.yml
+++ b/generators/go/model/versions.yml
@@ -1,4 +1,12 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+- version: 0.24.0-rc.2
+  changelogEntry:
+    - summary: |
+        Support custom license files when the generator runs as a native local command.
+      type: feat
+  createdAt: "2026-07-21"
+  irVersion: 67
+
 - version: 0.24.0-rc.1
   changelogEntry:
     - summary: |

--- a/generators/go/sdk/versions.yml
+++ b/generators/go/sdk/versions.yml
@@ -1,4 +1,11 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+- version: 1.51.0
+  changelogEntry:
+    - summary: |
+        Support custom license files when the generator runs as a native local command.
+      type: feat
+  createdAt: "2026-07-21"
+  irVersion: 67
 - version: 1.50.1
   changelogEntry:
     - summary: |

--- a/generators/java/generator-utils/src/main/java/com/fern/java/AbstractGeneratorCli.java
+++ b/generators/java/generator-utils/src/main/java/com/fern/java/AbstractGeneratorCli.java
@@ -823,7 +823,8 @@ public abstract class AbstractGeneratorCli<T extends ICustomConfig, K extends ID
 
                     @Override
                     public Void visitCustom(com.fern.generator.exec.model.config.CustomLicense customLicense) {
-                        Path dockerLicensePath = Paths.get("/tmp/LICENSE");
+                        Path dockerLicensePath =
+                                Paths.get(System.getenv().getOrDefault("FERN_LICENSE_PATH", "/tmp/LICENSE"));
                         Path destinationPath = outputDirectory.resolve(customLicense.getFilename());
 
                         try {

--- a/generators/java/model/versions.yml
+++ b/generators/java/model/versions.yml
@@ -1,4 +1,12 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+- version: 1.9.0-rc.1
+  changelogEntry:
+    - summary: |
+        Support custom license files when the generator runs as a native local command.
+      type: feat
+  createdAt: "2026-07-21"
+  irVersion: 67
+
 - version: 1.9.0-rc.0
   changelogEntry:
     - summary: |

--- a/generators/java/sdk/versions.yml
+++ b/generators/java/sdk/versions.yml
@@ -1,4 +1,11 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+- version: 4.15.0
+  changelogEntry:
+    - summary: |
+        Support custom license files when the generator runs as a native local command.
+      type: feat
+  createdAt: "2026-07-21"
+  irVersion: 67
 - version: 4.14.6
   changelogEntry:
     - summary: |

--- a/generators/php/base/src/project/PhpProject.ts
+++ b/generators/php/base/src/project/PhpProject.ts
@@ -25,9 +25,8 @@ const CUSTOM_LICENSE_NAME = "LicenseRef-LICENSE";
 
 const COMPOSER_JSON_FILENAME = "composer.json";
 
-// In the Docker execution environment (local generation), the license file is mounted here.
-// For remote generation, Fiddle handles writing the LICENSE file after generation.
-const DOCKER_LICENSE_PATH = "/tmp/LICENSE";
+// Local generators read custom licenses from FERN_LICENSE_PATH.
+const DOCKER_LICENSE_PATH = process.env.FERN_LICENSE_PATH ?? "/tmp/LICENSE";
 
 /**
  * In memory representation of a PHP project.

--- a/generators/php/model/versions.yml
+++ b/generators/php/model/versions.yml
@@ -1,5 +1,13 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
 
+- version: 0.1.0-rc.1
+  changelogEntry:
+    - summary: |
+        Support custom license files when the generator runs as a native local command.
+      type: feat
+  createdAt: "2026-07-21"
+  irVersion: 67
+
 - version: 0.1.0-rc.0
   changelogEntry:
     - summary: |

--- a/generators/php/sdk/versions.yml
+++ b/generators/php/sdk/versions.yml
@@ -1,4 +1,11 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+- version: 2.15.0
+  changelogEntry:
+    - summary: |
+        Support custom license files when the generator runs as a native local command.
+      type: feat
+  createdAt: "2026-07-21"
+  irVersion: 67
 - version: 2.14.0
   changelogEntry:
     - summary: |

--- a/generators/python/pydantic/versions.yml
+++ b/generators/python/pydantic/versions.yml
@@ -1,5 +1,13 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
 
+- version: 1.12.0-rc.4
+  changelogEntry:
+    - summary: |
+        Support custom license files when the generator runs as a native local command.
+      type: feat
+  createdAt: "2026-07-21"
+  irVersion: 67
+
 - version: 1.12.0-rc.3
   changelogEntry:
     - summary: |

--- a/generators/python/sdk/versions.yml
+++ b/generators/python/sdk/versions.yml
@@ -1,4 +1,11 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+- version: 5.21.0
+  changelogEntry:
+    - summary: |
+        Support custom license files when the generator runs as a native local command.
+      type: feat
+  createdAt: "2026-07-21"
+  irVersion: 67
 - version: 5.20.2
   changelogEntry:
     - summary: |

--- a/generators/python/src/fern_python/codegen/project.py
+++ b/generators/python/src/fern_python/codegen/project.py
@@ -369,13 +369,12 @@ __all__ = ["{next_part}"]
             current_path = os.path.join(current_path, part)
 
     def _copy_license_file(self) -> None:
-        """Copy LICENSE file from /tmp/LICENSE to project root for local generation."""
+        """Copy the configured license into the project."""
         if self.license_ is not None:
             license_union = self.license_.get_as_union()
             if license_union.type == "custom":
-                # In Docker execution environment (local generation), the license file is mounted at /tmp/LICENSE
-                # For remote generation, Fiddle handles writing the LICENSE file after generation
-                docker_license_path = "/tmp/LICENSE"
+                # Local generators read custom licenses from FERN_LICENSE_PATH.
+                docker_license_path = os.environ.get("FERN_LICENSE_PATH", "/tmp/LICENSE")
                 destination_path = os.path.join(self._root_filepath, license_union.filename)
 
                 try:

--- a/generators/typescript/sdk/cli/src/SdkGeneratorCli.ts
+++ b/generators/typescript/sdk/cli/src/SdkGeneratorCli.ts
@@ -331,8 +331,8 @@ export class SdkGeneratorCli extends AbstractGeneratorCli<SdkCustomConfig> {
     }
 
     private async copyLicenseFile(destinationPath: string): Promise<void> {
-        // In Docker execution environment, the license file is mounted at /tmp/LICENSE
-        const dockerLicensePath = "/tmp/LICENSE";
+        // Fall back to the Docker license mount.
+        const dockerLicensePath = process.env.FERN_LICENSE_PATH ?? "/tmp/LICENSE";
 
         try {
             await copyFile(dockerLicensePath, destinationPath);

--- a/generators/typescript/sdk/versions.yml
+++ b/generators/typescript/sdk/versions.yml
@@ -1,4 +1,11 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+- version: 3.83.0
+  changelogEntry:
+    - summary: |
+        Support custom license files when the generator runs as a native local command.
+      type: feat
+  createdAt: "2026-07-21"
+  irVersion: 67
 - version: 3.82.3
   changelogEntry:
     - summary: |

--- a/packages/cli/cli/versions.yml
+++ b/packages/cli/cli/versions.yml
@@ -1,4 +1,11 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+- version: 5.77.0
+  changelogEntry:
+    - summary: |
+        Support running local generators as native commands without a Docker image.
+      type: feat
+  createdAt: "2026-07-21"
+  irVersion: 67
 - version: 5.76.0
   changelogEntry:
     - summary: |

--- a/packages/cli/configuration-loader/src/generators-yml/__test__/convertGeneratorsConfiguration.test.ts
+++ b/packages/cli/configuration-loader/src/generators-yml/__test__/convertGeneratorsConfiguration.test.ts
@@ -1207,6 +1207,57 @@ describe("convertGeneratorsConfiguration", () => {
         expect(generator?.name).toBe("fernapi/fern-typescript-sdk");
     });
 
+    it("resolves a native generator command relative to generators.yml", async () => {
+        const context = createMockTaskContext();
+        const converted = await convertGeneratorsConfiguration({
+            absolutePathToGeneratorsConfiguration: AbsoluteFilePath.of("/path/to/repo/fern/api/generators.yml"),
+            rawGeneratorsConfiguration: {
+                groups: {
+                    group1: {
+                        generators: [
+                            {
+                                name: "fernapi/fern-typescript-sdk",
+                                version: "1.0.0",
+                                "local-command": ["node", "./generator.cjs", "argument with spaces"],
+                                output: { location: "local-file-system", path: "/out" }
+                            }
+                        ]
+                    }
+                }
+            },
+            context
+        });
+
+        expect(converted.groups[0]?.generators[0]?.nativeExecution).toEqual({
+            executable: "node",
+            args: ["./generator.cjs", "argument with spaces"],
+            workingDirectory: AbsoluteFilePath.of("/path/to/repo/fern/api")
+        });
+    });
+
+    it("rejects an empty native generator command", async () => {
+        await expect(
+            convertGeneratorsConfiguration({
+                absolutePathToGeneratorsConfiguration: AbsoluteFilePath.of("/path/to/repo/fern/api/generators.yml"),
+                rawGeneratorsConfiguration: {
+                    groups: {
+                        group1: {
+                            generators: [
+                                {
+                                    name: "fernapi/fern-typescript-sdk",
+                                    version: "1.0.0",
+                                    "local-command": [],
+                                    output: { location: "local-file-system", path: "/out" }
+                                }
+                            ]
+                        }
+                    }
+                },
+                context: createMockTaskContext()
+            })
+        ).rejects.toThrow("local-command requires an executable");
+    });
+
     it("custom image generators are identifiable for remote generation guard", async () => {
         const context = createMockTaskContext();
         const converted = await convertGeneratorsConfiguration({

--- a/packages/cli/configuration-loader/src/generators-yml/convertGeneratorsConfiguration.ts
+++ b/packages/cli/configuration-loader/src/generators-yml/convertGeneratorsConfiguration.ts
@@ -698,6 +698,24 @@ async function convertGenerator({
     context: TaskContext;
 }): Promise<generatorsYml.GeneratorInvocation> {
     const { normalizedName, containerImage } = getGeneratorNameAndImage(generator, context);
+    const localCommand = generator["local-command"];
+    const nativeExecution = (() => {
+        if (localCommand == null) {
+            return undefined;
+        }
+        const [executable, ...args] = localCommand;
+        if (executable == null || executable.trim().length === 0) {
+            throw new CliError({
+                message: "local-command requires an executable",
+                code: CliError.Code.ConfigError
+            });
+        }
+        return {
+            executable,
+            args,
+            workingDirectory: dirname(absolutePathToGeneratorsConfiguration)
+        };
+    })();
     const perGeneratorIdempotencyKeyGeneration =
         typeof generator.config === "object" && generator.config !== null
             ? (generator.config as { "auto-generate-idempotency-key"?: unknown })["auto-generate-idempotency-key"]
@@ -712,6 +730,7 @@ async function convertGenerator({
         }),
         name: normalizedName,
         containerImage,
+        nativeExecution,
         version: generator.version,
         config: generator.config,
         outputMode: await convertOutputMode({

--- a/packages/cli/configuration/src/generators-yml/GeneratorsConfiguration.ts
+++ b/packages/cli/configuration/src/generators-yml/GeneratorsConfiguration.ts
@@ -186,6 +186,13 @@ export interface GeneratorInvocation {
     name: string;
     /** Fully-qualified container image for local generation (e.g., `ghcr.io/myorg/fernapi/fern-typescript-sdk`). Undefined means use Docker Hub default. */
     containerImage: string | undefined;
+    nativeExecution?:
+        | {
+              executable: string;
+              args: string[];
+              workingDirectory: AbsoluteFilePath;
+          }
+        | undefined;
     irVersionOverride: string | undefined;
     version: string;
     config: unknown;

--- a/packages/cli/configuration/src/generators-yml/schemas/api/resources/group/types/BaseGeneratorInvocationSchema.ts
+++ b/packages/cli/configuration/src/generators-yml/schemas/api/resources/group/types/BaseGeneratorInvocationSchema.ts
@@ -22,6 +22,8 @@ export interface BaseGeneratorInvocationSchema {
      * Defaults to false, which keeps the digit run fused to the following word.
      */
     "smart-casing-digit-word-boundary"?: boolean;
+    /** Host command for local generation. Fern appends the config path. No shell expansion. */
+    "local-command"?: string[];
     /** Override API import settings (this is applied across all specs) */
     api?: GeneratorsYml.GeneratorApiSettingsSchema;
     /** Temporary way to unblock example serialization. */

--- a/packages/cli/configuration/src/generators-yml/schemas/serialization/resources/group/types/BaseGeneratorInvocationSchema.ts
+++ b/packages/cli/configuration/src/generators-yml/schemas/serialization/resources/group/types/BaseGeneratorInvocationSchema.ts
@@ -24,6 +24,7 @@ export const BaseGeneratorInvocationSchema: core.serialization.ObjectSchema<
     "ir-version": core.serialization.string().optional(),
     "smart-casing": core.serialization.boolean().optional(),
     "smart-casing-digit-word-boundary": core.serialization.boolean().optional(),
+    "local-command": core.serialization.list(core.serialization.string()).optional(),
     api: GeneratorApiSettingsSchema.optional(),
     "disable-examples": core.serialization.boolean().optional(),
     "publish-metadata": GeneratorPublishMetadataSchema.optional(),
@@ -43,6 +44,7 @@ export declare namespace BaseGeneratorInvocationSchema {
         "ir-version"?: string | null;
         "smart-casing"?: boolean | null;
         "smart-casing-digit-word-boundary"?: boolean | null;
+        "local-command"?: string[] | null;
         api?: GeneratorApiSettingsSchema.Raw | null;
         "disable-examples"?: boolean | null;
         "publish-metadata"?: GeneratorPublishMetadataSchema.Raw | null;

--- a/packages/cli/generation/local-generation/local-workspace-runner/src/NativeExecutionEnvironment.ts
+++ b/packages/cli/generation/local-generation/local-workspace-runner/src/NativeExecutionEnvironment.ts
@@ -1,3 +1,4 @@
+import { AbsoluteFilePath } from "@fern-api/fs-utils";
 import { loggingExeca } from "@fern-api/logging-execa";
 import { CliError } from "@fern-api/task-context";
 import { copyFile, rm } from "fs/promises";
@@ -11,14 +12,12 @@ import { ExecutionEnvironment, SourceMount } from "./ExecutionEnvironment.js";
 
 const LICENSE_MOUNT_PATH = "/tmp/LICENSE";
 
-/**
- * Executes generators natively on the host system using provided commands.
- */
 export class NativeExecutionEnvironment implements ExecutionEnvironment {
     public readonly usesContainerPaths = false;
     private readonly commands: string[];
     private readonly workingDirectory?: string;
     private readonly env?: Record<string, string>;
+    private argv?: { executable: string; args: string[] };
     constructor({
         commands,
         workingDirectory,
@@ -33,6 +32,22 @@ export class NativeExecutionEnvironment implements ExecutionEnvironment {
         this.env = env;
     }
 
+    public static fromArgv({
+        executable,
+        args,
+        workingDirectory,
+        env
+    }: {
+        executable: string;
+        args: string[];
+        workingDirectory?: AbsoluteFilePath;
+        env?: Record<string, string>;
+    }): NativeExecutionEnvironment {
+        const environment = new NativeExecutionEnvironment({ commands: [], workingDirectory, env });
+        environment.argv = { executable, args };
+        return environment;
+    }
+
     public async execute({
         generatorName,
         irPath,
@@ -45,13 +60,11 @@ export class NativeExecutionEnvironment implements ExecutionEnvironment {
         context,
         inspect
     }: ExecutionEnvironment.ExecuteArgs): Promise<void> {
-        context.logger.info(
-            `Executing generator ${generatorName} natively with commands: ${this.commands.join(" && ")}`
-        );
+        context.logger.info(`Executing generator ${generatorName} natively`);
 
-        // Copy license file to /tmp/LICENSE to match the Docker mount path that generators expect
+        // Legacy commands expect the license at the Docker mount path.
         let copiedLicense = false;
-        if (licenseFilePath != null) {
+        if (licenseFilePath != null && this.argv == null) {
             try {
                 await copyFile(licenseFilePath, LICENSE_MOUNT_PATH);
                 copiedLicense = true;
@@ -63,9 +76,6 @@ export class NativeExecutionEnvironment implements ExecutionEnvironment {
             }
         }
 
-        // Resolve source-mount env vars for native execution. In container mode these
-        // become Docker volume mounts; natively we expose them as environment variables
-        // so generators can locate mounted directories (e.g. FERN_SPECS_DIR).
         const specsMount = sourceMounts?.find((m: SourceMount) => m.containerPath === CONTAINER_SPECS_DIRECTORY);
         const specsEnv = specsMount != null ? { FERN_SPECS_DIR: specsMount.hostPath } : {};
 
@@ -78,6 +88,40 @@ export class NativeExecutionEnvironment implements ExecutionEnvironment {
         };
 
         try {
+            if (this.argv != null) {
+                const result = await loggingExeca(
+                    context.logger,
+                    this.argv.executable,
+                    [...this.argv.args, configPath],
+                    {
+                        doNotPipeOutput: false,
+                        reject: false,
+                        cwd: this.workingDirectory,
+                        env: {
+                            ...process.env,
+                            ...this.env,
+                            ...specsEnv,
+                            ...relocationsEnv,
+                            IR_PATH: irPath,
+                            CONFIG_PATH: configPath,
+                            OUTPUT_PATH: outputPath,
+                            SNIPPET_PATH: snippetPath || "",
+                            SNIPPET_TEMPLATE_PATH: snippetTemplatePath || "",
+                            GENERATOR_NAME: generatorName,
+                            ...(licenseFilePath != null ? { FERN_LICENSE_PATH: licenseFilePath } : {}),
+                            ...(inspect ? { NODE_OPTIONS: "--inspect-brk=0.0.0.0:9229" } : {})
+                        },
+                        shell: false
+                    }
+                );
+                if (result.failed) {
+                    throw new CliError({
+                        message: `Command failed: ${this.argv.executable}\n${result.stderr || result.stdout}`,
+                        code: CliError.Code.InternalError
+                    });
+                }
+                return;
+            }
             for (const command of this.commands) {
                 const processedCommand = command
                     .replace("{IR_PATH}", irPath)

--- a/packages/cli/generation/local-generation/local-workspace-runner/src/__test__/NativeExecutionEnvironment.test.ts
+++ b/packages/cli/generation/local-generation/local-workspace-runner/src/__test__/NativeExecutionEnvironment.test.ts
@@ -1,0 +1,62 @@
+import { AbsoluteFilePath } from "@fern-api/fs-utils";
+import { loggingExeca } from "@fern-api/logging-execa";
+import { createMockTaskContext } from "@fern-api/task-context";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { NativeExecutionEnvironment } from "../NativeExecutionEnvironment.js";
+
+vi.mock("@fern-api/logging-execa", () => ({ loggingExeca: vi.fn() }));
+
+describe("NativeExecutionEnvironment", () => {
+    beforeEach(() => {
+        vi.mocked(loggingExeca).mockReset();
+        vi.mocked(loggingExeca).mockResolvedValue({ failed: false, stdout: "", stderr: "" } as never);
+    });
+
+    it("passes argv without shell parsing", async () => {
+        const environment = NativeExecutionEnvironment.fromArgv({
+            executable: "node",
+            args: ["generator.cjs", "argument with spaces", "; touch /tmp/pwned"],
+            workingDirectory: AbsoluteFilePath.of("/workspace")
+        });
+
+        await environment.execute({
+            generatorName: "example/generator",
+            irPath: AbsoluteFilePath.of("/tmp/ir.json"),
+            configPath: AbsoluteFilePath.of("/tmp/config with spaces.json"),
+            outputPath: AbsoluteFilePath.of("/tmp/output"),
+            licenseFilePath: AbsoluteFilePath.of("/workspace/LICENSE"),
+            context: createMockTaskContext(),
+            inspect: false,
+            runner: undefined
+        });
+
+        expect(loggingExeca).toHaveBeenCalledWith(
+            expect.anything(),
+            "node",
+            ["generator.cjs", "argument with spaces", "; touch /tmp/pwned", "/tmp/config with spaces.json"],
+            expect.objectContaining({
+                cwd: "/workspace",
+                shell: false,
+                env: expect.objectContaining({ FERN_LICENSE_PATH: "/workspace/LICENSE" })
+            })
+        );
+    });
+
+    it("reports native command failures", async () => {
+        vi.mocked(loggingExeca).mockResolvedValue({ failed: true, stdout: "", stderr: "failure" } as never);
+        const environment = NativeExecutionEnvironment.fromArgv({ executable: "generator", args: [] });
+
+        await expect(
+            environment.execute({
+                generatorName: "example/generator",
+                irPath: AbsoluteFilePath.of("/tmp/ir.json"),
+                configPath: AbsoluteFilePath.of("/tmp/config.json"),
+                outputPath: AbsoluteFilePath.of("/tmp/output"),
+                context: createMockTaskContext(),
+                inspect: false,
+                runner: undefined
+            })
+        ).rejects.toThrow("Command failed: generator");
+    });
+});

--- a/packages/cli/generation/local-generation/local-workspace-runner/src/runLocalGenerationForWorkspace.ts
+++ b/packages/cli/generation/local-generation/local-workspace-runner/src/runLocalGenerationForWorkspace.ts
@@ -47,6 +47,7 @@ import path from "path";
 import tmp from "tmp-promise";
 import { generatorWantsSpecs } from "./constants.js";
 import { getGeneratorOutputSubfolder } from "./getGeneratorOutputSubfolder.js";
+import { NativeExecutionEnvironment } from "./NativeExecutionEnvironment.js";
 import { writeFilesToDiskAndRunGenerator } from "./runGenerator.js";
 
 export async function runLocalGenerationForWorkspace({
@@ -422,7 +423,10 @@ export async function runLocalGenerationForWorkspace({
                     generatePaginatedClients: orgBody?.paginationEnabled ?? false,
                     includeOptionalRequestPropertyExamples: false,
                     inspect,
-                    executionEnvironment: undefined, // This should use the Docker fallback with proper image name
+                    executionEnvironment:
+                        generatorInvocation.nativeExecution != null
+                            ? NativeExecutionEnvironment.fromArgv(generatorInvocation.nativeExecution)
+                            : undefined,
                     ir: intermediateRepresentation,
                     whiteLabel: orgBody?.isWhitelabled ?? false,
                     publishToRegistry,

--- a/seed/java-model/seed.yml
+++ b/seed/java-model/seed.yml
@@ -1,4 +1,4 @@
-irVersion: v66
+irVersion: v67
 displayName: Java Model
 # This generator is no longer actively supported. The workspace is retained for
 # historical reference but seed tests, publishing, and builds are skipped.

--- a/seed/php-model/seed.yml
+++ b/seed/php-model/seed.yml
@@ -1,4 +1,4 @@
-irVersion: v66
+irVersion: v67
 displayName: PHP Model
 image: fernapi/fern-php-model
 # This generator is no longer actively supported. The workspace is retained for

--- a/seed/pydantic-v2/seed.yml
+++ b/seed/pydantic-v2/seed.yml
@@ -1,4 +1,4 @@
-irVersion: v66
+irVersion: v67
 displayName: Pydantic Model
 image: fernapi/fern-pydantic-model-v2
 changelogLocation: ../../generators/python/pydantic/versions.yml

--- a/seed/pydantic/seed.yml
+++ b/seed/pydantic/seed.yml
@@ -1,4 +1,4 @@
-irVersion: v66
+irVersion: v67
 displayName: Pydantic Model
 image: fernapi/fern-pydantic-model
 # This generator is no longer actively supported. The workspace is retained for


### PR DESCRIPTION
## Summary

Allow local generator configuration to specify a native command and arguments instead of requiring a Docker image.

Native execution reuses the existing local generation lifecycle, including configuration conversion, validation, and output handling.

## Testing

- Added generator configuration conversion coverage
- Added native execution environment coverage
- Local workspace runner tests pass
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/17163" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->