### PR TITLE
fix(csharp): apply client-default to global headers in root client constructor

### DIFF
--- a/generators/csharp/sdk/changes/unreleased/fix-global-header-client-default.yml
+++ b/generators/csharp/sdk/changes/unreleased/fix-global-header-client-default.yml
@@ -1,0 +1,7 @@
+- summary: |
+    Global headers now honor their `client-default` value. The constructor
+    initializes the header from the explicit argument, then the environment
+    variable, then the client default. Previously the client default was only
+    applied on the header-dictionary path and was dropped entirely under
+    `any`-composed multi-scheme auth and endpoint-level security.
+  type: fix

--- a/generators/csharp/sdk/src/root-client/RootClientGenerator.ts
+++ b/generators/csharp/sdk/src/root-client/RootClientGenerator.ts
@@ -478,6 +478,10 @@ export class RootClientGenerator extends FileGenerator<CSharpFile, SdkGeneratorC
                     }
 
                     for (const param of optionalParameters) {
+                        const clientDefaultLiteral =
+                            param.isGlobalHeader && param.clientDefault != null
+                                ? this.getHeaderFallback(param)
+                                : undefined;
                         if (param.environmentVariable != null) {
                             const target = paramAccess(param);
                             if (anyAuthMultiScheme || endpointSecurity || (param.isGlobalHeader && param.isOptional)) {
@@ -485,7 +489,11 @@ export class RootClientGenerator extends FileGenerator<CSharpFile, SdkGeneratorC
                                 // missing — the caller may be authenticating with another scheme.
                                 innerWriter.write(`${target} ??= Environment.GetEnvironmentVariable(`);
                                 innerWriter.writeNode(this.csharp.string_({ string: param.environmentVariable }));
-                                innerWriter.writeTextStatement(")");
+                                if (clientDefaultLiteral != null) {
+                                    innerWriter.writeTextStatement(`) ?? ${clientDefaultLiteral}`);
+                                } else {
+                                    innerWriter.writeTextStatement(")");
+                                }
                             } else {
                                 innerWriter.writeLine(`${target} ??= ${GetFromEnvironmentOrThrow}(`);
                                 innerWriter.indent();
@@ -497,6 +505,11 @@ export class RootClientGenerator extends FileGenerator<CSharpFile, SdkGeneratorC
                                 innerWriter.dedent();
                                 innerWriter.writeLine(");");
                             }
+                        } else if (clientDefaultLiteral != null && (anyAuthMultiScheme || endpointSecurity)) {
+                            // Header dictionary entries apply the client default inline elsewhere,
+                            // but the `any`-composed multi-scheme and endpoint-security paths write
+                            // headers conditionally, so the default must be applied here.
+                            innerWriter.writeTextStatement(`${paramAccess(param)} ??= ${clientDefaultLiteral}`);
                         }
                     }
 

--- a/seed/csharp-sdk/csharp-global-header-env/.fern/metadata.json
+++ b/seed/csharp-sdk/csharp-global-header-env/.fern/metadata.json
@@ -4,8 +4,7 @@
   "generatorVersion": "local",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/csharp-global-header-env/README.md
+++ b/seed/csharp-sdk/csharp-global-header-env/README.md
@@ -42,7 +42,7 @@ Instantiate and use the client with the following:
 ```csharp
 using SeedCsharpGlobalHeaderEnv;
 
-var client = new SeedCsharpGlobalHeaderEnvClient("VERSION");
+var client = new SeedCsharpGlobalHeaderEnvClient("USERNAME", "PASSWORD", "TOKEN", "VERSION");
 await client.Service.GetWithApiVersionAsync();
 ```
 

--- a/seed/csharp-sdk/csharp-global-header-env/Snippets/Example0.cs
+++ b/seed/csharp-sdk/csharp-global-header-env/Snippets/Example0.cs
@@ -4,6 +4,8 @@ public partial class Examples
 {
     public async Task Example0() {
         var client = new SeedCsharpGlobalHeaderEnvClient(
+            username: "<username>",
+            password: "<password>",
             clientOptions: new ClientOptions {
                 BaseUrl = "https://api.fern.com"
             }

--- a/seed/csharp-sdk/csharp-global-header-env/snippet.json
+++ b/seed/csharp-sdk/csharp-global-header-env/snippet.json
@@ -10,7 +10,7 @@
             },
             "snippet": {
                 "type": "csharp",
-                "client": "using SeedCsharpGlobalHeaderEnv;\n\nvar client = new SeedCsharpGlobalHeaderEnvClient(\"VERSION\");\nawait client.Service.GetWithApiVersionAsync();\n"
+                "client": "using SeedCsharpGlobalHeaderEnv;\n\nvar client = new SeedCsharpGlobalHeaderEnvClient(\"USERNAME\", \"PASSWORD\", \"TOKEN\", \"VERSION\");\nawait client.Service.GetWithApiVersionAsync();\n"
             }
         }
     ]

