### PR TITLE
fix(java): set ConsoleHandler level to ALL so ConsoleLogger emits DEBUG logs

### DIFF
--- a/generators/java/sdk/changes/unreleased/fix-console-logger-debug-level.yml
+++ b/generators/java/sdk/changes/unreleased/fix-console-logger-debug-level.yml
@@ -1,0 +1,7 @@
+- summary: |
+    Fix `ConsoleLogger` dropping DEBUG-level log messages. The `ConsoleHandler` used by the
+    default logger keeps java.util.logging's default `INFO` handler level, so `FINE` records
+    (SDK debug logs, including HTTP request/response logging) were silently discarded even
+    when `LogConfig` was configured with `LogLevel.DEBUG` and `silent(false)`. The handler
+    level is now set to `ALL` so the configured `LogLevel` controls filtering.
+  type: fix

--- a/generators/java/sdk/src/main/resources/ConsoleLogger.java
+++ b/generators/java/sdk/src/main/resources/ConsoleLogger.java
@@ -18,6 +18,7 @@ public final class ConsoleLogger implements ILogger {
                     return record.getLevel() + " - " + record.getMessage() + System.lineSeparator();
                 }
             });
+            handler.setLevel(Level.ALL);
             logger.addHandler(handler);
             logger.setUseParentHandlers(false);
             logger.setLevel(Level.ALL);

--- a/seed/java-sdk/accept-header/accept-header/src/main/java/com/seed/accept/core/ConsoleLogger.java
+++ b/seed/java-sdk/accept-header/accept-header/src/main/java/com/seed/accept/core/ConsoleLogger.java
@@ -23,6 +23,7 @@ public final class ConsoleLogger implements ILogger {
                     return record.getLevel() + " - " + record.getMessage() + System.lineSeparator();
                 }
             });
+            handler.setLevel(Level.ALL);
             logger.addHandler(handler);
             logger.setUseParentHandlers(false);
             logger.setLevel(Level.ALL);

--- a/seed/java-sdk/alias-extends/src/main/java/com/seed/aliasExtends/core/ConsoleLogger.java
+++ b/seed/java-sdk/alias-extends/src/main/java/com/seed/aliasExtends/core/ConsoleLogger.java
@@ -23,6 +23,7 @@ public final class ConsoleLogger implements ILogger {
                     return record.getLevel() + " - " + record.getMessage() + System.lineSeparator();
                 }
             });
+            handler.setLevel(Level.ALL);
             logger.addHandler(handler);
             logger.setUseParentHandlers(false);
             logger.setLevel(Level.ALL);

--- a/seed/java-sdk/alias/src/main/java/com/seed/alias/core/ConsoleLogger.java
+++ b/seed/java-sdk/alias/src/main/java/com/seed/alias/core/ConsoleLogger.java
@@ -23,6 +23,7 @@ public final class ConsoleLogger implements ILogger {
                     return record.getLevel() + " - " + record.getMessage() + System.lineSeparator();
                 }
             });
+            handler.setLevel(Level.ALL);
             logger.addHandler(handler);
             logger.setUseParentHandlers(false);
             logger.setLevel(Level.ALL);

--- a/seed/java-sdk/allof-inline/src/main/java/com/seed/api/core/ConsoleLogger.java
+++ b/seed/java-sdk/allof-inline/src/main/java/com/seed/api/core/ConsoleLogger.java
@@ -23,6 +23,7 @@ public final class ConsoleLogger implements ILogger {
                     return record.getLevel() + " - " + record.getMessage() + System.lineSeparator();
                 }
             });
+            handler.setLevel(Level.ALL);
             logger.addHandler(handler);
             logger.setUseParentHandlers(false);
             logger.setLevel(Level.ALL);

--- a/seed/java-sdk/allof/src/main/java/com/seed/api/core/ConsoleLogger.java
+++ b/seed/java-sdk/allof/src/main/java/com/seed/api/core/ConsoleLogger.java
@@ -23,6 +23,7 @@ public final class ConsoleLogger implements ILogger {
                     return record.getLevel() + " - " + record.getMessage() + System.lineSeparator();
                 }
             });
+            handler.setLevel(Level.ALL);
             logger.addHandler(handler);
             logger.setUseParentHandlers(false);
             logger.setLevel(Level.ALL);

--- a/seed/java-sdk/any-auth/src/main/java/com/seed/anyAuth/core/ConsoleLogger.java
+++ b/seed/java-sdk/any-auth/src/main/java/com/seed/anyAuth/core/ConsoleLogger.java
@@ -23,6 +23,7 @@ public final class ConsoleLogger implements ILogger {
                     return record.getLevel() + " - " + record.getMessage() + System.lineSeparator();
                 }
             });
+            handler.setLevel(Level.ALL);
             logger.addHandler(handler);
             logger.setUseParentHandlers(false);
             logger.setLevel(Level.ALL);

--- a/seed/java-sdk/api-wide-base-path-with-default/src/main/java/com/seed/api/core/ConsoleLogger.java
+++ b/seed/java-sdk/api-wide-base-path-with-default/src/main/java/com/seed/api/core/ConsoleLogger.java
@@ -23,6 +23,7 @@ public final class ConsoleLogger implements ILogger {
                     return record.getLevel() + " - " + record.getMessage() + System.lineSeparator();
                 }
             });
+            handler.setLevel(Level.ALL);
             logger.addHandler(handler);
             logger.setUseParentHandlers(false);
             logger.setLevel(Level.ALL);

--- a/seed/java-sdk/api-wide-base-path/src/main/java/com/seed/apiWideBasePath/core/ConsoleLogger.java
+++ b/seed/java-sdk/api-wide-base-path/src/main/java/com/seed/apiWideBasePath/core/ConsoleLogger.java
@@ -23,6 +23,7 @@ public final class ConsoleLogger implements ILogger {
                     return record.getLevel() + " - " + record.getMessage() + System.lineSeparator();
                 }
             });
+            handler.setLevel(Level.ALL);
             logger.addHandler(handler);
             logger.setUseParentHandlers(false);
             logger.setLevel(Level.ALL);

--- a/seed/java-sdk/audiences/src/main/java/com/seed/audiences/core/ConsoleLogger.java
+++ b/seed/java-sdk/audiences/src/main/java/com/seed/audiences/core/ConsoleLogger.java
@@ -23,6 +23,7 @@ public final class ConsoleLogger implements ILogger {
                     return record.getLevel() + " - " + record.getMessage() + System.lineSeparator();
                 }
             });
+            handler.setLevel(Level.ALL);
             logger.addHandler(handler);
             logger.setUseParentHandlers(false);
             logger.setLevel(Level.ALL);

--- a/seed/java-sdk/basic-auth-environment-variables/src/main/java/com/seed/basicAuthEnvironmentVariables/core/ConsoleLogger.java
+++ b/seed/java-sdk/basic-auth-environment-variables/src/main/java/com/seed/basicAuthEnvironmentVariables/core/ConsoleLogger.java
@@ -23,6 +23,7 @@ public final class ConsoleLogger implements ILogger {
                     return record.getLevel() + " - " + record.getMessage() + System.lineSeparator();
                 }
             });
+            handler.setLevel(Level.ALL);
             logger.addHandler(handler);
             logger.setUseParentHandlers(false);
             logger.setLevel(Level.ALL);

--- a/seed/java-sdk/basic-auth-pw-omitted/basic-auth-pw-omitted/src/main/java/com/seed/basicAuthPwOmitted/core/ConsoleLogger.java
+++ b/seed/java-sdk/basic-auth-pw-omitted/basic-auth-pw-omitted/src/main/java/com/seed/basicAuthPwOmitted/core/ConsoleLogger.java
@@ -23,6 +23,7 @@ public final class ConsoleLogger implements ILogger {
                     return record.getLevel() + " - " + record.getMessage() + System.lineSeparator();
                 }
             });
+            handler.setLevel(Level.ALL);
             logger.addHandler(handler);
             logger.setUseParentHandlers(false);
             logger.setLevel(Level.ALL);

--- a/seed/java-sdk/basic-auth/basic-auth/src/main/java/com/seed/basicAuth/core/ConsoleLogger.java
+++ b/seed/java-sdk/basic-auth/basic-auth/src/main/java/com/seed/basicAuth/core/ConsoleLogger.java
@@ -23,6 +23,7 @@ public final class ConsoleLogger implements ILogger {
                     return record.getLevel() + " - " + record.getMessage() + System.lineSeparator();
                 }
             });
+            handler.setLevel(Level.ALL);
             logger.addHandler(handler);
             logger.setUseParentHandlers(false);
             logger.setLevel(Level.ALL);

--- a/seed/java-sdk/bearer-token-environment-variable/src/main/java/com/seed/bearerTokenEnvironmentVariable/core/ConsoleLogger.java
+++ b/seed/java-sdk/bearer-token-environment-variable/src/main/java/com/seed/bearerTokenEnvironmentVariable/core/ConsoleLogger.java
@@ -23,6 +23,7 @@ public final class ConsoleLogger implements ILogger {
                     return record.getLevel() + " - " + record.getMessage() + System.lineSeparator();
                 }
             });
+            handler.setLevel(Level.ALL);
             logger.addHandler(handler);
             logger.setUseParentHandlers(false);
             logger.setLevel(Level.ALL);

--- a/seed/java-sdk/bytes-download/src/main/java/com/seed/bytesDownload/core/ConsoleLogger.java
+++ b/seed/java-sdk/bytes-download/src/main/java/com/seed/bytesDownload/core/ConsoleLogger.java
@@ -23,6 +23,7 @@ public final class ConsoleLogger implements ILogger {
                     return record.getLevel() + " - " + record.getMessage() + System.lineSeparator();
                 }
             });
+            handler.setLevel(Level.ALL);
             logger.addHandler(handler);
             logger.setUseParentHandlers(false);
             logger.setLevel(Level.ALL);

--- a/seed/java-sdk/bytes-upload/src/main/java/com/seed/bytesUpload/core/ConsoleLogger.java
+++ b/seed/java-sdk/bytes-upload/src/main/java/com/seed/bytesUpload/core/ConsoleLogger.java
@@ -23,6 +23,7 @@ public final class ConsoleLogger implements ILogger {
                     return record.getLevel() + " - " + record.getMessage() + System.lineSeparator();
                 }
             });
+            handler.setLevel(Level.ALL);
             logger.addHandler(handler);
             logger.setUseParentHandlers(false);
             logger.setLevel(Level.ALL);

--- a/seed/java-sdk/circular-references-advanced/src/main/java/com/seed/api/core/ConsoleLogger.java
+++ b/seed/java-sdk/circular-references-advanced/src/main/java/com/seed/api/core/ConsoleLogger.java
@@ -23,6 +23,7 @@ public final class ConsoleLogger implements ILogger {
                     return record.getLevel() + " - " + record.getMessage() + System.lineSeparator();
                 }
             });
+            handler.setLevel(Level.ALL);
             logger.addHandler(handler);
             logger.setUseParentHandlers(false);
             logger.setLevel(Level.ALL);

--- a/seed/java-sdk/circular-references-extends/src/main/java/com/seed/api/core/ConsoleLogger.java
+++ b/seed/java-sdk/circular-references-extends/src/main/java/com/seed/api/core/ConsoleLogger.java
@@ -23,6 +23,7 @@ public final class ConsoleLogger implements ILogger {
                     return record.getLevel() + " - " + record.getMessage() + System.lineSeparator();
                 }
             });
+            handler.setLevel(Level.ALL);
             logger.addHandler(handler);
             logger.setUseParentHandlers(false);
             logger.setLevel(Level.ALL);

--- a/seed/java-sdk/circular-references/src/main/java/com/seed/api/core/ConsoleLogger.java
+++ b/seed/java-sdk/circular-references/src/main/java/com/seed/api/core/ConsoleLogger.java
@@ -23,6 +23,7 @@ public final class ConsoleLogger implements ILogger {
                     return record.getLevel() + " - " + record.getMessage() + System.lineSeparator();
                 }
             });
+            handler.setLevel(Level.ALL);
             logger.addHandler(handler);
             logger.setUseParentHandlers(false);
             logger.setLevel(Level.ALL);

--- a/seed/java-sdk/cli-multi-spec-namespaced/src/main/java/com/seed/api/core/ConsoleLogger.java
+++ b/seed/java-sdk/cli-multi-spec-namespaced/src/main/java/com/seed/api/core/ConsoleLogger.java
@@ -23,6 +23,7 @@ public final class ConsoleLogger implements ILogger {
                     return record.getLevel() + " - " + record.getMessage() + System.lineSeparator();
                 }
             });
+            handler.setLevel(Level.ALL);
             logger.addHandler(handler);
             logger.setUseParentHandlers(false);
             logger.setLevel(Level.ALL);

--- a/seed/java-sdk/cli-multi-spec/src/main/java/com/seed/api/core/ConsoleLogger.java
+++ b/seed/java-sdk/cli-multi-spec/src/main/java/com/seed/api/core/ConsoleLogger.java
@@ -23,6 +23,7 @@ public final class ConsoleLogger implements ILogger {
                     return record.getLevel() + " - " + record.getMessage() + System.lineSeparator();
                 }
             });
+            handler.setLevel(Level.ALL);
             logger.addHandler(handler);
             logger.setUseParentHandlers(false);
             logger.setLevel(Level.ALL);

--- a/seed/java-sdk/client-side-params/default/src/main/java/com/seed/clientSideParams/core/ConsoleLogger.java
+++ b/seed/java-sdk/client-side-params/default/src/main/java/com/seed/clientSideParams/core/ConsoleLogger.java
@@ -23,6 +23,7 @@ public final class ConsoleLogger implements ILogger {
                     return record.getLevel() + " - " + record.getMessage() + System.lineSeparator();
                 }
             });
+            handler.setLevel(Level.ALL);
             logger.addHandler(handler);
             logger.setUseParentHandlers(false);
             logger.setLevel(Level.ALL);

--- a/seed/java-sdk/content-type/src/main/java/com/seed/contentTypes/core/ConsoleLogger.java
+++ b/seed/java-sdk/content-type/src/main/java/com/seed/contentTypes/core/ConsoleLogger.java
@@ -23,6 +23,7 @@ public final class ConsoleLogger implements ILogger {
                     return record.getLevel() + " - " + record.getMessage() + System.lineSeparator();
                 }
             });
+            handler.setLevel(Level.ALL);
             logger.addHandler(handler);
             logger.setUseParentHandlers(false);
             logger.setLevel(Level.ALL);

--- a/seed/java-sdk/cross-package-type-names/src/main/java/com/seed/crossPackageTypeNames/core/ConsoleLogger.java
+++ b/seed/java-sdk/cross-package-type-names/src/main/java/com/seed/crossPackageTypeNames/core/ConsoleLogger.java
@@ -23,6 +23,7 @@ public final class ConsoleLogger implements ILogger {
                     return record.getLevel() + " - " + record.getMessage() + System.lineSeparator();
                 }
             });
+            handler.setLevel(Level.ALL);
             logger.addHandler(handler);
             logger.setUseParentHandlers(false);
             logger.setLevel(Level.ALL);

