### PR TITLE
feat(cli): add ignore-tags OpenAPI setting to derive SDK structure from operationIds

### DIFF
--- a/fern-yml.schema.json
+++ b/fern-yml.schema.json
@@ -4010,6 +4010,9 @@
                       },
                       "disambiguate-request-names": {
                         "type": "boolean"
+                      },
+                      "ignore-tags": {
+                        "type": "boolean"
                       }
                     },
                     "additionalProperties": false
@@ -4586,6 +4589,9 @@
                           "type": "boolean"
                         },
                         "disambiguate-request-names": {
+                          "type": "boolean"
+                        },
+                        "ignore-tags": {
                           "type": "boolean"
                         }
                       },

--- a/fern/apis/generators-yml/definition/generators.yml
+++ b/fern/apis/generators-yml/definition/generators.yml
@@ -590,6 +590,14 @@ types:
           If false, keep the original "Request" suffix regardless of collisions.
           Defaults to true.
         default: true
+      ignore-tags:
+        type: optional<boolean>
+        docs: |
+          If true, ignore operation-level tags when determining the SDK structure.
+          Endpoints fall back to the root package (or their namespace) and method
+          names are derived from each operation's operationId.
+          Defaults to false.
+        default: false
 
   ResolveAliases:
     discriminated: false

--- a/generators-yml.schema.json
+++ b/generators-yml.schema.json
@@ -2449,6 +2449,17 @@
             }
           ],
           "description": "If true, disambiguate generated request wrapper names that collide with\ncomponent schema names by replacing the \"Request\" suffix with \"Body\".\nIf false, keep the original \"Request\" suffix regardless of collisions.\nDefaults to true."
+        },
+        "ignore-tags": {
+          "oneOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "If true, ignore operation-level tags when determining the SDK structure.\nEndpoints fall back to the root package (or their namespace) and method\nnames are derived from each operation's operationId.\nDefaults to false."
         }
       },
       "additionalProperties": false
@@ -3098,6 +3109,17 @@
             }
           ],
           "description": "If true, disambiguate generated request wrapper names that collide with\ncomponent schema names by replacing the \"Request\" suffix with \"Body\".\nIf false, keep the original \"Request\" suffix regardless of collisions.\nDefaults to true."