--- a/seed/csharp-sdk/csharp-global-header-env/src/SeedCsharpGlobalHeaderEnv.Test/Unit/MockServer/BaseMockServerTest.cs
+++ b/seed/csharp-sdk/csharp-global-header-env/src/SeedCsharpGlobalHeaderEnv.Test/Unit/MockServer/BaseMockServerTest.cs
@@ -24,6 +24,9 @@ public class BaseMockServerTest
 
         // Initialize the Client
         Client = new SeedCsharpGlobalHeaderEnvClient(
+            "USERNAME",
+            "PASSWORD",
+            "TOKEN",
             "VERSION",
             clientOptions: new ClientOptions { BaseUrl = Server.Urls[0], MaxRetries = 0 }
         );

--- a/seed/csharp-sdk/csharp-global-header-env/src/SeedCsharpGlobalHeaderEnv/SeedCsharpGlobalHeaderEnvClient.cs
+++ b/seed/csharp-sdk/csharp-global-header-env/src/SeedCsharpGlobalHeaderEnv/SeedCsharpGlobalHeaderEnvClient.cs
@@ -7,11 +7,17 @@ public partial class SeedCsharpGlobalHeaderEnvClient : ISeedCsharpGlobalHeaderEn
     private readonly RawClient _client;
 
     public SeedCsharpGlobalHeaderEnvClient(
+        string? username = null,
+        string? password = null,
+        string? token = null,
         string? version = null,
         ClientOptions? clientOptions = null
     )
     {
-        version ??= Environment.GetEnvironmentVariable("MY_API_VERSION");
+        username ??= Environment.GetEnvironmentVariable("MY_USERNAME");
+        password ??= Environment.GetEnvironmentVariable("MY_PASSWORD");
+        token ??= Environment.GetEnvironmentVariable("MY_TOKEN");
+        version ??= Environment.GetEnvironmentVariable("MY_API_VERSION") ?? "2024-01-01";
         clientOptions ??= new ClientOptions();
         var platformHeaders = new Headers(
             new Dictionary<string, string>()
@@ -30,12 +36,18 @@ public partial class SeedCsharpGlobalHeaderEnvClient : ISeedCsharpGlobalHeaderEn
             }
         }
         var clientOptionsWithAuth = clientOptions.Clone();
-        var authHeaders = new Headers(
-            new Dictionary<string, string>() { { "X-API-Version", version ?? "" } }
-        );
-        foreach (var header in authHeaders)
+        if (token != null)
         {
-            clientOptionsWithAuth.Headers[header.Key] = header.Value;
+            clientOptionsWithAuth.Headers["Authorization"] = $"Bearer {token}";
+        }
+        if (version != null)
+        {
+            clientOptionsWithAuth.Headers["X-API-Version"] = version;
+        }
+        if (username != null && password != null)
+        {
+            clientOptionsWithAuth.Headers["Authorization"] =
+                $"Basic {Convert.ToBase64String(global::System.Text.Encoding.UTF8.GetBytes($"{username}:{password}"))}";
         }
         _client = new RawClient(clientOptionsWithAuth);
         Service = new ServiceClient(_client);

--- a/test-definitions/fern/apis/csharp-global-header-env/definition/api.yml
+++ b/test-definitions/fern/apis/csharp-global-header-env/definition/api.yml
@@ -4,3 +4,21 @@ headers:
     name: version
     type: optional<string>
     env: MY_API_VERSION
+    client-default: "2024-01-01"
+auth:
+  any:
+    - Basic
+    - Bearer
+auth-schemes:
+  Basic:
+    scheme: basic
+    username:
+      name: username
+      env: MY_USERNAME
+    password:
+      name: password
+      env: MY_PASSWORD
+  Bearer:
+    scheme: bearer
+    token:
+      env: MY_TOKEN


### PR DESCRIPTION
## Description
Global headers with a `client-default` were not applied by the C# SDK generator. The default was only used on the header-dictionary path (`version ?? "default"`), and was dropped entirely under `any`-composed multi-scheme auth and endpoint-level security, where headers are written conditionally (`if (version != null) ...`). This is the C# counterpart of #17243 (TS/Java).

## Changes Made
- `RootClientGenerator`: resolve global header params in the constructor as explicit arg → env var → client default:
  ```csharp
  version ??= Environment.GetEnvironmentVariable("MY_API_VERSION") ?? "2024-01-01";
  ```
  and, when the header has no env var, `version ??= "2024-01-01";` on the `any`-auth / endpoint-security paths so the conditional header write always fires.
- Extended the `csharp-global-header-env` fixture with `client-default` and `any`-composed auth (Basic + Bearer) to mirror the reporting customer's setup, and regenerated its seed.

## Testing
- [x] `pnpm seed test --generator csharp-sdk --fixture csharp-global-header-env --skip-scripts` — passes; generated client now sends `X-API-Version` by default
- [x] `pnpm seed test --generator csharp-sdk --fixture any-auth --skip-scripts` — passes, no output diff (no regression)

Link to Devin session: https://app.devin.ai/sessions/6ca6e050e4044819bc867ce3cfb11359
Requested by: @iamnamananand996
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/17247" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->