--- a/seed/java-sdk/discriminated-union-with-nested-oneof/src/main/java/com/seed/api/core/ConsoleLogger.java
+++ b/seed/java-sdk/discriminated-union-with-nested-oneof/src/main/java/com/seed/api/core/ConsoleLogger.java
@@ -23,6 +23,7 @@ public final class ConsoleLogger implements ILogger {
                     return record.getLevel() + " - " + record.getMessage() + System.lineSeparator();
                 }
             });
+            handler.setLevel(Level.ALL);
             logger.addHandler(handler);
             logger.setUseParentHandlers(false);
             logger.setLevel(Level.ALL);

--- a/seed/java-sdk/dollar-string-examples/src/main/java/com/seed/dollarStringExamples/core/ConsoleLogger.java
+++ b/seed/java-sdk/dollar-string-examples/src/main/java/com/seed/dollarStringExamples/core/ConsoleLogger.java
@@ -23,6 +23,7 @@ public final class ConsoleLogger implements ILogger {
                     return record.getLevel() + " - " + record.getMessage() + System.lineSeparator();
                 }
             });
+            handler.setLevel(Level.ALL);
             logger.addHandler(handler);
             logger.setUseParentHandlers(false);
             logger.setLevel(Level.ALL);

--- a/seed/java-sdk/empty-clients/src/main/java/com/seed/emptyClients/core/ConsoleLogger.java
+++ b/seed/java-sdk/empty-clients/src/main/java/com/seed/emptyClients/core/ConsoleLogger.java
@@ -23,6 +23,7 @@ public final class ConsoleLogger implements ILogger {
                     return record.getLevel() + " - " + record.getMessage() + System.lineSeparator();
                 }
             });
+            handler.setLevel(Level.ALL);
             logger.addHandler(handler);
             logger.setUseParentHandlers(false);
             logger.setLevel(Level.ALL);

--- a/seed/java-sdk/endpoint-security-auth/src/main/java/com/seed/endpointSecurityAuth/core/ConsoleLogger.java
+++ b/seed/java-sdk/endpoint-security-auth/src/main/java/com/seed/endpointSecurityAuth/core/ConsoleLogger.java
@@ -23,6 +23,7 @@ public final class ConsoleLogger implements ILogger {
                     return record.getLevel() + " - " + record.getMessage() + System.lineSeparator();
                 }
             });
+            handler.setLevel(Level.ALL);
             logger.addHandler(handler);
             logger.setUseParentHandlers(false);
             logger.setLevel(Level.ALL);

--- a/seed/java-sdk/enum/forward-compatible-enums/src/main/java/com/seed/_enum/core/ConsoleLogger.java
+++ b/seed/java-sdk/enum/forward-compatible-enums/src/main/java/com/seed/_enum/core/ConsoleLogger.java
@@ -23,6 +23,7 @@ public final class ConsoleLogger implements ILogger {
                     return record.getLevel() + " - " + record.getMessage() + System.lineSeparator();
                 }
             });
+            handler.setLevel(Level.ALL);
             logger.addHandler(handler);
             logger.setUseParentHandlers(false);
             logger.setLevel(Level.ALL);

--- a/seed/java-sdk/enum/no-custom-config/src/main/java/com/seed/_enum/core/ConsoleLogger.java
+++ b/seed/java-sdk/enum/no-custom-config/src/main/java/com/seed/_enum/core/ConsoleLogger.java
@@ -23,6 +23,7 @@ public final class ConsoleLogger implements ILogger {
                     return record.getLevel() + " - " + record.getMessage() + System.lineSeparator();
                 }
             });
+            handler.setLevel(Level.ALL);
             logger.addHandler(handler);
             logger.setUseParentHandlers(false);
             logger.setLevel(Level.ALL);

--- a/seed/java-sdk/error-property/src/main/java/com/seed/errorProperty/core/ConsoleLogger.java
+++ b/seed/java-sdk/error-property/src/main/java/com/seed/errorProperty/core/ConsoleLogger.java
@@ -23,6 +23,7 @@ public final class ConsoleLogger implements ILogger {
                     return record.getLevel() + " - " + record.getMessage() + System.lineSeparator();
                 }
             });
+            handler.setLevel(Level.ALL);
             logger.addHandler(handler);
             logger.setUseParentHandlers(false);
             logger.setLevel(Level.ALL);

--- a/seed/java-sdk/errors/src/main/java/com/seed/errors/core/ConsoleLogger.java
+++ b/seed/java-sdk/errors/src/main/java/com/seed/errors/core/ConsoleLogger.java
@@ -23,6 +23,7 @@ public final class ConsoleLogger implements ILogger {
                     return record.getLevel() + " - " + record.getMessage() + System.lineSeparator();
                 }
             });
+            handler.setLevel(Level.ALL);
             logger.addHandler(handler);
             logger.setUseParentHandlers(false);
             logger.setLevel(Level.ALL);

--- a/seed/java-sdk/examples/default/src/main/java/com/seed/examples/core/ConsoleLogger.java
+++ b/seed/java-sdk/examples/default/src/main/java/com/seed/examples/core/ConsoleLogger.java
@@ -23,6 +23,7 @@ public final class ConsoleLogger implements ILogger {
                     return record.getLevel() + " - " + record.getMessage() + System.lineSeparator();
                 }
             });
+            handler.setLevel(Level.ALL);
             logger.addHandler(handler);
             logger.setUseParentHandlers(false);
             logger.setLevel(Level.ALL);

--- a/seed/java-sdk/examples/inline-file-properties/src/main/java/com/seed/examples/core/ConsoleLogger.java
+++ b/seed/java-sdk/examples/inline-file-properties/src/main/java/com/seed/examples/core/ConsoleLogger.java
@@ -23,6 +23,7 @@ public final class ConsoleLogger implements ILogger {
                     return record.getLevel() + " - " + record.getMessage() + System.lineSeparator();
                 }
             });
+            handler.setLevel(Level.ALL);
             logger.addHandler(handler);
             logger.setUseParentHandlers(false);
             logger.setLevel(Level.ALL);

--- a/seed/java-sdk/examples/no-custom-config/src/main/java/com/seed/examples/core/ConsoleLogger.java
+++ b/seed/java-sdk/examples/no-custom-config/src/main/java/com/seed/examples/core/ConsoleLogger.java
@@ -23,6 +23,7 @@ public final class ConsoleLogger implements ILogger {
                     return record.getLevel() + " - " + record.getMessage() + System.lineSeparator();
                 }
             });
+            handler.setLevel(Level.ALL);
             logger.addHandler(handler);
             logger.setUseParentHandlers(false);
             logger.setLevel(Level.ALL);

--- a/seed/java-sdk/examples/readme-config/src/main/java/com/seed/examples/core/ConsoleLogger.java
+++ b/seed/java-sdk/examples/readme-config/src/main/java/com/seed/examples/core/ConsoleLogger.java
@@ -23,6 +23,7 @@ public final class ConsoleLogger implements ILogger {
                     return record.getLevel() + " - " + record.getMessage() + System.lineSeparator();
                 }
             });
+            handler.setLevel(Level.ALL);
             logger.addHandler(handler);
             logger.setUseParentHandlers(false);
             logger.setLevel(Level.ALL);

--- a/seed/java-sdk/exhaustive/custom-client-class-name/src/main/java/com/seed/exhaustive/core/ConsoleLogger.java
+++ b/seed/java-sdk/exhaustive/custom-client-class-name/src/main/java/com/seed/exhaustive/core/ConsoleLogger.java
@@ -23,6 +23,7 @@ public final class ConsoleLogger implements ILogger {
                     return record.getLevel() + " - " + record.getMessage() + System.lineSeparator();
                 }
             });
+            handler.setLevel(Level.ALL);
             logger.addHandler(handler);
             logger.setUseParentHandlers(false);
             logger.setLevel(Level.ALL);

--- a/seed/java-sdk/exhaustive/custom-dependency/src/main/java/com/seed/exhaustive/core/ConsoleLogger.java
+++ b/seed/java-sdk/exhaustive/custom-dependency/src/main/java/com/seed/exhaustive/core/ConsoleLogger.java
@@ -23,6 +23,7 @@ public final class ConsoleLogger implements ILogger {
                     return record.getLevel() + " - " + record.getMessage() + System.lineSeparator();
                 }
             });
+            handler.setLevel(Level.ALL);
             logger.addHandler(handler);
             logger.setUseParentHandlers(false);
             logger.setLevel(Level.ALL);

--- a/seed/java-sdk/exhaustive/custom-error-names/src/main/java/com/seed/exhaustive/core/ConsoleLogger.java
+++ b/seed/java-sdk/exhaustive/custom-error-names/src/main/java/com/seed/exhaustive/core/ConsoleLogger.java
@@ -23,6 +23,7 @@ public final class ConsoleLogger implements ILogger {
                     return record.getLevel() + " - " + record.getMessage() + System.lineSeparator();
                 }
             });
+            handler.setLevel(Level.ALL);
             logger.addHandler(handler);
             logger.setUseParentHandlers(false);
             logger.setLevel(Level.ALL);

--- a/seed/java-sdk/exhaustive/custom-interceptors/src/main/java/com/seed/exhaustive/core/ConsoleLogger.java
+++ b/seed/java-sdk/exhaustive/custom-interceptors/src/main/java/com/seed/exhaustive/core/ConsoleLogger.java
@@ -23,6 +23,7 @@ public final class ConsoleLogger implements ILogger {
                     return record.getLevel() + " - " + record.getMessage() + System.lineSeparator();
                 }
             });
+            handler.setLevel(Level.ALL);
             logger.addHandler(handler);
             logger.setUseParentHandlers(false);
             logger.setLevel(Level.ALL);

--- a/seed/java-sdk/exhaustive/custom-license/src/main/java/com/seed/exhaustive/core/ConsoleLogger.java
+++ b/seed/java-sdk/exhaustive/custom-license/src/main/java/com/seed/exhaustive/core/ConsoleLogger.java
@@ -23,6 +23,7 @@ public final class ConsoleLogger implements ILogger {
                     return record.getLevel() + " - " + record.getMessage() + System.lineSeparator();
                 }
             });
+            handler.setLevel(Level.ALL);
             logger.addHandler(handler);
             logger.setUseParentHandlers(false);
             logger.setLevel(Level.ALL);

--- a/seed/java-sdk/exhaustive/custom-plugins/src/main/java/com/seed/exhaustive/core/ConsoleLogger.java
+++ b/seed/java-sdk/exhaustive/custom-plugins/src/main/java/com/seed/exhaustive/core/ConsoleLogger.java
@@ -23,6 +23,7 @@ public final class ConsoleLogger implements ILogger {
                     return record.getLevel() + " - " + record.getMessage() + System.lineSeparator();
                 }
             });
+            handler.setLevel(Level.ALL);
             logger.addHandler(handler);
             logger.setUseParentHandlers(false);
             logger.setLevel(Level.ALL);

--- a/seed/java-sdk/exhaustive/enable-public-constructors/src/main/java/com/seed/exhaustive/core/ConsoleLogger.java
+++ b/seed/java-sdk/exhaustive/enable-public-constructors/src/main/java/com/seed/exhaustive/core/ConsoleLogger.java
@@ -23,6 +23,7 @@ public final class ConsoleLogger implements ILogger {
                     return record.getLevel() + " - " + record.getMessage() + System.lineSeparator();
                 }
             });
+            handler.setLevel(Level.ALL);
             logger.addHandler(handler);
             logger.setUseParentHandlers(false);
             logger.setLevel(Level.ALL);

--- a/seed/java-sdk/exhaustive/flat-package-layout/src/main/java/com/seed/exhaustive/core/ConsoleLogger.java
+++ b/seed/java-sdk/exhaustive/flat-package-layout/src/main/java/com/seed/exhaustive/core/ConsoleLogger.java
@@ -23,6 +23,7 @@ public final class ConsoleLogger implements ILogger {
                     return record.getLevel() + " - " + record.getMessage() + System.lineSeparator();
                 }
             });
+            handler.setLevel(Level.ALL);
             logger.addHandler(handler);
             logger.setUseParentHandlers(false);
             logger.setLevel(Level.ALL);

--- a/seed/java-sdk/exhaustive/forward-compatible-enums/src/main/java/com/seed/exhaustive/core/ConsoleLogger.java
+++ b/seed/java-sdk/exhaustive/forward-compatible-enums/src/main/java/com/seed/exhaustive/core/ConsoleLogger.java
@@ -23,6 +23,7 @@ public final class ConsoleLogger implements ILogger {
                     return record.getLevel() + " - " + record.getMessage() + System.lineSeparator();
                 }
             });
+            handler.setLevel(Level.ALL);
             logger.addHandler(handler);
             logger.setUseParentHandlers(false);
             logger.setLevel(Level.ALL);

--- a/seed/java-sdk/exhaustive/json-include-non-empty/src/main/java/com/seed/exhaustive/core/ConsoleLogger.java
+++ b/seed/java-sdk/exhaustive/json-include-non-empty/src/main/java/com/seed/exhaustive/core/ConsoleLogger.java
@@ -23,6 +23,7 @@ public final class ConsoleLogger implements ILogger {
                     return record.getLevel() + " - " + record.getMessage() + System.lineSeparator();
                 }
             });
+            handler.setLevel(Level.ALL);
             logger.addHandler(handler);
             logger.setUseParentHandlers(false);
             logger.setLevel(Level.ALL);

--- a/seed/java-sdk/exhaustive/local-files/src/main/java/core/ConsoleLogger.java
+++ b/seed/java-sdk/exhaustive/local-files/src/main/java/core/ConsoleLogger.java
@@ -24,6 +24,7 @@ public final class ConsoleLogger implements ILogger {
                     return record.getLevel() + " - " + record.getMessage() + System.lineSeparator();
                 }
             });
+            handler.setLevel(Level.ALL);
             logger.addHandler(handler);
             logger.setUseParentHandlers(false);
             logger.setLevel(Level.ALL);

--- a/seed/java-sdk/exhaustive/no-custom-config/src/main/java/com/seed/exhaustive/core/ConsoleLogger.java
+++ b/seed/java-sdk/exhaustive/no-custom-config/src/main/java/com/seed/exhaustive/core/ConsoleLogger.java
@@ -23,6 +23,7 @@ public final class ConsoleLogger implements ILogger {
                     return record.getLevel() + " - " + record.getMessage() + System.lineSeparator();
                 }
             });
+            handler.setLevel(Level.ALL);
             logger.addHandler(handler);
             logger.setUseParentHandlers(false);
             logger.setLevel(Level.ALL);

--- a/seed/java-sdk/exhaustive/publish-to/src/main/java/com/seed/exhaustive/core/ConsoleLogger.java
+++ b/seed/java-sdk/exhaustive/publish-to/src/main/java/com/seed/exhaustive/core/ConsoleLogger.java
@@ -23,6 +23,7 @@ public final class ConsoleLogger implements ILogger {
                     return record.getLevel() + " - " + record.getMessage() + System.lineSeparator();
                 }
             });
+            handler.setLevel(Level.ALL);
             logger.addHandler(handler);
             logger.setUseParentHandlers(false);
             logger.setLevel(Level.ALL);