+        },
+        "ignore-tags": {
+          "oneOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "If true, ignore operation-level tags when determining the SDK structure.\nEndpoints fall back to the root package (or their namespace) and method\nnames are derived from each operation's operationId.\nDefaults to false."
         },
         "respect-nullable-schemas": {
           "oneOf": [

--- a/packages/cli/api-importers/openapi/openapi-ir-parser/src/openapi/v3/converters/operation/convertHttpOperation.ts
+++ b/packages/cli/api-importers/openapi/openapi-ir-parser/src/openapi/v3/converters/operation/convertHttpOperation.ts
@@ -335,7 +335,7 @@ export function convertHttpOperation({
             operation.operationId != null && suffix != null
                 ? operation.operationId + "_" + suffix
                 : operation.operationId,
-        tags: context.resolveTagsToTagIds(operation.tags),
+        tags: context.options.ignoreTags ? [] : context.resolveTagsToTagIds(operation.tags),
         namespace: context.namespace,
         sdkName: createOperationSdkMethodName({ operationContext, request }),
         pathParameters: convertedParameters.pathParameters,

--- a/packages/cli/api-importers/openapi/openapi-ir-parser/src/options.ts
+++ b/packages/cli/api-importers/openapi/openapi-ir-parser/src/options.ts
@@ -149,6 +149,14 @@ export interface ParseOpenAPIOptions {
      * Defaults to true.
      */
     disambiguateRequestNames: boolean;
+
+    /**
+     * If true, ignore operation-level tags when determining the SDK structure.
+     * Endpoints fall back to the root package (or their namespace) and method
+     * names are derived from each operation's operationId.
+     * Defaults to false.
+     */
+    ignoreTags: boolean;
 }
 
 export const DEFAULT_PARSE_OPENAPI_SETTINGS: ParseOpenAPIOptions = {
@@ -189,7 +197,8 @@ export const DEFAULT_PARSE_OPENAPI_SETTINGS: ParseOpenAPIOptions = {
     coerceConstsTo: "enums-coerceable-to-literals",
     respectByteFormat: false,
     shouldInferDiscriminatedUnionBaseProperties: false,
-    disambiguateRequestNames: true
+    disambiguateRequestNames: true,
+    ignoreTags: false
 };
 
 function mergeOptions<T extends object>(params: {

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir-in-memory/anyOf.json
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir-in-memory/anyOf.json
@@ -109,6 +109,7 @@
     "coerceConstsTo": "enums-coerceable-to-literals",
     "respectByteFormat": false,
     "shouldInferDiscriminatedUnionBaseProperties": false,
-    "disambiguateRequestNames": true
+    "disambiguateRequestNames": true,
+    "ignoreTags": false
   }
 }

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir-in-memory/application-json.json
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir-in-memory/application-json.json
@@ -89,6 +89,7 @@
     "coerceConstsTo": "enums-coerceable-to-literals",
     "respectByteFormat": false,
     "shouldInferDiscriminatedUnionBaseProperties": false,
-    "disambiguateRequestNames": true
+    "disambiguateRequestNames": true,
+    "ignoreTags": false
   }
 }

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir-in-memory/availability.json
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir-in-memory/availability.json
@@ -420,6 +420,7 @@
     "coerceConstsTo": "enums-coerceable-to-literals",
     "respectByteFormat": false,
     "shouldInferDiscriminatedUnionBaseProperties": false,
-    "disambiguateRequestNames": true
+    "disambiguateRequestNames": true,
+    "ignoreTags": false
   }
 }

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir-in-memory/const.json
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir-in-memory/const.json
@@ -123,6 +123,7 @@
     "coerceConstsTo": "enums-coerceable-to-literals",
     "respectByteFormat": false,
     "shouldInferDiscriminatedUnionBaseProperties": false,
-    "disambiguateRequestNames": true
+    "disambiguateRequestNames": true,
+    "ignoreTags": false
   }
 }

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir-in-memory/dates.json
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir-in-memory/dates.json
@@ -133,6 +133,7 @@
     "coerceConstsTo": "enums-coerceable-to-literals",
     "respectByteFormat": false,
     "shouldInferDiscriminatedUnionBaseProperties": false,
-    "disambiguateRequestNames": true
+    "disambiguateRequestNames": true,
+    "ignoreTags": false
   }
 }

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir-in-memory/inline-schema-reference.json
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir-in-memory/inline-schema-reference.json
@@ -121,6 +121,7 @@
     "coerceConstsTo": "enums-coerceable-to-literals",
     "respectByteFormat": false,
     "shouldInferDiscriminatedUnionBaseProperties": false,
-    "disambiguateRequestNames": true
+    "disambiguateRequestNames": true,
+    "ignoreTags": false
   }
 }

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir-in-memory/preserve-single-schema-oneof.json
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir-in-memory/preserve-single-schema-oneof.json
@@ -88,6 +88,7 @@
     "coerceConstsTo": "enums-coerceable-to-literals",
     "respectByteFormat": false,
     "shouldInferDiscriminatedUnionBaseProperties": false,
-    "disambiguateRequestNames": true
+    "disambiguateRequestNames": true,
+    "ignoreTags": false
   }
 }

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir-in-memory/url-reference.json
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir-in-memory/url-reference.json
@@ -76,6 +76,7 @@
     "coerceConstsTo": "enums-coerceable-to-literals",
     "respectByteFormat": false,
     "shouldInferDiscriminatedUnionBaseProperties": false,
-    "disambiguateRequestNames": true
+    "disambiguateRequestNames": true,
+    "ignoreTags": false
   }
 }

--- a/packages/cli/cli-v2/src/api/adapter/LegacyApiSpecAdapter.ts
+++ b/packages/cli/cli-v2/src/api/adapter/LegacyApiSpecAdapter.ts
@@ -204,7 +204,8 @@ export class LegacyApiSpecAdapter {
             defaultIntegerFormat: this.adaptDefaultIntegerFormat(settings.defaultIntegerFormat),
             coerceConstsTo: settings.coerceConstsTo,
             shouldInferDiscriminatedUnionBaseProperties: settings.inferDiscriminatedUnionBaseProperties,
-            disambiguateRequestNames: settings["disambiguate-request-names"]
+            disambiguateRequestNames: settings["disambiguate-request-names"],
+            ignoreTags: settings["ignore-tags"]
         };
 
         const hasSettings = Object.values(result).some((v) => v != null);

