### PR TITLE
feat(docs): error when an API reference sets both collapsed and flattened

### DIFF
--- a/packages/cli/yaml/docs-validator/src/getAllRules.ts
+++ b/packages/cli/yaml/docs-validator/src/getAllRules.ts
@@ -5,6 +5,7 @@ import { FilepathsExistRule } from "./rules/filepaths-exist/index.js";
 import { MissingRedirectsRule } from "./rules/missing-redirects/index.js";
 import { NavigationConflicts } from "./rules/navigation-conflicts/index.js";
 import { NoCircularRedirectsRule } from "./rules/no-circular-redirects/index.js";
+import { NoCollapsedFlattenedApiReferenceRule } from "./rules/no-collapsed-flattened-api-reference/index.js";
 import { NoNonComponentRefsRule } from "./rules/no-non-component-refs/index.js";
 import { NoOpenApiV2InDocsRule } from "./rules/no-openapi-v2-in-docs/index.js";
 import { TranslationDirectoriesExistRule } from "./rules/translation-directories-exist/index.js";
@@ -31,6 +32,7 @@ const allRules = [
     ValidLocalReferencesRule, // Validate that local references actually exist
     ValidMarkdownRule, // Compile each page's MDX and surface syntax errors (e.g. unclosed components)
     NavigationConflicts,
+    NoCollapsedFlattenedApiReferenceRule, // `collapsed` + `flattened: true` on an API reference are mutually exclusive
     ValidateVersionFileRule,
     ValidateProductFileRule,
     ValidInstanceUrlRule, // Validate instance URLs have valid subdomains

--- a/packages/cli/yaml/docs-validator/src/rules/no-collapsed-flattened-api-reference/__test__/no-collapsed-flattened-api-reference.test.ts
+++ b/packages/cli/yaml/docs-validator/src/rules/no-collapsed-flattened-api-reference/__test__/no-collapsed-flattened-api-reference.test.ts
@@ -1,0 +1,48 @@
+import type { docsYml } from "@fern-api/configuration-loader";
+import { describe, expect, it } from "vitest";
+
+import type { DocsConfigFileAstNodeTypes } from "../../../docsAst/DocsConfigFileAstVisitor.js";
+import type { RuleContext } from "../../../Rule.js";
+import { NoCollapsedFlattenedApiReferenceRule } from "../no-collapsed-flattened-api-reference.js";
+
+async function runRuleOnApiSection(config: docsYml.RawSchemas.ApiReferenceConfiguration) {
+    const visitor = await NoCollapsedFlattenedApiReferenceRule.create({} as RuleContext);
+    const apiSectionVisitor = visitor.apiSection;
+    if (apiSectionVisitor == null) {
+        throw new Error("Expected the rule to define an `apiSection` visitor");
+    }
+    const node = { config } as DocsConfigFileAstNodeTypes["apiSection"];
+    return apiSectionVisitor(node);
+}
+
+describe("no-collapsed-flattened-api-reference", () => {
+    it("allows collapsed without flattened", async () => {
+        const violations = await runRuleOnApiSection({ api: "My API", collapsed: "open-by-default" });
+        expect(violations).toEqual([]);
+    });
+
+    it("allows flattened without collapsed", async () => {
+        const violations = await runRuleOnApiSection({ api: "My API", flattened: true });
+        expect(violations).toEqual([]);
+    });
+
+    it("allows collapsed with flattened:false (flattened:false is the default no-op)", async () => {
+        const violations = await runRuleOnApiSection({ api: "My API", collapsed: true, flattened: false });
+        expect(violations).toEqual([]);
+    });
+
+    it("rejects collapsed together with flattened:true", async () => {
+        const violations = await runRuleOnApiSection({ api: "My API", collapsed: true, flattened: true });
+        expect(violations).toHaveLength(1);
+        expect(violations[0]?.severity).toBe("error");
+        expect(violations[0]?.message).toContain("collapsed");
+        expect(violations[0]?.message).toContain("flattened");
+    });
+
+    it("rejects every CollapsedValue when combined with flattened:true", async () => {
+        for (const collapsed of ["open-by-default", true, false] as const) {
+            const violations = await runRuleOnApiSection({ api: "My API", collapsed, flattened: true });
+            expect(violations).toHaveLength(1);
+        }
+    });
+});

--- a/packages/cli/yaml/docs-validator/src/rules/no-collapsed-flattened-api-reference/index.ts
+++ b/packages/cli/yaml/docs-validator/src/rules/no-collapsed-flattened-api-reference/index.ts
@@ -1,0 +1,1 @@
+export { NoCollapsedFlattenedApiReferenceRule } from "./no-collapsed-flattened-api-reference.js";

--- a/packages/cli/yaml/docs-validator/src/rules/no-collapsed-flattened-api-reference/no-collapsed-flattened-api-reference.ts
+++ b/packages/cli/yaml/docs-validator/src/rules/no-collapsed-flattened-api-reference/no-collapsed-flattened-api-reference.ts
@@ -1,0 +1,31 @@
+import { Rule, RuleViolation } from "../../Rule.js";
+
+/**
+ * `collapsed` and `flattened: true` are mutually exclusive on an API reference.
+ *
+ * `flattened: true` hoists the API reference's contents into its parent, so the
+ * reference has no heading/group of its own left to collapse — a `collapsed`
+ * value on the same entry is therefore meaningless. Surface a readable error
+ * instead of silently ignoring one of the two.
+ */
+export const NoCollapsedFlattenedApiReferenceRule: Rule = {
+    name: "no-collapsed-flattened-api-reference",
+    create: () => {
+        return {
+            apiSection: ({ config }) => {
+                const violations: RuleViolation[] = [];
+                if (config.collapsed != null && config.flattened === true) {
+                    violations.push({
+                        severity: "error",
+                        message:
+                            "An API reference cannot set both `collapsed` and `flattened: true`. " +
+                            "`flattened: true` hoists the API reference's contents into its parent, so there is " +
+                            "no API reference group left to collapse. Remove `collapsed` to keep the API " +
+                            "reference flattened, or remove `flattened` to render it as its own collapsible group."
+                    });
+                }
+                return violations;
+            }
+        };
+    }
+};


### PR DESCRIPTION
## What

Adds a `fern check` docs-validator rule that raises a **readable error** when an API reference navigation entry sets both `collapsed` and `flattened: true`.

```yaml
navigation:
  - api: My API
    collapsed: open-by-default   # ❌ error: can't combine with flattened: true
    flattened: true
```

## Why

`flattened: true` hoists an API reference's contents into its parent, so the reference has no group/heading of its own left to collapse — a `collapsed` value on the same entry is meaningless. Previously one of the two was silently ignored. This surfaces the conflict at authoring time instead.

## Details

- New rule `no-collapsed-flattened-api-reference` (`packages/cli/yaml/docs-validator/src/rules/…`), hooked on the `apiSection` AST node (fires for API references at any nesting depth), registered in `getAllRules`.
- Fires only for the real conflict — `collapsed` + `flattened: true`. `flattened: false` (the default no-op) alongside `collapsed` is allowed, so this doesn't false-positive on existing configs.
- Severity `error` (fails `fern check`, reports-and-continues rather than aborting).
- Unit tested: allowed combinations (collapsed only, flattened only, collapsed + flattened:false) and the conflict for every `CollapsedValue` (`open-by-default` / `true` / `false`). All pass locally.

## Related

Companion to fern-platform PR that makes root-level API references honor `collapsed` (fern-api/fern-platform#13377). That feature makes `collapsed` on an API reference meaningful, which is what motivates guarding the nonsensical `collapsed` + `flattened: true` combination here.

Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/17228" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->