--- a/seed/java-sdk/exhaustive/signed_publish/src/main/java/com/seed/exhaustive/core/ConsoleLogger.java
+++ b/seed/java-sdk/exhaustive/signed_publish/src/main/java/com/seed/exhaustive/core/ConsoleLogger.java
@@ -23,6 +23,7 @@ public final class ConsoleLogger implements ILogger {
                     return record.getLevel() + " - " + record.getMessage() + System.lineSeparator();
                 }
             });
+            handler.setLevel(Level.ALL);
             logger.addHandler(handler);
             logger.setUseParentHandlers(false);
             logger.setLevel(Level.ALL);

--- a/seed/java-sdk/extends/src/main/java/com/seed/_extends/core/ConsoleLogger.java
+++ b/seed/java-sdk/extends/src/main/java/com/seed/_extends/core/ConsoleLogger.java
@@ -23,6 +23,7 @@ public final class ConsoleLogger implements ILogger {
                     return record.getLevel() + " - " + record.getMessage() + System.lineSeparator();
                 }
             });
+            handler.setLevel(Level.ALL);
             logger.addHandler(handler);
             logger.setUseParentHandlers(false);
             logger.setLevel(Level.ALL);

--- a/seed/java-sdk/extra-properties/src/main/java/com/seed/extraProperties/core/ConsoleLogger.java
+++ b/seed/java-sdk/extra-properties/src/main/java/com/seed/extraProperties/core/ConsoleLogger.java
@@ -23,6 +23,7 @@ public final class ConsoleLogger implements ILogger {
                     return record.getLevel() + " - " + record.getMessage() + System.lineSeparator();
                 }
             });
+            handler.setLevel(Level.ALL);
             logger.addHandler(handler);
             logger.setUseParentHandlers(false);
             logger.setLevel(Level.ALL);

--- a/seed/java-sdk/file-download/src/main/java/com/seed/fileDownload/core/ConsoleLogger.java
+++ b/seed/java-sdk/file-download/src/main/java/com/seed/fileDownload/core/ConsoleLogger.java
@@ -23,6 +23,7 @@ public final class ConsoleLogger implements ILogger {
                     return record.getLevel() + " - " + record.getMessage() + System.lineSeparator();
                 }
             });
+            handler.setLevel(Level.ALL);
             logger.addHandler(handler);
             logger.setUseParentHandlers(false);
             logger.setLevel(Level.ALL);

--- a/seed/java-sdk/file-upload-openapi/src/main/java/com/seed/api/core/ConsoleLogger.java
+++ b/seed/java-sdk/file-upload-openapi/src/main/java/com/seed/api/core/ConsoleLogger.java
@@ -23,6 +23,7 @@ public final class ConsoleLogger implements ILogger {
                     return record.getLevel() + " - " + record.getMessage() + System.lineSeparator();
                 }
             });
+            handler.setLevel(Level.ALL);
             logger.addHandler(handler);
             logger.setUseParentHandlers(false);
             logger.setLevel(Level.ALL);

--- a/seed/java-sdk/file-upload/inline-file-properties/src/main/java/com/seed/fileUpload/core/ConsoleLogger.java
+++ b/seed/java-sdk/file-upload/inline-file-properties/src/main/java/com/seed/fileUpload/core/ConsoleLogger.java
@@ -23,6 +23,7 @@ public final class ConsoleLogger implements ILogger {
                     return record.getLevel() + " - " + record.getMessage() + System.lineSeparator();
                 }
             });
+            handler.setLevel(Level.ALL);
             logger.addHandler(handler);
             logger.setUseParentHandlers(false);
             logger.setLevel(Level.ALL);

--- a/seed/java-sdk/file-upload/no-custom-config/src/main/java/com/seed/fileUpload/core/ConsoleLogger.java
+++ b/seed/java-sdk/file-upload/no-custom-config/src/main/java/com/seed/fileUpload/core/ConsoleLogger.java
@@ -23,6 +23,7 @@ public final class ConsoleLogger implements ILogger {
                     return record.getLevel() + " - " + record.getMessage() + System.lineSeparator();
                 }
             });
+            handler.setLevel(Level.ALL);
             logger.addHandler(handler);
             logger.setUseParentHandlers(false);
             logger.setLevel(Level.ALL);

--- a/seed/java-sdk/file-upload/wrapped-aliases/src/main/java/com/seed/fileUpload/core/ConsoleLogger.java
+++ b/seed/java-sdk/file-upload/wrapped-aliases/src/main/java/com/seed/fileUpload/core/ConsoleLogger.java
@@ -23,6 +23,7 @@ public final class ConsoleLogger implements ILogger {
                     return record.getLevel() + " - " + record.getMessage() + System.lineSeparator();
                 }
             });
+            handler.setLevel(Level.ALL);
             logger.addHandler(handler);
             logger.setUseParentHandlers(false);
             logger.setLevel(Level.ALL);

--- a/seed/java-sdk/folders/src/main/java/com/seed/api/core/ConsoleLogger.java
+++ b/seed/java-sdk/folders/src/main/java/com/seed/api/core/ConsoleLogger.java
@@ -23,6 +23,7 @@ public final class ConsoleLogger implements ILogger {
                     return record.getLevel() + " - " + record.getMessage() + System.lineSeparator();
                 }
             });
+            handler.setLevel(Level.ALL);
             logger.addHandler(handler);
             logger.setUseParentHandlers(false);
             logger.setLevel(Level.ALL);

--- a/seed/java-sdk/header-auth-environment-variable/src/main/java/com/seed/headerTokenEnvironmentVariable/core/ConsoleLogger.java
+++ b/seed/java-sdk/header-auth-environment-variable/src/main/java/com/seed/headerTokenEnvironmentVariable/core/ConsoleLogger.java
@@ -23,6 +23,7 @@ public final class ConsoleLogger implements ILogger {
                     return record.getLevel() + " - " + record.getMessage() + System.lineSeparator();
                 }
             });
+            handler.setLevel(Level.ALL);
             logger.addHandler(handler);
             logger.setUseParentHandlers(false);
             logger.setLevel(Level.ALL);

--- a/seed/java-sdk/header-auth/header-auth/src/main/java/com/seed/headerToken/core/ConsoleLogger.java
+++ b/seed/java-sdk/header-auth/header-auth/src/main/java/com/seed/headerToken/core/ConsoleLogger.java
@@ -23,6 +23,7 @@ public final class ConsoleLogger implements ILogger {
                     return record.getLevel() + " - " + record.getMessage() + System.lineSeparator();
                 }
             });
+            handler.setLevel(Level.ALL);
             logger.addHandler(handler);
             logger.setUseParentHandlers(false);
             logger.setLevel(Level.ALL);

--- a/seed/java-sdk/http-head/src/main/java/com/seed/httpHead/core/ConsoleLogger.java
+++ b/seed/java-sdk/http-head/src/main/java/com/seed/httpHead/core/ConsoleLogger.java
@@ -23,6 +23,7 @@ public final class ConsoleLogger implements ILogger {
                     return record.getLevel() + " - " + record.getMessage() + System.lineSeparator();
                 }
             });
+            handler.setLevel(Level.ALL);
             logger.addHandler(handler);
             logger.setUseParentHandlers(false);
             logger.setLevel(Level.ALL);

--- a/seed/java-sdk/idempotency-headers/auto-generate-idempotency-key/src/main/java/com/seed/idempotencyHeaders/core/ConsoleLogger.java
+++ b/seed/java-sdk/idempotency-headers/auto-generate-idempotency-key/src/main/java/com/seed/idempotencyHeaders/core/ConsoleLogger.java
@@ -23,6 +23,7 @@ public final class ConsoleLogger implements ILogger {
                     return record.getLevel() + " - " + record.getMessage() + System.lineSeparator();
                 }
             });
+            handler.setLevel(Level.ALL);
             logger.addHandler(handler);
             logger.setUseParentHandlers(false);
             logger.setLevel(Level.ALL);

--- a/seed/java-sdk/idempotency-headers/no-custom-config/src/main/java/com/seed/idempotencyHeaders/core/ConsoleLogger.java
+++ b/seed/java-sdk/idempotency-headers/no-custom-config/src/main/java/com/seed/idempotencyHeaders/core/ConsoleLogger.java
@@ -23,6 +23,7 @@ public final class ConsoleLogger implements ILogger {
                     return record.getLevel() + " - " + record.getMessage() + System.lineSeparator();
                 }
             });
+            handler.setLevel(Level.ALL);
             logger.addHandler(handler);
             logger.setUseParentHandlers(false);
             logger.setLevel(Level.ALL);

--- a/seed/java-sdk/imdb/disable-required-property-builder-checks/src/main/java/com/seed/api/core/ConsoleLogger.java
+++ b/seed/java-sdk/imdb/disable-required-property-builder-checks/src/main/java/com/seed/api/core/ConsoleLogger.java
@@ -23,6 +23,7 @@ public final class ConsoleLogger implements ILogger {
                     return record.getLevel() + " - " + record.getMessage() + System.lineSeparator();
                 }
             });
+            handler.setLevel(Level.ALL);
             logger.addHandler(handler);
             logger.setUseParentHandlers(false);
             logger.setLevel(Level.ALL);

--- a/seed/java-sdk/imdb/flat-package-layout/src/main/java/com/seed/api/core/ConsoleLogger.java
+++ b/seed/java-sdk/imdb/flat-package-layout/src/main/java/com/seed/api/core/ConsoleLogger.java
@@ -23,6 +23,7 @@ public final class ConsoleLogger implements ILogger {
                     return record.getLevel() + " - " + record.getMessage() + System.lineSeparator();
                 }
             });
+            handler.setLevel(Level.ALL);
             logger.addHandler(handler);
             logger.setUseParentHandlers(false);
             logger.setLevel(Level.ALL);

--- a/seed/java-sdk/imdb/include-platform-headers/src/main/java/com/seed/api/core/ConsoleLogger.java
+++ b/seed/java-sdk/imdb/include-platform-headers/src/main/java/com/seed/api/core/ConsoleLogger.java
@@ -23,6 +23,7 @@ public final class ConsoleLogger implements ILogger {
                     return record.getLevel() + " - " + record.getMessage() + System.lineSeparator();
                 }
             });
+            handler.setLevel(Level.ALL);
             logger.addHandler(handler);
             logger.setUseParentHandlers(false);
             logger.setLevel(Level.ALL);

--- a/seed/java-sdk/imdb/omit-fern-headers/src/main/java/com/seed/api/core/ConsoleLogger.java
+++ b/seed/java-sdk/imdb/omit-fern-headers/src/main/java/com/seed/api/core/ConsoleLogger.java
@@ -23,6 +23,7 @@ public final class ConsoleLogger implements ILogger {
                     return record.getLevel() + " - " + record.getMessage() + System.lineSeparator();
                 }
             });
+            handler.setLevel(Level.ALL);
             logger.addHandler(handler);
             logger.setUseParentHandlers(false);
             logger.setLevel(Level.ALL);

--- a/seed/java-sdk/inferred-auth-explicit/src/main/java/com/seed/inferredAuthExplicit/core/ConsoleLogger.java
+++ b/seed/java-sdk/inferred-auth-explicit/src/main/java/com/seed/inferredAuthExplicit/core/ConsoleLogger.java
@@ -23,6 +23,7 @@ public final class ConsoleLogger implements ILogger {
                     return record.getLevel() + " - " + record.getMessage() + System.lineSeparator();
                 }
             });
+            handler.setLevel(Level.ALL);
             logger.addHandler(handler);
             logger.setUseParentHandlers(false);
             logger.setLevel(Level.ALL);

--- a/seed/java-sdk/inferred-auth-implicit-api-key/src/main/java/com/seed/inferredAuthImplicitApiKey/core/ConsoleLogger.java
+++ b/seed/java-sdk/inferred-auth-implicit-api-key/src/main/java/com/seed/inferredAuthImplicitApiKey/core/ConsoleLogger.java
@@ -23,6 +23,7 @@ public final class ConsoleLogger implements ILogger {
                     return record.getLevel() + " - " + record.getMessage() + System.lineSeparator();
                 }
             });
+            handler.setLevel(Level.ALL);
             logger.addHandler(handler);
             logger.setUseParentHandlers(false);
             logger.setLevel(Level.ALL);

--- a/seed/java-sdk/inferred-auth-implicit-no-expiry/src/main/java/com/seed/inferredAuthImplicitNoExpiry/core/ConsoleLogger.java
+++ b/seed/java-sdk/inferred-auth-implicit-no-expiry/src/main/java/com/seed/inferredAuthImplicitNoExpiry/core/ConsoleLogger.java
@@ -23,6 +23,7 @@ public final class ConsoleLogger implements ILogger {
                     return record.getLevel() + " - " + record.getMessage() + System.lineSeparator();
                 }
             });
+            handler.setLevel(Level.ALL);
             logger.addHandler(handler);
             logger.setUseParentHandlers(false);
             logger.setLevel(Level.ALL);

--- a/seed/java-sdk/inferred-auth-implicit-reference/src/main/java/com/seed/inferredAuthImplicit/core/ConsoleLogger.java
+++ b/seed/java-sdk/inferred-auth-implicit-reference/src/main/java/com/seed/inferredAuthImplicit/core/ConsoleLogger.java
@@ -23,6 +23,7 @@ public final class ConsoleLogger implements ILogger {
                     return record.getLevel() + " - " + record.getMessage() + System.lineSeparator();
                 }
             });
+            handler.setLevel(Level.ALL);
             logger.addHandler(handler);
             logger.setUseParentHandlers(false);
             logger.setLevel(Level.ALL);

--- a/seed/java-sdk/inferred-auth-implicit/src/main/java/com/seed/inferredAuthImplicit/core/ConsoleLogger.java
+++ b/seed/java-sdk/inferred-auth-implicit/src/main/java/com/seed/inferredAuthImplicit/core/ConsoleLogger.java
@@ -23,6 +23,7 @@ public final class ConsoleLogger implements ILogger {
                     return record.getLevel() + " - " + record.getMessage() + System.lineSeparator();
                 }
             });
+            handler.setLevel(Level.ALL);
             logger.addHandler(handler);
             logger.setUseParentHandlers(false);
             logger.setLevel(Level.ALL);

--- a/seed/java-sdk/inline-enum-type-name-override/src/main/java/com/seed/api/core/ConsoleLogger.java
+++ b/seed/java-sdk/inline-enum-type-name-override/src/main/java/com/seed/api/core/ConsoleLogger.java
@@ -23,6 +23,7 @@ public final class ConsoleLogger implements ILogger {
                     return record.getLevel() + " - " + record.getMessage() + System.lineSeparator();
                 }
             });
+            handler.setLevel(Level.ALL);
             logger.addHandler(handler);
             logger.setUseParentHandlers(false);
             logger.setLevel(Level.ALL);

--- a/seed/java-sdk/java-builder-extension/base-client/src/main/java/com/seed/builderExtension/core/ConsoleLogger.java
+++ b/seed/java-sdk/java-builder-extension/base-client/src/main/java/com/seed/builderExtension/core/ConsoleLogger.java
@@ -23,6 +23,7 @@ public final class ConsoleLogger implements ILogger {
                     return record.getLevel() + " - " + record.getMessage() + System.lineSeparator();
                 }
             });
