### PR TITLE
fix(go): client-level global header options no longer clobbered by env/client-default resolution

### DIFF
--- a/generators/go-v2/sdk/src/authUtils.ts
+++ b/generators/go-v2/sdk/src/authUtils.ts
@@ -118,6 +118,16 @@ export function isPlainStringType(typeRef: FernIr.TypeReference): boolean {
     return false;
 }
 
+/**
+ * Returns true if the given type reference is a non-optional, non-nullable boolean primitive.
+ */
+export function isPlainBooleanType(typeRef: FernIr.TypeReference): boolean {
+    if (typeRef.type === "primitive") {
+        return typeRef.primitive.v1 === FernIr.PrimitiveTypeV1.Boolean;
+    }
+    return false;
+}
+
 export function isTypeReferencePointer(
     typeRef: FernIr.TypeReference | undefined,
     irTypes: Record<string, FernIr.TypeDeclaration>,

--- a/generators/go-v2/sdk/src/client/ClientGenerator.ts
+++ b/generators/go-v2/sdk/src/client/ClientGenerator.ts
@@ -601,13 +601,22 @@ export class ClientGenerator extends FileGenerator<GoFile, SdkCustomConfigSchema
                     });
                 }
             }
-            // After env fallback, apply clientDefault if present and type is plain string
-            if (header.clientDefault != null && isPlainStringType(header.valueType)) {
-                this.writeClientDefaultConditional({
-                    writer,
-                    propertyReference: this.getOptionsPropertyReference(header.name),
-                    clientDefault: header.clientDefault
-                });
+            // After env fallback, apply clientDefault if present
+            if (header.clientDefault != null) {
+                if (isTypeReferencePointer(header.valueType, this.context.ir.types)) {
+                    this.writeOptionalClientDefaultConditional({
+                        writer,
+                        propertyReference: this.getOptionsPropertyReference(header.name),
+                        clientDefault: header.clientDefault,
+                        localVariableName: `${this.context.getParameterName(header.name)}Default`
+                    });
+                } else if (isPlainStringType(header.valueType)) {
+                    this.writeClientDefaultConditional({
+                        writer,
+                        propertyReference: this.getOptionsPropertyReference(header.name),
+                        clientDefault: header.clientDefault
+                    });
+                }
             }
         }
     }
@@ -1334,6 +1343,30 @@ export class ClientGenerator extends FileGenerator<GoFile, SdkCustomConfigSchema
         writer.write(" = ");
         writer.writeNode(this.context.getLiteralValue(clientDefault));
         writer.newLine();
+        writer.dedent();
+        writer.writeLine("}");
+    }
+
+    private writeOptionalClientDefaultConditional({
+        writer,
+        propertyReference,
+        clientDefault,
+        localVariableName
+    }: {
+        writer: go.Writer;
+        propertyReference: go.Selector;
+        clientDefault: FernIr.Literal;
+        localVariableName: string;
+    }): void {
+        writer.write("if ");
+        writer.writeNode(propertyReference);
+        writer.writeLine(" == nil {");
+        writer.indent();
+        writer.write(`${localVariableName} := `);
+        writer.writeNode(this.context.getLiteralValue(clientDefault));
+        writer.newLine();
+        writer.writeNode(propertyReference);
+        writer.writeLine(` = &${localVariableName}`);
         writer.dedent();
         writer.writeLine("}");
     }

--- a/generators/go-v2/sdk/src/client/ClientGenerator.ts
+++ b/generators/go-v2/sdk/src/client/ClientGenerator.ts
@@ -12,6 +12,7 @@ import {
     getRequestPropertyFieldName,
     getRequestPropertyValueType,
     isGrantTypeRequestProperty,
+    isPlainBooleanType,
     isPlainStringType,
     isRequestPropertyPointer,
     isTypeReferenceLiteral,
@@ -610,7 +611,7 @@ export class ClientGenerator extends FileGenerator<GoFile, SdkCustomConfigSchema
                         clientDefault: header.clientDefault,
                         localVariableName: `${this.context.getParameterName(header.name)}Default`
                     });