--- a/packages/cli/cli/changes/unreleased/add-ignore-tags-setting.yml
+++ b/packages/cli/cli/changes/unreleased/add-ignore-tags-setting.yml
@@ -1,0 +1,14 @@
+- summary: |
+    Add an `ignore-tags` OpenAPI setting to `generators.yml`. When enabled,
+    operation-level tags are ignored when determining the SDK structure:
+    endpoints fall back to the root package (or their namespace) and method
+    names are derived from each operation's `operationId`.
+
+    ```yaml
+    api:
+      specs:
+        - openapi: ./openapi.yml
+          settings:
+            ignore-tags: true
+    ```
+  type: feat

--- a/packages/cli/config/src/schemas/settings/OpenApiSettingsSchema.ts
+++ b/packages/cli/config/src/schemas/settings/OpenApiSettingsSchema.ts
@@ -100,7 +100,15 @@ export const OpenApiSettingsSchema = BaseApiSettingsSchema.extend({
      * If false, keep the original "Request" suffix regardless of collisions.
      * Defaults to true.
      */
-    "disambiguate-request-names": z.boolean().optional()
+    "disambiguate-request-names": z.boolean().optional(),
+
+    /**
+     * If true, ignore operation-level tags when determining the SDK structure.
+     * Endpoints fall back to the root package (or their namespace) and method
+     * names are derived from each operation's operationId.
+     * Defaults to false.
+     */
+    "ignore-tags": z.boolean().optional()
 });
 
 export type OpenApiSettingsSchema = z.infer<typeof OpenApiSettingsSchema>;

--- a/packages/cli/configuration-loader/src/generators-yml/convertGeneratorsConfiguration.ts
+++ b/packages/cli/configuration-loader/src/generators-yml/convertGeneratorsConfiguration.ts
@@ -72,7 +72,8 @@ const UNDEFINED_API_DEFINITION_SETTINGS: generatorsYml.APIDefinitionSettings = {
     inferForwardCompatible: undefined,
     coerceConstsTo: undefined,
     shouldInferDiscriminatedUnionBaseProperties: undefined,
-    disambiguateRequestNames: undefined
+    disambiguateRequestNames: undefined,
+    ignoreTags: undefined
 };
 
 export async function convertGeneratorsConfiguration({
@@ -181,7 +182,8 @@ function parseOpenApiDefinitionSettingsSchema(
         defaultIntegerFormat: settings?.["default-integer-format"],
         pathParameterOrder: settings?.["path-parameter-order"],
         shouldInferDiscriminatedUnionBaseProperties: settings?.["infer-discriminated-union-base-properties"],
-        disambiguateRequestNames: settings?.["disambiguate-request-names"]
+        disambiguateRequestNames: settings?.["disambiguate-request-names"],
+        ignoreTags: settings?.["ignore-tags"]
     };
 }
 

--- a/packages/cli/configuration/src/generators-yml/GeneratorsConfiguration.ts
+++ b/packages/cli/configuration/src/generators-yml/GeneratorsConfiguration.ts
@@ -100,6 +100,7 @@ export interface APIDefinitionSettings {
     coerceConstsTo: "literals" | "enums" | "enums-coerceable-to-literals" | undefined;
     shouldInferDiscriminatedUnionBaseProperties: boolean | undefined;
     disambiguateRequestNames: boolean | undefined;
+    ignoreTags: boolean | undefined;
 }
 
 export interface GitSource {

--- a/packages/cli/configuration/src/generators-yml/schemas/api/resources/generators/types/OpenApiSettingsSchema.ts
+++ b/packages/cli/configuration/src/generators-yml/schemas/api/resources/generators/types/OpenApiSettingsSchema.ts
@@ -74,4 +74,11 @@ export interface OpenApiSettingsSchema extends GeneratorsYml.BaseApiSettingsSche
      * Defaults to false.
      */
     "disambiguate-request-names"?: boolean;
+    /**
+     * If true, ignore operation-level tags when determining the SDK structure.
+     * Endpoints fall back to the root package (or their namespace) and method
+     * names are derived from each operation's operationId.
+     * Defaults to false.
+     */
+    "ignore-tags"?: boolean;
 }

--- a/packages/cli/configuration/src/generators-yml/schemas/serialization/resources/generators/types/OpenApiSettingsSchema.ts
+++ b/packages/cli/configuration/src/generators-yml/schemas/serialization/resources/generators/types/OpenApiSettingsSchema.ts
@@ -35,6 +35,7 @@ export const OpenApiSettingsSchema: core.serialization.ObjectSchema<
         "default-integer-format": DefaultIntegerFormat.optional(),
         "infer-discriminated-union-base-properties": core.serialization.boolean().optional(),
         "disambiguate-request-names": core.serialization.boolean().optional(),
+        "ignore-tags": core.serialization.boolean().optional(),
     })
     .extend(BaseApiSettingsSchema);
 