+            handler.setLevel(Level.ALL);
             logger.addHandler(handler);
             logger.setUseParentHandlers(false);
             logger.setLevel(Level.ALL);

--- a/seed/java-sdk/java-builder-extension/extensible-builders/src/main/java/com/seed/builderExtension/core/ConsoleLogger.java
+++ b/seed/java-sdk/java-builder-extension/extensible-builders/src/main/java/com/seed/builderExtension/core/ConsoleLogger.java
@@ -23,6 +23,7 @@ public final class ConsoleLogger implements ILogger {
                     return record.getLevel() + " - " + record.getMessage() + System.lineSeparator();
                 }
             });
+            handler.setLevel(Level.ALL);
             logger.addHandler(handler);
             logger.setUseParentHandlers(false);
             logger.setLevel(Level.ALL);

--- a/seed/java-sdk/java-custom-package-prefix/java-custom-package-prefix/src/main/java/com/customprefix/core/ConsoleLogger.java
+++ b/seed/java-sdk/java-custom-package-prefix/java-custom-package-prefix/src/main/java/com/customprefix/core/ConsoleLogger.java
@@ -23,6 +23,7 @@ public final class ConsoleLogger implements ILogger {
                     return record.getLevel() + " - " + record.getMessage() + System.lineSeparator();
                 }
             });
+            handler.setLevel(Level.ALL);
             logger.addHandler(handler);
             logger.setUseParentHandlers(false);
             logger.setLevel(Level.ALL);

--- a/seed/java-sdk/java-default-timeout/default/src/main/java/com/seed/javaDefaultTimeout/core/ConsoleLogger.java
+++ b/seed/java-sdk/java-default-timeout/default/src/main/java/com/seed/javaDefaultTimeout/core/ConsoleLogger.java
@@ -23,6 +23,7 @@ public final class ConsoleLogger implements ILogger {
                     return record.getLevel() + " - " + record.getMessage() + System.lineSeparator();
                 }
             });
+            handler.setLevel(Level.ALL);
             logger.addHandler(handler);
             logger.setUseParentHandlers(false);
             logger.setLevel(Level.ALL);

--- a/seed/java-sdk/java-idempotency-headers-file-upload/auto-generate-idempotency-key/src/main/java/com/seed/javaIdempotencyHeadersFileUpload/core/ConsoleLogger.java
+++ b/seed/java-sdk/java-idempotency-headers-file-upload/auto-generate-idempotency-key/src/main/java/com/seed/javaIdempotencyHeadersFileUpload/core/ConsoleLogger.java
@@ -23,6 +23,7 @@ public final class ConsoleLogger implements ILogger {
                     return record.getLevel() + " - " + record.getMessage() + System.lineSeparator();
                 }
             });
+            handler.setLevel(Level.ALL);
             logger.addHandler(handler);
             logger.setUseParentHandlers(false);
             logger.setLevel(Level.ALL);

--- a/seed/java-sdk/java-idempotency-headers-file-upload/default/src/main/java/com/seed/javaIdempotencyHeadersFileUpload/core/ConsoleLogger.java
+++ b/seed/java-sdk/java-idempotency-headers-file-upload/default/src/main/java/com/seed/javaIdempotencyHeadersFileUpload/core/ConsoleLogger.java
@@ -23,6 +23,7 @@ public final class ConsoleLogger implements ILogger {
                     return record.getLevel() + " - " + record.getMessage() + System.lineSeparator();
                 }
             });
+            handler.setLevel(Level.ALL);
             logger.addHandler(handler);
             logger.setUseParentHandlers(false);
             logger.setLevel(Level.ALL);

--- a/seed/java-sdk/java-inline-types/enable-forward-compatible-enums/src/main/java/com/seed/object/core/ConsoleLogger.java
+++ b/seed/java-sdk/java-inline-types/enable-forward-compatible-enums/src/main/java/com/seed/object/core/ConsoleLogger.java
@@ -23,6 +23,7 @@ public final class ConsoleLogger implements ILogger {
                     return record.getLevel() + " - " + record.getMessage() + System.lineSeparator();
                 }
             });
+            handler.setLevel(Level.ALL);
             logger.addHandler(handler);
             logger.setUseParentHandlers(false);
             logger.setLevel(Level.ALL);

--- a/seed/java-sdk/java-inline-types/inline/src/main/java/com/seed/object/core/ConsoleLogger.java
+++ b/seed/java-sdk/java-inline-types/inline/src/main/java/com/seed/object/core/ConsoleLogger.java
@@ -23,6 +23,7 @@ public final class ConsoleLogger implements ILogger {
                     return record.getLevel() + " - " + record.getMessage() + System.lineSeparator();
                 }
             });
+            handler.setLevel(Level.ALL);
             logger.addHandler(handler);
             logger.setUseParentHandlers(false);
             logger.setLevel(Level.ALL);

--- a/seed/java-sdk/java-inline-types/no-inline/src/main/java/com/seed/object/core/ConsoleLogger.java
+++ b/seed/java-sdk/java-inline-types/no-inline/src/main/java/com/seed/object/core/ConsoleLogger.java
@@ -23,6 +23,7 @@ public final class ConsoleLogger implements ILogger {
                     return record.getLevel() + " - " + record.getMessage() + System.lineSeparator();
                 }
             });
+            handler.setLevel(Level.ALL);
             logger.addHandler(handler);
             logger.setUseParentHandlers(false);
             logger.setLevel(Level.ALL);

--- a/seed/java-sdk/java-inline-types/no-wrapped-aliases/src/main/java/com/seed/object/core/ConsoleLogger.java
+++ b/seed/java-sdk/java-inline-types/no-wrapped-aliases/src/main/java/com/seed/object/core/ConsoleLogger.java
@@ -23,6 +23,7 @@ public final class ConsoleLogger implements ILogger {
                     return record.getLevel() + " - " + record.getMessage() + System.lineSeparator();
                 }
             });
+            handler.setLevel(Level.ALL);
             logger.addHandler(handler);
             logger.setUseParentHandlers(false);
             logger.setLevel(Level.ALL);

--- a/seed/java-sdk/java-many-properties/default/src/main/java/com/seed/manyProperties/core/ConsoleLogger.java
+++ b/seed/java-sdk/java-many-properties/default/src/main/java/com/seed/manyProperties/core/ConsoleLogger.java
@@ -23,6 +23,7 @@ public final class ConsoleLogger implements ILogger {
                     return record.getLevel() + " - " + record.getMessage() + System.lineSeparator();
                 }
             });
+            handler.setLevel(Level.ALL);
             logger.addHandler(handler);
             logger.setUseParentHandlers(false);
             logger.setLevel(Level.ALL);

--- a/seed/java-sdk/java-multi-env-url-templating/no-custom-config/src/main/java/com/seed/api/core/ConsoleLogger.java
+++ b/seed/java-sdk/java-multi-env-url-templating/no-custom-config/src/main/java/com/seed/api/core/ConsoleLogger.java
@@ -23,6 +23,7 @@ public final class ConsoleLogger implements ILogger {
                     return record.getLevel() + " - " + record.getMessage() + System.lineSeparator();
                 }
             });
+            handler.setLevel(Level.ALL);
             logger.addHandler(handler);
             logger.setUseParentHandlers(false);
             logger.setLevel(Level.ALL);

--- a/seed/java-sdk/java-nullable-named-request-types/custom-config/src/main/java/com/seed/api/core/ConsoleLogger.java
+++ b/seed/java-sdk/java-nullable-named-request-types/custom-config/src/main/java/com/seed/api/core/ConsoleLogger.java
@@ -23,6 +23,7 @@ public final class ConsoleLogger implements ILogger {
                     return record.getLevel() + " - " + record.getMessage() + System.lineSeparator();
                 }
             });
+            handler.setLevel(Level.ALL);
             logger.addHandler(handler);
             logger.setUseParentHandlers(false);
             logger.setLevel(Level.ALL);

--- a/seed/java-sdk/java-oauth-token-optional/no-custom-config/src/main/java/com/seed/javaOauthTokenOptional/core/ConsoleLogger.java
+++ b/seed/java-sdk/java-oauth-token-optional/no-custom-config/src/main/java/com/seed/javaOauthTokenOptional/core/ConsoleLogger.java
@@ -23,6 +23,7 @@ public final class ConsoleLogger implements ILogger {
                     return record.getLevel() + " - " + record.getMessage() + System.lineSeparator();
                 }
             });
+            handler.setLevel(Level.ALL);
             logger.addHandler(handler);
             logger.setUseParentHandlers(false);
             logger.setLevel(Level.ALL);

--- a/seed/java-sdk/java-optional-nullable-query-params/default/src/main/java/com/seed/javaOptionalNullableQueryParams/core/ConsoleLogger.java
+++ b/seed/java-sdk/java-optional-nullable-query-params/default/src/main/java/com/seed/javaOptionalNullableQueryParams/core/ConsoleLogger.java
@@ -23,6 +23,7 @@ public final class ConsoleLogger implements ILogger {
                     return record.getLevel() + " - " + record.getMessage() + System.lineSeparator();
                 }
             });
+            handler.setLevel(Level.ALL);
             logger.addHandler(handler);
             logger.setUseParentHandlers(false);
             logger.setLevel(Level.ALL);

--- a/seed/java-sdk/java-optional-query-params-overloads/src/main/java/com/seed/javaOptionalQueryParamsOverloads/core/ConsoleLogger.java
+++ b/seed/java-sdk/java-optional-query-params-overloads/src/main/java/com/seed/javaOptionalQueryParamsOverloads/core/ConsoleLogger.java
@@ -23,6 +23,7 @@ public final class ConsoleLogger implements ILogger {
                     return record.getLevel() + " - " + record.getMessage() + System.lineSeparator();
                 }
             });
+            handler.setLevel(Level.ALL);
             logger.addHandler(handler);
             logger.setUseParentHandlers(false);
             logger.setLevel(Level.ALL);

--- a/seed/java-sdk/java-output-directory/no-config/src/main/java/core/ConsoleLogger.java
+++ b/seed/java-sdk/java-output-directory/no-config/src/main/java/core/ConsoleLogger.java
@@ -24,6 +24,7 @@ public final class ConsoleLogger implements ILogger {
                     return record.getLevel() + " - " + record.getMessage() + System.lineSeparator();
                 }
             });
+            handler.setLevel(Level.ALL);
             logger.addHandler(handler);
             logger.setUseParentHandlers(false);
             logger.setLevel(Level.ALL);

--- a/seed/java-sdk/java-output-directory/project-root/src/main/java/core/ConsoleLogger.java
+++ b/seed/java-sdk/java-output-directory/project-root/src/main/java/core/ConsoleLogger.java
@@ -24,6 +24,7 @@ public final class ConsoleLogger implements ILogger {
                     return record.getLevel() + " - " + record.getMessage() + System.lineSeparator();
                 }
             });
+            handler.setLevel(Level.ALL);
             logger.addHandler(handler);
             logger.setUseParentHandlers(false);
             logger.setLevel(Level.ALL);

--- a/seed/java-sdk/java-output-directory/source-root/core/ConsoleLogger.java
+++ b/seed/java-sdk/java-output-directory/source-root/core/ConsoleLogger.java
@@ -24,6 +24,7 @@ public final class ConsoleLogger implements ILogger {
                     return record.getLevel() + " - " + record.getMessage() + System.lineSeparator();
                 }
             });
+            handler.setLevel(Level.ALL);
             logger.addHandler(handler);
             logger.setUseParentHandlers(false);
             logger.setLevel(Level.ALL);

--- a/seed/java-sdk/java-pagination-deep-cursor-path/java-pagination-deep-cursor-path/src/main/java/com/seed/deepCursorPath/core/ConsoleLogger.java
+++ b/seed/java-sdk/java-pagination-deep-cursor-path/java-pagination-deep-cursor-path/src/main/java/com/seed/deepCursorPath/core/ConsoleLogger.java
@@ -23,6 +23,7 @@ public final class ConsoleLogger implements ILogger {
                     return record.getLevel() + " - " + record.getMessage() + System.lineSeparator();
                 }
             });
+            handler.setLevel(Level.ALL);
             logger.addHandler(handler);
             logger.setUseParentHandlers(false);
             logger.setLevel(Level.ALL);

--- a/seed/java-sdk/java-pagination-deep-cursor-path/wire-tests/src/main/java/com/seed/deepCursorPath/core/ConsoleLogger.java
+++ b/seed/java-sdk/java-pagination-deep-cursor-path/wire-tests/src/main/java/com/seed/deepCursorPath/core/ConsoleLogger.java
@@ -23,6 +23,7 @@ public final class ConsoleLogger implements ILogger {
                     return record.getLevel() + " - " + record.getMessage() + System.lineSeparator();
                 }
             });
+            handler.setLevel(Level.ALL);
             logger.addHandler(handler);
             logger.setUseParentHandlers(false);
             logger.setLevel(Level.ALL);

--- a/seed/java-sdk/java-path-param-key-conflict/default/src/main/java/com/seed/api/core/ConsoleLogger.java
+++ b/seed/java-sdk/java-path-param-key-conflict/default/src/main/java/com/seed/api/core/ConsoleLogger.java
@@ -23,6 +23,7 @@ public final class ConsoleLogger implements ILogger {
                     return record.getLevel() + " - " + record.getMessage() + System.lineSeparator();
                 }
             });
+            handler.setLevel(Level.ALL);
             logger.addHandler(handler);
             logger.setUseParentHandlers(false);
             logger.setLevel(Level.ALL);

--- a/seed/java-sdk/java-path-parameter-suffix/default/src/main/java/com/seed/api/core/ConsoleLogger.java
+++ b/seed/java-sdk/java-path-parameter-suffix/default/src/main/java/com/seed/api/core/ConsoleLogger.java
@@ -23,6 +23,7 @@ public final class ConsoleLogger implements ILogger {
                     return record.getLevel() + " - " + record.getMessage() + System.lineSeparator();
                 }
             });
+            handler.setLevel(Level.ALL);
             logger.addHandler(handler);
             logger.setUseParentHandlers(false);
             logger.setLevel(Level.ALL);

--- a/seed/java-sdk/java-required-body-optional-headers/src/main/java/com/seed/javaRequiredBodyOptionalHeaders/core/ConsoleLogger.java
+++ b/seed/java-sdk/java-required-body-optional-headers/src/main/java/com/seed/javaRequiredBodyOptionalHeaders/core/ConsoleLogger.java
@@ -23,6 +23,7 @@ public final class ConsoleLogger implements ILogger {
                     return record.getLevel() + " - " + record.getMessage() + System.lineSeparator();
                 }
             });
+            handler.setLevel(Level.ALL);
             logger.addHandler(handler);
             logger.setUseParentHandlers(false);
             logger.setLevel(Level.ALL);

