### PR TITLE
fix(generator-cli): bound autoversion re-anchor history walk

### DIFF
--- a/packages/generator-cli/changes/unreleased/fix-autoversion-bound-history-walk.yml
+++ b/packages/generator-cli/changes/unreleased/fix-autoversion-bound-history-walk.yml
@@ -1,0 +1,11 @@
+# yaml-language-server: $schema=../../../../fern-changes-yml.schema.json
+
+- summary: |
+    Fix AUTO versioning saturating a CPU core on large repos. When the previous generation SHA
+    recorded in `replay.lock` is unreachable, `AutoVersionStep` re-anchors its diff baseline by
+    walking first-parent history; that `git log --first-parent` walk was unbounded, so on a repo
+    with a large history it traversed everything synchronously and pegged the CPU. The walk is
+    now bounded to the most recent 200 first-parent commits via git's own `--max-count` (the JS
+    early-break did not stop git's traversal) plus a wall-clock timeout, degrading to the
+    metadata/git-tags fallback rather than hanging.
+  type: fix

--- a/packages/generator-cli/src/__test__/auto-version-step.execute.test.ts
+++ b/packages/generator-cli/src/__test__/auto-version-step.execute.test.ts
@@ -25,6 +25,14 @@ vi.mock("@fern-api/cli-ai", () => ({
     VersionBump: { MAJOR: "MAJOR", MINOR: "MINOR", PATCH: "PATCH", NO_CHANGE: "NO_CHANGE" }
 }));
 
+// Wrap child_process so a test can assert the exact git argv AutoVersionStep spawns while still
+// running real git. execFileSync is a live named import both here and in AutoVersionStep, so an
+// ESM-namespace spy isn't possible; a module mock that forwards to the original is.
+vi.mock("child_process", async (importOriginal) => {
+    const actual = await importOriginal<typeof import("child_process")>();
+    return { ...actual, execFileSync: vi.fn(actual.execFileSync) };
+});
+
 import type { PipelineLogger } from "../pipeline/PipelineLogger";
 import { AutoVersionStep } from "../pipeline/steps/AutoVersionStep";
 import type { AutoVersionStepConfig, PipelineContext } from "../pipeline/types";