@@ -60,5 +61,6 @@ export declare namespace OpenApiSettingsSchema {
         "default-integer-format"?: DefaultIntegerFormat.Raw | null;
         "infer-discriminated-union-base-properties"?: boolean | null;
         "disambiguate-request-names"?: boolean | null;
+        "ignore-tags"?: boolean | null;
     }
 }

--- a/packages/commons/api-workspace-commons/src/openapi/getAPIDefinitionSettings.ts
+++ b/packages/commons/api-workspace-commons/src/openapi/getAPIDefinitionSettings.ts
@@ -67,7 +67,8 @@ const FIELD_MAPPINGS: Partial<MappableFields> = {
     inferForwardCompatible: "inferForwardCompatible",
     coerceConstsTo: "coerceConstsTo",
     shouldInferDiscriminatedUnionBaseProperties: "shouldInferDiscriminatedUnionBaseProperties",
-    disambiguateRequestNames: "disambiguateRequestNames"
+    disambiguateRequestNames: "disambiguateRequestNames",
+    ignoreTags: "ignoreTags"
 };
 
 function setIfDefined<K extends keyof OpenAPISettings>(


### PR DESCRIPTION
## Description
Adds a new per-spec OpenAPI setting `ignore-tags` to `generators.yml`. When enabled, operation-level tags are ignored when determining the SDK structure: endpoints fall back to the root package (or their explicit namespace) and method names are derived from each operation's `operationId`. This provides a config-only alternative to stripping `tags` from source specs (e.g. Twilio's `ConversationsV2Configuration` tag producing a `conversations_v2_configuration` sub-client).

```yaml
api:
  specs:
    - openapi: ./openapi.yml
      settings:
        ignore-tags: true
```

Defaults to `false`, so existing behavior is unchanged. Explicit `x-fern-sdk-group-name` / `x-fern-sdk-method-name` overrides continue to take priority.

## Changes Made
- `fern/apis/generators-yml/definition/generators.yml`: new optional `ignore-tags` boolean on `OpenAPISettingsSchema` (+ regenerated `generators-yml.schema.json` / `fern-yml.schema.json`)
- Plumbed through configuration (`GeneratorsConfiguration.APIDefinitionSettings.ignoreTags`, `convertGeneratorsConfiguration`, generated api/serialization schemas), commons (`getAPIDefinitionSettings` field mapping), cli-v2 (`LegacyApiSpecAdapter`), and zod config schema
- `openapi-ir-parser`: new `ParseOpenAPIOptions.ignoreTags` (default `false`); `convertHttpOperation` now emits `tags: []` when set, so endpoints resolve to the root package and are named from `operationId`
- Updated `openapi-ir-to-fern-tests` snapshots for the new option
- CLI changelog entry under `packages/cli/cli/changes/unreleased/`
- [ ] Updated README.md generator (if applicable)

## Testing
- [x] Unit tests added/updated — existing suites pass (`openapi-ir-parser`, `configuration-loader`, `api-workspace-commons`, `configuration`, `config`, `cli-v2`; snapshots updated for `openapi-ir-to-fern-tests`)
- [x] Manual testing completed — built the prod CLI and generated IR for a spec with a `ConversationsV2Configuration` tag: with `ignore-tags: false` a `conversationsV2Configuration` subpackage is created; with `ignore-tags: true` there are no subpackages and endpoints are named `ListConfiguration` / `CreateConfiguration` from their `operationId`s. `fern check` passes.


Link to Devin session: https://app.devin.ai/sessions/7fc276a2d7f5447ba61db25422d5d944
Requested by: @iamnamananand996
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/17180" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->