--- a/seed/java-sdk/java-single-property-endpoint/java-single-property-endpoint/src/main/java/com/seed/singleProperty/core/ConsoleLogger.java
+++ b/seed/java-sdk/java-single-property-endpoint/java-single-property-endpoint/src/main/java/com/seed/singleProperty/core/ConsoleLogger.java
@@ -23,6 +23,7 @@ public final class ConsoleLogger implements ILogger {
                     return record.getLevel() + " - " + record.getMessage() + System.lineSeparator();
                 }
             });
+            handler.setLevel(Level.ALL);
             logger.addHandler(handler);
             logger.setUseParentHandlers(false);
             logger.setLevel(Level.ALL);

--- a/seed/java-sdk/java-staged-builder-ordering/src/main/java/com/seed/stagedBuilderOrdering/core/ConsoleLogger.java
+++ b/seed/java-sdk/java-staged-builder-ordering/src/main/java/com/seed/stagedBuilderOrdering/core/ConsoleLogger.java
@@ -23,6 +23,7 @@ public final class ConsoleLogger implements ILogger {
                     return record.getLevel() + " - " + record.getMessage() + System.lineSeparator();
                 }
             });
+            handler.setLevel(Level.ALL);
             logger.addHandler(handler);
             logger.setUseParentHandlers(false);
             logger.setLevel(Level.ALL);

--- a/seed/java-sdk/java-streaming-accept-header/src/main/java/com/seed/javaStreamingAcceptHeader/core/ConsoleLogger.java
+++ b/seed/java-sdk/java-streaming-accept-header/src/main/java/com/seed/javaStreamingAcceptHeader/core/ConsoleLogger.java
@@ -23,6 +23,7 @@ public final class ConsoleLogger implements ILogger {
                     return record.getLevel() + " - " + record.getMessage() + System.lineSeparator();
                 }
             });
+            handler.setLevel(Level.ALL);
             logger.addHandler(handler);
             logger.setUseParentHandlers(false);
             logger.setLevel(Level.ALL);

--- a/seed/java-sdk/java-websocket-shared-discriminator/src/main/java/com/seed/javaWebsocketSharedDiscriminator/core/ConsoleLogger.java
+++ b/seed/java-sdk/java-websocket-shared-discriminator/src/main/java/com/seed/javaWebsocketSharedDiscriminator/core/ConsoleLogger.java
@@ -23,6 +23,7 @@ public final class ConsoleLogger implements ILogger {
                     return record.getLevel() + " - " + record.getMessage() + System.lineSeparator();
                 }
             });
+            handler.setLevel(Level.ALL);
             logger.addHandler(handler);
             logger.setUseParentHandlers(false);
             logger.setLevel(Level.ALL);

--- a/seed/java-sdk/java-with-property-conflict/default/src/main/java/com/seed/javaWithPropertyConflict/core/ConsoleLogger.java
+++ b/seed/java-sdk/java-with-property-conflict/default/src/main/java/com/seed/javaWithPropertyConflict/core/ConsoleLogger.java
@@ -23,6 +23,7 @@ public final class ConsoleLogger implements ILogger {
                     return record.getLevel() + " - " + record.getMessage() + System.lineSeparator();
                 }
             });
+            handler.setLevel(Level.ALL);
             logger.addHandler(handler);
             logger.setUseParentHandlers(false);
             logger.setLevel(Level.ALL);

--- a/seed/java-sdk/license/src/main/java/com/seed/license/core/ConsoleLogger.java
+++ b/seed/java-sdk/license/src/main/java/com/seed/license/core/ConsoleLogger.java
@@ -23,6 +23,7 @@ public final class ConsoleLogger implements ILogger {
                     return record.getLevel() + " - " + record.getMessage() + System.lineSeparator();
                 }
             });
+            handler.setLevel(Level.ALL);
             logger.addHandler(handler);
             logger.setUseParentHandlers(false);
             logger.setLevel(Level.ALL);

--- a/seed/java-sdk/literal-user-agent/src/main/java/com/seed/literalUserAgent/core/ConsoleLogger.java
+++ b/seed/java-sdk/literal-user-agent/src/main/java/com/seed/literalUserAgent/core/ConsoleLogger.java
@@ -23,6 +23,7 @@ public final class ConsoleLogger implements ILogger {
                     return record.getLevel() + " - " + record.getMessage() + System.lineSeparator();
                 }
             });
+            handler.setLevel(Level.ALL);
             logger.addHandler(handler);
             logger.setUseParentHandlers(false);
             logger.setLevel(Level.ALL);

--- a/seed/java-sdk/literal/src/main/java/com/seed/literal/core/ConsoleLogger.java
+++ b/seed/java-sdk/literal/src/main/java/com/seed/literal/core/ConsoleLogger.java
@@ -23,6 +23,7 @@ public final class ConsoleLogger implements ILogger {
                     return record.getLevel() + " - " + record.getMessage() + System.lineSeparator();
                 }
             });
+            handler.setLevel(Level.ALL);
             logger.addHandler(handler);
             logger.setUseParentHandlers(false);
             logger.setLevel(Level.ALL);

--- a/seed/java-sdk/literals-unions/src/main/java/com/seed/literalsUnions/core/ConsoleLogger.java
+++ b/seed/java-sdk/literals-unions/src/main/java/com/seed/literalsUnions/core/ConsoleLogger.java
@@ -23,6 +23,7 @@ public final class ConsoleLogger implements ILogger {
                     return record.getLevel() + " - " + record.getMessage() + System.lineSeparator();
                 }
             });
+            handler.setLevel(Level.ALL);
             logger.addHandler(handler);
             logger.setUseParentHandlers(false);
             logger.setLevel(Level.ALL);

--- a/seed/java-sdk/mixed-case/src/main/java/com/seed/mixedCase/core/ConsoleLogger.java
+++ b/seed/java-sdk/mixed-case/src/main/java/com/seed/mixedCase/core/ConsoleLogger.java
@@ -23,6 +23,7 @@ public final class ConsoleLogger implements ILogger {
                     return record.getLevel() + " - " + record.getMessage() + System.lineSeparator();
                 }
             });
+            handler.setLevel(Level.ALL);
             logger.addHandler(handler);
             logger.setUseParentHandlers(false);
             logger.setLevel(Level.ALL);

--- a/seed/java-sdk/mixed-file-directory/src/main/java/com/seed/mixedFileDirectory/core/ConsoleLogger.java
+++ b/seed/java-sdk/mixed-file-directory/src/main/java/com/seed/mixedFileDirectory/core/ConsoleLogger.java
@@ -23,6 +23,7 @@ public final class ConsoleLogger implements ILogger {
                     return record.getLevel() + " - " + record.getMessage() + System.lineSeparator();
                 }
             });
+            handler.setLevel(Level.ALL);
             logger.addHandler(handler);
             logger.setUseParentHandlers(false);
             logger.setLevel(Level.ALL);

--- a/seed/java-sdk/multi-content-type-examples/src/main/java/com/seed/api/core/ConsoleLogger.java
+++ b/seed/java-sdk/multi-content-type-examples/src/main/java/com/seed/api/core/ConsoleLogger.java
@@ -23,6 +23,7 @@ public final class ConsoleLogger implements ILogger {
                     return record.getLevel() + " - " + record.getMessage() + System.lineSeparator();
                 }
             });
+            handler.setLevel(Level.ALL);
             logger.addHandler(handler);
             logger.setUseParentHandlers(false);
             logger.setLevel(Level.ALL);

--- a/seed/java-sdk/multi-line-docs/src/main/java/com/seed/multiLineDocs/core/ConsoleLogger.java
+++ b/seed/java-sdk/multi-line-docs/src/main/java/com/seed/multiLineDocs/core/ConsoleLogger.java
@@ -23,6 +23,7 @@ public final class ConsoleLogger implements ILogger {
                     return record.getLevel() + " - " + record.getMessage() + System.lineSeparator();
                 }
             });
+            handler.setLevel(Level.ALL);
             logger.addHandler(handler);
             logger.setUseParentHandlers(false);
             logger.setLevel(Level.ALL);

--- a/seed/java-sdk/multi-url-environment-no-default/src/main/java/com/seed/multiUrlEnvironmentNoDefault/core/ConsoleLogger.java
+++ b/seed/java-sdk/multi-url-environment-no-default/src/main/java/com/seed/multiUrlEnvironmentNoDefault/core/ConsoleLogger.java
@@ -23,6 +23,7 @@ public final class ConsoleLogger implements ILogger {
                     return record.getLevel() + " - " + record.getMessage() + System.lineSeparator();
                 }
             });
+            handler.setLevel(Level.ALL);
             logger.addHandler(handler);
             logger.setUseParentHandlers(false);
             logger.setLevel(Level.ALL);

--- a/seed/java-sdk/multi-url-environment-reference/src/main/java/com/seed/api/core/ConsoleLogger.java
+++ b/seed/java-sdk/multi-url-environment-reference/src/main/java/com/seed/api/core/ConsoleLogger.java
@@ -23,6 +23,7 @@ public final class ConsoleLogger implements ILogger {
                     return record.getLevel() + " - " + record.getMessage() + System.lineSeparator();
                 }
             });
+            handler.setLevel(Level.ALL);
             logger.addHandler(handler);
             logger.setUseParentHandlers(false);
             logger.setLevel(Level.ALL);

--- a/seed/java-sdk/multi-url-environment/src/main/java/com/seed/multiUrlEnvironment/core/ConsoleLogger.java
+++ b/seed/java-sdk/multi-url-environment/src/main/java/com/seed/multiUrlEnvironment/core/ConsoleLogger.java
@@ -23,6 +23,7 @@ public final class ConsoleLogger implements ILogger {
                     return record.getLevel() + " - " + record.getMessage() + System.lineSeparator();
                 }
             });
+            handler.setLevel(Level.ALL);
             logger.addHandler(handler);
             logger.setUseParentHandlers(false);
             logger.setLevel(Level.ALL);

--- a/seed/java-sdk/multiple-request-bodies/src/main/java/com/seed/api/core/ConsoleLogger.java
+++ b/seed/java-sdk/multiple-request-bodies/src/main/java/com/seed/api/core/ConsoleLogger.java
@@ -23,6 +23,7 @@ public final class ConsoleLogger implements ILogger {
                     return record.getLevel() + " - " + record.getMessage() + System.lineSeparator();
                 }
             });
+            handler.setLevel(Level.ALL);
             logger.addHandler(handler);
             logger.setUseParentHandlers(false);
             logger.setLevel(Level.ALL);

--- a/seed/java-sdk/no-content-response/src/main/java/com/seed/api/core/ConsoleLogger.java
+++ b/seed/java-sdk/no-content-response/src/main/java/com/seed/api/core/ConsoleLogger.java
@@ -23,6 +23,7 @@ public final class ConsoleLogger implements ILogger {
                     return record.getLevel() + " - " + record.getMessage() + System.lineSeparator();
                 }
             });
+            handler.setLevel(Level.ALL);
             logger.addHandler(handler);
             logger.setUseParentHandlers(false);
             logger.setLevel(Level.ALL);

--- a/seed/java-sdk/no-environment/src/main/java/com/seed/noEnvironment/core/ConsoleLogger.java
+++ b/seed/java-sdk/no-environment/src/main/java/com/seed/noEnvironment/core/ConsoleLogger.java
@@ -23,6 +23,7 @@ public final class ConsoleLogger implements ILogger {
                     return record.getLevel() + " - " + record.getMessage() + System.lineSeparator();
                 }
             });
+            handler.setLevel(Level.ALL);
             logger.addHandler(handler);
             logger.setUseParentHandlers(false);
             logger.setLevel(Level.ALL);

--- a/seed/java-sdk/no-retries/src/main/java/com/seed/noRetries/core/ConsoleLogger.java
+++ b/seed/java-sdk/no-retries/src/main/java/com/seed/noRetries/core/ConsoleLogger.java
@@ -23,6 +23,7 @@ public final class ConsoleLogger implements ILogger {
                     return record.getLevel() + " - " + record.getMessage() + System.lineSeparator();
                 }
             });
+            handler.setLevel(Level.ALL);
             logger.addHandler(handler);
             logger.setUseParentHandlers(false);
             logger.setLevel(Level.ALL);

--- a/seed/java-sdk/null-type/src/main/java/com/seed/api/core/ConsoleLogger.java
+++ b/seed/java-sdk/null-type/src/main/java/com/seed/api/core/ConsoleLogger.java
@@ -23,6 +23,7 @@ public final class ConsoleLogger implements ILogger {
                     return record.getLevel() + " - " + record.getMessage() + System.lineSeparator();
                 }
             });
+            handler.setLevel(Level.ALL);
             logger.addHandler(handler);
             logger.setUseParentHandlers(false);
             logger.setLevel(Level.ALL);

--- a/seed/java-sdk/nullable-allof-extends/src/main/java/com/seed/api/core/ConsoleLogger.java
+++ b/seed/java-sdk/nullable-allof-extends/src/main/java/com/seed/api/core/ConsoleLogger.java
@@ -23,6 +23,7 @@ public final class ConsoleLogger implements ILogger {
                     return record.getLevel() + " - " + record.getMessage() + System.lineSeparator();
                 }
             });
+            handler.setLevel(Level.ALL);
             logger.addHandler(handler);
             logger.setUseParentHandlers(false);
             logger.setLevel(Level.ALL);

--- a/seed/java-sdk/nullable-optional/collapse-optional-nullable/src/main/java/com/seed/nullableOptional/core/ConsoleLogger.java
+++ b/seed/java-sdk/nullable-optional/collapse-optional-nullable/src/main/java/com/seed/nullableOptional/core/ConsoleLogger.java
@@ -23,6 +23,7 @@ public final class ConsoleLogger implements ILogger {
                     return record.getLevel() + " - " + record.getMessage() + System.lineSeparator();
                 }
             });
+            handler.setLevel(Level.ALL);
             logger.addHandler(handler);
             logger.setUseParentHandlers(false);
             logger.setLevel(Level.ALL);

--- a/seed/java-sdk/nullable-optional/legacy/src/main/java/com/seed/nullableOptional/core/ConsoleLogger.java
+++ b/seed/java-sdk/nullable-optional/legacy/src/main/java/com/seed/nullableOptional/core/ConsoleLogger.java
@@ -23,6 +23,7 @@ public final class ConsoleLogger implements ILogger {
                     return record.getLevel() + " - " + record.getMessage() + System.lineSeparator();
                 }
             });
+            handler.setLevel(Level.ALL);
             logger.addHandler(handler);
             logger.setUseParentHandlers(false);
             logger.setLevel(Level.ALL);

--- a/seed/java-sdk/nullable-optional/with-nullable-annotation/src/main/java/com/seed/nullableOptional/core/ConsoleLogger.java
+++ b/seed/java-sdk/nullable-optional/with-nullable-annotation/src/main/java/com/seed/nullableOptional/core/ConsoleLogger.java
@@ -23,6 +23,7 @@ public final class ConsoleLogger implements ILogger {
                     return record.getLevel() + " - " + record.getMessage() + System.lineSeparator();
                 }
             });
+            handler.setLevel(Level.ALL);
             logger.addHandler(handler);
             logger.setUseParentHandlers(false);
             logger.setLevel(Level.ALL);