@@ -495,6 +503,43 @@ describe("AutoVersionStep.execute() — adversarial baseline recovery", () => {
         expect(result.previousVersion).toBe("1.0.0");
         expect(result.version).toBe("1.1.0");
         expect(packageVersion(repoPath)).toBe("1.1.0");
+    });
+
+    it("bounds the re-anchor history walk with --max-count so it cannot traverse full history (FSE-50)", async () => {
+        // Regression: on a large repo an unreachable recorded SHA triggered an *unbounded*
+        // `git log --first-parent` that walked the entire history and pegged a coordinator CPU
+        // core (generator-cli 0.9.46). The JS early-break below does not help — git produces its
+        // whole output before Node reads a byte — so the walk must be bounded via git's own
+        // --max-count. Assert the re-anchor invocation carries that bound.
+        mockAnalyzeSdkDiff.mockResolvedValue(minorAnalysis);
+        const repoPath = await newRepo();
+        commit(repoPath, "[fern-generated] gen 1", { "package.json": pkg("1.0.0"), "src/client.ts": "export {};\n" });
+        const currentSha = commit(repoPath, "[fern-generated] gen 2", { "package.json": pkg(MAGIC), ...FEATURE });
+
+        vi.mocked(execFileSync).mockClear();
+        const step = new AutoVersionStep(repoPath, makeLogger(), baseConfig);
+        const result = await step.execute(
+            makeContext(
+                fakePreparedReplay({
+                    outputDir: repoPath,
+                    previousGenerationSha: "0".repeat(40),
+                    currentGenerationSha: currentSha
+                })
+            )
+        );
+
+        expect(result.success).toBe(true);
+        expect(result.version).toBe("1.1.0");
+
+        const historyWalk = vi.mocked(execFileSync).mock.calls.find(
+            ([cmd, args]) =>
+                cmd === "git" &&
+                Array.isArray(args) &&
+                args[0] === "log" &&
+                (args as string[]).includes("--first-parent")
+        );
+        expect(historyWalk, "expected a re-anchor `git log --first-parent` invocation").toBeDefined();
+        expect(historyWalk![1] as string[]).toContain("--max-count=200");
     });
 
     it("ignores a rogue [fern-generated] commit on a merged side branch (--first-parent)", async () => {

--- a/packages/generator-cli/src/pipeline/steps/AutoVersionStep.ts
+++ b/packages/generator-cli/src/pipeline/steps/AutoVersionStep.ts
@@ -26,6 +26,19 @@ import { BaseStep } from "./BaseStep";
 const COMMIT_MARKER = "[fern-autoversion]";
 const FERN_TRAILER = "\n\n🌿 Generated with Fern";
 
+// Upper bound on the first-parent history walk used to re-anchor the autoversion baseline when
+// the recorded replay.lock SHA is unreachable. The walk only needs the *most recent* prior
+// [fern-generated] commit, which sits at (or within a handful of commits of) HEAD in a normal SDK
+// repo, so a modest cap reliably finds it. Bounding git itself is what matters: `git log` produces
+// its entire output before Node reads a byte, so the JS-side early break does NOT stop traversal —
+// on a large repo (huge history + thousands of branches) the unbounded walk pegged a CPU core.
+// Matches @fern-api/replay's detectPatchesViaCommitScan cap. See FSE-50.
+const HISTORY_WALK_MAX_COMMITS = 200;
+
+// Defense-in-depth wall-clock cap on the git subprocess: even bounded, a pathological repo/filesystem
+// should degrade to the metadata/git-tags fallback rather than block the (synchronous) event loop.
+const GIT_HISTORY_WALK_TIMEOUT_MS = 30_000;
+
 type VersionBumpLabel = "MAJOR" | "MINOR" | "PATCH" | "NO_CHANGE";
 
 /**
@@ -747,17 +760,28 @@ export class AutoVersionStep extends BaseStep {
      * Walks first-parent history from the current generation commit and returns the most
      * recent prior [fern-generated] commit — the reachable equivalent of replay.lock's
      * recorded baseline. Mirrors @fern-api/replay's `findPreviousGenerationFromHistory`.
+     *
+     * The walk is bounded to the most recent HISTORY_WALK_MAX_COMMITS first-parent commits (via
+     * git's own `--max-count`, not just the JS break below) and time-bounded, so an unreachable
+     * SHA on a large repo can no longer trigger a full-history traversal that pegs the CPU. If no
+     * [fern-generated] commit is found within the window, returns null and the caller falls back
+     * to metadata/git-tags — the same path taken when no baseline is reachable at all.
      */
     private findPreviousGenerationFromHistory(currentGenerationSha: string): string | null {
         const start = this.commitExists(currentGenerationSha) ? currentGenerationSha : "HEAD";
         let log: string;
         try {
-            log = execFileSync("git", ["log", "--first-parent", "--format=%H%x00%s", start], {
-                cwd: this.outputDir,
-                encoding: "utf-8",
-                stdio: "pipe",
-                maxBuffer: 64 * 1024 * 1024
-            });
+            log = execFileSync(
+                "git",
+                ["log", "--first-parent", `--max-count=${HISTORY_WALK_MAX_COMMITS}`, "--format=%H%x00%s", start],
+                {
+                    cwd: this.outputDir,
+                    encoding: "utf-8",
+                    stdio: "pipe",
+                    maxBuffer: 64 * 1024 * 1024,
+                    timeout: GIT_HISTORY_WALK_TIMEOUT_MS
+                }
+            );
         } catch (error) {
             this.logger.debug(`AutoVersionStep: git log history walk failed (${String(error)}); no baseline derived.`);
             return null;


### PR DESCRIPTION
## Problem

`AutoVersionStep` re-anchors its diff baseline by walking first-parent history (`findPreviousGenerationFromHistory`) when the previous-generation SHA recorded in `replay.lock` is unreachable — which is the normal case, since signed-commit pushes recreate every `[fern-generated]` commit under a new SHA.

That walk is unbounded:

```ts
execFileSync("git", ["log", "--first-parent", "--format=%H%x00%s", start], { ... })
```

`git log` materializes its **entire** output before Node reads a byte, so the JS-side early `break` on the first `[fern-generated]` commit does **not** stop git's traversal. On a repo with a large history + many branches, this walks all of history synchronously on every generation and can saturate a CPU core.

## Fix

Bound git's own traversal instead of relying on the JS loop's early break:

- `--max-count=200` on the `git log --first-parent` walk. Only the *most recent* `[fern-generated]` commit is needed to re-anchor, and it sits at (or within a handful of commits of) HEAD in a normal SDK repo, so a modest cap reliably finds it. Matches `@fern-api/replay`'s `detectPatchesViaCommitScan` cap.
- A defensive `timeout` on the subprocess so a pathological repo/filesystem degrades to the metadata/git-tags fallback instead of blocking the synchronous event loop.

If no `[fern-generated]` commit is found within the window, `findPreviousGenerationFromHistory` returns `null` and the caller falls back to metadata/git-tags — the same path already taken when no baseline is reachable at all, so version-resolution behavior is unchanged for real SDK repos.

## Testing

Added a regression test in `auto-version-step.execute.test.ts` asserting the re-anchor `git log --first-parent` invocation carries `--max-count`. All tests in that file pass:

```
✓ src/__test__/auto-version-step.execute.test.ts (39 tests)
  ✓ bounds the re-anchor history walk with --max-count so it cannot traverse full history
```

Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/17165" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->