-                } else if (isPlainStringType(header.valueType)) {
+                } else if (isPlainStringType(header.valueType) || isPlainBooleanType(header.valueType)) {
                     this.writeClientDefaultConditional({
                         writer,
                         propertyReference: this.getOptionsPropertyReference(header.name),
@@ -1335,9 +1336,10 @@ export class ClientGenerator extends FileGenerator<GoFile, SdkCustomConfigSchema
         propertyReference: go.Selector;
         clientDefault: FernIr.Literal;
     }): void {
+        const zeroValue = clientDefault.type === "boolean" ? "false" : '""';
         writer.write("if ");
         writer.writeNode(propertyReference);
-        writer.writeLine(' == "" {');
+        writer.writeLine(` == ${zeroValue} {`);
         writer.indent();
         writer.writeNode(propertyReference);
         writer.write(" = ");

--- a/generators/go/internal/generator/sdk.go
+++ b/generators/go/internal/generator/sdk.go
@@ -704,25 +704,11 @@ func (f *fileWriter) WriteRequestOptionsDefinition(
 			}
 			continue
 		}
-		if header.ClientDefault != nil {
-			formatValue := `fmt.Sprintf("%v",` + literalToValue(header.ClientDefault) + ")"
-			f.P(header.Name.Name.CamelCase.SafeName, " := ", formatValue)
-			if header.Env != nil {
-				f.P(`if envValue := os.Getenv("`, *header.Env, `"); envValue != "" {`)
-				f.P(header.Name.Name.CamelCase.SafeName, " = envValue")
-				f.P("}")
-			}
-			value := valueTypeFormat.Prefix + "r." + header.Name.Name.PascalCase.UnsafeName + valueTypeFormat.Suffix
-			if valueTypeFormat.IsOptional {
-				f.P("if r.", header.Name.Name.PascalCase.UnsafeName, " != nil {")
-			} else {
-				f.P("if r.", header.Name.Name.PascalCase.UnsafeName, " != ", valueTypeFormat.ZeroValue, " {")
-			}
-			f.P(header.Name.Name.CamelCase.SafeName, ` = fmt.Sprintf("%v", `, value, ")")
-			f.P("}")
-			f.P(`header.Set("`, header.Name.WireValue, `", `, header.Name.Name.CamelCase.SafeName, ")")
-			continue
-		}
+		// Headers with an env var and/or client default are resolved into the
+		// client-level options at construction time, so ToHeader only emits
+		// values that are explicitly set on the options. Setting the resolved
+		// fallback here would clobber the client-level value on every request,
+		// since empty per-request options win the header merge.
 		value := valueTypeFormat.Prefix + "r." + header.Name.Name.PascalCase.UnsafeName + valueTypeFormat.Suffix
 		if valueTypeFormat.IsOptional {
 			f.P("if r.", header.Name.Name.PascalCase.UnsafeName, " != nil {")

--- a/generators/go/internal/generator/sdk.go
+++ b/generators/go/internal/generator/sdk.go
@@ -708,7 +708,24 @@ func (f *fileWriter) WriteRequestOptionsDefinition(
 		// client-level options at construction time, so ToHeader only emits
 		// values that are explicitly set on the options. Setting the resolved
 		// fallback here would clobber the client-level value on every request,
-		// since empty per-request options win the header merge.
+		// since empty per-request options win the header merge. Construction-time
+		// resolution only covers optional, string, and boolean header types, so
+		// other types keep the request-time client default fallback.
+		if header.ClientDefault != nil && !isClientDefaultResolvedAtConstruction(header.ValueType, valueTypeFormat) {
+			formatValue := `fmt.Sprintf("%v",` + literalToValue(header.ClientDefault) + ")"
+			f.P(header.Name.Name.CamelCase.SafeName, " := ", formatValue)
+			if header.Env != nil {
+				f.P(`if envValue := os.Getenv("`, *header.Env, `"); envValue != "" {`)
+				f.P(header.Name.Name.CamelCase.SafeName, " = envValue")
+				f.P("}")
+			}
+			value := valueTypeFormat.Prefix + "r." + header.Name.Name.PascalCase.UnsafeName + valueTypeFormat.Suffix
+			f.P("if r.", header.Name.Name.PascalCase.UnsafeName, " != ", valueTypeFormat.ZeroValue, " {")
+			f.P(header.Name.Name.CamelCase.SafeName, ` = fmt.Sprintf("%v", `, value, ")")
+			f.P("}")
+			f.P(`header.Set("`, header.Name.WireValue, `", `, header.Name.Name.CamelCase.SafeName, ")")
+			continue
+		}
 		value := valueTypeFormat.Prefix + "r." + header.Name.Name.PascalCase.UnsafeName + valueTypeFormat.Suffix
 		if valueTypeFormat.IsOptional {
 			f.P("if r.", header.Name.Name.PascalCase.UnsafeName, " != nil {")
@@ -4724,6 +4741,21 @@ func isStringType(valueType *ir.TypeReference) bool {
 	}
 	primitive := maybePrimitive(valueType)
 	return primitive != nil && primitive.V1 == common.PrimitiveTypeV1String
+}
+
+// isClientDefaultResolvedAtConstruction returns true if a header's client
+// default is applied to the client-level options at construction time (by the
+// v2 client generator), which covers optional (pointer) types plus plain
+// string and boolean primitives. For those types, ToHeader must not re-apply
+// the fallback, or it would clobber the client-level value on every request.
+func isClientDefaultResolvedAtConstruction(valueType *ir.TypeReference, valueTypeFormat *valueTypeFormat) bool {
+	if valueTypeFormat.IsOptional {
+		return true
+	}
+	if valueType.Primitive == nil {
+		return false
+	}
+	return valueType.Primitive.V1 == common.PrimitiveTypeV1String || valueType.Primitive.V1 == common.PrimitiveTypeV1Boolean
 }
 
 // isPrimitiveInteger returns true if the given primitive type is an integer.

--- a/generators/go/sdk/changes/unreleased/fix-client-level-header-option-clobbered.yml
+++ b/generators/go/sdk/changes/unreleased/fix-client-level-header-option-clobbered.yml
@@ -1,0 +1,8 @@
+- summary: |
+    Client-level global header options (e.g. `option.WithVersion(...)` passed
+    to the root client constructor) are no longer clobbered by env-var or
+    `client-default` resolution on every request. Env and client-default
+    fallbacks are now resolved once at client construction, and per-request
+    options only override the header when explicitly set. Precedence is:
+    request-level option > client-level option > env var > client default.
+  type: fix

--- a/packages/cli/generation/ir-generator-tests/src/ir/__test__/test-definitions/go-optional-header-env.json
+++ b/packages/cli/generation/ir-generator-tests/src/ir/__test__/test-definitions/go-optional-header-env.json
@@ -44,7 +44,10 @@
                 }
             },
             "env": "MY_API_VERSION",
-            "clientDefault": null,
+            "clientDefault": {
+                "type": "string",
+                "string": "2024-01-01"
+            },
             "defaultValue": null,
             "v2Examples": {
                 "userSpecifiedExamples": {},

--- a/seed/go-sdk/go-optional-header-env/client/client.go
+++ b/seed/go-sdk/go-optional-header-env/client/client.go
@@ -29,6 +29,10 @@ func NewClient(opts ...option.RequestOption) *Client {
 			options.Version = &value
 		}
 	}
+	if options.Version == nil {
+		versionDefault := "2024-01-01"
+		options.Version = &versionDefault
+	}
 	return &Client{
 		Service: service.NewClient(options),
 		options: options,

--- a/seed/go-sdk/go-optional-header-env/service/client.go
+++ b/seed/go-sdk/go-optional-header-env/service/client.go
@@ -28,6 +28,10 @@ func NewClient(options *core.RequestOptions) *Client {
 			options.Version = &value
 		}
 	}
+	if options.Version == nil {
+		versionDefault := "2024-01-01"
+		options.Version = &versionDefault
+	}
 	return &Client{
 		WithRawResponse: NewRawClient(options),
 		options:         options,

--- a/seed/go-sdk/x-fern-default/client/client.go
+++ b/seed/go-sdk/x-fern-default/client/client.go
@@ -21,6 +21,10 @@ type Client struct {
 
 func NewClient(opts ...option.RequestOption) *Client {
 	options := core.NewRequestOptions(opts...)
+	if options.APIVersion == nil {
+		apiVersionDefault := "2024-02-08"
+		options.APIVersion = &apiVersionDefault
+	}
 	return &Client{
 		WithRawResponse: NewRawClient(options),
 		options:         options,

--- a/seed/go-sdk/x-fern-default/core/request_option.go
+++ b/seed/go-sdk/x-fern-default/core/request_option.go
@@ -51,11 +51,9 @@ func NewRequestOptions(opts ...RequestOption) *RequestOptions {
 // for the request(s).
 func (r *RequestOptions) ToHeader() http.Header {
 	header := r.cloneHeader()
-	apiVersion := fmt.Sprintf("%v", "2024-02-08")
 	if r.APIVersion != nil {
-		apiVersion = fmt.Sprintf("%v", *r.APIVersion)
+		header.Set("X-API-Version", fmt.Sprintf("%v", *r.APIVersion))
 	}
-	header.Set("X-API-Version", apiVersion)
 	return header
 }
 

--- a/test-definitions/fern/apis/go-optional-header-env/definition/api.yml
+++ b/test-definitions/fern/apis/go-optional-header-env/definition/api.yml
@@ -11,3 +11,4 @@ headers:
     name: version
     type: optional<string>
     env: MY_API_VERSION
+    client-default: "2024-01-01"


### PR DESCRIPTION
## Description
Linear ticket: Refs

Runtime testing of a customer SDK (fern-demo/twilio-core-fern-config#118) found that a client-level `option.WithXxx(...)` for a global header is silently ignored when the header has an `env` var or `client-default`. Raw clients merge `MergeHeaders(r.options.ToHeader(), options.ToHeader())` with the per-request side winning, and `RequestOptions.ToHeader()` unconditionally re-resolved env/default — so empty per-request options always clobbered the client-level value.

This moves env/client-default resolution to client construction time and makes `ToHeader()` only emit explicitly-set values for those headers. Resulting precedence: request-level option > client-level option > env var > client default.

## Changes Made
- v1 `sdk.go`: for headers whose client default is resolved at construction (optional/pointer types, plain `string`, plain `boolean` — see `isClientDefaultResolvedAtConstruction`), the generated `ToHeader()` no longer re-applies env/default and only emits explicitly-set values:
  ```diff
  -	apiVersion := fmt.Sprintf("%v", "2024-02-08")
  	if r.APIVersion != nil {
  -		apiVersion = fmt.Sprintf("%v", *r.APIVersion)
  +		header.Set("X-API-Version", fmt.Sprintf("%v", *r.APIVersion))
  	}
  -	header.Set("X-API-Version", apiVersion)
  ```
  Other header types (non-optional non-string/bool primitives, aliases) keep the previous request-time client-default fallback so their default is never dropped.
- v2 `ClientGenerator.ts`: `writeHeaderEnvironmentVariables` now applies `clientDefault` for optional (pointer) header types and plain booleans too — previously only plain `string`:
  ```go
  if options.Version == nil {
  	versionDefault := "2024-01-01"
  	options.Version = &versionDefault
  }
  ```
  (placed after the existing env fallback, preserving env > default). Added `isPlainBooleanType` to `authUtils.ts`; `writeClientDefaultConditional` compares against the literal's zero value (`""` / `false`).
- Extended `go-optional-header-env` fixture with `client-default: "2024-01-01"`; regenerated its seed, `x-fern-default`, and the IR test snapshot.
- Added changelog entry under `generators/go/sdk/changes/unreleased/`.
- [ ] Updated README.md generator (if applicable)

## Testing
- [x] `go build ./...` and `go test ./...` in `generators/go` pass
- [x] `pnpm seed test --generator go-sdk --fixture go-optional-header-env --skip-scripts` — passes
- [x] `pnpm seed test --generator go-sdk --fixture x-fern-default --skip-scripts` — passes; default still applied (now via constructor)
- [ ] Unit tests added/updated
- [x] Manual testing completed (runtime capture-server verification on the customer SDK identified the bug and validated the intended precedence)

Link to Devin session: https://app.devin.ai/sessions/6ca6e050e4044819bc867ce3cfb11359
Requested by: @iamnamananand996
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/17250" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->