--- a/seed/java-sdk/nullable-request-body/src/main/java/com/seed/api/core/ConsoleLogger.java
+++ b/seed/java-sdk/nullable-request-body/src/main/java/com/seed/api/core/ConsoleLogger.java
@@ -23,6 +23,7 @@ public final class ConsoleLogger implements ILogger {
                     return record.getLevel() + " - " + record.getMessage() + System.lineSeparator();
                 }
             });
+            handler.setLevel(Level.ALL);
             logger.addHandler(handler);
             logger.setUseParentHandlers(false);
             logger.setLevel(Level.ALL);

--- a/seed/java-sdk/nullable/no-custom-config/src/main/java/com/seed/nullable/core/ConsoleLogger.java
+++ b/seed/java-sdk/nullable/no-custom-config/src/main/java/com/seed/nullable/core/ConsoleLogger.java
@@ -23,6 +23,7 @@ public final class ConsoleLogger implements ILogger {
                     return record.getLevel() + " - " + record.getMessage() + System.lineSeparator();
                 }
             });
+            handler.setLevel(Level.ALL);
             logger.addHandler(handler);
             logger.setUseParentHandlers(false);
             logger.setLevel(Level.ALL);

--- a/seed/java-sdk/nullable/wrapped-aliases/src/main/java/com/seed/nullable/core/ConsoleLogger.java
+++ b/seed/java-sdk/nullable/wrapped-aliases/src/main/java/com/seed/nullable/core/ConsoleLogger.java
@@ -23,6 +23,7 @@ public final class ConsoleLogger implements ILogger {
                     return record.getLevel() + " - " + record.getMessage() + System.lineSeparator();
                 }
             });
+            handler.setLevel(Level.ALL);
             logger.addHandler(handler);
             logger.setUseParentHandlers(false);
             logger.setLevel(Level.ALL);

--- a/seed/java-sdk/oauth-client-credentials-custom/src/main/java/com/seed/oauthClientCredentials/core/ConsoleLogger.java
+++ b/seed/java-sdk/oauth-client-credentials-custom/src/main/java/com/seed/oauthClientCredentials/core/ConsoleLogger.java
@@ -23,6 +23,7 @@ public final class ConsoleLogger implements ILogger {
                     return record.getLevel() + " - " + record.getMessage() + System.lineSeparator();
                 }
             });
+            handler.setLevel(Level.ALL);
             logger.addHandler(handler);
             logger.setUseParentHandlers(false);
             logger.setLevel(Level.ALL);

--- a/seed/java-sdk/oauth-client-credentials-default/src/main/java/com/seed/oauthClientCredentialsDefault/core/ConsoleLogger.java
+++ b/seed/java-sdk/oauth-client-credentials-default/src/main/java/com/seed/oauthClientCredentialsDefault/core/ConsoleLogger.java
@@ -23,6 +23,7 @@ public final class ConsoleLogger implements ILogger {
                     return record.getLevel() + " - " + record.getMessage() + System.lineSeparator();
                 }
             });
+            handler.setLevel(Level.ALL);
             logger.addHandler(handler);
             logger.setUseParentHandlers(false);
             logger.setLevel(Level.ALL);

--- a/seed/java-sdk/oauth-client-credentials-environment-variables/src/main/java/com/seed/oauthClientCredentialsEnvironmentVariables/core/ConsoleLogger.java
+++ b/seed/java-sdk/oauth-client-credentials-environment-variables/src/main/java/com/seed/oauthClientCredentialsEnvironmentVariables/core/ConsoleLogger.java
@@ -23,6 +23,7 @@ public final class ConsoleLogger implements ILogger {
                     return record.getLevel() + " - " + record.getMessage() + System.lineSeparator();
                 }
             });
+            handler.setLevel(Level.ALL);
             logger.addHandler(handler);
             logger.setUseParentHandlers(false);
             logger.setLevel(Level.ALL);

--- a/seed/java-sdk/oauth-client-credentials-mandatory-auth/no-custom-config/src/main/java/com/seed/oauthClientCredentialsMandatoryAuth/core/ConsoleLogger.java
+++ b/seed/java-sdk/oauth-client-credentials-mandatory-auth/no-custom-config/src/main/java/com/seed/oauthClientCredentialsMandatoryAuth/core/ConsoleLogger.java
@@ -23,6 +23,7 @@ public final class ConsoleLogger implements ILogger {
                     return record.getLevel() + " - " + record.getMessage() + System.lineSeparator();
                 }
             });
+            handler.setLevel(Level.ALL);
             logger.addHandler(handler);
             logger.setUseParentHandlers(false);
             logger.setLevel(Level.ALL);

--- a/seed/java-sdk/oauth-client-credentials-nested-root/src/main/java/com/seed/oauthClientCredentials/core/ConsoleLogger.java
+++ b/seed/java-sdk/oauth-client-credentials-nested-root/src/main/java/com/seed/oauthClientCredentials/core/ConsoleLogger.java
@@ -23,6 +23,7 @@ public final class ConsoleLogger implements ILogger {
                     return record.getLevel() + " - " + record.getMessage() + System.lineSeparator();
                 }
             });
+            handler.setLevel(Level.ALL);
             logger.addHandler(handler);
             logger.setUseParentHandlers(false);
             logger.setLevel(Level.ALL);

--- a/seed/java-sdk/oauth-client-credentials-openapi/src/main/java/com/seed/api/core/ConsoleLogger.java
+++ b/seed/java-sdk/oauth-client-credentials-openapi/src/main/java/com/seed/api/core/ConsoleLogger.java
@@ -23,6 +23,7 @@ public final class ConsoleLogger implements ILogger {
                     return record.getLevel() + " - " + record.getMessage() + System.lineSeparator();
                 }
             });
+            handler.setLevel(Level.ALL);
             logger.addHandler(handler);
             logger.setUseParentHandlers(false);
             logger.setLevel(Level.ALL);

--- a/seed/java-sdk/oauth-client-credentials-reference/src/main/java/com/seed/oauthClientCredentialsReference/core/ConsoleLogger.java
+++ b/seed/java-sdk/oauth-client-credentials-reference/src/main/java/com/seed/oauthClientCredentialsReference/core/ConsoleLogger.java
@@ -23,6 +23,7 @@ public final class ConsoleLogger implements ILogger {
                     return record.getLevel() + " - " + record.getMessage() + System.lineSeparator();
                 }
             });
+            handler.setLevel(Level.ALL);
             logger.addHandler(handler);
             logger.setUseParentHandlers(false);
             logger.setLevel(Level.ALL);

--- a/seed/java-sdk/oauth-client-credentials-with-variables/src/main/java/com/seed/oauthClientCredentialsWithVariables/core/ConsoleLogger.java
+++ b/seed/java-sdk/oauth-client-credentials-with-variables/src/main/java/com/seed/oauthClientCredentialsWithVariables/core/ConsoleLogger.java
@@ -23,6 +23,7 @@ public final class ConsoleLogger implements ILogger {
                     return record.getLevel() + " - " + record.getMessage() + System.lineSeparator();
                 }
             });
+            handler.setLevel(Level.ALL);
             logger.addHandler(handler);
             logger.setUseParentHandlers(false);
             logger.setLevel(Level.ALL);

--- a/seed/java-sdk/oauth-client-credentials/custom-interceptors/src/main/java/com/seed/oauthClientCredentials/core/ConsoleLogger.java
+++ b/seed/java-sdk/oauth-client-credentials/custom-interceptors/src/main/java/com/seed/oauthClientCredentials/core/ConsoleLogger.java
@@ -23,6 +23,7 @@ public final class ConsoleLogger implements ILogger {
                     return record.getLevel() + " - " + record.getMessage() + System.lineSeparator();
                 }
             });
+            handler.setLevel(Level.ALL);
             logger.addHandler(handler);
             logger.setUseParentHandlers(false);
             logger.setLevel(Level.ALL);

--- a/seed/java-sdk/oauth-client-credentials/oauth-client-credentials/src/main/java/com/seed/oauthClientCredentials/core/ConsoleLogger.java
+++ b/seed/java-sdk/oauth-client-credentials/oauth-client-credentials/src/main/java/com/seed/oauthClientCredentials/core/ConsoleLogger.java
@@ -23,6 +23,7 @@ public final class ConsoleLogger implements ILogger {
                     return record.getLevel() + " - " + record.getMessage() + System.lineSeparator();
                 }
             });
+            handler.setLevel(Level.ALL);
             logger.addHandler(handler);
             logger.setUseParentHandlers(false);
             logger.setLevel(Level.ALL);

--- a/seed/java-sdk/oauth-pkce/src/main/java/com/seed/oauthPkce/core/ConsoleLogger.java
+++ b/seed/java-sdk/oauth-pkce/src/main/java/com/seed/oauthPkce/core/ConsoleLogger.java
@@ -23,6 +23,7 @@ public final class ConsoleLogger implements ILogger {
                     return record.getLevel() + " - " + record.getMessage() + System.lineSeparator();
                 }
             });
+            handler.setLevel(Level.ALL);
             logger.addHandler(handler);
             logger.setUseParentHandlers(false);
             logger.setLevel(Level.ALL);

--- a/seed/java-sdk/object/src/main/java/com/seed/object/core/ConsoleLogger.java
+++ b/seed/java-sdk/object/src/main/java/com/seed/object/core/ConsoleLogger.java
@@ -23,6 +23,7 @@ public final class ConsoleLogger implements ILogger {
                     return record.getLevel() + " - " + record.getMessage() + System.lineSeparator();
                 }
             });
+            handler.setLevel(Level.ALL);
             logger.addHandler(handler);
             logger.setUseParentHandlers(false);
             logger.setLevel(Level.ALL);

--- a/seed/java-sdk/objects-with-imports/src/main/java/com/seed/objectsWithImports/core/ConsoleLogger.java
+++ b/seed/java-sdk/objects-with-imports/src/main/java/com/seed/objectsWithImports/core/ConsoleLogger.java
@@ -23,6 +23,7 @@ public final class ConsoleLogger implements ILogger {
                     return record.getLevel() + " - " + record.getMessage() + System.lineSeparator();
                 }
             });
+            handler.setLevel(Level.ALL);
             logger.addHandler(handler);
             logger.setUseParentHandlers(false);
             logger.setLevel(Level.ALL);

--- a/seed/java-sdk/openapi-path-param-body-collision/src/main/java/com/seed/api/core/ConsoleLogger.java
+++ b/seed/java-sdk/openapi-path-param-body-collision/src/main/java/com/seed/api/core/ConsoleLogger.java
@@ -23,6 +23,7 @@ public final class ConsoleLogger implements ILogger {
                     return record.getLevel() + " - " + record.getMessage() + System.lineSeparator();
                 }
             });
+            handler.setLevel(Level.ALL);
             logger.addHandler(handler);
             logger.setUseParentHandlers(false);
             logger.setLevel(Level.ALL);

--- a/seed/java-sdk/openapi-request-body-ref/no-custom-config/src/main/java/com/seed/api/core/ConsoleLogger.java
+++ b/seed/java-sdk/openapi-request-body-ref/no-custom-config/src/main/java/com/seed/api/core/ConsoleLogger.java
@@ -23,6 +23,7 @@ public final class ConsoleLogger implements ILogger {
                     return record.getLevel() + " - " + record.getMessage() + System.lineSeparator();
                 }
             });
+            handler.setLevel(Level.ALL);
             logger.addHandler(handler);
             logger.setUseParentHandlers(false);
             logger.setLevel(Level.ALL);

--- a/seed/java-sdk/openapi-subtitle/src/main/java/com/seed/api/core/ConsoleLogger.java
+++ b/seed/java-sdk/openapi-subtitle/src/main/java/com/seed/api/core/ConsoleLogger.java
@@ -23,6 +23,7 @@ public final class ConsoleLogger implements ILogger {
                     return record.getLevel() + " - " + record.getMessage() + System.lineSeparator();
                 }
             });
+            handler.setLevel(Level.ALL);
             logger.addHandler(handler);
             logger.setUseParentHandlers(false);
             logger.setLevel(Level.ALL);

--- a/seed/java-sdk/optional/wire-tests/src/main/java/com/seed/objectsWithImports/core/ConsoleLogger.java
+++ b/seed/java-sdk/optional/wire-tests/src/main/java/com/seed/objectsWithImports/core/ConsoleLogger.java
@@ -23,6 +23,7 @@ public final class ConsoleLogger implements ILogger {
                     return record.getLevel() + " - " + record.getMessage() + System.lineSeparator();
                 }
             });
+            handler.setLevel(Level.ALL);
             logger.addHandler(handler);
             logger.setUseParentHandlers(false);
             logger.setLevel(Level.ALL);

--- a/seed/java-sdk/package-yml/src/main/java/com/seed/packageYml/core/ConsoleLogger.java
+++ b/seed/java-sdk/package-yml/src/main/java/com/seed/packageYml/core/ConsoleLogger.java
@@ -23,6 +23,7 @@ public final class ConsoleLogger implements ILogger {
                     return record.getLevel() + " - " + record.getMessage() + System.lineSeparator();
                 }
             });
+            handler.setLevel(Level.ALL);
             logger.addHandler(handler);
             logger.setUseParentHandlers(false);
             logger.setLevel(Level.ALL);

--- a/seed/java-sdk/pagination-custom/default/src/main/java/com/seed/pagination/core/ConsoleLogger.java
+++ b/seed/java-sdk/pagination-custom/default/src/main/java/com/seed/pagination/core/ConsoleLogger.java
@@ -23,6 +23,7 @@ public final class ConsoleLogger implements ILogger {
                     return record.getLevel() + " - " + record.getMessage() + System.lineSeparator();
                 }
             });
+            handler.setLevel(Level.ALL);
             logger.addHandler(handler);
             logger.setUseParentHandlers(false);
             logger.setLevel(Level.ALL);

--- a/seed/java-sdk/pagination-uri-path/wire-tests/src/main/java/com/seed/paginationUriPath/core/ConsoleLogger.java
+++ b/seed/java-sdk/pagination-uri-path/wire-tests/src/main/java/com/seed/paginationUriPath/core/ConsoleLogger.java
@@ -23,6 +23,7 @@ public final class ConsoleLogger implements ILogger {
                     return record.getLevel() + " - " + record.getMessage() + System.lineSeparator();
                 }
             });
+            handler.setLevel(Level.ALL);
             logger.addHandler(handler);
             logger.setUseParentHandlers(false);
             logger.setLevel(Level.ALL);

--- a/seed/java-sdk/pagination/default/src/main/java/com/seed/pagination/core/ConsoleLogger.java
+++ b/seed/java-sdk/pagination/default/src/main/java/com/seed/pagination/core/ConsoleLogger.java
@@ -23,6 +23,7 @@ public final class ConsoleLogger implements ILogger {
                     return record.getLevel() + " - " + record.getMessage() + System.lineSeparator();
                 }
             });
+            handler.setLevel(Level.ALL);
             logger.addHandler(handler);
             logger.setUseParentHandlers(false);
             logger.setLevel(Level.ALL);

--- a/seed/java-sdk/pagination/item-index-semantics/src/main/java/com/seed/pagination/core/ConsoleLogger.java
+++ b/seed/java-sdk/pagination/item-index-semantics/src/main/java/com/seed/pagination/core/ConsoleLogger.java
@@ -23,6 +23,7 @@ public final class ConsoleLogger implements ILogger {
                     return record.getLevel() + " - " + record.getMessage() + System.lineSeparator();
                 }
             });
+            handler.setLevel(Level.ALL);
             logger.addHandler(handler);
             logger.setUseParentHandlers(false);
             logger.setLevel(Level.ALL);

--- a/seed/java-sdk/path-parameters/src/main/java/com/seed/pathParameters/core/ConsoleLogger.java
+++ b/seed/java-sdk/path-parameters/src/main/java/com/seed/pathParameters/core/ConsoleLogger.java
@@ -23,6 +23,7 @@ public final class ConsoleLogger implements ILogger {
                     return record.getLevel() + " - " + record.getMessage() + System.lineSeparator();
                 }
             });
+            handler.setLevel(Level.ALL);
             logger.addHandler(handler);
             logger.setUseParentHandlers(false);
             logger.setLevel(Level.ALL);

--- a/seed/java-sdk/plain-text/src/main/java/com/seed/plainText/core/ConsoleLogger.java
+++ b/seed/java-sdk/plain-text/src/main/java/com/seed/plainText/core/ConsoleLogger.java
@@ -23,6 +23,7 @@ public final class ConsoleLogger implements ILogger {
                     return record.getLevel() + " - " + record.getMessage() + System.lineSeparator();
                 }
             });
+            handler.setLevel(Level.ALL);
             logger.addHandler(handler);
             logger.setUseParentHandlers(false);
             logger.setLevel(Level.ALL);

--- a/seed/java-sdk/property-access/src/main/java/com/seed/propertyAccess/core/ConsoleLogger.java
+++ b/seed/java-sdk/property-access/src/main/java/com/seed/propertyAccess/core/ConsoleLogger.java
@@ -23,6 +23,7 @@ public final class ConsoleLogger implements ILogger {
                     return record.getLevel() + " - " + record.getMessage() + System.lineSeparator();
                 }
             });
+            handler.setLevel(Level.ALL);
             logger.addHandler(handler);
             logger.setUseParentHandlers(false);
             logger.setLevel(Level.ALL);

--- a/seed/java-sdk/public-object/src/main/java/com/seed/publicObject/core/ConsoleLogger.java
+++ b/seed/java-sdk/public-object/src/main/java/com/seed/publicObject/core/ConsoleLogger.java
@@ -23,6 +23,7 @@ public final class ConsoleLogger implements ILogger {
                     return record.getLevel() + " - " + record.getMessage() + System.lineSeparator();
                 }
             });
+            handler.setLevel(Level.ALL);
             logger.addHandler(handler);
             logger.setUseParentHandlers(false);
             logger.setLevel(Level.ALL);

--- a/seed/java-sdk/query-param-name-conflict/src/main/java/com/seed/api/core/ConsoleLogger.java
+++ b/seed/java-sdk/query-param-name-conflict/src/main/java/com/seed/api/core/ConsoleLogger.java
@@ -23,6 +23,7 @@ public final class ConsoleLogger implements ILogger {
                     return record.getLevel() + " - " + record.getMessage() + System.lineSeparator();
                 }
             });
+            handler.setLevel(Level.ALL);
             logger.addHandler(handler);
             logger.setUseParentHandlers(false);
             logger.setLevel(Level.ALL);

--- a/seed/java-sdk/query-parameters-openapi-as-objects/src/main/java/com/seed/api/core/ConsoleLogger.java
+++ b/seed/java-sdk/query-parameters-openapi-as-objects/src/main/java/com/seed/api/core/ConsoleLogger.java
@@ -23,6 +23,7 @@ public final class ConsoleLogger implements ILogger {
                     return record.getLevel() + " - " + record.getMessage() + System.lineSeparator();
                 }
             });
+            handler.setLevel(Level.ALL);
             logger.addHandler(handler);
             logger.setUseParentHandlers(false);
             logger.setLevel(Level.ALL);

--- a/seed/java-sdk/query-parameters-openapi/src/main/java/com/seed/api/core/ConsoleLogger.java
+++ b/seed/java-sdk/query-parameters-openapi/src/main/java/com/seed/api/core/ConsoleLogger.java
@@ -23,6 +23,7 @@ public final class ConsoleLogger implements ILogger {
                     return record.getLevel() + " - " + record.getMessage() + System.lineSeparator();
                 }
             });
+            handler.setLevel(Level.ALL);
             logger.addHandler(handler);
             logger.setUseParentHandlers(false);
             logger.setLevel(Level.ALL);

--- a/seed/java-sdk/query-parameters/src/main/java/com/seed/queryParameters/core/ConsoleLogger.java
+++ b/seed/java-sdk/query-parameters/src/main/java/com/seed/queryParameters/core/ConsoleLogger.java
@@ -23,6 +23,7 @@ public final class ConsoleLogger implements ILogger {
                     return record.getLevel() + " - " + record.getMessage() + System.lineSeparator();
                 }
             });
+            handler.setLevel(Level.ALL);
             logger.addHandler(handler);
             logger.setUseParentHandlers(false);
             logger.setLevel(Level.ALL);

--- a/seed/java-sdk/request-parameters/src/main/java/com/seed/requestParameters/core/ConsoleLogger.java
+++ b/seed/java-sdk/request-parameters/src/main/java/com/seed/requestParameters/core/ConsoleLogger.java
@@ -23,6 +23,7 @@ public final class ConsoleLogger implements ILogger {
                     return record.getLevel() + " - " + record.getMessage() + System.lineSeparator();
                 }
             });
+            handler.setLevel(Level.ALL);
             logger.addHandler(handler);
             logger.setUseParentHandlers(false);
             logger.setLevel(Level.ALL);

--- a/seed/java-sdk/required-nullable/src/main/java/com/seed/api/core/ConsoleLogger.java
+++ b/seed/java-sdk/required-nullable/src/main/java/com/seed/api/core/ConsoleLogger.java
@@ -23,6 +23,7 @@ public final class ConsoleLogger implements ILogger {
                     return record.getLevel() + " - " + record.getMessage() + System.lineSeparator();
                 }
             });
+            handler.setLevel(Level.ALL);
             logger.addHandler(handler);
             logger.setUseParentHandlers(false);
             logger.setLevel(Level.ALL);

--- a/seed/java-sdk/reserved-keywords/src/main/java/com/seed/nurseryApi/core/ConsoleLogger.java
+++ b/seed/java-sdk/reserved-keywords/src/main/java/com/seed/nurseryApi/core/ConsoleLogger.java
@@ -23,6 +23,7 @@ public final class ConsoleLogger implements ILogger {
                     return record.getLevel() + " - " + record.getMessage() + System.lineSeparator();
                 }
             });
+            handler.setLevel(Level.ALL);
             logger.addHandler(handler);
             logger.setUseParentHandlers(false);
             logger.setLevel(Level.ALL);

--- a/seed/java-sdk/response-property/src/main/java/com/seed/responseProperty/core/ConsoleLogger.java
+++ b/seed/java-sdk/response-property/src/main/java/com/seed/responseProperty/core/ConsoleLogger.java
@@ -23,6 +23,7 @@ public final class ConsoleLogger implements ILogger {
                     return record.getLevel() + " - " + record.getMessage() + System.lineSeparator();
                 }
             });
+            handler.setLevel(Level.ALL);
             logger.addHandler(handler);
             logger.setUseParentHandlers(false);
             logger.setLevel(Level.ALL);

--- a/seed/java-sdk/schemaless-request-body-examples/src/main/java/com/seed/api/core/ConsoleLogger.java
+++ b/seed/java-sdk/schemaless-request-body-examples/src/main/java/com/seed/api/core/ConsoleLogger.java
@@ -23,6 +23,7 @@ public final class ConsoleLogger implements ILogger {
                     return record.getLevel() + " - " + record.getMessage() + System.lineSeparator();
                 }
             });
+            handler.setLevel(Level.ALL);
             logger.addHandler(handler);
             logger.setUseParentHandlers(false);
             logger.setLevel(Level.ALL);

--- a/seed/java-sdk/server-sent-event-examples/no-custom-config/src/main/java/com/seed/serverSentEvents/core/ConsoleLogger.java
+++ b/seed/java-sdk/server-sent-event-examples/no-custom-config/src/main/java/com/seed/serverSentEvents/core/ConsoleLogger.java
@@ -23,6 +23,7 @@ public final class ConsoleLogger implements ILogger {
                     return record.getLevel() + " - " + record.getMessage() + System.lineSeparator();
                 }
             });
+            handler.setLevel(Level.ALL);
             logger.addHandler(handler);
             logger.setUseParentHandlers(false);
             logger.setLevel(Level.ALL);

--- a/seed/java-sdk/server-sent-event-examples/with-wire-tests/src/main/java/com/seed/serverSentEvents/core/ConsoleLogger.java
+++ b/seed/java-sdk/server-sent-event-examples/with-wire-tests/src/main/java/com/seed/serverSentEvents/core/ConsoleLogger.java
@@ -23,6 +23,7 @@ public final class ConsoleLogger implements ILogger {
                     return record.getLevel() + " - " + record.getMessage() + System.lineSeparator();
                 }
             });
+            handler.setLevel(Level.ALL);
             logger.addHandler(handler);
             logger.setUseParentHandlers(false);
             logger.setLevel(Level.ALL);

--- a/seed/java-sdk/server-sent-events-openapi/with-wire-tests/src/main/java/com/seed/api/core/ConsoleLogger.java
+++ b/seed/java-sdk/server-sent-events-openapi/with-wire-tests/src/main/java/com/seed/api/core/ConsoleLogger.java
@@ -23,6 +23,7 @@ public final class ConsoleLogger implements ILogger {
                     return record.getLevel() + " - " + record.getMessage() + System.lineSeparator();
                 }
             });
+            handler.setLevel(Level.ALL);
             logger.addHandler(handler);
             logger.setUseParentHandlers(false);
             logger.setLevel(Level.ALL);

--- a/seed/java-sdk/server-sent-events-resumable/src/main/java/com/seed/serverSentEventsResumable/core/ConsoleLogger.java
+++ b/seed/java-sdk/server-sent-events-resumable/src/main/java/com/seed/serverSentEventsResumable/core/ConsoleLogger.java
@@ -23,6 +23,7 @@ public final class ConsoleLogger implements ILogger {
                     return record.getLevel() + " - " + record.getMessage() + System.lineSeparator();
                 }
             });
+            handler.setLevel(Level.ALL);
             logger.addHandler(handler);
             logger.setUseParentHandlers(false);
             logger.setLevel(Level.ALL);

--- a/seed/java-sdk/server-sent-events/src/main/java/com/seed/serverSentEvents/core/ConsoleLogger.java
+++ b/seed/java-sdk/server-sent-events/src/main/java/com/seed/serverSentEvents/core/ConsoleLogger.java
@@ -23,6 +23,7 @@ public final class ConsoleLogger implements ILogger {
                     return record.getLevel() + " - " + record.getMessage() + System.lineSeparator();
                 }
             });
+            handler.setLevel(Level.ALL);
             logger.addHandler(handler);
             logger.setUseParentHandlers(false);
             logger.setLevel(Level.ALL);

--- a/seed/java-sdk/server-url-templating-single-url/src/main/java/com/seed/api/core/ConsoleLogger.java
+++ b/seed/java-sdk/server-url-templating-single-url/src/main/java/com/seed/api/core/ConsoleLogger.java
@@ -23,6 +23,7 @@ public final class ConsoleLogger implements ILogger {
                     return record.getLevel() + " - " + record.getMessage() + System.lineSeparator();
                 }
             });
+            handler.setLevel(Level.ALL);
             logger.addHandler(handler);
             logger.setUseParentHandlers(false);
             logger.setLevel(Level.ALL);

--- a/seed/java-sdk/server-url-templating/src/main/java/com/seed/api/core/ConsoleLogger.java
+++ b/seed/java-sdk/server-url-templating/src/main/java/com/seed/api/core/ConsoleLogger.java
@@ -23,6 +23,7 @@ public final class ConsoleLogger implements ILogger {
                     return record.getLevel() + " - " + record.getMessage() + System.lineSeparator();
                 }
             });
+            handler.setLevel(Level.ALL);
             logger.addHandler(handler);
             logger.setUseParentHandlers(false);
             logger.setLevel(Level.ALL);

--- a/seed/java-sdk/simple-api/src/main/java/com/seed/simpleApi/core/ConsoleLogger.java
+++ b/seed/java-sdk/simple-api/src/main/java/com/seed/simpleApi/core/ConsoleLogger.java
@@ -23,6 +23,7 @@ public final class ConsoleLogger implements ILogger {
                     return record.getLevel() + " - " + record.getMessage() + System.lineSeparator();
                 }
             });
+            handler.setLevel(Level.ALL);
             logger.addHandler(handler);
             logger.setUseParentHandlers(false);
             logger.setLevel(Level.ALL);

--- a/seed/java-sdk/simple-fhir/src/main/java/com/seed/api/core/ConsoleLogger.java
+++ b/seed/java-sdk/simple-fhir/src/main/java/com/seed/api/core/ConsoleLogger.java
@@ -23,6 +23,7 @@ public final class ConsoleLogger implements ILogger {
                     return record.getLevel() + " - " + record.getMessage() + System.lineSeparator();
                 }
             });
+            handler.setLevel(Level.ALL);
             logger.addHandler(handler);
             logger.setUseParentHandlers(false);
             logger.setLevel(Level.ALL);

--- a/seed/java-sdk/single-url-environment-default/src/main/java/com/seed/singleUrlEnvironmentDefault/core/ConsoleLogger.java
+++ b/seed/java-sdk/single-url-environment-default/src/main/java/com/seed/singleUrlEnvironmentDefault/core/ConsoleLogger.java
@@ -23,6 +23,7 @@ public final class ConsoleLogger implements ILogger {
                     return record.getLevel() + " - " + record.getMessage() + System.lineSeparator();
                 }
             });
+            handler.setLevel(Level.ALL);
             logger.addHandler(handler);
             logger.setUseParentHandlers(false);
             logger.setLevel(Level.ALL);

--- a/seed/java-sdk/single-url-environment-no-default/src/main/java/com/seed/singleUrlEnvironmentNoDefault/core/ConsoleLogger.java
+++ b/seed/java-sdk/single-url-environment-no-default/src/main/java/com/seed/singleUrlEnvironmentNoDefault/core/ConsoleLogger.java
@@ -23,6 +23,7 @@ public final class ConsoleLogger implements ILogger {
                     return record.getLevel() + " - " + record.getMessage() + System.lineSeparator();
                 }
             });
+            handler.setLevel(Level.ALL);
             logger.addHandler(handler);
             logger.setUseParentHandlers(false);
             logger.setLevel(Level.ALL);

--- a/seed/java-sdk/streaming-parameter/src/main/java/com/seed/streaming/core/ConsoleLogger.java
+++ b/seed/java-sdk/streaming-parameter/src/main/java/com/seed/streaming/core/ConsoleLogger.java
@@ -23,6 +23,7 @@ public final class ConsoleLogger implements ILogger {
                     return record.getLevel() + " - " + record.getMessage() + System.lineSeparator();
                 }
             });
+            handler.setLevel(Level.ALL);
             logger.addHandler(handler);
             logger.setUseParentHandlers(false);
             logger.setLevel(Level.ALL);

--- a/seed/java-sdk/streaming/streaming/src/main/java/com/seed/streaming/core/ConsoleLogger.java
+++ b/seed/java-sdk/streaming/streaming/src/main/java/com/seed/streaming/core/ConsoleLogger.java
@@ -23,6 +23,7 @@ public final class ConsoleLogger implements ILogger {
                     return record.getLevel() + " - " + record.getMessage() + System.lineSeparator();
                 }
             });
+            handler.setLevel(Level.ALL);
             logger.addHandler(handler);
             logger.setUseParentHandlers(false);
             logger.setLevel(Level.ALL);

--- a/seed/java-sdk/trace/src/main/java/com/seed/trace/core/ConsoleLogger.java
+++ b/seed/java-sdk/trace/src/main/java/com/seed/trace/core/ConsoleLogger.java
@@ -23,6 +23,7 @@ public final class ConsoleLogger implements ILogger {
                     return record.getLevel() + " - " + record.getMessage() + System.lineSeparator();
                 }
             });
+            handler.setLevel(Level.ALL);
             logger.addHandler(handler);
             logger.setUseParentHandlers(false);
             logger.setLevel(Level.ALL);

--- a/seed/java-sdk/undiscriminated-union-with-response-property/src/main/java/com/seed/undiscriminatedUnionWithResponseProperty/core/ConsoleLogger.java
+++ b/seed/java-sdk/undiscriminated-union-with-response-property/src/main/java/com/seed/undiscriminatedUnionWithResponseProperty/core/ConsoleLogger.java
@@ -23,6 +23,7 @@ public final class ConsoleLogger implements ILogger {
                     return record.getLevel() + " - " + record.getMessage() + System.lineSeparator();
                 }
             });
+            handler.setLevel(Level.ALL);
             logger.addHandler(handler);
             logger.setUseParentHandlers(false);
             logger.setLevel(Level.ALL);

--- a/seed/java-sdk/undiscriminated-unions/src/main/java/com/seed/undiscriminatedUnions/core/ConsoleLogger.java
+++ b/seed/java-sdk/undiscriminated-unions/src/main/java/com/seed/undiscriminatedUnions/core/ConsoleLogger.java
@@ -23,6 +23,7 @@ public final class ConsoleLogger implements ILogger {
                     return record.getLevel() + " - " + record.getMessage() + System.lineSeparator();
                 }
             });
+            handler.setLevel(Level.ALL);
             logger.addHandler(handler);
             logger.setUseParentHandlers(false);
             logger.setLevel(Level.ALL);

--- a/seed/java-sdk/union-query-parameters/src/main/java/com/seed/unionQueryParameters/core/ConsoleLogger.java
+++ b/seed/java-sdk/union-query-parameters/src/main/java/com/seed/unionQueryParameters/core/ConsoleLogger.java
@@ -23,6 +23,7 @@ public final class ConsoleLogger implements ILogger {
                     return record.getLevel() + " - " + record.getMessage() + System.lineSeparator();
                 }
             });
+            handler.setLevel(Level.ALL);
             logger.addHandler(handler);
             logger.setUseParentHandlers(false);
             logger.setLevel(Level.ALL);

--- a/seed/java-sdk/unions-with-local-date/default/src/main/java/com/seed/unions/core/ConsoleLogger.java
+++ b/seed/java-sdk/unions-with-local-date/default/src/main/java/com/seed/unions/core/ConsoleLogger.java
@@ -23,6 +23,7 @@ public final class ConsoleLogger implements ILogger {
                     return record.getLevel() + " - " + record.getMessage() + System.lineSeparator();
                 }
             });
+            handler.setLevel(Level.ALL);
             logger.addHandler(handler);
             logger.setUseParentHandlers(false);
             logger.setLevel(Level.ALL);

--- a/seed/java-sdk/unions/default/src/main/java/com/seed/unions/core/ConsoleLogger.java
+++ b/seed/java-sdk/unions/default/src/main/java/com/seed/unions/core/ConsoleLogger.java
@@ -23,6 +23,7 @@ public final class ConsoleLogger implements ILogger {
                     return record.getLevel() + " - " + record.getMessage() + System.lineSeparator();
                 }
             });
+            handler.setLevel(Level.ALL);
             logger.addHandler(handler);
             logger.setUseParentHandlers(false);
             logger.setLevel(Level.ALL);

--- a/seed/java-sdk/unknown/src/main/java/com/seed/unknownAsAny/core/ConsoleLogger.java
+++ b/seed/java-sdk/unknown/src/main/java/com/seed/unknownAsAny/core/ConsoleLogger.java
@@ -23,6 +23,7 @@ public final class ConsoleLogger implements ILogger {
                     return record.getLevel() + " - " + record.getMessage() + System.lineSeparator();
                 }
             });
+            handler.setLevel(Level.ALL);
             logger.addHandler(handler);
             logger.setUseParentHandlers(false);
             logger.setLevel(Level.ALL);

--- a/seed/java-sdk/url-form-encoded/src/main/java/com/seed/api/core/ConsoleLogger.java
+++ b/seed/java-sdk/url-form-encoded/src/main/java/com/seed/api/core/ConsoleLogger.java
@@ -23,6 +23,7 @@ public final class ConsoleLogger implements ILogger {
                     return record.getLevel() + " - " + record.getMessage() + System.lineSeparator();
                 }
             });
+            handler.setLevel(Level.ALL);
             logger.addHandler(handler);
             logger.setUseParentHandlers(false);
             logger.setLevel(Level.ALL);

--- a/seed/java-sdk/validation/src/main/java/com/seed/validation/core/ConsoleLogger.java
+++ b/seed/java-sdk/validation/src/main/java/com/seed/validation/core/ConsoleLogger.java
@@ -23,6 +23,7 @@ public final class ConsoleLogger implements ILogger {
                     return record.getLevel() + " - " + record.getMessage() + System.lineSeparator();
                 }
             });
+            handler.setLevel(Level.ALL);
             logger.addHandler(handler);
             logger.setUseParentHandlers(false);
             logger.setLevel(Level.ALL);

--- a/seed/java-sdk/variables/src/main/java/com/seed/variables/core/ConsoleLogger.java
+++ b/seed/java-sdk/variables/src/main/java/com/seed/variables/core/ConsoleLogger.java
@@ -23,6 +23,7 @@ public final class ConsoleLogger implements ILogger {
                     return record.getLevel() + " - " + record.getMessage() + System.lineSeparator();
                 }
             });
+            handler.setLevel(Level.ALL);
             logger.addHandler(handler);
             logger.setUseParentHandlers(false);
             logger.setLevel(Level.ALL);

--- a/seed/java-sdk/version-no-default/src/main/java/com/seed/version/core/ConsoleLogger.java
+++ b/seed/java-sdk/version-no-default/src/main/java/com/seed/version/core/ConsoleLogger.java
@@ -23,6 +23,7 @@ public final class ConsoleLogger implements ILogger {
                     return record.getLevel() + " - " + record.getMessage() + System.lineSeparator();
                 }
             });
+            handler.setLevel(Level.ALL);
             logger.addHandler(handler);
             logger.setUseParentHandlers(false);
             logger.setLevel(Level.ALL);

--- a/seed/java-sdk/version/forward-compatible-enums/src/main/java/com/seed/version/core/ConsoleLogger.java
+++ b/seed/java-sdk/version/forward-compatible-enums/src/main/java/com/seed/version/core/ConsoleLogger.java
@@ -23,6 +23,7 @@ public final class ConsoleLogger implements ILogger {
                     return record.getLevel() + " - " + record.getMessage() + System.lineSeparator();
                 }
             });
+            handler.setLevel(Level.ALL);
             logger.addHandler(handler);
             logger.setUseParentHandlers(false);
             logger.setLevel(Level.ALL);

--- a/seed/java-sdk/version/no-custom-config/src/main/java/com/seed/version/core/ConsoleLogger.java
+++ b/seed/java-sdk/version/no-custom-config/src/main/java/com/seed/version/core/ConsoleLogger.java
@@ -23,6 +23,7 @@ public final class ConsoleLogger implements ILogger {
                     return record.getLevel() + " - " + record.getMessage() + System.lineSeparator();
                 }
             });
+            handler.setLevel(Level.ALL);
             logger.addHandler(handler);
             logger.setUseParentHandlers(false);
             logger.setLevel(Level.ALL);

--- a/seed/java-sdk/webhook-audience/src/main/java/com/seed/api/core/ConsoleLogger.java
+++ b/seed/java-sdk/webhook-audience/src/main/java/com/seed/api/core/ConsoleLogger.java
@@ -23,6 +23,7 @@ public final class ConsoleLogger implements ILogger {
                     return record.getLevel() + " - " + record.getMessage() + System.lineSeparator();
                 }
             });
+            handler.setLevel(Level.ALL);
             logger.addHandler(handler);
             logger.setUseParentHandlers(false);
             logger.setLevel(Level.ALL);

--- a/seed/java-sdk/webhooks/src/main/java/com/seed/webhooks/core/ConsoleLogger.java
+++ b/seed/java-sdk/webhooks/src/main/java/com/seed/webhooks/core/ConsoleLogger.java
@@ -23,6 +23,7 @@ public final class ConsoleLogger implements ILogger {
                     return record.getLevel() + " - " + record.getMessage() + System.lineSeparator();
                 }
             });
+            handler.setLevel(Level.ALL);
             logger.addHandler(handler);
             logger.setUseParentHandlers(false);
             logger.setLevel(Level.ALL);

--- a/seed/java-sdk/websocket-bearer-auth/src/main/java/com/seed/websocketBearerAuth/core/ConsoleLogger.java
+++ b/seed/java-sdk/websocket-bearer-auth/src/main/java/com/seed/websocketBearerAuth/core/ConsoleLogger.java
@@ -23,6 +23,7 @@ public final class ConsoleLogger implements ILogger {
                     return record.getLevel() + " - " + record.getMessage() + System.lineSeparator();
                 }
             });
+            handler.setLevel(Level.ALL);
             logger.addHandler(handler);
             logger.setUseParentHandlers(false);
             logger.setLevel(Level.ALL);

--- a/seed/java-sdk/websocket-inferred-auth/src/main/java/com/seed/websocketAuth/core/ConsoleLogger.java
+++ b/seed/java-sdk/websocket-inferred-auth/src/main/java/com/seed/websocketAuth/core/ConsoleLogger.java
@@ -23,6 +23,7 @@ public final class ConsoleLogger implements ILogger {
                     return record.getLevel() + " - " + record.getMessage() + System.lineSeparator();
                 }
             });
+            handler.setLevel(Level.ALL);
             logger.addHandler(handler);
             logger.setUseParentHandlers(false);
             logger.setLevel(Level.ALL);

--- a/seed/java-sdk/websocket-multi-url/src/main/java/com/seed/websocketMultiUrl/core/ConsoleLogger.java
+++ b/seed/java-sdk/websocket-multi-url/src/main/java/com/seed/websocketMultiUrl/core/ConsoleLogger.java
@@ -23,6 +23,7 @@ public final class ConsoleLogger implements ILogger {
                     return record.getLevel() + " - " + record.getMessage() + System.lineSeparator();
                 }
             });
+            handler.setLevel(Level.ALL);
             logger.addHandler(handler);
             logger.setUseParentHandlers(false);
             logger.setLevel(Level.ALL);

--- a/seed/java-sdk/websocket/src/main/java/com/seed/websocket/core/ConsoleLogger.java
+++ b/seed/java-sdk/websocket/src/main/java/com/seed/websocket/core/ConsoleLogger.java
@@ -23,6 +23,7 @@ public final class ConsoleLogger implements ILogger {
                     return record.getLevel() + " - " + record.getMessage() + System.lineSeparator();
                 }
             });
+            handler.setLevel(Level.ALL);
             logger.addHandler(handler);
             logger.setUseParentHandlers(false);
             logger.setLevel(Level.ALL);

--- a/seed/java-sdk/x-fern-default/src/main/java/com/seed/api/core/ConsoleLogger.java
+++ b/seed/java-sdk/x-fern-default/src/main/java/com/seed/api/core/ConsoleLogger.java
@@ -23,6 +23,7 @@ public final class ConsoleLogger implements ILogger {
                     return record.getLevel() + " - " + record.getMessage() + System.lineSeparator();
                 }
             });
+            handler.setLevel(Level.ALL);
             logger.addHandler(handler);
             logger.setUseParentHandlers(false);
             logger.setLevel(Level.ALL);

--- a/seed/java-sdk/x-fern-global-parameters/src/main/java/com/seed/api/core/ConsoleLogger.java
+++ b/seed/java-sdk/x-fern-global-parameters/src/main/java/com/seed/api/core/ConsoleLogger.java
@@ -23,6 +23,7 @@ public final class ConsoleLogger implements ILogger {
                     return record.getLevel() + " - " + record.getMessage() + System.lineSeparator();
                 }
             });
+            handler.setLevel(Level.ALL);
             logger.addHandler(handler);
             logger.setUseParentHandlers(false);
             logger.setLevel(Level.ALL);


### PR DESCRIPTION
## Description
Linear ticket: N/A

The default `ConsoleLogger` shipped with generated Java SDKs (added in java-sdk 3.39.0) never emits DEBUG-level messages. The static initializer sets the `java.util.logging.Logger` level to `ALL` but leaves the attached `ConsoleHandler` at java.util.logging's default handler level (`INFO`), so `FINE` records are discarded by the handler. Since the `LoggingInterceptor` logs HTTP request/response details only at debug level, configuring

```java
.logging(LogConfig.builder().level(LogLevel.DEBUG).silent(false).build())
```

with the default logger produced no output at all. Custom `ILogger` implementations were unaffected.

## Changes Made
- Add `handler.setLevel(Level.ALL);` in the `ConsoleLogger` as-is resource (`generators/java/sdk/src/main/resources/ConsoleLogger.java`) so the configured `LogLevel`/`silent` in `LogConfig` is the sole filter
- Apply the same one-line change to all 193 `ConsoleLogger.java` files in `seed/java-sdk/` (as-is file, copied verbatim)
- Add unreleased changelog entry under `generators/java/sdk/changes/unreleased/`
- [ ] Updated README.md generator (if applicable)

## Testing
- [ ] Unit tests added/updated
- [x] Manual testing completed — reproduced against a generated SDK (fern-demo/twilio-core-fern-config Java SDK): with the default `ConsoleLogger` at `LogLevel.DEBUG`/`silent(false)`, an HTTP call produced no output; after this fix, `FINE - HTTP Request: GET ...` / `FINE - HTTP Response: status=200 ...` lines are emitted as expected.

Link to Devin session: https://app.devin.ai/sessions/1a058403a8784849aa7a0397acdfc898
Requested by: @iamnamananand996
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/17202" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->