### PR TITLE
fix(ruby): normalize enum string casing to wire format in Enum.coerce

### DIFF
--- a/generators/ruby-v2/base/src/asIs/internal/types/enum.Template.rb
+++ b/generators/ruby-v2/base/src/asIs/internal/types/enum.Template.rb
@@ -30,9 +30,15 @@ module <%= gem_namespace %>
         end
 
         def coerce(value, strict: strict?)
-          coerced_value = Utils.coerce(Symbol, value)
+          return value if values.include?(value)
 
-          return coerced_value if values.include?(coerced_value)
+          if value.is_a?(::String) || value.is_a?(::Symbol)
+            candidate = value.to_s
+            match = values.find do |member|
+              (member.is_a?(::String) || member.is_a?(::Symbol)) && member.to_s.casecmp?(candidate)
+            end
+            return match unless match.nil?
+          end
 
           raise Errors::TypeError, "`#{value}` not in enum #{self}" if strict
 

--- a/generators/ruby-v2/base/src/asIs/test/unit/internal/types/test_enum.Template.rb
+++ b/generators/ruby-v2/base/src/asIs/test/unit/internal/types/test_enum.Template.rb
@@ -12,6 +12,16 @@ describe <%= gem_namespace %>::Internal::Types::Enum do
 
       finalize!
     end
+
+    module StringEnum
+      extend <%= gem_namespace %>::Internal::Types::Enum
+
+      ACTIVE = "ACTIVE"
+      CLOSED = "CLOSED"
+      GROUP_BY_PROFILE = "GROUP_BY_PROFILE"
+
+      finalize!
+    end
   end
 
   describe "#values" do
@@ -27,6 +37,19 @@ describe <%= gem_namespace %>::Internal::Types::Enum do
 
     it "coerces a string version of a member" do
       assert_equal :foo, EnumTest::ExampleEnum.coerce("foo")
+    end
+
+    it "coerces an existing string member" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce("CLOSED")
+    end
+
+    it "normalizes casing to the wire format" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce("closed")
+      assert_equal "GROUP_BY_PROFILE", EnumTest::StringEnum.coerce("group_by_profile")
+    end
+
+    it "coerces a symbol to the string member" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce(:closed)
     end
 
     it "returns the value if not a member with strictness off" do

--- a/generators/ruby-v2/sdk/changes/unreleased/fix-enum-coerce-casing.yml
+++ b/generators/ruby-v2/sdk/changes/unreleased/fix-enum-coerce-casing.yml
@@ -1,0 +1,6 @@
+- summary: |
+    Enum coercion now matches values against the enum's actual members instead of
+    always symbolizing the input, and normalizes case-insensitive matches to the
+    canonical wire format. For example, passing `status: "closed"` to an enum with
+    member `CLOSED` now serializes as `"CLOSED"` instead of being sent as-is.
+  type: fix

--- a/seed/ruby-sdk-v2/accept-header/lib/seed/internal/types/enum.rb
+++ b/seed/ruby-sdk-v2/accept-header/lib/seed/internal/types/enum.rb
@@ -30,9 +30,15 @@ module Seed
         end
 
         def coerce(value, strict: strict?)
-          coerced_value = Utils.coerce(Symbol, value)
+          return value if values.include?(value)
 
-          return coerced_value if values.include?(coerced_value)
+          if value.is_a?(::String) || value.is_a?(::Symbol)
+            candidate = value.to_s
+            match = values.find do |member|
+              (member.is_a?(::String) || member.is_a?(::Symbol)) && member.to_s.casecmp?(candidate)
+            end
+            return match unless match.nil?
+          end
 
           raise Errors::TypeError, "`#{value}` not in enum #{self}" if strict
 

--- a/seed/ruby-sdk-v2/accept-header/test/unit/internal/types/test_enum.rb
+++ b/seed/ruby-sdk-v2/accept-header/test/unit/internal/types/test_enum.rb
@@ -12,6 +12,16 @@ describe Seed::Internal::Types::Enum do
 
       finalize!
     end
+
+    module StringEnum
+      extend Seed::Internal::Types::Enum
+
+      ACTIVE = "ACTIVE"
+      CLOSED = "CLOSED"
+      GROUP_BY_PROFILE = "GROUP_BY_PROFILE"
+
+      finalize!
+    end
   end
 
   describe "#values" do
@@ -27,6 +37,19 @@ describe Seed::Internal::Types::Enum do
 
     it "coerces a string version of a member" do
       assert_equal :foo, EnumTest::ExampleEnum.coerce("foo")
+    end
+
+    it "coerces an existing string member" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce("CLOSED")
+    end
+
+    it "normalizes casing to the wire format" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce("closed")
+      assert_equal "GROUP_BY_PROFILE", EnumTest::StringEnum.coerce("group_by_profile")
+    end
+
+    it "coerces a symbol to the string member" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce(:closed)
     end
 
     it "returns the value if not a member with strictness off" do

--- a/seed/ruby-sdk-v2/alias-extends/lib/seed/internal/types/enum.rb
+++ b/seed/ruby-sdk-v2/alias-extends/lib/seed/internal/types/enum.rb
@@ -30,9 +30,15 @@ module Seed
         end
 
         def coerce(value, strict: strict?)
-          coerced_value = Utils.coerce(Symbol, value)
+          return value if values.include?(value)
 
-          return coerced_value if values.include?(coerced_value)
+          if value.is_a?(::String) || value.is_a?(::Symbol)
+            candidate = value.to_s
+            match = values.find do |member|
+              (member.is_a?(::String) || member.is_a?(::Symbol)) && member.to_s.casecmp?(candidate)
+            end
+            return match unless match.nil?
+          end
 
           raise Errors::TypeError, "`#{value}` not in enum #{self}" if strict
 

--- a/seed/ruby-sdk-v2/alias-extends/test/unit/internal/types/test_enum.rb
+++ b/seed/ruby-sdk-v2/alias-extends/test/unit/internal/types/test_enum.rb
@@ -12,6 +12,16 @@ describe Seed::Internal::Types::Enum do
 
       finalize!
     end
+
+    module StringEnum
+      extend Seed::Internal::Types::Enum
+
+      ACTIVE = "ACTIVE"
+      CLOSED = "CLOSED"
+      GROUP_BY_PROFILE = "GROUP_BY_PROFILE"
+
+      finalize!
+    end
   end
 
   describe "#values" do
@@ -27,6 +37,19 @@ describe Seed::Internal::Types::Enum do
 
     it "coerces a string version of a member" do
       assert_equal :foo, EnumTest::ExampleEnum.coerce("foo")
+    end
+
+    it "coerces an existing string member" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce("CLOSED")
+    end
+
+    it "normalizes casing to the wire format" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce("closed")
+      assert_equal "GROUP_BY_PROFILE", EnumTest::StringEnum.coerce("group_by_profile")
+    end
+
+    it "coerces a symbol to the string member" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce(:closed)
     end
 
     it "returns the value if not a member with strictness off" do

--- a/seed/ruby-sdk-v2/alias/lib/seed/internal/types/enum.rb
+++ b/seed/ruby-sdk-v2/alias/lib/seed/internal/types/enum.rb
@@ -30,9 +30,15 @@ module Seed
         end
 
         def coerce(value, strict: strict?)
-          coerced_value = Utils.coerce(Symbol, value)
+          return value if values.include?(value)
 
-          return coerced_value if values.include?(coerced_value)
+          if value.is_a?(::String) || value.is_a?(::Symbol)
+            candidate = value.to_s
+            match = values.find do |member|
+              (member.is_a?(::String) || member.is_a?(::Symbol)) && member.to_s.casecmp?(candidate)
+            end
+            return match unless match.nil?
+          end
 
           raise Errors::TypeError, "`#{value}` not in enum #{self}" if strict
 

--- a/seed/ruby-sdk-v2/alias/test/unit/internal/types/test_enum.rb
+++ b/seed/ruby-sdk-v2/alias/test/unit/internal/types/test_enum.rb
@@ -12,6 +12,16 @@ describe Seed::Internal::Types::Enum do
 
       finalize!
     end
+
+    module StringEnum
+      extend Seed::Internal::Types::Enum
+
+      ACTIVE = "ACTIVE"
+      CLOSED = "CLOSED"
+      GROUP_BY_PROFILE = "GROUP_BY_PROFILE"
+
+      finalize!
+    end
   end
 
   describe "#values" do
@@ -27,6 +37,19 @@ describe Seed::Internal::Types::Enum do
 
     it "coerces a string version of a member" do
       assert_equal :foo, EnumTest::ExampleEnum.coerce("foo")
+    end
+
+    it "coerces an existing string member" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce("CLOSED")
+    end
+
+    it "normalizes casing to the wire format" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce("closed")
+      assert_equal "GROUP_BY_PROFILE", EnumTest::StringEnum.coerce("group_by_profile")
+    end
+
+    it "coerces a symbol to the string member" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce(:closed)
     end
 
     it "returns the value if not a member with strictness off" do

--- a/seed/ruby-sdk-v2/allof-inline/lib/seed/internal/types/enum.rb
+++ b/seed/ruby-sdk-v2/allof-inline/lib/seed/internal/types/enum.rb
@@ -30,9 +30,15 @@ module Seed
         end
 
         def coerce(value, strict: strict?)
-          coerced_value = Utils.coerce(Symbol, value)
+          return value if values.include?(value)
 
-          return coerced_value if values.include?(coerced_value)
+          if value.is_a?(::String) || value.is_a?(::Symbol)
+            candidate = value.to_s
+            match = values.find do |member|
+              (member.is_a?(::String) || member.is_a?(::Symbol)) && member.to_s.casecmp?(candidate)
+            end
+            return match unless match.nil?
+          end
 
           raise Errors::TypeError, "`#{value}` not in enum #{self}" if strict
 

--- a/seed/ruby-sdk-v2/allof-inline/test/unit/internal/types/test_enum.rb
+++ b/seed/ruby-sdk-v2/allof-inline/test/unit/internal/types/test_enum.rb
@@ -12,6 +12,16 @@ describe Seed::Internal::Types::Enum do
 
       finalize!
     end
+
+    module StringEnum
+      extend Seed::Internal::Types::Enum
+
+      ACTIVE = "ACTIVE"
+      CLOSED = "CLOSED"
+      GROUP_BY_PROFILE = "GROUP_BY_PROFILE"
+
+      finalize!
+    end
   end
 
   describe "#values" do
@@ -27,6 +37,19 @@ describe Seed::Internal::Types::Enum do
 
     it "coerces a string version of a member" do
       assert_equal :foo, EnumTest::ExampleEnum.coerce("foo")
+    end
+
+    it "coerces an existing string member" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce("CLOSED")
+    end
+
+    it "normalizes casing to the wire format" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce("closed")
+      assert_equal "GROUP_BY_PROFILE", EnumTest::StringEnum.coerce("group_by_profile")
+    end
+
+    it "coerces a symbol to the string member" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce(:closed)
     end
 
     it "returns the value if not a member with strictness off" do

--- a/seed/ruby-sdk-v2/allof/lib/seed/internal/types/enum.rb
+++ b/seed/ruby-sdk-v2/allof/lib/seed/internal/types/enum.rb
@@ -30,9 +30,15 @@ module Seed
         end
 
         def coerce(value, strict: strict?)
-          coerced_value = Utils.coerce(Symbol, value)
+          return value if values.include?(value)
 
-          return coerced_value if values.include?(coerced_value)
+          if value.is_a?(::String) || value.is_a?(::Symbol)
+            candidate = value.to_s
+            match = values.find do |member|
+              (member.is_a?(::String) || member.is_a?(::Symbol)) && member.to_s.casecmp?(candidate)
+            end
+            return match unless match.nil?
+          end
 
           raise Errors::TypeError, "`#{value}` not in enum #{self}" if strict
 

--- a/seed/ruby-sdk-v2/allof/test/unit/internal/types/test_enum.rb
+++ b/seed/ruby-sdk-v2/allof/test/unit/internal/types/test_enum.rb
@@ -12,6 +12,16 @@ describe Seed::Internal::Types::Enum do
 
       finalize!
     end
+
+    module StringEnum
+      extend Seed::Internal::Types::Enum
+
+      ACTIVE = "ACTIVE"
+      CLOSED = "CLOSED"
+      GROUP_BY_PROFILE = "GROUP_BY_PROFILE"
+
+      finalize!
+    end
   end
 
   describe "#values" do
@@ -27,6 +37,19 @@ describe Seed::Internal::Types::Enum do
 
     it "coerces a string version of a member" do
       assert_equal :foo, EnumTest::ExampleEnum.coerce("foo")
+    end
+
+    it "coerces an existing string member" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce("CLOSED")
+    end
+
+    it "normalizes casing to the wire format" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce("closed")
+      assert_equal "GROUP_BY_PROFILE", EnumTest::StringEnum.coerce("group_by_profile")
+    end
+
+    it "coerces a symbol to the string member" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce(:closed)
     end
 
     it "returns the value if not a member with strictness off" do

--- a/seed/ruby-sdk-v2/any-auth/lib/seed/internal/types/enum.rb
+++ b/seed/ruby-sdk-v2/any-auth/lib/seed/internal/types/enum.rb
@@ -30,9 +30,15 @@ module Seed
         end
 
         def coerce(value, strict: strict?)
-          coerced_value = Utils.coerce(Symbol, value)
+          return value if values.include?(value)
 
-          return coerced_value if values.include?(coerced_value)
+          if value.is_a?(::String) || value.is_a?(::Symbol)
+            candidate = value.to_s
+            match = values.find do |member|
+              (member.is_a?(::String) || member.is_a?(::Symbol)) && member.to_s.casecmp?(candidate)
+            end
+            return match unless match.nil?
+          end
 
           raise Errors::TypeError, "`#{value}` not in enum #{self}" if strict
 

--- a/seed/ruby-sdk-v2/any-auth/test/unit/internal/types/test_enum.rb
+++ b/seed/ruby-sdk-v2/any-auth/test/unit/internal/types/test_enum.rb
@@ -12,6 +12,16 @@ describe Seed::Internal::Types::Enum do
 
       finalize!
     end
+
+    module StringEnum
+      extend Seed::Internal::Types::Enum
+
+      ACTIVE = "ACTIVE"
+      CLOSED = "CLOSED"
+      GROUP_BY_PROFILE = "GROUP_BY_PROFILE"
+
+      finalize!
+    end
   end
 
   describe "#values" do
@@ -27,6 +37,19 @@ describe Seed::Internal::Types::Enum do
 
     it "coerces a string version of a member" do
       assert_equal :foo, EnumTest::ExampleEnum.coerce("foo")
+    end
+
+    it "coerces an existing string member" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce("CLOSED")
+    end
+
+    it "normalizes casing to the wire format" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce("closed")
+      assert_equal "GROUP_BY_PROFILE", EnumTest::StringEnum.coerce("group_by_profile")
+    end
+
+    it "coerces a symbol to the string member" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce(:closed)
     end
 
     it "returns the value if not a member with strictness off" do

--- a/seed/ruby-sdk-v2/api-wide-base-path-with-default/lib/seed/internal/types/enum.rb
+++ b/seed/ruby-sdk-v2/api-wide-base-path-with-default/lib/seed/internal/types/enum.rb
@@ -30,9 +30,15 @@ module Seed
         end
 
         def coerce(value, strict: strict?)
-          coerced_value = Utils.coerce(Symbol, value)
+          return value if values.include?(value)
 
-          return coerced_value if values.include?(coerced_value)
+          if value.is_a?(::String) || value.is_a?(::Symbol)
+            candidate = value.to_s
+            match = values.find do |member|
+              (member.is_a?(::String) || member.is_a?(::Symbol)) && member.to_s.casecmp?(candidate)
+            end
+            return match unless match.nil?
+          end
 
           raise Errors::TypeError, "`#{value}` not in enum #{self}" if strict
 

--- a/seed/ruby-sdk-v2/api-wide-base-path-with-default/test/unit/internal/types/test_enum.rb
+++ b/seed/ruby-sdk-v2/api-wide-base-path-with-default/test/unit/internal/types/test_enum.rb
@@ -12,6 +12,16 @@ describe Seed::Internal::Types::Enum do
 
       finalize!
     end
+
+    module StringEnum
+      extend Seed::Internal::Types::Enum
+
+      ACTIVE = "ACTIVE"
+      CLOSED = "CLOSED"
+      GROUP_BY_PROFILE = "GROUP_BY_PROFILE"
+
+      finalize!
+    end
   end
 
   describe "#values" do
@@ -27,6 +37,19 @@ describe Seed::Internal::Types::Enum do
 
     it "coerces a string version of a member" do
       assert_equal :foo, EnumTest::ExampleEnum.coerce("foo")
+    end
+
+    it "coerces an existing string member" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce("CLOSED")
+    end
+
+    it "normalizes casing to the wire format" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce("closed")
+      assert_equal "GROUP_BY_PROFILE", EnumTest::StringEnum.coerce("group_by_profile")
+    end
+
+    it "coerces a symbol to the string member" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce(:closed)
     end
 
     it "returns the value if not a member with strictness off" do

--- a/seed/ruby-sdk-v2/api-wide-base-path/lib/seed/internal/types/enum.rb
+++ b/seed/ruby-sdk-v2/api-wide-base-path/lib/seed/internal/types/enum.rb
@@ -30,9 +30,15 @@ module Seed
         end
 
         def coerce(value, strict: strict?)
-          coerced_value = Utils.coerce(Symbol, value)
+          return value if values.include?(value)
 
-          return coerced_value if values.include?(coerced_value)
+          if value.is_a?(::String) || value.is_a?(::Symbol)
+            candidate = value.to_s
+            match = values.find do |member|
+              (member.is_a?(::String) || member.is_a?(::Symbol)) && member.to_s.casecmp?(candidate)
+            end
+            return match unless match.nil?
+          end
 
           raise Errors::TypeError, "`#{value}` not in enum #{self}" if strict
 

--- a/seed/ruby-sdk-v2/api-wide-base-path/test/unit/internal/types/test_enum.rb
+++ b/seed/ruby-sdk-v2/api-wide-base-path/test/unit/internal/types/test_enum.rb
@@ -12,6 +12,16 @@ describe Seed::Internal::Types::Enum do
 
       finalize!
     end
+
+    module StringEnum
+      extend Seed::Internal::Types::Enum
+
+      ACTIVE = "ACTIVE"
+      CLOSED = "CLOSED"
+      GROUP_BY_PROFILE = "GROUP_BY_PROFILE"
+
+      finalize!
+    end
   end
 
   describe "#values" do
@@ -27,6 +37,19 @@ describe Seed::Internal::Types::Enum do
 
     it "coerces a string version of a member" do
       assert_equal :foo, EnumTest::ExampleEnum.coerce("foo")
+    end
+
+    it "coerces an existing string member" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce("CLOSED")
+    end
+
+    it "normalizes casing to the wire format" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce("closed")
+      assert_equal "GROUP_BY_PROFILE", EnumTest::StringEnum.coerce("group_by_profile")
+    end
+
+    it "coerces a symbol to the string member" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce(:closed)
     end
 
     it "returns the value if not a member with strictness off" do

--- a/seed/ruby-sdk-v2/audiences/lib/seed/internal/types/enum.rb
+++ b/seed/ruby-sdk-v2/audiences/lib/seed/internal/types/enum.rb
@@ -30,9 +30,15 @@ module Seed
         end
 
         def coerce(value, strict: strict?)
-          coerced_value = Utils.coerce(Symbol, value)
+          return value if values.include?(value)
 
-          return coerced_value if values.include?(coerced_value)
+          if value.is_a?(::String) || value.is_a?(::Symbol)
+            candidate = value.to_s
+            match = values.find do |member|
+              (member.is_a?(::String) || member.is_a?(::Symbol)) && member.to_s.casecmp?(candidate)
+            end
+            return match unless match.nil?
+          end
 
           raise Errors::TypeError, "`#{value}` not in enum #{self}" if strict
 

--- a/seed/ruby-sdk-v2/audiences/test/unit/internal/types/test_enum.rb
+++ b/seed/ruby-sdk-v2/audiences/test/unit/internal/types/test_enum.rb
@@ -12,6 +12,16 @@ describe Seed::Internal::Types::Enum do
 
       finalize!
     end
+
+    module StringEnum
+      extend Seed::Internal::Types::Enum
+
+      ACTIVE = "ACTIVE"
+      CLOSED = "CLOSED"
+      GROUP_BY_PROFILE = "GROUP_BY_PROFILE"
+
+      finalize!
+    end
   end
 
   describe "#values" do
@@ -27,6 +37,19 @@ describe Seed::Internal::Types::Enum do
 
     it "coerces a string version of a member" do
       assert_equal :foo, EnumTest::ExampleEnum.coerce("foo")
+    end
+
+    it "coerces an existing string member" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce("CLOSED")
+    end
+
+    it "normalizes casing to the wire format" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce("closed")
+      assert_equal "GROUP_BY_PROFILE", EnumTest::StringEnum.coerce("group_by_profile")
+    end
+
+    it "coerces a symbol to the string member" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce(:closed)
     end
 
     it "returns the value if not a member with strictness off" do

--- a/seed/ruby-sdk-v2/basic-auth-environment-variables/lib/seed/internal/types/enum.rb
+++ b/seed/ruby-sdk-v2/basic-auth-environment-variables/lib/seed/internal/types/enum.rb
@@ -30,9 +30,15 @@ module Seed
         end
 
         def coerce(value, strict: strict?)
-          coerced_value = Utils.coerce(Symbol, value)
+          return value if values.include?(value)
 
-          return coerced_value if values.include?(coerced_value)
+          if value.is_a?(::String) || value.is_a?(::Symbol)
+            candidate = value.to_s
+            match = values.find do |member|
+              (member.is_a?(::String) || member.is_a?(::Symbol)) && member.to_s.casecmp?(candidate)
+            end
+            return match unless match.nil?
+          end
 
           raise Errors::TypeError, "`#{value}` not in enum #{self}" if strict
 

--- a/seed/ruby-sdk-v2/basic-auth-environment-variables/test/unit/internal/types/test_enum.rb
+++ b/seed/ruby-sdk-v2/basic-auth-environment-variables/test/unit/internal/types/test_enum.rb
@@ -12,6 +12,16 @@ describe Seed::Internal::Types::Enum do
 
       finalize!
     end
+
+    module StringEnum
+      extend Seed::Internal::Types::Enum
+
+      ACTIVE = "ACTIVE"
+      CLOSED = "CLOSED"
+      GROUP_BY_PROFILE = "GROUP_BY_PROFILE"
+
+      finalize!
+    end
   end
 
   describe "#values" do
@@ -27,6 +37,19 @@ describe Seed::Internal::Types::Enum do
 
     it "coerces a string version of a member" do
       assert_equal :foo, EnumTest::ExampleEnum.coerce("foo")
+    end
+
+    it "coerces an existing string member" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce("CLOSED")
+    end
+
+    it "normalizes casing to the wire format" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce("closed")
+      assert_equal "GROUP_BY_PROFILE", EnumTest::StringEnum.coerce("group_by_profile")
+    end
+
+    it "coerces a symbol to the string member" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce(:closed)
     end
 
     it "returns the value if not a member with strictness off" do

--- a/seed/ruby-sdk-v2/basic-auth-pw-omitted/wire-tests/lib/seed/internal/types/enum.rb
+++ b/seed/ruby-sdk-v2/basic-auth-pw-omitted/wire-tests/lib/seed/internal/types/enum.rb
@@ -30,9 +30,15 @@ module Seed
         end
 
         def coerce(value, strict: strict?)
-          coerced_value = Utils.coerce(Symbol, value)
+          return value if values.include?(value)
 
-          return coerced_value if values.include?(coerced_value)
+          if value.is_a?(::String) || value.is_a?(::Symbol)
+            candidate = value.to_s
+            match = values.find do |member|
+              (member.is_a?(::String) || member.is_a?(::Symbol)) && member.to_s.casecmp?(candidate)
+            end
+            return match unless match.nil?
+          end
 
           raise Errors::TypeError, "`#{value}` not in enum #{self}" if strict
 

--- a/seed/ruby-sdk-v2/basic-auth-pw-omitted/wire-tests/test/unit/internal/types/test_enum.rb
+++ b/seed/ruby-sdk-v2/basic-auth-pw-omitted/wire-tests/test/unit/internal/types/test_enum.rb
@@ -12,6 +12,16 @@ describe Seed::Internal::Types::Enum do
 
       finalize!
     end
+
+    module StringEnum
+      extend Seed::Internal::Types::Enum
+
+      ACTIVE = "ACTIVE"
+      CLOSED = "CLOSED"
+      GROUP_BY_PROFILE = "GROUP_BY_PROFILE"
+
+      finalize!
+    end
   end
 
   describe "#values" do
@@ -27,6 +37,19 @@ describe Seed::Internal::Types::Enum do
 
     it "coerces a string version of a member" do
       assert_equal :foo, EnumTest::ExampleEnum.coerce("foo")
+    end
+
+    it "coerces an existing string member" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce("CLOSED")
+    end
+
+    it "normalizes casing to the wire format" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce("closed")
+      assert_equal "GROUP_BY_PROFILE", EnumTest::StringEnum.coerce("group_by_profile")
+    end
+
+    it "coerces a symbol to the string member" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce(:closed)
     end
 
     it "returns the value if not a member with strictness off" do

--- a/seed/ruby-sdk-v2/basic-auth/wire-tests/lib/seed/internal/types/enum.rb
+++ b/seed/ruby-sdk-v2/basic-auth/wire-tests/lib/seed/internal/types/enum.rb
@@ -30,9 +30,15 @@ module Seed
         end
 
         def coerce(value, strict: strict?)
-          coerced_value = Utils.coerce(Symbol, value)
+          return value if values.include?(value)
 
-          return coerced_value if values.include?(coerced_value)
+          if value.is_a?(::String) || value.is_a?(::Symbol)
+            candidate = value.to_s
+            match = values.find do |member|
+              (member.is_a?(::String) || member.is_a?(::Symbol)) && member.to_s.casecmp?(candidate)
+            end
+            return match unless match.nil?
+          end
 
           raise Errors::TypeError, "`#{value}` not in enum #{self}" if strict
 

--- a/seed/ruby-sdk-v2/basic-auth/wire-tests/test/unit/internal/types/test_enum.rb
+++ b/seed/ruby-sdk-v2/basic-auth/wire-tests/test/unit/internal/types/test_enum.rb
@@ -12,6 +12,16 @@ describe Seed::Internal::Types::Enum do
 
       finalize!
     end
+
+    module StringEnum
+      extend Seed::Internal::Types::Enum
+
+      ACTIVE = "ACTIVE"
+      CLOSED = "CLOSED"
+      GROUP_BY_PROFILE = "GROUP_BY_PROFILE"
+
+      finalize!
+    end
   end
 
   describe "#values" do
@@ -27,6 +37,19 @@ describe Seed::Internal::Types::Enum do
 
     it "coerces a string version of a member" do
       assert_equal :foo, EnumTest::ExampleEnum.coerce("foo")
+    end
+
+    it "coerces an existing string member" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce("CLOSED")
+    end
+
+    it "normalizes casing to the wire format" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce("closed")
+      assert_equal "GROUP_BY_PROFILE", EnumTest::StringEnum.coerce("group_by_profile")
+    end
+
+    it "coerces a symbol to the string member" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce(:closed)
     end
 
     it "returns the value if not a member with strictness off" do

--- a/seed/ruby-sdk-v2/bearer-token-environment-variable/lib/seed/internal/types/enum.rb
+++ b/seed/ruby-sdk-v2/bearer-token-environment-variable/lib/seed/internal/types/enum.rb
@@ -30,9 +30,15 @@ module Seed
         end
 
         def coerce(value, strict: strict?)
-          coerced_value = Utils.coerce(Symbol, value)
+          return value if values.include?(value)
 
-          return coerced_value if values.include?(coerced_value)
+          if value.is_a?(::String) || value.is_a?(::Symbol)
+            candidate = value.to_s
+            match = values.find do |member|
+              (member.is_a?(::String) || member.is_a?(::Symbol)) && member.to_s.casecmp?(candidate)
+            end
+            return match unless match.nil?
+          end
 
           raise Errors::TypeError, "`#{value}` not in enum #{self}" if strict
 

--- a/seed/ruby-sdk-v2/bearer-token-environment-variable/test/unit/internal/types/test_enum.rb
+++ b/seed/ruby-sdk-v2/bearer-token-environment-variable/test/unit/internal/types/test_enum.rb
@@ -12,6 +12,16 @@ describe Seed::Internal::Types::Enum do
 
       finalize!
     end
+
+    module StringEnum
+      extend Seed::Internal::Types::Enum
+
+      ACTIVE = "ACTIVE"
+      CLOSED = "CLOSED"
+      GROUP_BY_PROFILE = "GROUP_BY_PROFILE"
+
+      finalize!
+    end
   end
 
   describe "#values" do
@@ -27,6 +37,19 @@ describe Seed::Internal::Types::Enum do
 
     it "coerces a string version of a member" do
       assert_equal :foo, EnumTest::ExampleEnum.coerce("foo")
+    end
+
+    it "coerces an existing string member" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce("CLOSED")
+    end
+
+    it "normalizes casing to the wire format" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce("closed")
+      assert_equal "GROUP_BY_PROFILE", EnumTest::StringEnum.coerce("group_by_profile")
+    end
+
+    it "coerces a symbol to the string member" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce(:closed)
     end
 
     it "returns the value if not a member with strictness off" do

--- a/seed/ruby-sdk-v2/bytes-download/lib/seed/internal/types/enum.rb
+++ b/seed/ruby-sdk-v2/bytes-download/lib/seed/internal/types/enum.rb
@@ -30,9 +30,15 @@ module Seed
         end
 
         def coerce(value, strict: strict?)
-          coerced_value = Utils.coerce(Symbol, value)
+          return value if values.include?(value)
 
-          return coerced_value if values.include?(coerced_value)
+          if value.is_a?(::String) || value.is_a?(::Symbol)
+            candidate = value.to_s
+            match = values.find do |member|
+              (member.is_a?(::String) || member.is_a?(::Symbol)) && member.to_s.casecmp?(candidate)
+            end
+            return match unless match.nil?
+          end
 
           raise Errors::TypeError, "`#{value}` not in enum #{self}" if strict
 

--- a/seed/ruby-sdk-v2/bytes-download/test/unit/internal/types/test_enum.rb
+++ b/seed/ruby-sdk-v2/bytes-download/test/unit/internal/types/test_enum.rb
@@ -12,6 +12,16 @@ describe Seed::Internal::Types::Enum do
 
       finalize!
     end
+
+    module StringEnum
+      extend Seed::Internal::Types::Enum
+
+      ACTIVE = "ACTIVE"
+      CLOSED = "CLOSED"
+      GROUP_BY_PROFILE = "GROUP_BY_PROFILE"
+
+      finalize!
+    end
   end
 
   describe "#values" do
@@ -27,6 +37,19 @@ describe Seed::Internal::Types::Enum do
 
     it "coerces a string version of a member" do
       assert_equal :foo, EnumTest::ExampleEnum.coerce("foo")
+    end
+
+    it "coerces an existing string member" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce("CLOSED")
+    end
+
+    it "normalizes casing to the wire format" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce("closed")
+      assert_equal "GROUP_BY_PROFILE", EnumTest::StringEnum.coerce("group_by_profile")
+    end
+
+    it "coerces a symbol to the string member" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce(:closed)
     end
 
     it "returns the value if not a member with strictness off" do

--- a/seed/ruby-sdk-v2/bytes-upload/lib/seed/internal/types/enum.rb
+++ b/seed/ruby-sdk-v2/bytes-upload/lib/seed/internal/types/enum.rb
@@ -30,9 +30,15 @@ module Seed
         end
 
         def coerce(value, strict: strict?)
-          coerced_value = Utils.coerce(Symbol, value)
+          return value if values.include?(value)
 
-          return coerced_value if values.include?(coerced_value)
+          if value.is_a?(::String) || value.is_a?(::Symbol)
+            candidate = value.to_s
+            match = values.find do |member|
+              (member.is_a?(::String) || member.is_a?(::Symbol)) && member.to_s.casecmp?(candidate)
+            end
+            return match unless match.nil?
+          end
 
           raise Errors::TypeError, "`#{value}` not in enum #{self}" if strict
 

--- a/seed/ruby-sdk-v2/bytes-upload/test/unit/internal/types/test_enum.rb
+++ b/seed/ruby-sdk-v2/bytes-upload/test/unit/internal/types/test_enum.rb
@@ -12,6 +12,16 @@ describe Seed::Internal::Types::Enum do
 
       finalize!
     end
+
+    module StringEnum
+      extend Seed::Internal::Types::Enum
+
+      ACTIVE = "ACTIVE"
+      CLOSED = "CLOSED"
+      GROUP_BY_PROFILE = "GROUP_BY_PROFILE"
+
+      finalize!
+    end
   end
 
   describe "#values" do
@@ -27,6 +37,19 @@ describe Seed::Internal::Types::Enum do
 
     it "coerces a string version of a member" do
       assert_equal :foo, EnumTest::ExampleEnum.coerce("foo")
+    end
+
+    it "coerces an existing string member" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce("CLOSED")
+    end
+
+    it "normalizes casing to the wire format" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce("closed")
+      assert_equal "GROUP_BY_PROFILE", EnumTest::StringEnum.coerce("group_by_profile")
+    end
+
+    it "coerces a symbol to the string member" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce(:closed)
     end
 
     it "returns the value if not a member with strictness off" do

--- a/seed/ruby-sdk-v2/circular-references-advanced/lib/seed/internal/types/enum.rb
+++ b/seed/ruby-sdk-v2/circular-references-advanced/lib/seed/internal/types/enum.rb
@@ -30,9 +30,15 @@ module Seed
         end
 
         def coerce(value, strict: strict?)
-          coerced_value = Utils.coerce(Symbol, value)
+          return value if values.include?(value)
 
-          return coerced_value if values.include?(coerced_value)
+          if value.is_a?(::String) || value.is_a?(::Symbol)
+            candidate = value.to_s
+            match = values.find do |member|
+              (member.is_a?(::String) || member.is_a?(::Symbol)) && member.to_s.casecmp?(candidate)
+            end
+            return match unless match.nil?
+          end
 
           raise Errors::TypeError, "`#{value}` not in enum #{self}" if strict
 

--- a/seed/ruby-sdk-v2/circular-references-advanced/test/unit/internal/types/test_enum.rb
+++ b/seed/ruby-sdk-v2/circular-references-advanced/test/unit/internal/types/test_enum.rb
@@ -12,6 +12,16 @@ describe Seed::Internal::Types::Enum do
 
       finalize!
     end
+
+    module StringEnum
+      extend Seed::Internal::Types::Enum
+
+      ACTIVE = "ACTIVE"
+      CLOSED = "CLOSED"
+      GROUP_BY_PROFILE = "GROUP_BY_PROFILE"
+
+      finalize!
+    end
   end
 
   describe "#values" do
@@ -27,6 +37,19 @@ describe Seed::Internal::Types::Enum do
 
     it "coerces a string version of a member" do
       assert_equal :foo, EnumTest::ExampleEnum.coerce("foo")
+    end
+
+    it "coerces an existing string member" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce("CLOSED")
+    end
+
+    it "normalizes casing to the wire format" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce("closed")
+      assert_equal "GROUP_BY_PROFILE", EnumTest::StringEnum.coerce("group_by_profile")
+    end
+
+    it "coerces a symbol to the string member" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce(:closed)
     end
 
     it "returns the value if not a member with strictness off" do

--- a/seed/ruby-sdk-v2/circular-references-extends/lib/seed/internal/types/enum.rb
+++ b/seed/ruby-sdk-v2/circular-references-extends/lib/seed/internal/types/enum.rb
@@ -30,9 +30,15 @@ module Seed
         end
 
         def coerce(value, strict: strict?)
-          coerced_value = Utils.coerce(Symbol, value)
+          return value if values.include?(value)
 
-          return coerced_value if values.include?(coerced_value)
+          if value.is_a?(::String) || value.is_a?(::Symbol)
+            candidate = value.to_s
+            match = values.find do |member|
+              (member.is_a?(::String) || member.is_a?(::Symbol)) && member.to_s.casecmp?(candidate)
+            end
+            return match unless match.nil?
+          end
 
           raise Errors::TypeError, "`#{value}` not in enum #{self}" if strict
 

--- a/seed/ruby-sdk-v2/circular-references-extends/test/unit/internal/types/test_enum.rb
+++ b/seed/ruby-sdk-v2/circular-references-extends/test/unit/internal/types/test_enum.rb
@@ -12,6 +12,16 @@ describe Seed::Internal::Types::Enum do
 
       finalize!
     end
+
+    module StringEnum
+      extend Seed::Internal::Types::Enum
+
+      ACTIVE = "ACTIVE"
+      CLOSED = "CLOSED"
+      GROUP_BY_PROFILE = "GROUP_BY_PROFILE"
+
+      finalize!
+    end
   end
 
   describe "#values" do
@@ -27,6 +37,19 @@ describe Seed::Internal::Types::Enum do
 
     it "coerces a string version of a member" do
       assert_equal :foo, EnumTest::ExampleEnum.coerce("foo")
+    end
+
+    it "coerces an existing string member" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce("CLOSED")
+    end
+
+    it "normalizes casing to the wire format" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce("closed")
+      assert_equal "GROUP_BY_PROFILE", EnumTest::StringEnum.coerce("group_by_profile")
+    end
+
+    it "coerces a symbol to the string member" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce(:closed)
     end
 
     it "returns the value if not a member with strictness off" do

--- a/seed/ruby-sdk-v2/circular-references/lib/seed/internal/types/enum.rb
+++ b/seed/ruby-sdk-v2/circular-references/lib/seed/internal/types/enum.rb
@@ -30,9 +30,15 @@ module Seed
         end
 
         def coerce(value, strict: strict?)
-          coerced_value = Utils.coerce(Symbol, value)
+          return value if values.include?(value)
 
-          return coerced_value if values.include?(coerced_value)
+          if value.is_a?(::String) || value.is_a?(::Symbol)
+            candidate = value.to_s
+            match = values.find do |member|
+              (member.is_a?(::String) || member.is_a?(::Symbol)) && member.to_s.casecmp?(candidate)
+            end
+            return match unless match.nil?
+          end
 
           raise Errors::TypeError, "`#{value}` not in enum #{self}" if strict
 

--- a/seed/ruby-sdk-v2/circular-references/test/unit/internal/types/test_enum.rb
+++ b/seed/ruby-sdk-v2/circular-references/test/unit/internal/types/test_enum.rb
@@ -12,6 +12,16 @@ describe Seed::Internal::Types::Enum do
 
       finalize!
     end
+
+    module StringEnum
+      extend Seed::Internal::Types::Enum
+
+      ACTIVE = "ACTIVE"
+      CLOSED = "CLOSED"
+      GROUP_BY_PROFILE = "GROUP_BY_PROFILE"
+
+      finalize!
+    end
   end
 
   describe "#values" do
@@ -27,6 +37,19 @@ describe Seed::Internal::Types::Enum do
 
     it "coerces a string version of a member" do
       assert_equal :foo, EnumTest::ExampleEnum.coerce("foo")
+    end
+
+    it "coerces an existing string member" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce("CLOSED")
+    end
+
+    it "normalizes casing to the wire format" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce("closed")
+      assert_equal "GROUP_BY_PROFILE", EnumTest::StringEnum.coerce("group_by_profile")
+    end
+
+    it "coerces a symbol to the string member" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce(:closed)
     end
 
     it "returns the value if not a member with strictness off" do

--- a/seed/ruby-sdk-v2/client-side-params/lib/seed/internal/types/enum.rb
+++ b/seed/ruby-sdk-v2/client-side-params/lib/seed/internal/types/enum.rb
@@ -30,9 +30,15 @@ module Seed
         end
 
         def coerce(value, strict: strict?)
-          coerced_value = Utils.coerce(Symbol, value)
+          return value if values.include?(value)
 
-          return coerced_value if values.include?(coerced_value)
+          if value.is_a?(::String) || value.is_a?(::Symbol)
+            candidate = value.to_s
+            match = values.find do |member|
+              (member.is_a?(::String) || member.is_a?(::Symbol)) && member.to_s.casecmp?(candidate)
+            end
+            return match unless match.nil?
+          end
 
           raise Errors::TypeError, "`#{value}` not in enum #{self}" if strict
 

--- a/seed/ruby-sdk-v2/client-side-params/test/unit/internal/types/test_enum.rb
+++ b/seed/ruby-sdk-v2/client-side-params/test/unit/internal/types/test_enum.rb
@@ -12,6 +12,16 @@ describe Seed::Internal::Types::Enum do
 
       finalize!
     end
+
+    module StringEnum
+      extend Seed::Internal::Types::Enum
+
+      ACTIVE = "ACTIVE"
+      CLOSED = "CLOSED"
+      GROUP_BY_PROFILE = "GROUP_BY_PROFILE"
+
+      finalize!
+    end
   end
 
   describe "#values" do
@@ -27,6 +37,19 @@ describe Seed::Internal::Types::Enum do
 
     it "coerces a string version of a member" do
       assert_equal :foo, EnumTest::ExampleEnum.coerce("foo")
+    end
+
+    it "coerces an existing string member" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce("CLOSED")
+    end
+
+    it "normalizes casing to the wire format" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce("closed")
+      assert_equal "GROUP_BY_PROFILE", EnumTest::StringEnum.coerce("group_by_profile")
+    end
+
+    it "coerces a symbol to the string member" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce(:closed)
     end
 
     it "returns the value if not a member with strictness off" do

--- a/seed/ruby-sdk-v2/content-type/lib/seed/internal/types/enum.rb
+++ b/seed/ruby-sdk-v2/content-type/lib/seed/internal/types/enum.rb
@@ -30,9 +30,15 @@ module Seed
         end
 
         def coerce(value, strict: strict?)
-          coerced_value = Utils.coerce(Symbol, value)
+          return value if values.include?(value)
 
-          return coerced_value if values.include?(coerced_value)
+          if value.is_a?(::String) || value.is_a?(::Symbol)
+            candidate = value.to_s
+            match = values.find do |member|
+              (member.is_a?(::String) || member.is_a?(::Symbol)) && member.to_s.casecmp?(candidate)
+            end
+            return match unless match.nil?
+          end
 
           raise Errors::TypeError, "`#{value}` not in enum #{self}" if strict
 

--- a/seed/ruby-sdk-v2/content-type/test/unit/internal/types/test_enum.rb
+++ b/seed/ruby-sdk-v2/content-type/test/unit/internal/types/test_enum.rb
@@ -12,6 +12,16 @@ describe Seed::Internal::Types::Enum do
 
       finalize!
     end
+
+    module StringEnum
+      extend Seed::Internal::Types::Enum
+
+      ACTIVE = "ACTIVE"
+      CLOSED = "CLOSED"
+      GROUP_BY_PROFILE = "GROUP_BY_PROFILE"
+
+      finalize!
+    end
   end
 
   describe "#values" do
@@ -27,6 +37,19 @@ describe Seed::Internal::Types::Enum do
 
     it "coerces a string version of a member" do
       assert_equal :foo, EnumTest::ExampleEnum.coerce("foo")
+    end
+
+    it "coerces an existing string member" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce("CLOSED")
+    end
+
+    it "normalizes casing to the wire format" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce("closed")
+      assert_equal "GROUP_BY_PROFILE", EnumTest::StringEnum.coerce("group_by_profile")
+    end
+
+    it "coerces a symbol to the string member" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce(:closed)
     end
 
     it "returns the value if not a member with strictness off" do

--- a/seed/ruby-sdk-v2/cross-package-type-names/lib/seed/internal/types/enum.rb
+++ b/seed/ruby-sdk-v2/cross-package-type-names/lib/seed/internal/types/enum.rb
@@ -30,9 +30,15 @@ module Seed
         end
 
         def coerce(value, strict: strict?)
-          coerced_value = Utils.coerce(Symbol, value)
+          return value if values.include?(value)
 
-          return coerced_value if values.include?(coerced_value)
+          if value.is_a?(::String) || value.is_a?(::Symbol)
+            candidate = value.to_s
+            match = values.find do |member|
+              (member.is_a?(::String) || member.is_a?(::Symbol)) && member.to_s.casecmp?(candidate)
+            end
+            return match unless match.nil?
+          end
 
           raise Errors::TypeError, "`#{value}` not in enum #{self}" if strict
 

--- a/seed/ruby-sdk-v2/cross-package-type-names/test/unit/internal/types/test_enum.rb
+++ b/seed/ruby-sdk-v2/cross-package-type-names/test/unit/internal/types/test_enum.rb
@@ -12,6 +12,16 @@ describe Seed::Internal::Types::Enum do
 
       finalize!
     end
+
+    module StringEnum
+      extend Seed::Internal::Types::Enum
+
+      ACTIVE = "ACTIVE"
+      CLOSED = "CLOSED"
+      GROUP_BY_PROFILE = "GROUP_BY_PROFILE"
+
+      finalize!
+    end
   end
 
   describe "#values" do
@@ -27,6 +37,19 @@ describe Seed::Internal::Types::Enum do
 
     it "coerces a string version of a member" do
       assert_equal :foo, EnumTest::ExampleEnum.coerce("foo")
+    end
+
+    it "coerces an existing string member" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce("CLOSED")
+    end
+
+    it "normalizes casing to the wire format" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce("closed")
+      assert_equal "GROUP_BY_PROFILE", EnumTest::StringEnum.coerce("group_by_profile")
+    end
+
+    it "coerces a symbol to the string member" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce(:closed)
     end
 
     it "returns the value if not a member with strictness off" do

--- a/seed/ruby-sdk-v2/discriminated-union-with-nested-oneof/lib/seed/internal/types/enum.rb
+++ b/seed/ruby-sdk-v2/discriminated-union-with-nested-oneof/lib/seed/internal/types/enum.rb
@@ -30,9 +30,15 @@ module Seed
         end
 
         def coerce(value, strict: strict?)
-          coerced_value = Utils.coerce(Symbol, value)
+          return value if values.include?(value)
 
-          return coerced_value if values.include?(coerced_value)
+          if value.is_a?(::String) || value.is_a?(::Symbol)
+            candidate = value.to_s
+            match = values.find do |member|
+              (member.is_a?(::String) || member.is_a?(::Symbol)) && member.to_s.casecmp?(candidate)
+            end
+            return match unless match.nil?
+          end
 
           raise Errors::TypeError, "`#{value}` not in enum #{self}" if strict
 

--- a/seed/ruby-sdk-v2/discriminated-union-with-nested-oneof/test/unit/internal/types/test_enum.rb
+++ b/seed/ruby-sdk-v2/discriminated-union-with-nested-oneof/test/unit/internal/types/test_enum.rb
@@ -12,6 +12,16 @@ describe Seed::Internal::Types::Enum do
 
       finalize!
     end
+
+    module StringEnum
+      extend Seed::Internal::Types::Enum
+
+      ACTIVE = "ACTIVE"
+      CLOSED = "CLOSED"
+      GROUP_BY_PROFILE = "GROUP_BY_PROFILE"
+
+      finalize!
+    end
   end
 
   describe "#values" do
@@ -27,6 +37,19 @@ describe Seed::Internal::Types::Enum do
 
     it "coerces a string version of a member" do
       assert_equal :foo, EnumTest::ExampleEnum.coerce("foo")
+    end
+
+    it "coerces an existing string member" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce("CLOSED")
+    end
+
+    it "normalizes casing to the wire format" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce("closed")
+      assert_equal "GROUP_BY_PROFILE", EnumTest::StringEnum.coerce("group_by_profile")
+    end
+
+    it "coerces a symbol to the string member" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce(:closed)
     end
 
     it "returns the value if not a member with strictness off" do

--- a/seed/ruby-sdk-v2/dollar-string-examples/lib/seed/internal/types/enum.rb
+++ b/seed/ruby-sdk-v2/dollar-string-examples/lib/seed/internal/types/enum.rb
@@ -30,9 +30,15 @@ module Seed
         end
 
         def coerce(value, strict: strict?)
-          coerced_value = Utils.coerce(Symbol, value)
+          return value if values.include?(value)
 
-          return coerced_value if values.include?(coerced_value)
+          if value.is_a?(::String) || value.is_a?(::Symbol)
+            candidate = value.to_s
+            match = values.find do |member|
+              (member.is_a?(::String) || member.is_a?(::Symbol)) && member.to_s.casecmp?(candidate)
+            end
+            return match unless match.nil?
+          end
 
           raise Errors::TypeError, "`#{value}` not in enum #{self}" if strict
 

--- a/seed/ruby-sdk-v2/dollar-string-examples/test/unit/internal/types/test_enum.rb
+++ b/seed/ruby-sdk-v2/dollar-string-examples/test/unit/internal/types/test_enum.rb
@@ -12,6 +12,16 @@ describe Seed::Internal::Types::Enum do
 
       finalize!
     end
+
+    module StringEnum
+      extend Seed::Internal::Types::Enum
+
+      ACTIVE = "ACTIVE"
+      CLOSED = "CLOSED"
+      GROUP_BY_PROFILE = "GROUP_BY_PROFILE"
+
+      finalize!
+    end
   end
 
   describe "#values" do
@@ -27,6 +37,19 @@ describe Seed::Internal::Types::Enum do
 
     it "coerces a string version of a member" do
       assert_equal :foo, EnumTest::ExampleEnum.coerce("foo")
+    end
+
+    it "coerces an existing string member" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce("CLOSED")
+    end
+
+    it "normalizes casing to the wire format" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce("closed")
+      assert_equal "GROUP_BY_PROFILE", EnumTest::StringEnum.coerce("group_by_profile")
+    end
+
+    it "coerces a symbol to the string member" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce(:closed)
     end
 
     it "returns the value if not a member with strictness off" do

--- a/seed/ruby-sdk-v2/empty-clients/lib/seed/internal/types/enum.rb
+++ b/seed/ruby-sdk-v2/empty-clients/lib/seed/internal/types/enum.rb
@@ -30,9 +30,15 @@ module Seed
         end
 
         def coerce(value, strict: strict?)
-          coerced_value = Utils.coerce(Symbol, value)
+          return value if values.include?(value)
 
-          return coerced_value if values.include?(coerced_value)
+          if value.is_a?(::String) || value.is_a?(::Symbol)
+            candidate = value.to_s
+            match = values.find do |member|
+              (member.is_a?(::String) || member.is_a?(::Symbol)) && member.to_s.casecmp?(candidate)
+            end
+            return match unless match.nil?
+          end
 
           raise Errors::TypeError, "`#{value}` not in enum #{self}" if strict
 

--- a/seed/ruby-sdk-v2/empty-clients/test/unit/internal/types/test_enum.rb
+++ b/seed/ruby-sdk-v2/empty-clients/test/unit/internal/types/test_enum.rb
@@ -12,6 +12,16 @@ describe Seed::Internal::Types::Enum do
 
       finalize!
     end
+
+    module StringEnum
+      extend Seed::Internal::Types::Enum
+
+      ACTIVE = "ACTIVE"
+      CLOSED = "CLOSED"
+      GROUP_BY_PROFILE = "GROUP_BY_PROFILE"
+
+      finalize!
+    end
   end
 
   describe "#values" do
@@ -27,6 +37,19 @@ describe Seed::Internal::Types::Enum do
 
     it "coerces a string version of a member" do
       assert_equal :foo, EnumTest::ExampleEnum.coerce("foo")
+    end
+
+    it "coerces an existing string member" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce("CLOSED")
+    end
+
+    it "normalizes casing to the wire format" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce("closed")
+      assert_equal "GROUP_BY_PROFILE", EnumTest::StringEnum.coerce("group_by_profile")
+    end
+
+    it "coerces a symbol to the string member" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce(:closed)
     end
 
     it "returns the value if not a member with strictness off" do

--- a/seed/ruby-sdk-v2/endpoint-security-auth/wire-tests/lib/seed/internal/types/enum.rb
+++ b/seed/ruby-sdk-v2/endpoint-security-auth/wire-tests/lib/seed/internal/types/enum.rb
@@ -30,9 +30,15 @@ module Seed
         end
 
         def coerce(value, strict: strict?)
-          coerced_value = Utils.coerce(Symbol, value)
+          return value if values.include?(value)
 
-          return coerced_value if values.include?(coerced_value)
+          if value.is_a?(::String) || value.is_a?(::Symbol)
+            candidate = value.to_s
+            match = values.find do |member|
+              (member.is_a?(::String) || member.is_a?(::Symbol)) && member.to_s.casecmp?(candidate)
+            end
+            return match unless match.nil?
+          end
 
           raise Errors::TypeError, "`#{value}` not in enum #{self}" if strict
 

--- a/seed/ruby-sdk-v2/endpoint-security-auth/wire-tests/test/unit/internal/types/test_enum.rb
+++ b/seed/ruby-sdk-v2/endpoint-security-auth/wire-tests/test/unit/internal/types/test_enum.rb
@@ -12,6 +12,16 @@ describe Seed::Internal::Types::Enum do
 
       finalize!
     end
+
+    module StringEnum
+      extend Seed::Internal::Types::Enum
+
+      ACTIVE = "ACTIVE"
+      CLOSED = "CLOSED"
+      GROUP_BY_PROFILE = "GROUP_BY_PROFILE"
+
+      finalize!
+    end
   end
 
   describe "#values" do
@@ -27,6 +37,19 @@ describe Seed::Internal::Types::Enum do
 
     it "coerces a string version of a member" do
       assert_equal :foo, EnumTest::ExampleEnum.coerce("foo")
+    end
+
+    it "coerces an existing string member" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce("CLOSED")
+    end
+
+    it "normalizes casing to the wire format" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce("closed")
+      assert_equal "GROUP_BY_PROFILE", EnumTest::StringEnum.coerce("group_by_profile")
+    end
+
+    it "coerces a symbol to the string member" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce(:closed)
     end
 
     it "returns the value if not a member with strictness off" do

--- a/seed/ruby-sdk-v2/enum/lib/seed/internal/types/enum.rb
+++ b/seed/ruby-sdk-v2/enum/lib/seed/internal/types/enum.rb
@@ -30,9 +30,15 @@ module Seed
         end
 
         def coerce(value, strict: strict?)
-          coerced_value = Utils.coerce(Symbol, value)
+          return value if values.include?(value)
 
-          return coerced_value if values.include?(coerced_value)
+          if value.is_a?(::String) || value.is_a?(::Symbol)
+            candidate = value.to_s
+            match = values.find do |member|
+              (member.is_a?(::String) || member.is_a?(::Symbol)) && member.to_s.casecmp?(candidate)
+            end
+            return match unless match.nil?
+          end
 
           raise Errors::TypeError, "`#{value}` not in enum #{self}" if strict
 

--- a/seed/ruby-sdk-v2/enum/test/unit/internal/types/test_enum.rb
+++ b/seed/ruby-sdk-v2/enum/test/unit/internal/types/test_enum.rb
@@ -12,6 +12,16 @@ describe Seed::Internal::Types::Enum do
 
       finalize!
     end
+
+    module StringEnum
+      extend Seed::Internal::Types::Enum
+
+      ACTIVE = "ACTIVE"
+      CLOSED = "CLOSED"
+      GROUP_BY_PROFILE = "GROUP_BY_PROFILE"
+
+      finalize!
+    end
   end
 
   describe "#values" do
@@ -27,6 +37,19 @@ describe Seed::Internal::Types::Enum do
 
     it "coerces a string version of a member" do
       assert_equal :foo, EnumTest::ExampleEnum.coerce("foo")
+    end
+
+    it "coerces an existing string member" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce("CLOSED")
+    end
+
+    it "normalizes casing to the wire format" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce("closed")
+      assert_equal "GROUP_BY_PROFILE", EnumTest::StringEnum.coerce("group_by_profile")
+    end
+
+    it "coerces a symbol to the string member" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce(:closed)
     end
 
     it "returns the value if not a member with strictness off" do

--- a/seed/ruby-sdk-v2/error-property/lib/seed/internal/types/enum.rb
+++ b/seed/ruby-sdk-v2/error-property/lib/seed/internal/types/enum.rb
@@ -30,9 +30,15 @@ module Seed
         end
 
         def coerce(value, strict: strict?)
-          coerced_value = Utils.coerce(Symbol, value)
+          return value if values.include?(value)
 
-          return coerced_value if values.include?(coerced_value)
+          if value.is_a?(::String) || value.is_a?(::Symbol)
+            candidate = value.to_s
+            match = values.find do |member|
+              (member.is_a?(::String) || member.is_a?(::Symbol)) && member.to_s.casecmp?(candidate)
+            end
+            return match unless match.nil?
+          end
 
           raise Errors::TypeError, "`#{value}` not in enum #{self}" if strict
 

--- a/seed/ruby-sdk-v2/error-property/test/unit/internal/types/test_enum.rb
+++ b/seed/ruby-sdk-v2/error-property/test/unit/internal/types/test_enum.rb
@@ -12,6 +12,16 @@ describe Seed::Internal::Types::Enum do
 
       finalize!
     end
+
+    module StringEnum
+      extend Seed::Internal::Types::Enum
+
+      ACTIVE = "ACTIVE"
+      CLOSED = "CLOSED"
+      GROUP_BY_PROFILE = "GROUP_BY_PROFILE"
+
+      finalize!
+    end
   end
 
   describe "#values" do
@@ -27,6 +37,19 @@ describe Seed::Internal::Types::Enum do
 
     it "coerces a string version of a member" do
       assert_equal :foo, EnumTest::ExampleEnum.coerce("foo")
+    end
+
+    it "coerces an existing string member" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce("CLOSED")
+    end
+
+    it "normalizes casing to the wire format" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce("closed")
+      assert_equal "GROUP_BY_PROFILE", EnumTest::StringEnum.coerce("group_by_profile")
+    end
+
+    it "coerces a symbol to the string member" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce(:closed)
     end
 
     it "returns the value if not a member with strictness off" do

--- a/seed/ruby-sdk-v2/errors/lib/seed/internal/types/enum.rb
+++ b/seed/ruby-sdk-v2/errors/lib/seed/internal/types/enum.rb
@@ -30,9 +30,15 @@ module Seed
         end
 
         def coerce(value, strict: strict?)
-          coerced_value = Utils.coerce(Symbol, value)
+          return value if values.include?(value)
 
-          return coerced_value if values.include?(coerced_value)
+          if value.is_a?(::String) || value.is_a?(::Symbol)
+            candidate = value.to_s
+            match = values.find do |member|
+              (member.is_a?(::String) || member.is_a?(::Symbol)) && member.to_s.casecmp?(candidate)
+            end
+            return match unless match.nil?
+          end
 
           raise Errors::TypeError, "`#{value}` not in enum #{self}" if strict
 

--- a/seed/ruby-sdk-v2/errors/test/unit/internal/types/test_enum.rb
+++ b/seed/ruby-sdk-v2/errors/test/unit/internal/types/test_enum.rb
@@ -12,6 +12,16 @@ describe Seed::Internal::Types::Enum do
 
       finalize!
     end
+
+    module StringEnum
+      extend Seed::Internal::Types::Enum
+
+      ACTIVE = "ACTIVE"
+      CLOSED = "CLOSED"
+      GROUP_BY_PROFILE = "GROUP_BY_PROFILE"
+
+      finalize!
+    end
   end
 
   describe "#values" do
@@ -27,6 +37,19 @@ describe Seed::Internal::Types::Enum do
 
     it "coerces a string version of a member" do
       assert_equal :foo, EnumTest::ExampleEnum.coerce("foo")
+    end
+
+    it "coerces an existing string member" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce("CLOSED")
+    end
+
+    it "normalizes casing to the wire format" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce("closed")
+      assert_equal "GROUP_BY_PROFILE", EnumTest::StringEnum.coerce("group_by_profile")
+    end
+
+    it "coerces a symbol to the string member" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce(:closed)
     end
 
     it "returns the value if not a member with strictness off" do

--- a/seed/ruby-sdk-v2/examples/include-platform-headers/lib/seed/internal/types/enum.rb
+++ b/seed/ruby-sdk-v2/examples/include-platform-headers/lib/seed/internal/types/enum.rb
@@ -30,9 +30,15 @@ module Seed
         end
 
         def coerce(value, strict: strict?)
-          coerced_value = Utils.coerce(Symbol, value)
+          return value if values.include?(value)
 
-          return coerced_value if values.include?(coerced_value)
+          if value.is_a?(::String) || value.is_a?(::Symbol)
+            candidate = value.to_s
+            match = values.find do |member|
+              (member.is_a?(::String) || member.is_a?(::Symbol)) && member.to_s.casecmp?(candidate)
+            end
+            return match unless match.nil?
+          end
 
           raise Errors::TypeError, "`#{value}` not in enum #{self}" if strict
 

--- a/seed/ruby-sdk-v2/examples/include-platform-headers/test/unit/internal/types/test_enum.rb
+++ b/seed/ruby-sdk-v2/examples/include-platform-headers/test/unit/internal/types/test_enum.rb
@@ -12,6 +12,16 @@ describe Seed::Internal::Types::Enum do
 
       finalize!
     end
+
+    module StringEnum
+      extend Seed::Internal::Types::Enum
+
+      ACTIVE = "ACTIVE"
+      CLOSED = "CLOSED"
+      GROUP_BY_PROFILE = "GROUP_BY_PROFILE"
+
+      finalize!
+    end
   end
 
   describe "#values" do
@@ -27,6 +37,19 @@ describe Seed::Internal::Types::Enum do
 
     it "coerces a string version of a member" do
       assert_equal :foo, EnumTest::ExampleEnum.coerce("foo")
+    end
+
+    it "coerces an existing string member" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce("CLOSED")
+    end
+
+    it "normalizes casing to the wire format" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce("closed")
+      assert_equal "GROUP_BY_PROFILE", EnumTest::StringEnum.coerce("group_by_profile")
+    end
+
+    it "coerces a symbol to the string member" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce(:closed)
     end
 
     it "returns the value if not a member with strictness off" do

--- a/seed/ruby-sdk-v2/examples/no-custom-config/lib/seed/internal/types/enum.rb
+++ b/seed/ruby-sdk-v2/examples/no-custom-config/lib/seed/internal/types/enum.rb
@@ -30,9 +30,15 @@ module Seed
         end
 
         def coerce(value, strict: strict?)
-          coerced_value = Utils.coerce(Symbol, value)
+          return value if values.include?(value)
 
-          return coerced_value if values.include?(coerced_value)
+          if value.is_a?(::String) || value.is_a?(::Symbol)
+            candidate = value.to_s
+            match = values.find do |member|
+              (member.is_a?(::String) || member.is_a?(::Symbol)) && member.to_s.casecmp?(candidate)
+            end
+            return match unless match.nil?
+          end
 
           raise Errors::TypeError, "`#{value}` not in enum #{self}" if strict
 

--- a/seed/ruby-sdk-v2/examples/no-custom-config/test/unit/internal/types/test_enum.rb
+++ b/seed/ruby-sdk-v2/examples/no-custom-config/test/unit/internal/types/test_enum.rb
@@ -12,6 +12,16 @@ describe Seed::Internal::Types::Enum do
 
       finalize!
     end
+
+    module StringEnum
+      extend Seed::Internal::Types::Enum
+
+      ACTIVE = "ACTIVE"
+      CLOSED = "CLOSED"
+      GROUP_BY_PROFILE = "GROUP_BY_PROFILE"
+
+      finalize!
+    end
   end
 
   describe "#values" do
@@ -27,6 +37,19 @@ describe Seed::Internal::Types::Enum do
 
     it "coerces a string version of a member" do
       assert_equal :foo, EnumTest::ExampleEnum.coerce("foo")
+    end
+
+    it "coerces an existing string member" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce("CLOSED")
+    end
+
+    it "normalizes casing to the wire format" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce("closed")
+      assert_equal "GROUP_BY_PROFILE", EnumTest::StringEnum.coerce("group_by_profile")
+    end
+
+    it "coerces a symbol to the string member" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce(:closed)
     end
 
     it "returns the value if not a member with strictness off" do

--- a/seed/ruby-sdk-v2/examples/omit-fern-headers/lib/seed/internal/types/enum.rb
+++ b/seed/ruby-sdk-v2/examples/omit-fern-headers/lib/seed/internal/types/enum.rb
@@ -30,9 +30,15 @@ module Seed
         end
 
         def coerce(value, strict: strict?)
-          coerced_value = Utils.coerce(Symbol, value)
+          return value if values.include?(value)
 
-          return coerced_value if values.include?(coerced_value)
+          if value.is_a?(::String) || value.is_a?(::Symbol)
+            candidate = value.to_s
+            match = values.find do |member|
+              (member.is_a?(::String) || member.is_a?(::Symbol)) && member.to_s.casecmp?(candidate)
+            end
+            return match unless match.nil?
+          end
 
           raise Errors::TypeError, "`#{value}` not in enum #{self}" if strict
 

--- a/seed/ruby-sdk-v2/examples/omit-fern-headers/test/unit/internal/types/test_enum.rb
+++ b/seed/ruby-sdk-v2/examples/omit-fern-headers/test/unit/internal/types/test_enum.rb
@@ -12,6 +12,16 @@ describe Seed::Internal::Types::Enum do
 
       finalize!
     end
+
+    module StringEnum
+      extend Seed::Internal::Types::Enum
+
+      ACTIVE = "ACTIVE"
+      CLOSED = "CLOSED"
+      GROUP_BY_PROFILE = "GROUP_BY_PROFILE"
+
+      finalize!
+    end
   end
 
   describe "#values" do
@@ -27,6 +37,19 @@ describe Seed::Internal::Types::Enum do
 
     it "coerces a string version of a member" do
       assert_equal :foo, EnumTest::ExampleEnum.coerce("foo")
+    end
+
+    it "coerces an existing string member" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce("CLOSED")
+    end
+
+    it "normalizes casing to the wire format" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce("closed")
+      assert_equal "GROUP_BY_PROFILE", EnumTest::StringEnum.coerce("group_by_profile")
+    end
+
+    it "coerces a symbol to the string member" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce(:closed)
     end
 
     it "returns the value if not a member with strictness off" do

--- a/seed/ruby-sdk-v2/examples/readme-config/lib/seed/internal/types/enum.rb
+++ b/seed/ruby-sdk-v2/examples/readme-config/lib/seed/internal/types/enum.rb
@@ -30,9 +30,15 @@ module Seed
         end
 
         def coerce(value, strict: strict?)
-          coerced_value = Utils.coerce(Symbol, value)
+          return value if values.include?(value)
 
-          return coerced_value if values.include?(coerced_value)
+          if value.is_a?(::String) || value.is_a?(::Symbol)
+            candidate = value.to_s
+            match = values.find do |member|
+              (member.is_a?(::String) || member.is_a?(::Symbol)) && member.to_s.casecmp?(candidate)
+            end
+            return match unless match.nil?
+          end
 
           raise Errors::TypeError, "`#{value}` not in enum #{self}" if strict
 

--- a/seed/ruby-sdk-v2/examples/readme-config/test/unit/internal/types/test_enum.rb
+++ b/seed/ruby-sdk-v2/examples/readme-config/test/unit/internal/types/test_enum.rb
@@ -12,6 +12,16 @@ describe Seed::Internal::Types::Enum do
 
       finalize!
     end
+
+    module StringEnum
+      extend Seed::Internal::Types::Enum
+
+      ACTIVE = "ACTIVE"
+      CLOSED = "CLOSED"
+      GROUP_BY_PROFILE = "GROUP_BY_PROFILE"
+
+      finalize!
+    end
   end
 
   describe "#values" do
@@ -27,6 +37,19 @@ describe Seed::Internal::Types::Enum do
 
     it "coerces a string version of a member" do
       assert_equal :foo, EnumTest::ExampleEnum.coerce("foo")
+    end
+
+    it "coerces an existing string member" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce("CLOSED")
+    end
+
+    it "normalizes casing to the wire format" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce("closed")
+      assert_equal "GROUP_BY_PROFILE", EnumTest::StringEnum.coerce("group_by_profile")
+    end
+
+    it "coerces a symbol to the string member" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce(:closed)
     end
 
     it "returns the value if not a member with strictness off" do

--- a/seed/ruby-sdk-v2/examples/require-paths/lib/seed/internal/types/enum.rb
+++ b/seed/ruby-sdk-v2/examples/require-paths/lib/seed/internal/types/enum.rb
@@ -30,9 +30,15 @@ module Seed
         end
 
         def coerce(value, strict: strict?)
-          coerced_value = Utils.coerce(Symbol, value)
+          return value if values.include?(value)
 
-          return coerced_value if values.include?(coerced_value)
+          if value.is_a?(::String) || value.is_a?(::Symbol)
+            candidate = value.to_s
+            match = values.find do |member|
+              (member.is_a?(::String) || member.is_a?(::Symbol)) && member.to_s.casecmp?(candidate)
+            end
+            return match unless match.nil?
+          end
 
           raise Errors::TypeError, "`#{value}` not in enum #{self}" if strict
 

--- a/seed/ruby-sdk-v2/examples/require-paths/test/unit/internal/types/test_enum.rb
+++ b/seed/ruby-sdk-v2/examples/require-paths/test/unit/internal/types/test_enum.rb
@@ -12,6 +12,16 @@ describe Seed::Internal::Types::Enum do
 
       finalize!
     end
+
+    module StringEnum
+      extend Seed::Internal::Types::Enum
+
+      ACTIVE = "ACTIVE"
+      CLOSED = "CLOSED"
+      GROUP_BY_PROFILE = "GROUP_BY_PROFILE"
+
+      finalize!
+    end
   end
 
   describe "#values" do
@@ -27,6 +37,19 @@ describe Seed::Internal::Types::Enum do
 
     it "coerces a string version of a member" do
       assert_equal :foo, EnumTest::ExampleEnum.coerce("foo")
+    end
+
+    it "coerces an existing string member" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce("CLOSED")
+    end
+
+    it "normalizes casing to the wire format" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce("closed")
+      assert_equal "GROUP_BY_PROFILE", EnumTest::StringEnum.coerce("group_by_profile")
+    end
+
+    it "coerces a symbol to the string member" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce(:closed)
     end
 
     it "returns the value if not a member with strictness off" do

--- a/seed/ruby-sdk-v2/examples/wire-tests/lib/seed/internal/types/enum.rb
+++ b/seed/ruby-sdk-v2/examples/wire-tests/lib/seed/internal/types/enum.rb
@@ -30,9 +30,15 @@ module Seed
         end
 
         def coerce(value, strict: strict?)
-          coerced_value = Utils.coerce(Symbol, value)
+          return value if values.include?(value)
 
-          return coerced_value if values.include?(coerced_value)
+          if value.is_a?(::String) || value.is_a?(::Symbol)
+            candidate = value.to_s
+            match = values.find do |member|
+              (member.is_a?(::String) || member.is_a?(::Symbol)) && member.to_s.casecmp?(candidate)
+            end
+            return match unless match.nil?
+          end
 
           raise Errors::TypeError, "`#{value}` not in enum #{self}" if strict
 

--- a/seed/ruby-sdk-v2/examples/wire-tests/test/unit/internal/types/test_enum.rb
+++ b/seed/ruby-sdk-v2/examples/wire-tests/test/unit/internal/types/test_enum.rb
@@ -12,6 +12,16 @@ describe Seed::Internal::Types::Enum do
 
       finalize!
     end
+
+    module StringEnum
+      extend Seed::Internal::Types::Enum
+
+      ACTIVE = "ACTIVE"
+      CLOSED = "CLOSED"
+      GROUP_BY_PROFILE = "GROUP_BY_PROFILE"
+
+      finalize!
+    end
   end
 
   describe "#values" do
@@ -27,6 +37,19 @@ describe Seed::Internal::Types::Enum do
 
     it "coerces a string version of a member" do
       assert_equal :foo, EnumTest::ExampleEnum.coerce("foo")
+    end
+
+    it "coerces an existing string member" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce("CLOSED")
+    end
+
+    it "normalizes casing to the wire format" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce("closed")
+      assert_equal "GROUP_BY_PROFILE", EnumTest::StringEnum.coerce("group_by_profile")
+    end
+
+    it "coerces a symbol to the string member" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce(:closed)
     end
 
     it "returns the value if not a member with strictness off" do

--- a/seed/ruby-sdk-v2/exhaustive/wire-tests/lib/seed/internal/types/enum.rb
+++ b/seed/ruby-sdk-v2/exhaustive/wire-tests/lib/seed/internal/types/enum.rb
@@ -30,9 +30,15 @@ module Seed
         end
 
         def coerce(value, strict: strict?)
-          coerced_value = Utils.coerce(Symbol, value)
+          return value if values.include?(value)
 
-          return coerced_value if values.include?(coerced_value)
+          if value.is_a?(::String) || value.is_a?(::Symbol)
+            candidate = value.to_s
+            match = values.find do |member|
+              (member.is_a?(::String) || member.is_a?(::Symbol)) && member.to_s.casecmp?(candidate)
+            end
+            return match unless match.nil?
+          end
 
           raise Errors::TypeError, "`#{value}` not in enum #{self}" if strict
 

--- a/seed/ruby-sdk-v2/exhaustive/wire-tests/test/unit/internal/types/test_enum.rb
+++ b/seed/ruby-sdk-v2/exhaustive/wire-tests/test/unit/internal/types/test_enum.rb
@@ -12,6 +12,16 @@ describe Seed::Internal::Types::Enum do
 
       finalize!
     end
+
+    module StringEnum
+      extend Seed::Internal::Types::Enum
+
+      ACTIVE = "ACTIVE"
+      CLOSED = "CLOSED"
+      GROUP_BY_PROFILE = "GROUP_BY_PROFILE"
+
+      finalize!
+    end
   end
 
   describe "#values" do
@@ -27,6 +37,19 @@ describe Seed::Internal::Types::Enum do
 
     it "coerces a string version of a member" do
       assert_equal :foo, EnumTest::ExampleEnum.coerce("foo")
+    end
+
+    it "coerces an existing string member" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce("CLOSED")
+    end
+
+    it "normalizes casing to the wire format" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce("closed")
+      assert_equal "GROUP_BY_PROFILE", EnumTest::StringEnum.coerce("group_by_profile")
+    end
+
+    it "coerces a symbol to the string member" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce(:closed)
     end
 
     it "returns the value if not a member with strictness off" do

--- a/seed/ruby-sdk-v2/extends/lib/seed/internal/types/enum.rb
+++ b/seed/ruby-sdk-v2/extends/lib/seed/internal/types/enum.rb
@@ -30,9 +30,15 @@ module Seed
         end
 
         def coerce(value, strict: strict?)
-          coerced_value = Utils.coerce(Symbol, value)
+          return value if values.include?(value)
 
-          return coerced_value if values.include?(coerced_value)
+          if value.is_a?(::String) || value.is_a?(::Symbol)
+            candidate = value.to_s
+            match = values.find do |member|
+              (member.is_a?(::String) || member.is_a?(::Symbol)) && member.to_s.casecmp?(candidate)
+            end
+            return match unless match.nil?
+          end
 
           raise Errors::TypeError, "`#{value}` not in enum #{self}" if strict
 

--- a/seed/ruby-sdk-v2/extends/test/unit/internal/types/test_enum.rb
+++ b/seed/ruby-sdk-v2/extends/test/unit/internal/types/test_enum.rb
@@ -12,6 +12,16 @@ describe Seed::Internal::Types::Enum do
 
       finalize!
     end
+
+    module StringEnum
+      extend Seed::Internal::Types::Enum
+
+      ACTIVE = "ACTIVE"
+      CLOSED = "CLOSED"
+      GROUP_BY_PROFILE = "GROUP_BY_PROFILE"
+
+      finalize!
+    end
   end
 
   describe "#values" do
@@ -27,6 +37,19 @@ describe Seed::Internal::Types::Enum do
 
     it "coerces a string version of a member" do
       assert_equal :foo, EnumTest::ExampleEnum.coerce("foo")
+    end
+
+    it "coerces an existing string member" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce("CLOSED")
+    end
+
+    it "normalizes casing to the wire format" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce("closed")
+      assert_equal "GROUP_BY_PROFILE", EnumTest::StringEnum.coerce("group_by_profile")
+    end
+
+    it "coerces a symbol to the string member" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce(:closed)
     end
 
     it "returns the value if not a member with strictness off" do

--- a/seed/ruby-sdk-v2/extra-properties/lib/seed/internal/types/enum.rb
+++ b/seed/ruby-sdk-v2/extra-properties/lib/seed/internal/types/enum.rb
@@ -30,9 +30,15 @@ module Seed
         end
 
         def coerce(value, strict: strict?)
-          coerced_value = Utils.coerce(Symbol, value)
+          return value if values.include?(value)
 
-          return coerced_value if values.include?(coerced_value)
+          if value.is_a?(::String) || value.is_a?(::Symbol)
+            candidate = value.to_s
+            match = values.find do |member|
+              (member.is_a?(::String) || member.is_a?(::Symbol)) && member.to_s.casecmp?(candidate)
+            end
+            return match unless match.nil?
+          end
 
           raise Errors::TypeError, "`#{value}` not in enum #{self}" if strict
 

--- a/seed/ruby-sdk-v2/extra-properties/test/unit/internal/types/test_enum.rb
+++ b/seed/ruby-sdk-v2/extra-properties/test/unit/internal/types/test_enum.rb
@@ -12,6 +12,16 @@ describe Seed::Internal::Types::Enum do
 
       finalize!
     end
+
+    module StringEnum
+      extend Seed::Internal::Types::Enum
+
+      ACTIVE = "ACTIVE"
+      CLOSED = "CLOSED"
+      GROUP_BY_PROFILE = "GROUP_BY_PROFILE"
+
+      finalize!
+    end
   end
 
   describe "#values" do
@@ -27,6 +37,19 @@ describe Seed::Internal::Types::Enum do
 
     it "coerces a string version of a member" do
       assert_equal :foo, EnumTest::ExampleEnum.coerce("foo")
+    end
+
+    it "coerces an existing string member" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce("CLOSED")
+    end
+
+    it "normalizes casing to the wire format" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce("closed")
+      assert_equal "GROUP_BY_PROFILE", EnumTest::StringEnum.coerce("group_by_profile")
+    end
+
+    it "coerces a symbol to the string member" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce(:closed)
     end
 
     it "returns the value if not a member with strictness off" do

--- a/seed/ruby-sdk-v2/file-download/lib/seed/internal/types/enum.rb
+++ b/seed/ruby-sdk-v2/file-download/lib/seed/internal/types/enum.rb
@@ -30,9 +30,15 @@ module Seed
         end
 
         def coerce(value, strict: strict?)
-          coerced_value = Utils.coerce(Symbol, value)
+          return value if values.include?(value)
 
-          return coerced_value if values.include?(coerced_value)
+          if value.is_a?(::String) || value.is_a?(::Symbol)
+            candidate = value.to_s
+            match = values.find do |member|
+              (member.is_a?(::String) || member.is_a?(::Symbol)) && member.to_s.casecmp?(candidate)
+            end
+            return match unless match.nil?
+          end
 
           raise Errors::TypeError, "`#{value}` not in enum #{self}" if strict
 

--- a/seed/ruby-sdk-v2/file-download/test/unit/internal/types/test_enum.rb
+++ b/seed/ruby-sdk-v2/file-download/test/unit/internal/types/test_enum.rb
@@ -12,6 +12,16 @@ describe Seed::Internal::Types::Enum do
 
       finalize!
     end
+
+    module StringEnum
+      extend Seed::Internal::Types::Enum
+
+      ACTIVE = "ACTIVE"
+      CLOSED = "CLOSED"
+      GROUP_BY_PROFILE = "GROUP_BY_PROFILE"
+
+      finalize!
+    end
   end
 
   describe "#values" do
@@ -27,6 +37,19 @@ describe Seed::Internal::Types::Enum do
 
     it "coerces a string version of a member" do
       assert_equal :foo, EnumTest::ExampleEnum.coerce("foo")
+    end
+
+    it "coerces an existing string member" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce("CLOSED")
+    end
+
+    it "normalizes casing to the wire format" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce("closed")
+      assert_equal "GROUP_BY_PROFILE", EnumTest::StringEnum.coerce("group_by_profile")
+    end
+
+    it "coerces a symbol to the string member" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce(:closed)
     end
 
     it "returns the value if not a member with strictness off" do

--- a/seed/ruby-sdk-v2/file-upload-openapi/lib/seed/internal/types/enum.rb
+++ b/seed/ruby-sdk-v2/file-upload-openapi/lib/seed/internal/types/enum.rb
@@ -30,9 +30,15 @@ module Seed
         end
 
         def coerce(value, strict: strict?)
-          coerced_value = Utils.coerce(Symbol, value)
+          return value if values.include?(value)
 
-          return coerced_value if values.include?(coerced_value)
+          if value.is_a?(::String) || value.is_a?(::Symbol)
+            candidate = value.to_s
+            match = values.find do |member|
+              (member.is_a?(::String) || member.is_a?(::Symbol)) && member.to_s.casecmp?(candidate)
+            end
+            return match unless match.nil?
+          end
 
           raise Errors::TypeError, "`#{value}` not in enum #{self}" if strict
 

--- a/seed/ruby-sdk-v2/file-upload-openapi/test/unit/internal/types/test_enum.rb
+++ b/seed/ruby-sdk-v2/file-upload-openapi/test/unit/internal/types/test_enum.rb
@@ -12,6 +12,16 @@ describe Seed::Internal::Types::Enum do
 
       finalize!
     end
+
+    module StringEnum
+      extend Seed::Internal::Types::Enum
+
+      ACTIVE = "ACTIVE"
+      CLOSED = "CLOSED"
+      GROUP_BY_PROFILE = "GROUP_BY_PROFILE"
+
+      finalize!
+    end
   end
 
   describe "#values" do
@@ -27,6 +37,19 @@ describe Seed::Internal::Types::Enum do
 
     it "coerces a string version of a member" do
       assert_equal :foo, EnumTest::ExampleEnum.coerce("foo")
+    end
+
+    it "coerces an existing string member" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce("CLOSED")
+    end
+
+    it "normalizes casing to the wire format" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce("closed")
+      assert_equal "GROUP_BY_PROFILE", EnumTest::StringEnum.coerce("group_by_profile")
+    end
+
+    it "coerces a symbol to the string member" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce(:closed)
     end
 
     it "returns the value if not a member with strictness off" do

--- a/seed/ruby-sdk-v2/file-upload/lib/seed/internal/types/enum.rb
+++ b/seed/ruby-sdk-v2/file-upload/lib/seed/internal/types/enum.rb
@@ -30,9 +30,15 @@ module Seed
         end
 
         def coerce(value, strict: strict?)
-          coerced_value = Utils.coerce(Symbol, value)
+          return value if values.include?(value)
 
-          return coerced_value if values.include?(coerced_value)
+          if value.is_a?(::String) || value.is_a?(::Symbol)
+            candidate = value.to_s
+            match = values.find do |member|
+              (member.is_a?(::String) || member.is_a?(::Symbol)) && member.to_s.casecmp?(candidate)
+            end
+            return match unless match.nil?
+          end
 
           raise Errors::TypeError, "`#{value}` not in enum #{self}" if strict
 

--- a/seed/ruby-sdk-v2/file-upload/test/unit/internal/types/test_enum.rb
+++ b/seed/ruby-sdk-v2/file-upload/test/unit/internal/types/test_enum.rb
@@ -12,6 +12,16 @@ describe Seed::Internal::Types::Enum do
 
       finalize!
     end
+
+    module StringEnum
+      extend Seed::Internal::Types::Enum
+
+      ACTIVE = "ACTIVE"
+      CLOSED = "CLOSED"
+      GROUP_BY_PROFILE = "GROUP_BY_PROFILE"
+
+      finalize!
+    end
   end
 
   describe "#values" do
@@ -27,6 +37,19 @@ describe Seed::Internal::Types::Enum do
 
     it "coerces a string version of a member" do
       assert_equal :foo, EnumTest::ExampleEnum.coerce("foo")
+    end
+
+    it "coerces an existing string member" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce("CLOSED")
+    end
+
+    it "normalizes casing to the wire format" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce("closed")
+      assert_equal "GROUP_BY_PROFILE", EnumTest::StringEnum.coerce("group_by_profile")
+    end
+
+    it "coerces a symbol to the string member" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce(:closed)
     end
 
     it "returns the value if not a member with strictness off" do

--- a/seed/ruby-sdk-v2/folders/lib/seed/internal/types/enum.rb
+++ b/seed/ruby-sdk-v2/folders/lib/seed/internal/types/enum.rb
@@ -30,9 +30,15 @@ module Seed
         end
 
         def coerce(value, strict: strict?)
-          coerced_value = Utils.coerce(Symbol, value)
+          return value if values.include?(value)
 
-          return coerced_value if values.include?(coerced_value)
+          if value.is_a?(::String) || value.is_a?(::Symbol)
+            candidate = value.to_s
+            match = values.find do |member|
+              (member.is_a?(::String) || member.is_a?(::Symbol)) && member.to_s.casecmp?(candidate)
+            end
+            return match unless match.nil?
+          end
 
           raise Errors::TypeError, "`#{value}` not in enum #{self}" if strict
 

--- a/seed/ruby-sdk-v2/folders/test/unit/internal/types/test_enum.rb
+++ b/seed/ruby-sdk-v2/folders/test/unit/internal/types/test_enum.rb
@@ -12,6 +12,16 @@ describe Seed::Internal::Types::Enum do
 
       finalize!
     end
+
+    module StringEnum
+      extend Seed::Internal::Types::Enum
+
+      ACTIVE = "ACTIVE"
+      CLOSED = "CLOSED"
+      GROUP_BY_PROFILE = "GROUP_BY_PROFILE"
+
+      finalize!
+    end
   end
 
   describe "#values" do
@@ -27,6 +37,19 @@ describe Seed::Internal::Types::Enum do
 
     it "coerces a string version of a member" do
       assert_equal :foo, EnumTest::ExampleEnum.coerce("foo")
+    end
+
+    it "coerces an existing string member" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce("CLOSED")
+    end
+
+    it "normalizes casing to the wire format" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce("closed")
+      assert_equal "GROUP_BY_PROFILE", EnumTest::StringEnum.coerce("group_by_profile")
+    end
+
+    it "coerces a symbol to the string member" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce(:closed)
     end
 
     it "returns the value if not a member with strictness off" do

--- a/seed/ruby-sdk-v2/header-auth-environment-variable/lib/seed/internal/types/enum.rb
+++ b/seed/ruby-sdk-v2/header-auth-environment-variable/lib/seed/internal/types/enum.rb
@@ -30,9 +30,15 @@ module Seed
         end
 
         def coerce(value, strict: strict?)
-          coerced_value = Utils.coerce(Symbol, value)
+          return value if values.include?(value)
 
-          return coerced_value if values.include?(coerced_value)
+          if value.is_a?(::String) || value.is_a?(::Symbol)
+            candidate = value.to_s
+            match = values.find do |member|
+              (member.is_a?(::String) || member.is_a?(::Symbol)) && member.to_s.casecmp?(candidate)
+            end
+            return match unless match.nil?
+          end
 
           raise Errors::TypeError, "`#{value}` not in enum #{self}" if strict
 

--- a/seed/ruby-sdk-v2/header-auth-environment-variable/test/unit/internal/types/test_enum.rb
+++ b/seed/ruby-sdk-v2/header-auth-environment-variable/test/unit/internal/types/test_enum.rb
@@ -12,6 +12,16 @@ describe Seed::Internal::Types::Enum do
 
       finalize!
     end
+
+    module StringEnum
+      extend Seed::Internal::Types::Enum
+
+      ACTIVE = "ACTIVE"
+      CLOSED = "CLOSED"
+      GROUP_BY_PROFILE = "GROUP_BY_PROFILE"
+
+      finalize!
+    end
   end
 
   describe "#values" do
@@ -27,6 +37,19 @@ describe Seed::Internal::Types::Enum do
 
     it "coerces a string version of a member" do
       assert_equal :foo, EnumTest::ExampleEnum.coerce("foo")
+    end
+
+    it "coerces an existing string member" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce("CLOSED")
+    end
+
+    it "normalizes casing to the wire format" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce("closed")
+      assert_equal "GROUP_BY_PROFILE", EnumTest::StringEnum.coerce("group_by_profile")
+    end
+
+    it "coerces a symbol to the string member" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce(:closed)
     end
 
     it "returns the value if not a member with strictness off" do

--- a/seed/ruby-sdk-v2/header-auth/lib/seed/internal/types/enum.rb
+++ b/seed/ruby-sdk-v2/header-auth/lib/seed/internal/types/enum.rb
@@ -30,9 +30,15 @@ module Seed
         end
 
         def coerce(value, strict: strict?)
-          coerced_value = Utils.coerce(Symbol, value)
+          return value if values.include?(value)
 
-          return coerced_value if values.include?(coerced_value)
+          if value.is_a?(::String) || value.is_a?(::Symbol)
+            candidate = value.to_s
+            match = values.find do |member|
+              (member.is_a?(::String) || member.is_a?(::Symbol)) && member.to_s.casecmp?(candidate)
+            end
+            return match unless match.nil?
+          end
 
           raise Errors::TypeError, "`#{value}` not in enum #{self}" if strict
 

--- a/seed/ruby-sdk-v2/header-auth/test/unit/internal/types/test_enum.rb
+++ b/seed/ruby-sdk-v2/header-auth/test/unit/internal/types/test_enum.rb
@@ -12,6 +12,16 @@ describe Seed::Internal::Types::Enum do
 
       finalize!
     end
+
+    module StringEnum
+      extend Seed::Internal::Types::Enum
+
+      ACTIVE = "ACTIVE"
+      CLOSED = "CLOSED"
+      GROUP_BY_PROFILE = "GROUP_BY_PROFILE"
+
+      finalize!
+    end
   end
 
   describe "#values" do
@@ -27,6 +37,19 @@ describe Seed::Internal::Types::Enum do
 
     it "coerces a string version of a member" do
       assert_equal :foo, EnumTest::ExampleEnum.coerce("foo")
+    end
+
+    it "coerces an existing string member" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce("CLOSED")
+    end
+
+    it "normalizes casing to the wire format" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce("closed")
+      assert_equal "GROUP_BY_PROFILE", EnumTest::StringEnum.coerce("group_by_profile")
+    end
+
+    it "coerces a symbol to the string member" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce(:closed)
     end
 
     it "returns the value if not a member with strictness off" do

--- a/seed/ruby-sdk-v2/http-head/lib/seed/internal/types/enum.rb
+++ b/seed/ruby-sdk-v2/http-head/lib/seed/internal/types/enum.rb
@@ -30,9 +30,15 @@ module Seed
         end
 
         def coerce(value, strict: strict?)
-          coerced_value = Utils.coerce(Symbol, value)
+          return value if values.include?(value)
 
-          return coerced_value if values.include?(coerced_value)
+          if value.is_a?(::String) || value.is_a?(::Symbol)
+            candidate = value.to_s
+            match = values.find do |member|
+              (member.is_a?(::String) || member.is_a?(::Symbol)) && member.to_s.casecmp?(candidate)
+            end
+            return match unless match.nil?
+          end
 
           raise Errors::TypeError, "`#{value}` not in enum #{self}" if strict
 

--- a/seed/ruby-sdk-v2/http-head/test/unit/internal/types/test_enum.rb
+++ b/seed/ruby-sdk-v2/http-head/test/unit/internal/types/test_enum.rb
@@ -12,6 +12,16 @@ describe Seed::Internal::Types::Enum do
 
       finalize!
     end
+
+    module StringEnum
+      extend Seed::Internal::Types::Enum
+
+      ACTIVE = "ACTIVE"
+      CLOSED = "CLOSED"
+      GROUP_BY_PROFILE = "GROUP_BY_PROFILE"
+
+      finalize!
+    end
   end
 
   describe "#values" do
@@ -27,6 +37,19 @@ describe Seed::Internal::Types::Enum do
 
     it "coerces a string version of a member" do
       assert_equal :foo, EnumTest::ExampleEnum.coerce("foo")
+    end
+
+    it "coerces an existing string member" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce("CLOSED")
+    end
+
+    it "normalizes casing to the wire format" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce("closed")
+      assert_equal "GROUP_BY_PROFILE", EnumTest::StringEnum.coerce("group_by_profile")
+    end
+
+    it "coerces a symbol to the string member" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce(:closed)
     end
 
     it "returns the value if not a member with strictness off" do

--- a/seed/ruby-sdk-v2/idempotency-headers/auto-generate-idempotency-key/lib/seed/internal/types/enum.rb
+++ b/seed/ruby-sdk-v2/idempotency-headers/auto-generate-idempotency-key/lib/seed/internal/types/enum.rb
@@ -30,9 +30,15 @@ module Seed
         end
 
         def coerce(value, strict: strict?)
-          coerced_value = Utils.coerce(Symbol, value)
+          return value if values.include?(value)
 
-          return coerced_value if values.include?(coerced_value)
+          if value.is_a?(::String) || value.is_a?(::Symbol)
+            candidate = value.to_s
+            match = values.find do |member|
+              (member.is_a?(::String) || member.is_a?(::Symbol)) && member.to_s.casecmp?(candidate)
+            end
+            return match unless match.nil?
+          end
 
           raise Errors::TypeError, "`#{value}` not in enum #{self}" if strict
 

--- a/seed/ruby-sdk-v2/idempotency-headers/auto-generate-idempotency-key/test/unit/internal/types/test_enum.rb
+++ b/seed/ruby-sdk-v2/idempotency-headers/auto-generate-idempotency-key/test/unit/internal/types/test_enum.rb
@@ -12,6 +12,16 @@ describe Seed::Internal::Types::Enum do
 
       finalize!
     end
+
+    module StringEnum
+      extend Seed::Internal::Types::Enum
+
+      ACTIVE = "ACTIVE"
+      CLOSED = "CLOSED"
+      GROUP_BY_PROFILE = "GROUP_BY_PROFILE"
+
+      finalize!
+    end
   end
 
   describe "#values" do
@@ -27,6 +37,19 @@ describe Seed::Internal::Types::Enum do
 
     it "coerces a string version of a member" do
       assert_equal :foo, EnumTest::ExampleEnum.coerce("foo")
+    end
+
+    it "coerces an existing string member" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce("CLOSED")
+    end
+
+    it "normalizes casing to the wire format" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce("closed")
+      assert_equal "GROUP_BY_PROFILE", EnumTest::StringEnum.coerce("group_by_profile")
+    end
+
+    it "coerces a symbol to the string member" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce(:closed)
     end
 
     it "returns the value if not a member with strictness off" do

--- a/seed/ruby-sdk-v2/idempotency-headers/no-custom-config/lib/seed/internal/types/enum.rb
+++ b/seed/ruby-sdk-v2/idempotency-headers/no-custom-config/lib/seed/internal/types/enum.rb
@@ -30,9 +30,15 @@ module Seed
         end
 
         def coerce(value, strict: strict?)
-          coerced_value = Utils.coerce(Symbol, value)
+          return value if values.include?(value)
 
-          return coerced_value if values.include?(coerced_value)
+          if value.is_a?(::String) || value.is_a?(::Symbol)
+            candidate = value.to_s
+            match = values.find do |member|
+              (member.is_a?(::String) || member.is_a?(::Symbol)) && member.to_s.casecmp?(candidate)
+            end
+            return match unless match.nil?
+          end
 
           raise Errors::TypeError, "`#{value}` not in enum #{self}" if strict
 

--- a/seed/ruby-sdk-v2/idempotency-headers/no-custom-config/test/unit/internal/types/test_enum.rb
+++ b/seed/ruby-sdk-v2/idempotency-headers/no-custom-config/test/unit/internal/types/test_enum.rb
@@ -12,6 +12,16 @@ describe Seed::Internal::Types::Enum do
 
       finalize!
     end
+
+    module StringEnum
+      extend Seed::Internal::Types::Enum
+
+      ACTIVE = "ACTIVE"
+      CLOSED = "CLOSED"
+      GROUP_BY_PROFILE = "GROUP_BY_PROFILE"
+
+      finalize!
+    end
   end
 
   describe "#values" do
@@ -27,6 +37,19 @@ describe Seed::Internal::Types::Enum do
 
     it "coerces a string version of a member" do
       assert_equal :foo, EnumTest::ExampleEnum.coerce("foo")
+    end
+
+    it "coerces an existing string member" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce("CLOSED")
+    end
+
+    it "normalizes casing to the wire format" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce("closed")
+      assert_equal "GROUP_BY_PROFILE", EnumTest::StringEnum.coerce("group_by_profile")
+    end
+
+    it "coerces a symbol to the string member" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce(:closed)
     end
 
     it "returns the value if not a member with strictness off" do

--- a/seed/ruby-sdk-v2/imdb/lib/seed/internal/types/enum.rb
+++ b/seed/ruby-sdk-v2/imdb/lib/seed/internal/types/enum.rb
@@ -30,9 +30,15 @@ module Seed
         end
 
         def coerce(value, strict: strict?)
-          coerced_value = Utils.coerce(Symbol, value)
+          return value if values.include?(value)
 
-          return coerced_value if values.include?(coerced_value)
+          if value.is_a?(::String) || value.is_a?(::Symbol)
+            candidate = value.to_s
+            match = values.find do |member|
+              (member.is_a?(::String) || member.is_a?(::Symbol)) && member.to_s.casecmp?(candidate)
+            end
+            return match unless match.nil?
+          end
 
           raise Errors::TypeError, "`#{value}` not in enum #{self}" if strict
 

--- a/seed/ruby-sdk-v2/imdb/test/unit/internal/types/test_enum.rb
+++ b/seed/ruby-sdk-v2/imdb/test/unit/internal/types/test_enum.rb
@@ -12,6 +12,16 @@ describe Seed::Internal::Types::Enum do
 
       finalize!
     end
+
+    module StringEnum
+      extend Seed::Internal::Types::Enum
+
+      ACTIVE = "ACTIVE"
+      CLOSED = "CLOSED"
+      GROUP_BY_PROFILE = "GROUP_BY_PROFILE"
+
+      finalize!
+    end
   end
 
   describe "#values" do
@@ -27,6 +37,19 @@ describe Seed::Internal::Types::Enum do
 
     it "coerces a string version of a member" do
       assert_equal :foo, EnumTest::ExampleEnum.coerce("foo")
+    end
+
+    it "coerces an existing string member" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce("CLOSED")
+    end
+
+    it "normalizes casing to the wire format" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce("closed")
+      assert_equal "GROUP_BY_PROFILE", EnumTest::StringEnum.coerce("group_by_profile")
+    end
+
+    it "coerces a symbol to the string member" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce(:closed)
     end
 
     it "returns the value if not a member with strictness off" do

--- a/seed/ruby-sdk-v2/inferred-auth-explicit/lib/seed/internal/types/enum.rb
+++ b/seed/ruby-sdk-v2/inferred-auth-explicit/lib/seed/internal/types/enum.rb
@@ -30,9 +30,15 @@ module Seed
         end
 
         def coerce(value, strict: strict?)
-          coerced_value = Utils.coerce(Symbol, value)
+          return value if values.include?(value)
 
-          return coerced_value if values.include?(coerced_value)
+          if value.is_a?(::String) || value.is_a?(::Symbol)
+            candidate = value.to_s
+            match = values.find do |member|
+              (member.is_a?(::String) || member.is_a?(::Symbol)) && member.to_s.casecmp?(candidate)
+            end
+            return match unless match.nil?
+          end
 
           raise Errors::TypeError, "`#{value}` not in enum #{self}" if strict
 

--- a/seed/ruby-sdk-v2/inferred-auth-explicit/test/unit/internal/types/test_enum.rb
+++ b/seed/ruby-sdk-v2/inferred-auth-explicit/test/unit/internal/types/test_enum.rb
@@ -12,6 +12,16 @@ describe Seed::Internal::Types::Enum do
 
       finalize!
     end
+
+    module StringEnum
+      extend Seed::Internal::Types::Enum
+
+      ACTIVE = "ACTIVE"
+      CLOSED = "CLOSED"
+      GROUP_BY_PROFILE = "GROUP_BY_PROFILE"
+
+      finalize!
+    end
   end
 
   describe "#values" do
@@ -27,6 +37,19 @@ describe Seed::Internal::Types::Enum do
 
     it "coerces a string version of a member" do
       assert_equal :foo, EnumTest::ExampleEnum.coerce("foo")
+    end
+
+    it "coerces an existing string member" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce("CLOSED")
+    end
+
+    it "normalizes casing to the wire format" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce("closed")
+      assert_equal "GROUP_BY_PROFILE", EnumTest::StringEnum.coerce("group_by_profile")
+    end
+
+    it "coerces a symbol to the string member" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce(:closed)
     end
 
     it "returns the value if not a member with strictness off" do

--- a/seed/ruby-sdk-v2/inferred-auth-implicit-api-key/lib/seed/internal/types/enum.rb
+++ b/seed/ruby-sdk-v2/inferred-auth-implicit-api-key/lib/seed/internal/types/enum.rb
@@ -30,9 +30,15 @@ module Seed
         end
 
         def coerce(value, strict: strict?)
-          coerced_value = Utils.coerce(Symbol, value)
+          return value if values.include?(value)
 
-          return coerced_value if values.include?(coerced_value)
+          if value.is_a?(::String) || value.is_a?(::Symbol)
+            candidate = value.to_s
+            match = values.find do |member|
+              (member.is_a?(::String) || member.is_a?(::Symbol)) && member.to_s.casecmp?(candidate)
+            end
+            return match unless match.nil?
+          end
 
           raise Errors::TypeError, "`#{value}` not in enum #{self}" if strict
 

--- a/seed/ruby-sdk-v2/inferred-auth-implicit-api-key/test/unit/internal/types/test_enum.rb
+++ b/seed/ruby-sdk-v2/inferred-auth-implicit-api-key/test/unit/internal/types/test_enum.rb
@@ -12,6 +12,16 @@ describe Seed::Internal::Types::Enum do
 
       finalize!
     end
+
+    module StringEnum
+      extend Seed::Internal::Types::Enum
+
+      ACTIVE = "ACTIVE"
+      CLOSED = "CLOSED"
+      GROUP_BY_PROFILE = "GROUP_BY_PROFILE"
+
+      finalize!
+    end
   end
 
   describe "#values" do
@@ -27,6 +37,19 @@ describe Seed::Internal::Types::Enum do
 
     it "coerces a string version of a member" do
       assert_equal :foo, EnumTest::ExampleEnum.coerce("foo")
+    end
+
+    it "coerces an existing string member" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce("CLOSED")
+    end
+
+    it "normalizes casing to the wire format" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce("closed")
+      assert_equal "GROUP_BY_PROFILE", EnumTest::StringEnum.coerce("group_by_profile")
+    end
+
+    it "coerces a symbol to the string member" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce(:closed)
     end
 
     it "returns the value if not a member with strictness off" do

--- a/seed/ruby-sdk-v2/inferred-auth-implicit-no-expiry/lib/seed/internal/types/enum.rb
+++ b/seed/ruby-sdk-v2/inferred-auth-implicit-no-expiry/lib/seed/internal/types/enum.rb
@@ -30,9 +30,15 @@ module Seed
         end
 
         def coerce(value, strict: strict?)
-          coerced_value = Utils.coerce(Symbol, value)
+          return value if values.include?(value)
 
-          return coerced_value if values.include?(coerced_value)
+          if value.is_a?(::String) || value.is_a?(::Symbol)
+            candidate = value.to_s
+            match = values.find do |member|
+              (member.is_a?(::String) || member.is_a?(::Symbol)) && member.to_s.casecmp?(candidate)
+            end
+            return match unless match.nil?
+          end
 
           raise Errors::TypeError, "`#{value}` not in enum #{self}" if strict
 

--- a/seed/ruby-sdk-v2/inferred-auth-implicit-no-expiry/test/unit/internal/types/test_enum.rb
+++ b/seed/ruby-sdk-v2/inferred-auth-implicit-no-expiry/test/unit/internal/types/test_enum.rb
@@ -12,6 +12,16 @@ describe Seed::Internal::Types::Enum do
 
       finalize!
     end
+
+    module StringEnum
+      extend Seed::Internal::Types::Enum
+
+      ACTIVE = "ACTIVE"
+      CLOSED = "CLOSED"
+      GROUP_BY_PROFILE = "GROUP_BY_PROFILE"
+
+      finalize!
+    end
   end
 
   describe "#values" do
@@ -27,6 +37,19 @@ describe Seed::Internal::Types::Enum do
 
     it "coerces a string version of a member" do
       assert_equal :foo, EnumTest::ExampleEnum.coerce("foo")
+    end
+
+    it "coerces an existing string member" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce("CLOSED")
+    end
+
+    it "normalizes casing to the wire format" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce("closed")
+      assert_equal "GROUP_BY_PROFILE", EnumTest::StringEnum.coerce("group_by_profile")
+    end
+
+    it "coerces a symbol to the string member" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce(:closed)
     end
 
     it "returns the value if not a member with strictness off" do

--- a/seed/ruby-sdk-v2/inferred-auth-implicit-reference/lib/seed/internal/types/enum.rb
+++ b/seed/ruby-sdk-v2/inferred-auth-implicit-reference/lib/seed/internal/types/enum.rb
@@ -30,9 +30,15 @@ module Seed
         end
 
         def coerce(value, strict: strict?)
-          coerced_value = Utils.coerce(Symbol, value)
+          return value if values.include?(value)
 
-          return coerced_value if values.include?(coerced_value)
+          if value.is_a?(::String) || value.is_a?(::Symbol)
+            candidate = value.to_s
+            match = values.find do |member|
+              (member.is_a?(::String) || member.is_a?(::Symbol)) && member.to_s.casecmp?(candidate)
+            end
+            return match unless match.nil?
+          end
 
           raise Errors::TypeError, "`#{value}` not in enum #{self}" if strict
 

--- a/seed/ruby-sdk-v2/inferred-auth-implicit-reference/test/unit/internal/types/test_enum.rb
+++ b/seed/ruby-sdk-v2/inferred-auth-implicit-reference/test/unit/internal/types/test_enum.rb
@@ -12,6 +12,16 @@ describe Seed::Internal::Types::Enum do
 
       finalize!
     end
+
+    module StringEnum
+      extend Seed::Internal::Types::Enum
+
+      ACTIVE = "ACTIVE"
+      CLOSED = "CLOSED"
+      GROUP_BY_PROFILE = "GROUP_BY_PROFILE"
+
+      finalize!
+    end
   end
 
   describe "#values" do
@@ -27,6 +37,19 @@ describe Seed::Internal::Types::Enum do
 
     it "coerces a string version of a member" do
       assert_equal :foo, EnumTest::ExampleEnum.coerce("foo")
+    end
+
+    it "coerces an existing string member" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce("CLOSED")
+    end
+
+    it "normalizes casing to the wire format" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce("closed")
+      assert_equal "GROUP_BY_PROFILE", EnumTest::StringEnum.coerce("group_by_profile")
+    end
+
+    it "coerces a symbol to the string member" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce(:closed)
     end
 
     it "returns the value if not a member with strictness off" do

--- a/seed/ruby-sdk-v2/inferred-auth-implicit/lib/seed/internal/types/enum.rb
+++ b/seed/ruby-sdk-v2/inferred-auth-implicit/lib/seed/internal/types/enum.rb
@@ -30,9 +30,15 @@ module Seed
         end
 
         def coerce(value, strict: strict?)
-          coerced_value = Utils.coerce(Symbol, value)
+          return value if values.include?(value)
 
-          return coerced_value if values.include?(coerced_value)
+          if value.is_a?(::String) || value.is_a?(::Symbol)
+            candidate = value.to_s
+            match = values.find do |member|
+              (member.is_a?(::String) || member.is_a?(::Symbol)) && member.to_s.casecmp?(candidate)
+            end
+            return match unless match.nil?
+          end
 
           raise Errors::TypeError, "`#{value}` not in enum #{self}" if strict
 

--- a/seed/ruby-sdk-v2/inferred-auth-implicit/test/unit/internal/types/test_enum.rb
+++ b/seed/ruby-sdk-v2/inferred-auth-implicit/test/unit/internal/types/test_enum.rb
@@ -12,6 +12,16 @@ describe Seed::Internal::Types::Enum do
 
       finalize!
     end
+
+    module StringEnum
+      extend Seed::Internal::Types::Enum
+
+      ACTIVE = "ACTIVE"
+      CLOSED = "CLOSED"
+      GROUP_BY_PROFILE = "GROUP_BY_PROFILE"
+
+      finalize!
+    end
   end
 
   describe "#values" do
@@ -27,6 +37,19 @@ describe Seed::Internal::Types::Enum do
 
     it "coerces a string version of a member" do
       assert_equal :foo, EnumTest::ExampleEnum.coerce("foo")
+    end
+
+    it "coerces an existing string member" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce("CLOSED")
+    end
+
+    it "normalizes casing to the wire format" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce("closed")
+      assert_equal "GROUP_BY_PROFILE", EnumTest::StringEnum.coerce("group_by_profile")
+    end
+
+    it "coerces a symbol to the string member" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce(:closed)
     end
 
     it "returns the value if not a member with strictness off" do

--- a/seed/ruby-sdk-v2/inline-enum-type-name-override/lib/seed/internal/types/enum.rb
+++ b/seed/ruby-sdk-v2/inline-enum-type-name-override/lib/seed/internal/types/enum.rb
@@ -30,9 +30,15 @@ module Seed
         end
 
         def coerce(value, strict: strict?)
-          coerced_value = Utils.coerce(Symbol, value)
+          return value if values.include?(value)
 
-          return coerced_value if values.include?(coerced_value)
+          if value.is_a?(::String) || value.is_a?(::Symbol)
+            candidate = value.to_s
+            match = values.find do |member|
+              (member.is_a?(::String) || member.is_a?(::Symbol)) && member.to_s.casecmp?(candidate)
+            end
+            return match unless match.nil?
+          end
 
           raise Errors::TypeError, "`#{value}` not in enum #{self}" if strict
 

--- a/seed/ruby-sdk-v2/inline-enum-type-name-override/test/unit/internal/types/test_enum.rb
+++ b/seed/ruby-sdk-v2/inline-enum-type-name-override/test/unit/internal/types/test_enum.rb
@@ -12,6 +12,16 @@ describe Seed::Internal::Types::Enum do
 
       finalize!
     end
+
+    module StringEnum
+      extend Seed::Internal::Types::Enum
+
+      ACTIVE = "ACTIVE"
+      CLOSED = "CLOSED"
+      GROUP_BY_PROFILE = "GROUP_BY_PROFILE"
+
+      finalize!
+    end
   end
 
   describe "#values" do
@@ -27,6 +37,19 @@ describe Seed::Internal::Types::Enum do
 
     it "coerces a string version of a member" do
       assert_equal :foo, EnumTest::ExampleEnum.coerce("foo")
+    end
+
+    it "coerces an existing string member" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce("CLOSED")
+    end
+
+    it "normalizes casing to the wire format" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce("closed")
+      assert_equal "GROUP_BY_PROFILE", EnumTest::StringEnum.coerce("group_by_profile")
+    end
+
+    it "coerces a symbol to the string member" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce(:closed)
     end
 
     it "returns the value if not a member with strictness off" do

--- a/seed/ruby-sdk-v2/license/lib/seed/internal/types/enum.rb
+++ b/seed/ruby-sdk-v2/license/lib/seed/internal/types/enum.rb
@@ -30,9 +30,15 @@ module Seed
         end
 
         def coerce(value, strict: strict?)
-          coerced_value = Utils.coerce(Symbol, value)
+          return value if values.include?(value)
 
-          return coerced_value if values.include?(coerced_value)
+          if value.is_a?(::String) || value.is_a?(::Symbol)
+            candidate = value.to_s
+            match = values.find do |member|
+              (member.is_a?(::String) || member.is_a?(::Symbol)) && member.to_s.casecmp?(candidate)
+            end
+            return match unless match.nil?
+          end
 
           raise Errors::TypeError, "`#{value}` not in enum #{self}" if strict
 

--- a/seed/ruby-sdk-v2/license/test/unit/internal/types/test_enum.rb
+++ b/seed/ruby-sdk-v2/license/test/unit/internal/types/test_enum.rb
@@ -12,6 +12,16 @@ describe Seed::Internal::Types::Enum do
 
       finalize!
     end
+
+    module StringEnum
+      extend Seed::Internal::Types::Enum
+
+      ACTIVE = "ACTIVE"
+      CLOSED = "CLOSED"
+      GROUP_BY_PROFILE = "GROUP_BY_PROFILE"
+
+      finalize!
+    end
   end
 
   describe "#values" do
@@ -27,6 +37,19 @@ describe Seed::Internal::Types::Enum do
 
     it "coerces a string version of a member" do
       assert_equal :foo, EnumTest::ExampleEnum.coerce("foo")
+    end
+
+    it "coerces an existing string member" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce("CLOSED")
+    end
+
+    it "normalizes casing to the wire format" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce("closed")
+      assert_equal "GROUP_BY_PROFILE", EnumTest::StringEnum.coerce("group_by_profile")
+    end
+
+    it "coerces a symbol to the string member" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce(:closed)
     end
 
     it "returns the value if not a member with strictness off" do

--- a/seed/ruby-sdk-v2/literal-user-agent/lib/seed/internal/types/enum.rb
+++ b/seed/ruby-sdk-v2/literal-user-agent/lib/seed/internal/types/enum.rb
@@ -30,9 +30,15 @@ module Seed
         end
 
         def coerce(value, strict: strict?)
-          coerced_value = Utils.coerce(Symbol, value)
+          return value if values.include?(value)
 
-          return coerced_value if values.include?(coerced_value)
+          if value.is_a?(::String) || value.is_a?(::Symbol)
+            candidate = value.to_s
+            match = values.find do |member|
+              (member.is_a?(::String) || member.is_a?(::Symbol)) && member.to_s.casecmp?(candidate)
+            end
+            return match unless match.nil?
+          end
 
           raise Errors::TypeError, "`#{value}` not in enum #{self}" if strict
 

--- a/seed/ruby-sdk-v2/literal-user-agent/test/unit/internal/types/test_enum.rb
+++ b/seed/ruby-sdk-v2/literal-user-agent/test/unit/internal/types/test_enum.rb
@@ -12,6 +12,16 @@ describe Seed::Internal::Types::Enum do
 
       finalize!
     end
+
+    module StringEnum
+      extend Seed::Internal::Types::Enum
+
+      ACTIVE = "ACTIVE"
+      CLOSED = "CLOSED"
+      GROUP_BY_PROFILE = "GROUP_BY_PROFILE"
+
+      finalize!
+    end
   end
 
   describe "#values" do
@@ -27,6 +37,19 @@ describe Seed::Internal::Types::Enum do
 
     it "coerces a string version of a member" do
       assert_equal :foo, EnumTest::ExampleEnum.coerce("foo")
+    end
+
+    it "coerces an existing string member" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce("CLOSED")
+    end
+
+    it "normalizes casing to the wire format" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce("closed")
+      assert_equal "GROUP_BY_PROFILE", EnumTest::StringEnum.coerce("group_by_profile")
+    end
+
+    it "coerces a symbol to the string member" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce(:closed)
     end
 
     it "returns the value if not a member with strictness off" do

--- a/seed/ruby-sdk-v2/literal/lib/seed/internal/types/enum.rb
+++ b/seed/ruby-sdk-v2/literal/lib/seed/internal/types/enum.rb
@@ -30,9 +30,15 @@ module Seed
         end
 
         def coerce(value, strict: strict?)
-          coerced_value = Utils.coerce(Symbol, value)
+          return value if values.include?(value)
 
-          return coerced_value if values.include?(coerced_value)
+          if value.is_a?(::String) || value.is_a?(::Symbol)
+            candidate = value.to_s
+            match = values.find do |member|
+              (member.is_a?(::String) || member.is_a?(::Symbol)) && member.to_s.casecmp?(candidate)
+            end
+            return match unless match.nil?
+          end
 
           raise Errors::TypeError, "`#{value}` not in enum #{self}" if strict
 

--- a/seed/ruby-sdk-v2/literal/test/unit/internal/types/test_enum.rb
+++ b/seed/ruby-sdk-v2/literal/test/unit/internal/types/test_enum.rb
@@ -12,6 +12,16 @@ describe Seed::Internal::Types::Enum do
 
       finalize!
     end
+
+    module StringEnum
+      extend Seed::Internal::Types::Enum
+
+      ACTIVE = "ACTIVE"
+      CLOSED = "CLOSED"
+      GROUP_BY_PROFILE = "GROUP_BY_PROFILE"
+
+      finalize!
+    end
   end
 
   describe "#values" do
@@ -27,6 +37,19 @@ describe Seed::Internal::Types::Enum do
 
     it "coerces a string version of a member" do
       assert_equal :foo, EnumTest::ExampleEnum.coerce("foo")
+    end
+
+    it "coerces an existing string member" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce("CLOSED")
+    end
+
+    it "normalizes casing to the wire format" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce("closed")
+      assert_equal "GROUP_BY_PROFILE", EnumTest::StringEnum.coerce("group_by_profile")
+    end
+
+    it "coerces a symbol to the string member" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce(:closed)
     end
 
     it "returns the value if not a member with strictness off" do

--- a/seed/ruby-sdk-v2/literals-unions/lib/seed/internal/types/enum.rb
+++ b/seed/ruby-sdk-v2/literals-unions/lib/seed/internal/types/enum.rb
@@ -30,9 +30,15 @@ module Seed
         end
 
         def coerce(value, strict: strict?)
-          coerced_value = Utils.coerce(Symbol, value)
+          return value if values.include?(value)
 
-          return coerced_value if values.include?(coerced_value)
+          if value.is_a?(::String) || value.is_a?(::Symbol)
+            candidate = value.to_s
+            match = values.find do |member|
+              (member.is_a?(::String) || member.is_a?(::Symbol)) && member.to_s.casecmp?(candidate)
+            end
+            return match unless match.nil?
+          end
 
           raise Errors::TypeError, "`#{value}` not in enum #{self}" if strict
 

--- a/seed/ruby-sdk-v2/literals-unions/test/unit/internal/types/test_enum.rb
+++ b/seed/ruby-sdk-v2/literals-unions/test/unit/internal/types/test_enum.rb
@@ -12,6 +12,16 @@ describe Seed::Internal::Types::Enum do
 
       finalize!
     end
+
+    module StringEnum
+      extend Seed::Internal::Types::Enum
+
+      ACTIVE = "ACTIVE"
+      CLOSED = "CLOSED"
+      GROUP_BY_PROFILE = "GROUP_BY_PROFILE"
+
+      finalize!
+    end
   end
 
   describe "#values" do
@@ -27,6 +37,19 @@ describe Seed::Internal::Types::Enum do
 
     it "coerces a string version of a member" do
       assert_equal :foo, EnumTest::ExampleEnum.coerce("foo")
+    end
+
+    it "coerces an existing string member" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce("CLOSED")
+    end
+
+    it "normalizes casing to the wire format" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce("closed")
+      assert_equal "GROUP_BY_PROFILE", EnumTest::StringEnum.coerce("group_by_profile")
+    end
+
+    it "coerces a symbol to the string member" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce(:closed)
     end
 
     it "returns the value if not a member with strictness off" do

--- a/seed/ruby-sdk-v2/mixed-case/lib/seed/internal/types/enum.rb
+++ b/seed/ruby-sdk-v2/mixed-case/lib/seed/internal/types/enum.rb
@@ -30,9 +30,15 @@ module Seed
         end
 
         def coerce(value, strict: strict?)
-          coerced_value = Utils.coerce(Symbol, value)
+          return value if values.include?(value)
 
-          return coerced_value if values.include?(coerced_value)
+          if value.is_a?(::String) || value.is_a?(::Symbol)
+            candidate = value.to_s
+            match = values.find do |member|
+              (member.is_a?(::String) || member.is_a?(::Symbol)) && member.to_s.casecmp?(candidate)
+            end
+            return match unless match.nil?
+          end
 
           raise Errors::TypeError, "`#{value}` not in enum #{self}" if strict
 

--- a/seed/ruby-sdk-v2/mixed-case/test/unit/internal/types/test_enum.rb
+++ b/seed/ruby-sdk-v2/mixed-case/test/unit/internal/types/test_enum.rb
@@ -12,6 +12,16 @@ describe Seed::Internal::Types::Enum do
 
       finalize!
     end
+
+    module StringEnum
+      extend Seed::Internal::Types::Enum
+
+      ACTIVE = "ACTIVE"
+      CLOSED = "CLOSED"
+      GROUP_BY_PROFILE = "GROUP_BY_PROFILE"
+
+      finalize!
+    end
   end
 
   describe "#values" do
@@ -27,6 +37,19 @@ describe Seed::Internal::Types::Enum do
 
     it "coerces a string version of a member" do
       assert_equal :foo, EnumTest::ExampleEnum.coerce("foo")
+    end
+
+    it "coerces an existing string member" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce("CLOSED")
+    end
+
+    it "normalizes casing to the wire format" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce("closed")
+      assert_equal "GROUP_BY_PROFILE", EnumTest::StringEnum.coerce("group_by_profile")
+    end
+
+    it "coerces a symbol to the string member" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce(:closed)
     end
 
     it "returns the value if not a member with strictness off" do

--- a/seed/ruby-sdk-v2/mixed-file-directory/lib/seed/internal/types/enum.rb
+++ b/seed/ruby-sdk-v2/mixed-file-directory/lib/seed/internal/types/enum.rb
@@ -30,9 +30,15 @@ module Seed
         end
 
         def coerce(value, strict: strict?)
-          coerced_value = Utils.coerce(Symbol, value)
+          return value if values.include?(value)
 
-          return coerced_value if values.include?(coerced_value)
+          if value.is_a?(::String) || value.is_a?(::Symbol)
+            candidate = value.to_s
+            match = values.find do |member|
+              (member.is_a?(::String) || member.is_a?(::Symbol)) && member.to_s.casecmp?(candidate)
+            end
+            return match unless match.nil?
+          end
 
           raise Errors::TypeError, "`#{value}` not in enum #{self}" if strict
 

--- a/seed/ruby-sdk-v2/mixed-file-directory/test/unit/internal/types/test_enum.rb
+++ b/seed/ruby-sdk-v2/mixed-file-directory/test/unit/internal/types/test_enum.rb
@@ -12,6 +12,16 @@ describe Seed::Internal::Types::Enum do
 
       finalize!
     end
+
+    module StringEnum
+      extend Seed::Internal::Types::Enum
+
+      ACTIVE = "ACTIVE"
+      CLOSED = "CLOSED"
+      GROUP_BY_PROFILE = "GROUP_BY_PROFILE"
+
+      finalize!
+    end
   end
 
   describe "#values" do
@@ -27,6 +37,19 @@ describe Seed::Internal::Types::Enum do
 
     it "coerces a string version of a member" do
       assert_equal :foo, EnumTest::ExampleEnum.coerce("foo")
+    end
+
+    it "coerces an existing string member" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce("CLOSED")
+    end
+
+    it "normalizes casing to the wire format" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce("closed")
+      assert_equal "GROUP_BY_PROFILE", EnumTest::StringEnum.coerce("group_by_profile")
+    end
+
+    it "coerces a symbol to the string member" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce(:closed)
     end
 
     it "returns the value if not a member with strictness off" do

--- a/seed/ruby-sdk-v2/multi-content-type-examples/lib/seed/internal/types/enum.rb
+++ b/seed/ruby-sdk-v2/multi-content-type-examples/lib/seed/internal/types/enum.rb
@@ -30,9 +30,15 @@ module Seed
         end
 
         def coerce(value, strict: strict?)
-          coerced_value = Utils.coerce(Symbol, value)
+          return value if values.include?(value)
 
-          return coerced_value if values.include?(coerced_value)
+          if value.is_a?(::String) || value.is_a?(::Symbol)
+            candidate = value.to_s
+            match = values.find do |member|
+              (member.is_a?(::String) || member.is_a?(::Symbol)) && member.to_s.casecmp?(candidate)
+            end
+            return match unless match.nil?
+          end
 
           raise Errors::TypeError, "`#{value}` not in enum #{self}" if strict
 

--- a/seed/ruby-sdk-v2/multi-content-type-examples/test/unit/internal/types/test_enum.rb
+++ b/seed/ruby-sdk-v2/multi-content-type-examples/test/unit/internal/types/test_enum.rb
@@ -12,6 +12,16 @@ describe Seed::Internal::Types::Enum do
 
       finalize!
     end
+
+    module StringEnum
+      extend Seed::Internal::Types::Enum
+
+      ACTIVE = "ACTIVE"
+      CLOSED = "CLOSED"
+      GROUP_BY_PROFILE = "GROUP_BY_PROFILE"
+
+      finalize!
+    end
   end
 
   describe "#values" do
@@ -27,6 +37,19 @@ describe Seed::Internal::Types::Enum do
 
     it "coerces a string version of a member" do
       assert_equal :foo, EnumTest::ExampleEnum.coerce("foo")
+    end
+
+    it "coerces an existing string member" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce("CLOSED")
+    end
+
+    it "normalizes casing to the wire format" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce("closed")
+      assert_equal "GROUP_BY_PROFILE", EnumTest::StringEnum.coerce("group_by_profile")
+    end
+
+    it "coerces a symbol to the string member" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce(:closed)
     end
 
     it "returns the value if not a member with strictness off" do

--- a/seed/ruby-sdk-v2/multi-line-docs/lib/seed/internal/types/enum.rb
+++ b/seed/ruby-sdk-v2/multi-line-docs/lib/seed/internal/types/enum.rb
@@ -30,9 +30,15 @@ module Seed
         end
 
         def coerce(value, strict: strict?)
-          coerced_value = Utils.coerce(Symbol, value)
+          return value if values.include?(value)
 
-          return coerced_value if values.include?(coerced_value)
+          if value.is_a?(::String) || value.is_a?(::Symbol)
+            candidate = value.to_s
+            match = values.find do |member|
+              (member.is_a?(::String) || member.is_a?(::Symbol)) && member.to_s.casecmp?(candidate)
+            end
+            return match unless match.nil?
+          end
 
           raise Errors::TypeError, "`#{value}` not in enum #{self}" if strict
 

--- a/seed/ruby-sdk-v2/multi-line-docs/test/unit/internal/types/test_enum.rb
+++ b/seed/ruby-sdk-v2/multi-line-docs/test/unit/internal/types/test_enum.rb
@@ -12,6 +12,16 @@ describe Seed::Internal::Types::Enum do
 
       finalize!
     end
+
+    module StringEnum
+      extend Seed::Internal::Types::Enum
+
+      ACTIVE = "ACTIVE"
+      CLOSED = "CLOSED"
+      GROUP_BY_PROFILE = "GROUP_BY_PROFILE"
+
+      finalize!
+    end
   end
 
   describe "#values" do
@@ -27,6 +37,19 @@ describe Seed::Internal::Types::Enum do
 
     it "coerces a string version of a member" do
       assert_equal :foo, EnumTest::ExampleEnum.coerce("foo")
+    end
+
+    it "coerces an existing string member" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce("CLOSED")
+    end
+
+    it "normalizes casing to the wire format" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce("closed")
+      assert_equal "GROUP_BY_PROFILE", EnumTest::StringEnum.coerce("group_by_profile")
+    end
+
+    it "coerces a symbol to the string member" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce(:closed)
     end
 
     it "returns the value if not a member with strictness off" do

--- a/seed/ruby-sdk-v2/multi-url-environment-no-default/lib/seed/internal/types/enum.rb
+++ b/seed/ruby-sdk-v2/multi-url-environment-no-default/lib/seed/internal/types/enum.rb
@@ -30,9 +30,15 @@ module Seed
         end
 
         def coerce(value, strict: strict?)
-          coerced_value = Utils.coerce(Symbol, value)
+          return value if values.include?(value)
 
-          return coerced_value if values.include?(coerced_value)
+          if value.is_a?(::String) || value.is_a?(::Symbol)
+            candidate = value.to_s
+            match = values.find do |member|
+              (member.is_a?(::String) || member.is_a?(::Symbol)) && member.to_s.casecmp?(candidate)
+            end
+            return match unless match.nil?
+          end
 
           raise Errors::TypeError, "`#{value}` not in enum #{self}" if strict
 

--- a/seed/ruby-sdk-v2/multi-url-environment-no-default/test/unit/internal/types/test_enum.rb
+++ b/seed/ruby-sdk-v2/multi-url-environment-no-default/test/unit/internal/types/test_enum.rb
@@ -12,6 +12,16 @@ describe Seed::Internal::Types::Enum do
 
       finalize!
     end
+
+    module StringEnum
+      extend Seed::Internal::Types::Enum
+
+      ACTIVE = "ACTIVE"
+      CLOSED = "CLOSED"
+      GROUP_BY_PROFILE = "GROUP_BY_PROFILE"
+
+      finalize!
+    end
   end
 
   describe "#values" do
@@ -27,6 +37,19 @@ describe Seed::Internal::Types::Enum do
 
     it "coerces a string version of a member" do
       assert_equal :foo, EnumTest::ExampleEnum.coerce("foo")
+    end
+
+    it "coerces an existing string member" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce("CLOSED")
+    end
+
+    it "normalizes casing to the wire format" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce("closed")
+      assert_equal "GROUP_BY_PROFILE", EnumTest::StringEnum.coerce("group_by_profile")
+    end
+
+    it "coerces a symbol to the string member" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce(:closed)
     end
 
     it "returns the value if not a member with strictness off" do

--- a/seed/ruby-sdk-v2/multi-url-environment-reference/lib/seed/internal/types/enum.rb
+++ b/seed/ruby-sdk-v2/multi-url-environment-reference/lib/seed/internal/types/enum.rb
@@ -30,9 +30,15 @@ module Seed
         end
 
         def coerce(value, strict: strict?)
-          coerced_value = Utils.coerce(Symbol, value)
+          return value if values.include?(value)
 
-          return coerced_value if values.include?(coerced_value)
+          if value.is_a?(::String) || value.is_a?(::Symbol)
+            candidate = value.to_s
+            match = values.find do |member|
+              (member.is_a?(::String) || member.is_a?(::Symbol)) && member.to_s.casecmp?(candidate)
+            end
+            return match unless match.nil?
+          end
 
           raise Errors::TypeError, "`#{value}` not in enum #{self}" if strict
 

--- a/seed/ruby-sdk-v2/multi-url-environment-reference/test/unit/internal/types/test_enum.rb
+++ b/seed/ruby-sdk-v2/multi-url-environment-reference/test/unit/internal/types/test_enum.rb
@@ -12,6 +12,16 @@ describe Seed::Internal::Types::Enum do
 
       finalize!
     end
+
+    module StringEnum
+      extend Seed::Internal::Types::Enum
+
+      ACTIVE = "ACTIVE"
+      CLOSED = "CLOSED"
+      GROUP_BY_PROFILE = "GROUP_BY_PROFILE"
+
+      finalize!
+    end
   end
 
   describe "#values" do
@@ -27,6 +37,19 @@ describe Seed::Internal::Types::Enum do
 
     it "coerces a string version of a member" do
       assert_equal :foo, EnumTest::ExampleEnum.coerce("foo")
+    end
+
+    it "coerces an existing string member" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce("CLOSED")
+    end
+
+    it "normalizes casing to the wire format" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce("closed")
+      assert_equal "GROUP_BY_PROFILE", EnumTest::StringEnum.coerce("group_by_profile")
+    end
+
+    it "coerces a symbol to the string member" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce(:closed)
     end
 
     it "returns the value if not a member with strictness off" do

--- a/seed/ruby-sdk-v2/multi-url-environment/lib/seed/internal/types/enum.rb
+++ b/seed/ruby-sdk-v2/multi-url-environment/lib/seed/internal/types/enum.rb
@@ -30,9 +30,15 @@ module Seed
         end
 
         def coerce(value, strict: strict?)
-          coerced_value = Utils.coerce(Symbol, value)
+          return value if values.include?(value)
 
-          return coerced_value if values.include?(coerced_value)
+          if value.is_a?(::String) || value.is_a?(::Symbol)
+            candidate = value.to_s
+            match = values.find do |member|
+              (member.is_a?(::String) || member.is_a?(::Symbol)) && member.to_s.casecmp?(candidate)
+            end
+            return match unless match.nil?
+          end
 
           raise Errors::TypeError, "`#{value}` not in enum #{self}" if strict
 

--- a/seed/ruby-sdk-v2/multi-url-environment/test/unit/internal/types/test_enum.rb
+++ b/seed/ruby-sdk-v2/multi-url-environment/test/unit/internal/types/test_enum.rb
@@ -12,6 +12,16 @@ describe Seed::Internal::Types::Enum do
 
       finalize!
     end
+
+    module StringEnum
+      extend Seed::Internal::Types::Enum
+
+      ACTIVE = "ACTIVE"
+      CLOSED = "CLOSED"
+      GROUP_BY_PROFILE = "GROUP_BY_PROFILE"
+
+      finalize!
+    end
   end
 
   describe "#values" do
@@ -27,6 +37,19 @@ describe Seed::Internal::Types::Enum do
 
     it "coerces a string version of a member" do
       assert_equal :foo, EnumTest::ExampleEnum.coerce("foo")
+    end
+
+    it "coerces an existing string member" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce("CLOSED")
+    end
+
+    it "normalizes casing to the wire format" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce("closed")
+      assert_equal "GROUP_BY_PROFILE", EnumTest::StringEnum.coerce("group_by_profile")
+    end
+
+    it "coerces a symbol to the string member" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce(:closed)
     end
 
     it "returns the value if not a member with strictness off" do

--- a/seed/ruby-sdk-v2/multiple-request-bodies/lib/seed/internal/types/enum.rb
+++ b/seed/ruby-sdk-v2/multiple-request-bodies/lib/seed/internal/types/enum.rb
@@ -30,9 +30,15 @@ module Seed
         end
 
         def coerce(value, strict: strict?)
-          coerced_value = Utils.coerce(Symbol, value)
+          return value if values.include?(value)
 
-          return coerced_value if values.include?(coerced_value)
+          if value.is_a?(::String) || value.is_a?(::Symbol)
+            candidate = value.to_s
+            match = values.find do |member|
+              (member.is_a?(::String) || member.is_a?(::Symbol)) && member.to_s.casecmp?(candidate)
+            end
+            return match unless match.nil?
+          end
 
           raise Errors::TypeError, "`#{value}` not in enum #{self}" if strict
 

--- a/seed/ruby-sdk-v2/multiple-request-bodies/test/unit/internal/types/test_enum.rb
+++ b/seed/ruby-sdk-v2/multiple-request-bodies/test/unit/internal/types/test_enum.rb
@@ -12,6 +12,16 @@ describe Seed::Internal::Types::Enum do
 
       finalize!
     end
+
+    module StringEnum
+      extend Seed::Internal::Types::Enum
+
+      ACTIVE = "ACTIVE"
+      CLOSED = "CLOSED"
+      GROUP_BY_PROFILE = "GROUP_BY_PROFILE"
+
+      finalize!
+    end
   end
 
   describe "#values" do
@@ -27,6 +37,19 @@ describe Seed::Internal::Types::Enum do
 
     it "coerces a string version of a member" do
       assert_equal :foo, EnumTest::ExampleEnum.coerce("foo")
+    end
+
+    it "coerces an existing string member" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce("CLOSED")
+    end
+
+    it "normalizes casing to the wire format" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce("closed")
+      assert_equal "GROUP_BY_PROFILE", EnumTest::StringEnum.coerce("group_by_profile")
+    end
+
+    it "coerces a symbol to the string member" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce(:closed)
     end
 
     it "returns the value if not a member with strictness off" do

--- a/seed/ruby-sdk-v2/no-content-response/lib/seed/internal/types/enum.rb
+++ b/seed/ruby-sdk-v2/no-content-response/lib/seed/internal/types/enum.rb
@@ -30,9 +30,15 @@ module Seed
         end
 
         def coerce(value, strict: strict?)
-          coerced_value = Utils.coerce(Symbol, value)
+          return value if values.include?(value)
 
-          return coerced_value if values.include?(coerced_value)
+          if value.is_a?(::String) || value.is_a?(::Symbol)
+            candidate = value.to_s
+            match = values.find do |member|
+              (member.is_a?(::String) || member.is_a?(::Symbol)) && member.to_s.casecmp?(candidate)
+            end
+            return match unless match.nil?
+          end
 
           raise Errors::TypeError, "`#{value}` not in enum #{self}" if strict
 

--- a/seed/ruby-sdk-v2/no-content-response/test/unit/internal/types/test_enum.rb
+++ b/seed/ruby-sdk-v2/no-content-response/test/unit/internal/types/test_enum.rb
@@ -12,6 +12,16 @@ describe Seed::Internal::Types::Enum do
 
       finalize!
     end
+
+    module StringEnum
+      extend Seed::Internal::Types::Enum
+
+      ACTIVE = "ACTIVE"
+      CLOSED = "CLOSED"
+      GROUP_BY_PROFILE = "GROUP_BY_PROFILE"
+
+      finalize!
+    end
   end
 
   describe "#values" do
@@ -27,6 +37,19 @@ describe Seed::Internal::Types::Enum do
 
     it "coerces a string version of a member" do
       assert_equal :foo, EnumTest::ExampleEnum.coerce("foo")
+    end
+
+    it "coerces an existing string member" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce("CLOSED")
+    end
+
+    it "normalizes casing to the wire format" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce("closed")
+      assert_equal "GROUP_BY_PROFILE", EnumTest::StringEnum.coerce("group_by_profile")
+    end
+
+    it "coerces a symbol to the string member" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce(:closed)
     end
 
     it "returns the value if not a member with strictness off" do

--- a/seed/ruby-sdk-v2/no-environment/lib/seed/internal/types/enum.rb
+++ b/seed/ruby-sdk-v2/no-environment/lib/seed/internal/types/enum.rb
@@ -30,9 +30,15 @@ module Seed
         end
 
         def coerce(value, strict: strict?)
-          coerced_value = Utils.coerce(Symbol, value)
+          return value if values.include?(value)
 
-          return coerced_value if values.include?(coerced_value)
+          if value.is_a?(::String) || value.is_a?(::Symbol)
+            candidate = value.to_s
+            match = values.find do |member|
+              (member.is_a?(::String) || member.is_a?(::Symbol)) && member.to_s.casecmp?(candidate)
+            end
+            return match unless match.nil?
+          end
 
           raise Errors::TypeError, "`#{value}` not in enum #{self}" if strict
 

--- a/seed/ruby-sdk-v2/no-environment/test/unit/internal/types/test_enum.rb
+++ b/seed/ruby-sdk-v2/no-environment/test/unit/internal/types/test_enum.rb
@@ -12,6 +12,16 @@ describe Seed::Internal::Types::Enum do
 
       finalize!
     end
+
+    module StringEnum
+      extend Seed::Internal::Types::Enum
+
+      ACTIVE = "ACTIVE"
+      CLOSED = "CLOSED"
+      GROUP_BY_PROFILE = "GROUP_BY_PROFILE"
+
+      finalize!
+    end
   end
 
   describe "#values" do
@@ -27,6 +37,19 @@ describe Seed::Internal::Types::Enum do
 
     it "coerces a string version of a member" do
       assert_equal :foo, EnumTest::ExampleEnum.coerce("foo")
+    end
+
+    it "coerces an existing string member" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce("CLOSED")
+    end
+
+    it "normalizes casing to the wire format" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce("closed")
+      assert_equal "GROUP_BY_PROFILE", EnumTest::StringEnum.coerce("group_by_profile")
+    end
+
+    it "coerces a symbol to the string member" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce(:closed)
     end
 
     it "returns the value if not a member with strictness off" do

--- a/seed/ruby-sdk-v2/no-retries/lib/seed/internal/types/enum.rb
+++ b/seed/ruby-sdk-v2/no-retries/lib/seed/internal/types/enum.rb
@@ -30,9 +30,15 @@ module Seed
         end
 
         def coerce(value, strict: strict?)
-          coerced_value = Utils.coerce(Symbol, value)
+          return value if values.include?(value)
 
-          return coerced_value if values.include?(coerced_value)
+          if value.is_a?(::String) || value.is_a?(::Symbol)
+            candidate = value.to_s
+            match = values.find do |member|
+              (member.is_a?(::String) || member.is_a?(::Symbol)) && member.to_s.casecmp?(candidate)
+            end
+            return match unless match.nil?
+          end
 
           raise Errors::TypeError, "`#{value}` not in enum #{self}" if strict
 

--- a/seed/ruby-sdk-v2/no-retries/test/unit/internal/types/test_enum.rb
+++ b/seed/ruby-sdk-v2/no-retries/test/unit/internal/types/test_enum.rb
@@ -12,6 +12,16 @@ describe Seed::Internal::Types::Enum do
 
       finalize!
     end
+
+    module StringEnum
+      extend Seed::Internal::Types::Enum
+
+      ACTIVE = "ACTIVE"
+      CLOSED = "CLOSED"
+      GROUP_BY_PROFILE = "GROUP_BY_PROFILE"
+
+      finalize!
+    end
   end
 
   describe "#values" do
@@ -27,6 +37,19 @@ describe Seed::Internal::Types::Enum do
 
     it "coerces a string version of a member" do
       assert_equal :foo, EnumTest::ExampleEnum.coerce("foo")
+    end
+
+    it "coerces an existing string member" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce("CLOSED")
+    end
+
+    it "normalizes casing to the wire format" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce("closed")
+      assert_equal "GROUP_BY_PROFILE", EnumTest::StringEnum.coerce("group_by_profile")
+    end
+
+    it "coerces a symbol to the string member" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce(:closed)
     end
 
     it "returns the value if not a member with strictness off" do

--- a/seed/ruby-sdk-v2/null-type/lib/seed/internal/types/enum.rb
+++ b/seed/ruby-sdk-v2/null-type/lib/seed/internal/types/enum.rb
@@ -30,9 +30,15 @@ module Seed
         end
 
         def coerce(value, strict: strict?)
-          coerced_value = Utils.coerce(Symbol, value)
+          return value if values.include?(value)
 
-          return coerced_value if values.include?(coerced_value)
+          if value.is_a?(::String) || value.is_a?(::Symbol)
+            candidate = value.to_s
+            match = values.find do |member|
+              (member.is_a?(::String) || member.is_a?(::Symbol)) && member.to_s.casecmp?(candidate)
+            end
+            return match unless match.nil?
+          end
 
           raise Errors::TypeError, "`#{value}` not in enum #{self}" if strict
 

--- a/seed/ruby-sdk-v2/null-type/test/unit/internal/types/test_enum.rb
+++ b/seed/ruby-sdk-v2/null-type/test/unit/internal/types/test_enum.rb
@@ -12,6 +12,16 @@ describe Seed::Internal::Types::Enum do
 
       finalize!
     end
+
+    module StringEnum
+      extend Seed::Internal::Types::Enum
+
+      ACTIVE = "ACTIVE"
+      CLOSED = "CLOSED"
+      GROUP_BY_PROFILE = "GROUP_BY_PROFILE"
+
+      finalize!
+    end
   end
 
   describe "#values" do
@@ -27,6 +37,19 @@ describe Seed::Internal::Types::Enum do
 
     it "coerces a string version of a member" do
       assert_equal :foo, EnumTest::ExampleEnum.coerce("foo")
+    end
+
+    it "coerces an existing string member" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce("CLOSED")
+    end
+
+    it "normalizes casing to the wire format" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce("closed")
+      assert_equal "GROUP_BY_PROFILE", EnumTest::StringEnum.coerce("group_by_profile")
+    end
+
+    it "coerces a symbol to the string member" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce(:closed)
     end
 
     it "returns the value if not a member with strictness off" do

--- a/seed/ruby-sdk-v2/nullable-allof-extends/lib/seed/internal/types/enum.rb
+++ b/seed/ruby-sdk-v2/nullable-allof-extends/lib/seed/internal/types/enum.rb
@@ -30,9 +30,15 @@ module Seed
         end
 
         def coerce(value, strict: strict?)
-          coerced_value = Utils.coerce(Symbol, value)
+          return value if values.include?(value)
 
-          return coerced_value if values.include?(coerced_value)
+          if value.is_a?(::String) || value.is_a?(::Symbol)
+            candidate = value.to_s
+            match = values.find do |member|
+              (member.is_a?(::String) || member.is_a?(::Symbol)) && member.to_s.casecmp?(candidate)
+            end
+            return match unless match.nil?
+          end
 
           raise Errors::TypeError, "`#{value}` not in enum #{self}" if strict
 

--- a/seed/ruby-sdk-v2/nullable-allof-extends/test/unit/internal/types/test_enum.rb
+++ b/seed/ruby-sdk-v2/nullable-allof-extends/test/unit/internal/types/test_enum.rb
@@ -12,6 +12,16 @@ describe Seed::Internal::Types::Enum do
 
       finalize!
     end
+
+    module StringEnum
+      extend Seed::Internal::Types::Enum
+
+      ACTIVE = "ACTIVE"
+      CLOSED = "CLOSED"
+      GROUP_BY_PROFILE = "GROUP_BY_PROFILE"
+
+      finalize!
+    end
   end
 
   describe "#values" do
@@ -27,6 +37,19 @@ describe Seed::Internal::Types::Enum do
 
     it "coerces a string version of a member" do
       assert_equal :foo, EnumTest::ExampleEnum.coerce("foo")
+    end
+
+    it "coerces an existing string member" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce("CLOSED")
+    end
+
+    it "normalizes casing to the wire format" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce("closed")
+      assert_equal "GROUP_BY_PROFILE", EnumTest::StringEnum.coerce("group_by_profile")
+    end
+
+    it "coerces a symbol to the string member" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce(:closed)
     end
 
     it "returns the value if not a member with strictness off" do

--- a/seed/ruby-sdk-v2/nullable-optional/lib/seed/internal/types/enum.rb
+++ b/seed/ruby-sdk-v2/nullable-optional/lib/seed/internal/types/enum.rb
@@ -30,9 +30,15 @@ module Seed
         end
 
         def coerce(value, strict: strict?)
-          coerced_value = Utils.coerce(Symbol, value)
+          return value if values.include?(value)
 
-          return coerced_value if values.include?(coerced_value)
+          if value.is_a?(::String) || value.is_a?(::Symbol)
+            candidate = value.to_s
+            match = values.find do |member|
+              (member.is_a?(::String) || member.is_a?(::Symbol)) && member.to_s.casecmp?(candidate)
+            end
+            return match unless match.nil?
+          end
 
           raise Errors::TypeError, "`#{value}` not in enum #{self}" if strict
 

--- a/seed/ruby-sdk-v2/nullable-optional/test/unit/internal/types/test_enum.rb
+++ b/seed/ruby-sdk-v2/nullable-optional/test/unit/internal/types/test_enum.rb
@@ -12,6 +12,16 @@ describe Seed::Internal::Types::Enum do
 
       finalize!
     end
+
+    module StringEnum
+      extend Seed::Internal::Types::Enum
+
+      ACTIVE = "ACTIVE"
+      CLOSED = "CLOSED"
+      GROUP_BY_PROFILE = "GROUP_BY_PROFILE"
+
+      finalize!
+    end
   end
 
   describe "#values" do
@@ -27,6 +37,19 @@ describe Seed::Internal::Types::Enum do
 
     it "coerces a string version of a member" do
       assert_equal :foo, EnumTest::ExampleEnum.coerce("foo")
+    end
+
+    it "coerces an existing string member" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce("CLOSED")
+    end
+
+    it "normalizes casing to the wire format" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce("closed")
+      assert_equal "GROUP_BY_PROFILE", EnumTest::StringEnum.coerce("group_by_profile")
+    end
+
+    it "coerces a symbol to the string member" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce(:closed)
     end
 
     it "returns the value if not a member with strictness off" do

--- a/seed/ruby-sdk-v2/nullable-request-body/lib/seed/internal/types/enum.rb
+++ b/seed/ruby-sdk-v2/nullable-request-body/lib/seed/internal/types/enum.rb
@@ -30,9 +30,15 @@ module Seed
         end
 
         def coerce(value, strict: strict?)
-          coerced_value = Utils.coerce(Symbol, value)
+          return value if values.include?(value)
 
-          return coerced_value if values.include?(coerced_value)
+          if value.is_a?(::String) || value.is_a?(::Symbol)
+            candidate = value.to_s
+            match = values.find do |member|
+              (member.is_a?(::String) || member.is_a?(::Symbol)) && member.to_s.casecmp?(candidate)
+            end
+            return match unless match.nil?
+          end
 
           raise Errors::TypeError, "`#{value}` not in enum #{self}" if strict
 

--- a/seed/ruby-sdk-v2/nullable-request-body/test/unit/internal/types/test_enum.rb
+++ b/seed/ruby-sdk-v2/nullable-request-body/test/unit/internal/types/test_enum.rb
@@ -12,6 +12,16 @@ describe Seed::Internal::Types::Enum do
 
       finalize!
     end
+
+    module StringEnum
+      extend Seed::Internal::Types::Enum
+
+      ACTIVE = "ACTIVE"
+      CLOSED = "CLOSED"
+      GROUP_BY_PROFILE = "GROUP_BY_PROFILE"
+
+      finalize!
+    end
   end
 
   describe "#values" do
@@ -27,6 +37,19 @@ describe Seed::Internal::Types::Enum do
 
     it "coerces a string version of a member" do
       assert_equal :foo, EnumTest::ExampleEnum.coerce("foo")
+    end
+
+    it "coerces an existing string member" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce("CLOSED")
+    end
+
+    it "normalizes casing to the wire format" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce("closed")
+      assert_equal "GROUP_BY_PROFILE", EnumTest::StringEnum.coerce("group_by_profile")
+    end
+
+    it "coerces a symbol to the string member" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce(:closed)
     end
 
     it "returns the value if not a member with strictness off" do

--- a/seed/ruby-sdk-v2/nullable/lib/seed/internal/types/enum.rb
+++ b/seed/ruby-sdk-v2/nullable/lib/seed/internal/types/enum.rb
@@ -30,9 +30,15 @@ module Seed
         end
 
         def coerce(value, strict: strict?)
-          coerced_value = Utils.coerce(Symbol, value)
+          return value if values.include?(value)
 
-          return coerced_value if values.include?(coerced_value)
+          if value.is_a?(::String) || value.is_a?(::Symbol)
+            candidate = value.to_s
+            match = values.find do |member|
+              (member.is_a?(::String) || member.is_a?(::Symbol)) && member.to_s.casecmp?(candidate)
+            end
+            return match unless match.nil?
+          end
 
           raise Errors::TypeError, "`#{value}` not in enum #{self}" if strict
 

--- a/seed/ruby-sdk-v2/nullable/test/unit/internal/types/test_enum.rb
+++ b/seed/ruby-sdk-v2/nullable/test/unit/internal/types/test_enum.rb
@@ -12,6 +12,16 @@ describe Seed::Internal::Types::Enum do
 
       finalize!
     end
+
+    module StringEnum
+      extend Seed::Internal::Types::Enum
+
+      ACTIVE = "ACTIVE"
+      CLOSED = "CLOSED"
+      GROUP_BY_PROFILE = "GROUP_BY_PROFILE"
+
+      finalize!
+    end
   end
 
   describe "#values" do
@@ -27,6 +37,19 @@ describe Seed::Internal::Types::Enum do
 
     it "coerces a string version of a member" do
       assert_equal :foo, EnumTest::ExampleEnum.coerce("foo")
+    end
+
+    it "coerces an existing string member" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce("CLOSED")
+    end
+
+    it "normalizes casing to the wire format" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce("closed")
+      assert_equal "GROUP_BY_PROFILE", EnumTest::StringEnum.coerce("group_by_profile")
+    end
+
+    it "coerces a symbol to the string member" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce(:closed)
     end
 
     it "returns the value if not a member with strictness off" do

--- a/seed/ruby-sdk-v2/oauth-client-credentials-custom/lib/seed/internal/types/enum.rb
+++ b/seed/ruby-sdk-v2/oauth-client-credentials-custom/lib/seed/internal/types/enum.rb
@@ -30,9 +30,15 @@ module Seed
         end
 
         def coerce(value, strict: strict?)
-          coerced_value = Utils.coerce(Symbol, value)
+          return value if values.include?(value)
 
-          return coerced_value if values.include?(coerced_value)
+          if value.is_a?(::String) || value.is_a?(::Symbol)
+            candidate = value.to_s
+            match = values.find do |member|
+              (member.is_a?(::String) || member.is_a?(::Symbol)) && member.to_s.casecmp?(candidate)
+            end
+            return match unless match.nil?
+          end
 
           raise Errors::TypeError, "`#{value}` not in enum #{self}" if strict
 

--- a/seed/ruby-sdk-v2/oauth-client-credentials-custom/test/unit/internal/types/test_enum.rb
+++ b/seed/ruby-sdk-v2/oauth-client-credentials-custom/test/unit/internal/types/test_enum.rb
@@ -12,6 +12,16 @@ describe Seed::Internal::Types::Enum do
 
       finalize!
     end
+
+    module StringEnum
+      extend Seed::Internal::Types::Enum
+
+      ACTIVE = "ACTIVE"
+      CLOSED = "CLOSED"
+      GROUP_BY_PROFILE = "GROUP_BY_PROFILE"
+
+      finalize!
+    end
   end
 
   describe "#values" do
@@ -27,6 +37,19 @@ describe Seed::Internal::Types::Enum do
 
     it "coerces a string version of a member" do
       assert_equal :foo, EnumTest::ExampleEnum.coerce("foo")
+    end
+
+    it "coerces an existing string member" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce("CLOSED")
+    end
+
+    it "normalizes casing to the wire format" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce("closed")
+      assert_equal "GROUP_BY_PROFILE", EnumTest::StringEnum.coerce("group_by_profile")
+    end
+
+    it "coerces a symbol to the string member" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce(:closed)
     end
 
     it "returns the value if not a member with strictness off" do

--- a/seed/ruby-sdk-v2/oauth-client-credentials-default/lib/seed/internal/types/enum.rb
+++ b/seed/ruby-sdk-v2/oauth-client-credentials-default/lib/seed/internal/types/enum.rb
@@ -30,9 +30,15 @@ module Seed
         end
 
         def coerce(value, strict: strict?)
-          coerced_value = Utils.coerce(Symbol, value)
+          return value if values.include?(value)
 
-          return coerced_value if values.include?(coerced_value)
+          if value.is_a?(::String) || value.is_a?(::Symbol)
+            candidate = value.to_s
+            match = values.find do |member|
+              (member.is_a?(::String) || member.is_a?(::Symbol)) && member.to_s.casecmp?(candidate)
+            end
+            return match unless match.nil?
+          end
 
           raise Errors::TypeError, "`#{value}` not in enum #{self}" if strict
 

--- a/seed/ruby-sdk-v2/oauth-client-credentials-default/test/unit/internal/types/test_enum.rb
+++ b/seed/ruby-sdk-v2/oauth-client-credentials-default/test/unit/internal/types/test_enum.rb
@@ -12,6 +12,16 @@ describe Seed::Internal::Types::Enum do
 
       finalize!
     end
+
+    module StringEnum
+      extend Seed::Internal::Types::Enum
+
+      ACTIVE = "ACTIVE"
+      CLOSED = "CLOSED"
+      GROUP_BY_PROFILE = "GROUP_BY_PROFILE"
+
+      finalize!
+    end
   end
 
   describe "#values" do
@@ -27,6 +37,19 @@ describe Seed::Internal::Types::Enum do
 
     it "coerces a string version of a member" do
       assert_equal :foo, EnumTest::ExampleEnum.coerce("foo")
+    end
+
+    it "coerces an existing string member" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce("CLOSED")
+    end
+
+    it "normalizes casing to the wire format" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce("closed")
+      assert_equal "GROUP_BY_PROFILE", EnumTest::StringEnum.coerce("group_by_profile")
+    end
+
+    it "coerces a symbol to the string member" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce(:closed)
     end
 
     it "returns the value if not a member with strictness off" do

--- a/seed/ruby-sdk-v2/oauth-client-credentials-environment-variables/lib/seed/internal/types/enum.rb
+++ b/seed/ruby-sdk-v2/oauth-client-credentials-environment-variables/lib/seed/internal/types/enum.rb
@@ -30,9 +30,15 @@ module Seed
         end
 
         def coerce(value, strict: strict?)
-          coerced_value = Utils.coerce(Symbol, value)
+          return value if values.include?(value)
 
-          return coerced_value if values.include?(coerced_value)
+          if value.is_a?(::String) || value.is_a?(::Symbol)
+            candidate = value.to_s
+            match = values.find do |member|
+              (member.is_a?(::String) || member.is_a?(::Symbol)) && member.to_s.casecmp?(candidate)
+            end
+            return match unless match.nil?
+          end
 
           raise Errors::TypeError, "`#{value}` not in enum #{self}" if strict
 

--- a/seed/ruby-sdk-v2/oauth-client-credentials-environment-variables/test/unit/internal/types/test_enum.rb
+++ b/seed/ruby-sdk-v2/oauth-client-credentials-environment-variables/test/unit/internal/types/test_enum.rb
@@ -12,6 +12,16 @@ describe Seed::Internal::Types::Enum do
 
       finalize!
     end
+
+    module StringEnum
+      extend Seed::Internal::Types::Enum
+
+      ACTIVE = "ACTIVE"
+      CLOSED = "CLOSED"
+      GROUP_BY_PROFILE = "GROUP_BY_PROFILE"
+
+      finalize!
+    end
   end
 
   describe "#values" do
@@ -27,6 +37,19 @@ describe Seed::Internal::Types::Enum do
 
     it "coerces a string version of a member" do
       assert_equal :foo, EnumTest::ExampleEnum.coerce("foo")
+    end
+
+    it "coerces an existing string member" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce("CLOSED")
+    end
+
+    it "normalizes casing to the wire format" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce("closed")
+      assert_equal "GROUP_BY_PROFILE", EnumTest::StringEnum.coerce("group_by_profile")
+    end
+
+    it "coerces a symbol to the string member" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce(:closed)
     end
 
     it "returns the value if not a member with strictness off" do

--- a/seed/ruby-sdk-v2/oauth-client-credentials-mandatory-auth/lib/seed/internal/types/enum.rb
+++ b/seed/ruby-sdk-v2/oauth-client-credentials-mandatory-auth/lib/seed/internal/types/enum.rb
@@ -30,9 +30,15 @@ module Seed
         end
 
         def coerce(value, strict: strict?)
-          coerced_value = Utils.coerce(Symbol, value)
+          return value if values.include?(value)
 
-          return coerced_value if values.include?(coerced_value)
+          if value.is_a?(::String) || value.is_a?(::Symbol)
+            candidate = value.to_s
+            match = values.find do |member|
+              (member.is_a?(::String) || member.is_a?(::Symbol)) && member.to_s.casecmp?(candidate)
+            end
+            return match unless match.nil?
+          end
 
           raise Errors::TypeError, "`#{value}` not in enum #{self}" if strict
 

--- a/seed/ruby-sdk-v2/oauth-client-credentials-mandatory-auth/test/unit/internal/types/test_enum.rb
+++ b/seed/ruby-sdk-v2/oauth-client-credentials-mandatory-auth/test/unit/internal/types/test_enum.rb
@@ -12,6 +12,16 @@ describe Seed::Internal::Types::Enum do
 
       finalize!
     end
+
+    module StringEnum
+      extend Seed::Internal::Types::Enum
+
+      ACTIVE = "ACTIVE"
+      CLOSED = "CLOSED"
+      GROUP_BY_PROFILE = "GROUP_BY_PROFILE"
+
+      finalize!
+    end
   end
 
   describe "#values" do
@@ -27,6 +37,19 @@ describe Seed::Internal::Types::Enum do
 
     it "coerces a string version of a member" do
       assert_equal :foo, EnumTest::ExampleEnum.coerce("foo")
+    end
+
+    it "coerces an existing string member" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce("CLOSED")
+    end
+
+    it "normalizes casing to the wire format" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce("closed")
+      assert_equal "GROUP_BY_PROFILE", EnumTest::StringEnum.coerce("group_by_profile")
+    end
+
+    it "coerces a symbol to the string member" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce(:closed)
     end
 
     it "returns the value if not a member with strictness off" do

--- a/seed/ruby-sdk-v2/oauth-client-credentials-nested-root/lib/seed/internal/types/enum.rb
+++ b/seed/ruby-sdk-v2/oauth-client-credentials-nested-root/lib/seed/internal/types/enum.rb
@@ -30,9 +30,15 @@ module Seed
         end
 
         def coerce(value, strict: strict?)
-          coerced_value = Utils.coerce(Symbol, value)
+          return value if values.include?(value)
 
-          return coerced_value if values.include?(coerced_value)
+          if value.is_a?(::String) || value.is_a?(::Symbol)
+            candidate = value.to_s
+            match = values.find do |member|
+              (member.is_a?(::String) || member.is_a?(::Symbol)) && member.to_s.casecmp?(candidate)
+            end
+            return match unless match.nil?
+          end
 
           raise Errors::TypeError, "`#{value}` not in enum #{self}" if strict
 

--- a/seed/ruby-sdk-v2/oauth-client-credentials-nested-root/test/unit/internal/types/test_enum.rb
+++ b/seed/ruby-sdk-v2/oauth-client-credentials-nested-root/test/unit/internal/types/test_enum.rb
@@ -12,6 +12,16 @@ describe Seed::Internal::Types::Enum do
 
       finalize!
     end
+
+    module StringEnum
+      extend Seed::Internal::Types::Enum
+
+      ACTIVE = "ACTIVE"
+      CLOSED = "CLOSED"
+      GROUP_BY_PROFILE = "GROUP_BY_PROFILE"
+
+      finalize!
+    end
   end
 
   describe "#values" do
@@ -27,6 +37,19 @@ describe Seed::Internal::Types::Enum do
 
     it "coerces a string version of a member" do
       assert_equal :foo, EnumTest::ExampleEnum.coerce("foo")
+    end
+
+    it "coerces an existing string member" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce("CLOSED")
+    end
+
+    it "normalizes casing to the wire format" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce("closed")
+      assert_equal "GROUP_BY_PROFILE", EnumTest::StringEnum.coerce("group_by_profile")
+    end
+
+    it "coerces a symbol to the string member" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce(:closed)
     end
 
     it "returns the value if not a member with strictness off" do

--- a/seed/ruby-sdk-v2/oauth-client-credentials-openapi/lib/seed/internal/types/enum.rb
+++ b/seed/ruby-sdk-v2/oauth-client-credentials-openapi/lib/seed/internal/types/enum.rb
@@ -30,9 +30,15 @@ module Seed
         end
 
         def coerce(value, strict: strict?)
-          coerced_value = Utils.coerce(Symbol, value)
+          return value if values.include?(value)
 
-          return coerced_value if values.include?(coerced_value)
+          if value.is_a?(::String) || value.is_a?(::Symbol)
+            candidate = value.to_s
+            match = values.find do |member|
+              (member.is_a?(::String) || member.is_a?(::Symbol)) && member.to_s.casecmp?(candidate)
+            end
+            return match unless match.nil?
+          end
 
           raise Errors::TypeError, "`#{value}` not in enum #{self}" if strict
 

--- a/seed/ruby-sdk-v2/oauth-client-credentials-openapi/test/unit/internal/types/test_enum.rb
+++ b/seed/ruby-sdk-v2/oauth-client-credentials-openapi/test/unit/internal/types/test_enum.rb
@@ -12,6 +12,16 @@ describe Seed::Internal::Types::Enum do
 
       finalize!
     end
+
+    module StringEnum
+      extend Seed::Internal::Types::Enum
+
+      ACTIVE = "ACTIVE"
+      CLOSED = "CLOSED"
+      GROUP_BY_PROFILE = "GROUP_BY_PROFILE"
+
+      finalize!
+    end
   end
 
   describe "#values" do
@@ -27,6 +37,19 @@ describe Seed::Internal::Types::Enum do
 
     it "coerces a string version of a member" do
       assert_equal :foo, EnumTest::ExampleEnum.coerce("foo")
+    end
+
+    it "coerces an existing string member" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce("CLOSED")
+    end
+
+    it "normalizes casing to the wire format" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce("closed")
+      assert_equal "GROUP_BY_PROFILE", EnumTest::StringEnum.coerce("group_by_profile")
+    end
+
+    it "coerces a symbol to the string member" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce(:closed)
     end
 
     it "returns the value if not a member with strictness off" do

--- a/seed/ruby-sdk-v2/oauth-client-credentials-reference/lib/seed/internal/types/enum.rb
+++ b/seed/ruby-sdk-v2/oauth-client-credentials-reference/lib/seed/internal/types/enum.rb
@@ -30,9 +30,15 @@ module Seed
         end
 
         def coerce(value, strict: strict?)
-          coerced_value = Utils.coerce(Symbol, value)
+          return value if values.include?(value)
 
-          return coerced_value if values.include?(coerced_value)
+          if value.is_a?(::String) || value.is_a?(::Symbol)
+            candidate = value.to_s
+            match = values.find do |member|
+              (member.is_a?(::String) || member.is_a?(::Symbol)) && member.to_s.casecmp?(candidate)
+            end
+            return match unless match.nil?
+          end
 
           raise Errors::TypeError, "`#{value}` not in enum #{self}" if strict
 

--- a/seed/ruby-sdk-v2/oauth-client-credentials-reference/test/unit/internal/types/test_enum.rb
+++ b/seed/ruby-sdk-v2/oauth-client-credentials-reference/test/unit/internal/types/test_enum.rb
@@ -12,6 +12,16 @@ describe Seed::Internal::Types::Enum do
 
       finalize!
     end
+
+    module StringEnum
+      extend Seed::Internal::Types::Enum
+
+      ACTIVE = "ACTIVE"
+      CLOSED = "CLOSED"
+      GROUP_BY_PROFILE = "GROUP_BY_PROFILE"
+
+      finalize!
+    end
   end
 
   describe "#values" do
@@ -27,6 +37,19 @@ describe Seed::Internal::Types::Enum do
 
     it "coerces a string version of a member" do
       assert_equal :foo, EnumTest::ExampleEnum.coerce("foo")
+    end
+
+    it "coerces an existing string member" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce("CLOSED")
+    end
+
+    it "normalizes casing to the wire format" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce("closed")
+      assert_equal "GROUP_BY_PROFILE", EnumTest::StringEnum.coerce("group_by_profile")
+    end
+
+    it "coerces a symbol to the string member" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce(:closed)
     end
 
     it "returns the value if not a member with strictness off" do

--- a/seed/ruby-sdk-v2/oauth-client-credentials-with-variables/lib/seed/internal/types/enum.rb
+++ b/seed/ruby-sdk-v2/oauth-client-credentials-with-variables/lib/seed/internal/types/enum.rb
@@ -30,9 +30,15 @@ module Seed
         end
 
         def coerce(value, strict: strict?)
-          coerced_value = Utils.coerce(Symbol, value)
+          return value if values.include?(value)
 
-          return coerced_value if values.include?(coerced_value)
+          if value.is_a?(::String) || value.is_a?(::Symbol)
+            candidate = value.to_s
+            match = values.find do |member|
+              (member.is_a?(::String) || member.is_a?(::Symbol)) && member.to_s.casecmp?(candidate)
+            end
+            return match unless match.nil?
+          end
 
           raise Errors::TypeError, "`#{value}` not in enum #{self}" if strict
 

--- a/seed/ruby-sdk-v2/oauth-client-credentials-with-variables/test/unit/internal/types/test_enum.rb
+++ b/seed/ruby-sdk-v2/oauth-client-credentials-with-variables/test/unit/internal/types/test_enum.rb
@@ -12,6 +12,16 @@ describe Seed::Internal::Types::Enum do
 
       finalize!
     end
+
+    module StringEnum
+      extend Seed::Internal::Types::Enum
+
+      ACTIVE = "ACTIVE"
+      CLOSED = "CLOSED"
+      GROUP_BY_PROFILE = "GROUP_BY_PROFILE"
+
+      finalize!
+    end
   end
 
   describe "#values" do
@@ -27,6 +37,19 @@ describe Seed::Internal::Types::Enum do
 
     it "coerces a string version of a member" do
       assert_equal :foo, EnumTest::ExampleEnum.coerce("foo")
+    end
+
+    it "coerces an existing string member" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce("CLOSED")
+    end
+
+    it "normalizes casing to the wire format" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce("closed")
+      assert_equal "GROUP_BY_PROFILE", EnumTest::StringEnum.coerce("group_by_profile")
+    end
+
+    it "coerces a symbol to the string member" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce(:closed)
     end
 
     it "returns the value if not a member with strictness off" do

--- a/seed/ruby-sdk-v2/oauth-client-credentials/lib/seed/internal/types/enum.rb
+++ b/seed/ruby-sdk-v2/oauth-client-credentials/lib/seed/internal/types/enum.rb
@@ -30,9 +30,15 @@ module Seed
         end
 
         def coerce(value, strict: strict?)
-          coerced_value = Utils.coerce(Symbol, value)
+          return value if values.include?(value)
 
-          return coerced_value if values.include?(coerced_value)
+          if value.is_a?(::String) || value.is_a?(::Symbol)
+            candidate = value.to_s
+            match = values.find do |member|
+              (member.is_a?(::String) || member.is_a?(::Symbol)) && member.to_s.casecmp?(candidate)
+            end
+            return match unless match.nil?
+          end
 
           raise Errors::TypeError, "`#{value}` not in enum #{self}" if strict
 

--- a/seed/ruby-sdk-v2/oauth-client-credentials/test/unit/internal/types/test_enum.rb
+++ b/seed/ruby-sdk-v2/oauth-client-credentials/test/unit/internal/types/test_enum.rb
@@ -12,6 +12,16 @@ describe Seed::Internal::Types::Enum do
 
       finalize!
     end
+
+    module StringEnum
+      extend Seed::Internal::Types::Enum
+
+      ACTIVE = "ACTIVE"
+      CLOSED = "CLOSED"
+      GROUP_BY_PROFILE = "GROUP_BY_PROFILE"
+
+      finalize!
+    end
   end
 
   describe "#values" do
@@ -27,6 +37,19 @@ describe Seed::Internal::Types::Enum do
 
     it "coerces a string version of a member" do
       assert_equal :foo, EnumTest::ExampleEnum.coerce("foo")
+    end
+
+    it "coerces an existing string member" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce("CLOSED")
+    end
+
+    it "normalizes casing to the wire format" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce("closed")
+      assert_equal "GROUP_BY_PROFILE", EnumTest::StringEnum.coerce("group_by_profile")
+    end
+
+    it "coerces a symbol to the string member" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce(:closed)
     end
 
     it "returns the value if not a member with strictness off" do

--- a/seed/ruby-sdk-v2/oauth-pkce/lib/seed/internal/types/enum.rb
+++ b/seed/ruby-sdk-v2/oauth-pkce/lib/seed/internal/types/enum.rb
@@ -30,9 +30,15 @@ module Seed
         end
 
         def coerce(value, strict: strict?)
-          coerced_value = Utils.coerce(Symbol, value)
+          return value if values.include?(value)
 
-          return coerced_value if values.include?(coerced_value)
+          if value.is_a?(::String) || value.is_a?(::Symbol)
+            candidate = value.to_s
+            match = values.find do |member|
+              (member.is_a?(::String) || member.is_a?(::Symbol)) && member.to_s.casecmp?(candidate)
+            end
+            return match unless match.nil?
+          end
 
           raise Errors::TypeError, "`#{value}` not in enum #{self}" if strict
 

--- a/seed/ruby-sdk-v2/oauth-pkce/test/unit/internal/types/test_enum.rb
+++ b/seed/ruby-sdk-v2/oauth-pkce/test/unit/internal/types/test_enum.rb
@@ -12,6 +12,16 @@ describe Seed::Internal::Types::Enum do
 
       finalize!
     end
+
+    module StringEnum
+      extend Seed::Internal::Types::Enum
+
+      ACTIVE = "ACTIVE"
+      CLOSED = "CLOSED"
+      GROUP_BY_PROFILE = "GROUP_BY_PROFILE"
+
+      finalize!
+    end
   end
 
   describe "#values" do
@@ -27,6 +37,19 @@ describe Seed::Internal::Types::Enum do
 
     it "coerces a string version of a member" do
       assert_equal :foo, EnumTest::ExampleEnum.coerce("foo")
+    end
+
+    it "coerces an existing string member" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce("CLOSED")
+    end
+
+    it "normalizes casing to the wire format" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce("closed")
+      assert_equal "GROUP_BY_PROFILE", EnumTest::StringEnum.coerce("group_by_profile")
+    end
+
+    it "coerces a symbol to the string member" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce(:closed)
     end
 
     it "returns the value if not a member with strictness off" do

--- a/seed/ruby-sdk-v2/object/lib/seed/internal/types/enum.rb
+++ b/seed/ruby-sdk-v2/object/lib/seed/internal/types/enum.rb
@@ -30,9 +30,15 @@ module Seed
         end
 
         def coerce(value, strict: strict?)
-          coerced_value = Utils.coerce(Symbol, value)
+          return value if values.include?(value)
 
-          return coerced_value if values.include?(coerced_value)
+          if value.is_a?(::String) || value.is_a?(::Symbol)
+            candidate = value.to_s
+            match = values.find do |member|
+              (member.is_a?(::String) || member.is_a?(::Symbol)) && member.to_s.casecmp?(candidate)
+            end
+            return match unless match.nil?
+          end
 
           raise Errors::TypeError, "`#{value}` not in enum #{self}" if strict
 

--- a/seed/ruby-sdk-v2/object/test/unit/internal/types/test_enum.rb
+++ b/seed/ruby-sdk-v2/object/test/unit/internal/types/test_enum.rb
@@ -12,6 +12,16 @@ describe Seed::Internal::Types::Enum do
 
       finalize!
     end
+
+    module StringEnum
+      extend Seed::Internal::Types::Enum
+
+      ACTIVE = "ACTIVE"
+      CLOSED = "CLOSED"
+      GROUP_BY_PROFILE = "GROUP_BY_PROFILE"
+
+      finalize!
+    end
   end
 
   describe "#values" do
@@ -27,6 +37,19 @@ describe Seed::Internal::Types::Enum do
 
     it "coerces a string version of a member" do
       assert_equal :foo, EnumTest::ExampleEnum.coerce("foo")
+    end
+
+    it "coerces an existing string member" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce("CLOSED")
+    end
+
+    it "normalizes casing to the wire format" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce("closed")
+      assert_equal "GROUP_BY_PROFILE", EnumTest::StringEnum.coerce("group_by_profile")
+    end
+
+    it "coerces a symbol to the string member" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce(:closed)
     end
 
     it "returns the value if not a member with strictness off" do

--- a/seed/ruby-sdk-v2/objects-with-imports/lib/seed/internal/types/enum.rb
+++ b/seed/ruby-sdk-v2/objects-with-imports/lib/seed/internal/types/enum.rb
@@ -30,9 +30,15 @@ module Seed
         end
 
         def coerce(value, strict: strict?)
-          coerced_value = Utils.coerce(Symbol, value)
+          return value if values.include?(value)
 
-          return coerced_value if values.include?(coerced_value)
+          if value.is_a?(::String) || value.is_a?(::Symbol)
+            candidate = value.to_s
+            match = values.find do |member|
+              (member.is_a?(::String) || member.is_a?(::Symbol)) && member.to_s.casecmp?(candidate)
+            end
+            return match unless match.nil?
+          end
 
           raise Errors::TypeError, "`#{value}` not in enum #{self}" if strict
 

--- a/seed/ruby-sdk-v2/objects-with-imports/test/unit/internal/types/test_enum.rb
+++ b/seed/ruby-sdk-v2/objects-with-imports/test/unit/internal/types/test_enum.rb
@@ -12,6 +12,16 @@ describe Seed::Internal::Types::Enum do
 
       finalize!
     end
+
+    module StringEnum
+      extend Seed::Internal::Types::Enum
+
+      ACTIVE = "ACTIVE"
+      CLOSED = "CLOSED"
+      GROUP_BY_PROFILE = "GROUP_BY_PROFILE"
+
+      finalize!
+    end
   end
 
   describe "#values" do
@@ -27,6 +37,19 @@ describe Seed::Internal::Types::Enum do
 
     it "coerces a string version of a member" do
       assert_equal :foo, EnumTest::ExampleEnum.coerce("foo")
+    end
+
+    it "coerces an existing string member" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce("CLOSED")
+    end
+
+    it "normalizes casing to the wire format" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce("closed")
+      assert_equal "GROUP_BY_PROFILE", EnumTest::StringEnum.coerce("group_by_profile")
+    end
+
+    it "coerces a symbol to the string member" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce(:closed)
     end
 
     it "returns the value if not a member with strictness off" do

--- a/seed/ruby-sdk-v2/openapi-path-param-body-collision/lib/seed/internal/types/enum.rb
+++ b/seed/ruby-sdk-v2/openapi-path-param-body-collision/lib/seed/internal/types/enum.rb
@@ -30,9 +30,15 @@ module Seed
         end
 
         def coerce(value, strict: strict?)
-          coerced_value = Utils.coerce(Symbol, value)
+          return value if values.include?(value)
 
-          return coerced_value if values.include?(coerced_value)
+          if value.is_a?(::String) || value.is_a?(::Symbol)
+            candidate = value.to_s
+            match = values.find do |member|
+              (member.is_a?(::String) || member.is_a?(::Symbol)) && member.to_s.casecmp?(candidate)
+            end
+            return match unless match.nil?
+          end
 
           raise Errors::TypeError, "`#{value}` not in enum #{self}" if strict
 

--- a/seed/ruby-sdk-v2/openapi-path-param-body-collision/test/unit/internal/types/test_enum.rb
+++ b/seed/ruby-sdk-v2/openapi-path-param-body-collision/test/unit/internal/types/test_enum.rb
@@ -12,6 +12,16 @@ describe Seed::Internal::Types::Enum do
 
       finalize!
     end
+
+    module StringEnum
+      extend Seed::Internal::Types::Enum
+
+      ACTIVE = "ACTIVE"
+      CLOSED = "CLOSED"
+      GROUP_BY_PROFILE = "GROUP_BY_PROFILE"
+
+      finalize!
+    end
   end
 
   describe "#values" do
@@ -27,6 +37,19 @@ describe Seed::Internal::Types::Enum do
 
     it "coerces a string version of a member" do
       assert_equal :foo, EnumTest::ExampleEnum.coerce("foo")
+    end
+
+    it "coerces an existing string member" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce("CLOSED")
+    end
+
+    it "normalizes casing to the wire format" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce("closed")
+      assert_equal "GROUP_BY_PROFILE", EnumTest::StringEnum.coerce("group_by_profile")
+    end
+
+    it "coerces a symbol to the string member" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce(:closed)
     end
 
     it "returns the value if not a member with strictness off" do

--- a/seed/ruby-sdk-v2/openapi-request-body-ref/lib/seed/internal/types/enum.rb
+++ b/seed/ruby-sdk-v2/openapi-request-body-ref/lib/seed/internal/types/enum.rb
@@ -30,9 +30,15 @@ module Seed
         end
 
         def coerce(value, strict: strict?)
-          coerced_value = Utils.coerce(Symbol, value)
+          return value if values.include?(value)
 
-          return coerced_value if values.include?(coerced_value)
+          if value.is_a?(::String) || value.is_a?(::Symbol)
+            candidate = value.to_s
+            match = values.find do |member|
+              (member.is_a?(::String) || member.is_a?(::Symbol)) && member.to_s.casecmp?(candidate)
+            end
+            return match unless match.nil?
+          end
 
           raise Errors::TypeError, "`#{value}` not in enum #{self}" if strict
 

--- a/seed/ruby-sdk-v2/openapi-request-body-ref/test/unit/internal/types/test_enum.rb
+++ b/seed/ruby-sdk-v2/openapi-request-body-ref/test/unit/internal/types/test_enum.rb
@@ -12,6 +12,16 @@ describe Seed::Internal::Types::Enum do
 
       finalize!
     end
+
+    module StringEnum
+      extend Seed::Internal::Types::Enum
+
+      ACTIVE = "ACTIVE"
+      CLOSED = "CLOSED"
+      GROUP_BY_PROFILE = "GROUP_BY_PROFILE"
+
+      finalize!
+    end
   end
 
   describe "#values" do
@@ -27,6 +37,19 @@ describe Seed::Internal::Types::Enum do
 
     it "coerces a string version of a member" do
       assert_equal :foo, EnumTest::ExampleEnum.coerce("foo")
+    end
+
+    it "coerces an existing string member" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce("CLOSED")
+    end
+
+    it "normalizes casing to the wire format" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce("closed")
+      assert_equal "GROUP_BY_PROFILE", EnumTest::StringEnum.coerce("group_by_profile")
+    end
+
+    it "coerces a symbol to the string member" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce(:closed)
     end
 
     it "returns the value if not a member with strictness off" do

--- a/seed/ruby-sdk-v2/openapi-subtitle/lib/seed/internal/types/enum.rb
+++ b/seed/ruby-sdk-v2/openapi-subtitle/lib/seed/internal/types/enum.rb
@@ -30,9 +30,15 @@ module Seed
         end
 
         def coerce(value, strict: strict?)
-          coerced_value = Utils.coerce(Symbol, value)
+          return value if values.include?(value)
 
-          return coerced_value if values.include?(coerced_value)
+          if value.is_a?(::String) || value.is_a?(::Symbol)
+            candidate = value.to_s
+            match = values.find do |member|
+              (member.is_a?(::String) || member.is_a?(::Symbol)) && member.to_s.casecmp?(candidate)
+            end
+            return match unless match.nil?
+          end
 
           raise Errors::TypeError, "`#{value}` not in enum #{self}" if strict
 

--- a/seed/ruby-sdk-v2/openapi-subtitle/test/unit/internal/types/test_enum.rb
+++ b/seed/ruby-sdk-v2/openapi-subtitle/test/unit/internal/types/test_enum.rb
@@ -12,6 +12,16 @@ describe Seed::Internal::Types::Enum do
 
       finalize!
     end
+
+    module StringEnum
+      extend Seed::Internal::Types::Enum
+
+      ACTIVE = "ACTIVE"
+      CLOSED = "CLOSED"
+      GROUP_BY_PROFILE = "GROUP_BY_PROFILE"
+
+      finalize!
+    end
   end
 
   describe "#values" do
@@ -27,6 +37,19 @@ describe Seed::Internal::Types::Enum do
 
     it "coerces a string version of a member" do
       assert_equal :foo, EnumTest::ExampleEnum.coerce("foo")
+    end
+
+    it "coerces an existing string member" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce("CLOSED")
+    end
+
+    it "normalizes casing to the wire format" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce("closed")
+      assert_equal "GROUP_BY_PROFILE", EnumTest::StringEnum.coerce("group_by_profile")
+    end
+
+    it "coerces a symbol to the string member" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce(:closed)
     end
 
     it "returns the value if not a member with strictness off" do

--- a/seed/ruby-sdk-v2/optional/lib/seed/internal/types/enum.rb
+++ b/seed/ruby-sdk-v2/optional/lib/seed/internal/types/enum.rb
@@ -30,9 +30,15 @@ module Seed
         end
 
         def coerce(value, strict: strict?)
-          coerced_value = Utils.coerce(Symbol, value)
+          return value if values.include?(value)
 
-          return coerced_value if values.include?(coerced_value)
+          if value.is_a?(::String) || value.is_a?(::Symbol)
+            candidate = value.to_s
+            match = values.find do |member|
+              (member.is_a?(::String) || member.is_a?(::Symbol)) && member.to_s.casecmp?(candidate)
+            end
+            return match unless match.nil?
+          end
 
           raise Errors::TypeError, "`#{value}` not in enum #{self}" if strict
 

--- a/seed/ruby-sdk-v2/optional/test/unit/internal/types/test_enum.rb
+++ b/seed/ruby-sdk-v2/optional/test/unit/internal/types/test_enum.rb
@@ -12,6 +12,16 @@ describe Seed::Internal::Types::Enum do
 
       finalize!
     end
+
+    module StringEnum
+      extend Seed::Internal::Types::Enum
+
+      ACTIVE = "ACTIVE"
+      CLOSED = "CLOSED"
+      GROUP_BY_PROFILE = "GROUP_BY_PROFILE"
+
+      finalize!
+    end
   end
 
   describe "#values" do
@@ -27,6 +37,19 @@ describe Seed::Internal::Types::Enum do
 
     it "coerces a string version of a member" do
       assert_equal :foo, EnumTest::ExampleEnum.coerce("foo")
+    end
+
+    it "coerces an existing string member" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce("CLOSED")
+    end
+
+    it "normalizes casing to the wire format" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce("closed")
+      assert_equal "GROUP_BY_PROFILE", EnumTest::StringEnum.coerce("group_by_profile")
+    end
+
+    it "coerces a symbol to the string member" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce(:closed)
     end
 
     it "returns the value if not a member with strictness off" do

--- a/seed/ruby-sdk-v2/package-yml/lib/seed/internal/types/enum.rb
+++ b/seed/ruby-sdk-v2/package-yml/lib/seed/internal/types/enum.rb
@@ -30,9 +30,15 @@ module Seed
         end
 
         def coerce(value, strict: strict?)
-          coerced_value = Utils.coerce(Symbol, value)
+          return value if values.include?(value)
 
-          return coerced_value if values.include?(coerced_value)
+          if value.is_a?(::String) || value.is_a?(::Symbol)
+            candidate = value.to_s
+            match = values.find do |member|
+              (member.is_a?(::String) || member.is_a?(::Symbol)) && member.to_s.casecmp?(candidate)
+            end
+            return match unless match.nil?
+          end
 
           raise Errors::TypeError, "`#{value}` not in enum #{self}" if strict
 

--- a/seed/ruby-sdk-v2/package-yml/test/unit/internal/types/test_enum.rb
+++ b/seed/ruby-sdk-v2/package-yml/test/unit/internal/types/test_enum.rb
@@ -12,6 +12,16 @@ describe Seed::Internal::Types::Enum do
 
       finalize!
     end
+
+    module StringEnum
+      extend Seed::Internal::Types::Enum
+
+      ACTIVE = "ACTIVE"
+      CLOSED = "CLOSED"
+      GROUP_BY_PROFILE = "GROUP_BY_PROFILE"
+
+      finalize!
+    end
   end
 
   describe "#values" do
@@ -27,6 +37,19 @@ describe Seed::Internal::Types::Enum do
 
     it "coerces a string version of a member" do
       assert_equal :foo, EnumTest::ExampleEnum.coerce("foo")
+    end
+
+    it "coerces an existing string member" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce("CLOSED")
+    end
+
+    it "normalizes casing to the wire format" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce("closed")
+      assert_equal "GROUP_BY_PROFILE", EnumTest::StringEnum.coerce("group_by_profile")
+    end
+
+    it "coerces a symbol to the string member" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce(:closed)
     end
 
     it "returns the value if not a member with strictness off" do

--- a/seed/ruby-sdk-v2/pagination-custom/lib/seed/internal/types/enum.rb
+++ b/seed/ruby-sdk-v2/pagination-custom/lib/seed/internal/types/enum.rb
@@ -30,9 +30,15 @@ module Seed
         end
 
         def coerce(value, strict: strict?)
-          coerced_value = Utils.coerce(Symbol, value)
+          return value if values.include?(value)
 
-          return coerced_value if values.include?(coerced_value)
+          if value.is_a?(::String) || value.is_a?(::Symbol)
+            candidate = value.to_s
+            match = values.find do |member|
+              (member.is_a?(::String) || member.is_a?(::Symbol)) && member.to_s.casecmp?(candidate)
+            end
+            return match unless match.nil?
+          end
 
           raise Errors::TypeError, "`#{value}` not in enum #{self}" if strict
 

--- a/seed/ruby-sdk-v2/pagination-custom/test/unit/internal/types/test_enum.rb
+++ b/seed/ruby-sdk-v2/pagination-custom/test/unit/internal/types/test_enum.rb
@@ -12,6 +12,16 @@ describe Seed::Internal::Types::Enum do
 
       finalize!
     end
+
+    module StringEnum
+      extend Seed::Internal::Types::Enum
+
+      ACTIVE = "ACTIVE"
+      CLOSED = "CLOSED"
+      GROUP_BY_PROFILE = "GROUP_BY_PROFILE"
+
+      finalize!
+    end
   end
 
   describe "#values" do
@@ -27,6 +37,19 @@ describe Seed::Internal::Types::Enum do
 
     it "coerces a string version of a member" do
       assert_equal :foo, EnumTest::ExampleEnum.coerce("foo")
+    end
+
+    it "coerces an existing string member" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce("CLOSED")
+    end
+
+    it "normalizes casing to the wire format" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce("closed")
+      assert_equal "GROUP_BY_PROFILE", EnumTest::StringEnum.coerce("group_by_profile")
+    end
+
+    it "coerces a symbol to the string member" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce(:closed)
     end
 
     it "returns the value if not a member with strictness off" do

--- a/seed/ruby-sdk-v2/pagination-uri-path/lib/seed/internal/types/enum.rb
+++ b/seed/ruby-sdk-v2/pagination-uri-path/lib/seed/internal/types/enum.rb
@@ -30,9 +30,15 @@ module Seed
         end
 
         def coerce(value, strict: strict?)
-          coerced_value = Utils.coerce(Symbol, value)
+          return value if values.include?(value)
 
-          return coerced_value if values.include?(coerced_value)
+          if value.is_a?(::String) || value.is_a?(::Symbol)
+            candidate = value.to_s
+            match = values.find do |member|
+              (member.is_a?(::String) || member.is_a?(::Symbol)) && member.to_s.casecmp?(candidate)
+            end
+            return match unless match.nil?
+          end
 
           raise Errors::TypeError, "`#{value}` not in enum #{self}" if strict
 

--- a/seed/ruby-sdk-v2/pagination-uri-path/test/unit/internal/types/test_enum.rb
+++ b/seed/ruby-sdk-v2/pagination-uri-path/test/unit/internal/types/test_enum.rb
@@ -12,6 +12,16 @@ describe Seed::Internal::Types::Enum do
 
       finalize!
     end
+
+    module StringEnum
+      extend Seed::Internal::Types::Enum
+
+      ACTIVE = "ACTIVE"
+      CLOSED = "CLOSED"
+      GROUP_BY_PROFILE = "GROUP_BY_PROFILE"
+
+      finalize!
+    end
   end
 
   describe "#values" do
@@ -27,6 +37,19 @@ describe Seed::Internal::Types::Enum do
 
     it "coerces a string version of a member" do
       assert_equal :foo, EnumTest::ExampleEnum.coerce("foo")
+    end
+
+    it "coerces an existing string member" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce("CLOSED")
+    end
+
+    it "normalizes casing to the wire format" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce("closed")
+      assert_equal "GROUP_BY_PROFILE", EnumTest::StringEnum.coerce("group_by_profile")
+    end
+
+    it "coerces a symbol to the string member" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce(:closed)
     end
 
     it "returns the value if not a member with strictness off" do

--- a/seed/ruby-sdk-v2/pagination/no-custom-config/lib/seed/internal/types/enum.rb
+++ b/seed/ruby-sdk-v2/pagination/no-custom-config/lib/seed/internal/types/enum.rb
@@ -30,9 +30,15 @@ module Seed
         end
 
         def coerce(value, strict: strict?)
-          coerced_value = Utils.coerce(Symbol, value)
+          return value if values.include?(value)
 
-          return coerced_value if values.include?(coerced_value)
+          if value.is_a?(::String) || value.is_a?(::Symbol)
+            candidate = value.to_s
+            match = values.find do |member|
+              (member.is_a?(::String) || member.is_a?(::Symbol)) && member.to_s.casecmp?(candidate)
+            end
+            return match unless match.nil?
+          end
 
           raise Errors::TypeError, "`#{value}` not in enum #{self}" if strict
 

--- a/seed/ruby-sdk-v2/pagination/no-custom-config/test/unit/internal/types/test_enum.rb
+++ b/seed/ruby-sdk-v2/pagination/no-custom-config/test/unit/internal/types/test_enum.rb
@@ -12,6 +12,16 @@ describe Seed::Internal::Types::Enum do
 
       finalize!
     end
+
+    module StringEnum
+      extend Seed::Internal::Types::Enum
+
+      ACTIVE = "ACTIVE"
+      CLOSED = "CLOSED"
+      GROUP_BY_PROFILE = "GROUP_BY_PROFILE"
+
+      finalize!
+    end
   end
 
   describe "#values" do
@@ -27,6 +37,19 @@ describe Seed::Internal::Types::Enum do
 
     it "coerces a string version of a member" do
       assert_equal :foo, EnumTest::ExampleEnum.coerce("foo")
+    end
+
+    it "coerces an existing string member" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce("CLOSED")
+    end
+
+    it "normalizes casing to the wire format" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce("closed")
+      assert_equal "GROUP_BY_PROFILE", EnumTest::StringEnum.coerce("group_by_profile")
+    end
+
+    it "coerces a symbol to the string member" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce(:closed)
     end
 
     it "returns the value if not a member with strictness off" do

--- a/seed/ruby-sdk-v2/pagination/page-index-semantics/lib/seed/internal/types/enum.rb
+++ b/seed/ruby-sdk-v2/pagination/page-index-semantics/lib/seed/internal/types/enum.rb
@@ -30,9 +30,15 @@ module Seed
         end
 
         def coerce(value, strict: strict?)
-          coerced_value = Utils.coerce(Symbol, value)
+          return value if values.include?(value)
 
-          return coerced_value if values.include?(coerced_value)
+          if value.is_a?(::String) || value.is_a?(::Symbol)
+            candidate = value.to_s
+            match = values.find do |member|
+              (member.is_a?(::String) || member.is_a?(::Symbol)) && member.to_s.casecmp?(candidate)
+            end
+            return match unless match.nil?
+          end
 
           raise Errors::TypeError, "`#{value}` not in enum #{self}" if strict
 

--- a/seed/ruby-sdk-v2/pagination/page-index-semantics/test/unit/internal/types/test_enum.rb
+++ b/seed/ruby-sdk-v2/pagination/page-index-semantics/test/unit/internal/types/test_enum.rb
@@ -12,6 +12,16 @@ describe Seed::Internal::Types::Enum do
 
       finalize!
     end
+
+    module StringEnum
+      extend Seed::Internal::Types::Enum
+
+      ACTIVE = "ACTIVE"
+      CLOSED = "CLOSED"
+      GROUP_BY_PROFILE = "GROUP_BY_PROFILE"
+
+      finalize!
+    end
   end
 
   describe "#values" do
@@ -27,6 +37,19 @@ describe Seed::Internal::Types::Enum do
 
     it "coerces a string version of a member" do
       assert_equal :foo, EnumTest::ExampleEnum.coerce("foo")
+    end
+
+    it "coerces an existing string member" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce("CLOSED")
+    end
+
+    it "normalizes casing to the wire format" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce("closed")
+      assert_equal "GROUP_BY_PROFILE", EnumTest::StringEnum.coerce("group_by_profile")
+    end
+
+    it "coerces a symbol to the string member" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce(:closed)
     end
 
     it "returns the value if not a member with strictness off" do

--- a/seed/ruby-sdk-v2/path-parameters/lib/seed/internal/types/enum.rb
+++ b/seed/ruby-sdk-v2/path-parameters/lib/seed/internal/types/enum.rb
@@ -30,9 +30,15 @@ module Seed
         end
 
         def coerce(value, strict: strict?)
-          coerced_value = Utils.coerce(Symbol, value)
+          return value if values.include?(value)
 
-          return coerced_value if values.include?(coerced_value)
+          if value.is_a?(::String) || value.is_a?(::Symbol)
+            candidate = value.to_s
+            match = values.find do |member|
+              (member.is_a?(::String) || member.is_a?(::Symbol)) && member.to_s.casecmp?(candidate)
+            end
+            return match unless match.nil?
+          end
 
           raise Errors::TypeError, "`#{value}` not in enum #{self}" if strict
 

--- a/seed/ruby-sdk-v2/path-parameters/test/unit/internal/types/test_enum.rb
+++ b/seed/ruby-sdk-v2/path-parameters/test/unit/internal/types/test_enum.rb
@@ -12,6 +12,16 @@ describe Seed::Internal::Types::Enum do
 
       finalize!
     end
+
+    module StringEnum
+      extend Seed::Internal::Types::Enum
+
+      ACTIVE = "ACTIVE"
+      CLOSED = "CLOSED"
+      GROUP_BY_PROFILE = "GROUP_BY_PROFILE"
+
+      finalize!
+    end
   end
 
   describe "#values" do
@@ -27,6 +37,19 @@ describe Seed::Internal::Types::Enum do
 
     it "coerces a string version of a member" do
       assert_equal :foo, EnumTest::ExampleEnum.coerce("foo")
+    end
+
+    it "coerces an existing string member" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce("CLOSED")
+    end
+
+    it "normalizes casing to the wire format" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce("closed")
+      assert_equal "GROUP_BY_PROFILE", EnumTest::StringEnum.coerce("group_by_profile")
+    end
+
+    it "coerces a symbol to the string member" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce(:closed)
     end
 
     it "returns the value if not a member with strictness off" do

--- a/seed/ruby-sdk-v2/plain-text/lib/seed/internal/types/enum.rb
+++ b/seed/ruby-sdk-v2/plain-text/lib/seed/internal/types/enum.rb
@@ -30,9 +30,15 @@ module Seed
         end
 
         def coerce(value, strict: strict?)
-          coerced_value = Utils.coerce(Symbol, value)
+          return value if values.include?(value)
 
-          return coerced_value if values.include?(coerced_value)
+          if value.is_a?(::String) || value.is_a?(::Symbol)
+            candidate = value.to_s
+            match = values.find do |member|
+              (member.is_a?(::String) || member.is_a?(::Symbol)) && member.to_s.casecmp?(candidate)
+            end
+            return match unless match.nil?
+          end
 
           raise Errors::TypeError, "`#{value}` not in enum #{self}" if strict
 

--- a/seed/ruby-sdk-v2/plain-text/test/unit/internal/types/test_enum.rb
+++ b/seed/ruby-sdk-v2/plain-text/test/unit/internal/types/test_enum.rb
@@ -12,6 +12,16 @@ describe Seed::Internal::Types::Enum do
 
       finalize!
     end
+
+    module StringEnum
+      extend Seed::Internal::Types::Enum
+
+      ACTIVE = "ACTIVE"
+      CLOSED = "CLOSED"
+      GROUP_BY_PROFILE = "GROUP_BY_PROFILE"
+
+      finalize!
+    end
   end
 
   describe "#values" do
@@ -27,6 +37,19 @@ describe Seed::Internal::Types::Enum do
 
     it "coerces a string version of a member" do
       assert_equal :foo, EnumTest::ExampleEnum.coerce("foo")
+    end
+
+    it "coerces an existing string member" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce("CLOSED")
+    end
+
+    it "normalizes casing to the wire format" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce("closed")
+      assert_equal "GROUP_BY_PROFILE", EnumTest::StringEnum.coerce("group_by_profile")
+    end
+
+    it "coerces a symbol to the string member" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce(:closed)
     end
 
     it "returns the value if not a member with strictness off" do

--- a/seed/ruby-sdk-v2/property-access/lib/seed/internal/types/enum.rb
+++ b/seed/ruby-sdk-v2/property-access/lib/seed/internal/types/enum.rb
@@ -30,9 +30,15 @@ module Seed
         end
 
         def coerce(value, strict: strict?)
-          coerced_value = Utils.coerce(Symbol, value)
+          return value if values.include?(value)
 
-          return coerced_value if values.include?(coerced_value)
+          if value.is_a?(::String) || value.is_a?(::Symbol)
+            candidate = value.to_s
+            match = values.find do |member|
+              (member.is_a?(::String) || member.is_a?(::Symbol)) && member.to_s.casecmp?(candidate)
+            end
+            return match unless match.nil?
+          end
 
           raise Errors::TypeError, "`#{value}` not in enum #{self}" if strict
 

--- a/seed/ruby-sdk-v2/property-access/test/unit/internal/types/test_enum.rb
+++ b/seed/ruby-sdk-v2/property-access/test/unit/internal/types/test_enum.rb
@@ -12,6 +12,16 @@ describe Seed::Internal::Types::Enum do
 
       finalize!
     end
+
+    module StringEnum
+      extend Seed::Internal::Types::Enum
+
+      ACTIVE = "ACTIVE"
+      CLOSED = "CLOSED"
+      GROUP_BY_PROFILE = "GROUP_BY_PROFILE"
+
+      finalize!
+    end
   end
 
   describe "#values" do
@@ -27,6 +37,19 @@ describe Seed::Internal::Types::Enum do
 
     it "coerces a string version of a member" do
       assert_equal :foo, EnumTest::ExampleEnum.coerce("foo")
+    end
+
+    it "coerces an existing string member" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce("CLOSED")
+    end
+
+    it "normalizes casing to the wire format" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce("closed")
+      assert_equal "GROUP_BY_PROFILE", EnumTest::StringEnum.coerce("group_by_profile")
+    end
+
+    it "coerces a symbol to the string member" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce(:closed)
     end
 
     it "returns the value if not a member with strictness off" do

--- a/seed/ruby-sdk-v2/public-object/lib/seed/internal/types/enum.rb
+++ b/seed/ruby-sdk-v2/public-object/lib/seed/internal/types/enum.rb
@@ -30,9 +30,15 @@ module Seed
         end
 
         def coerce(value, strict: strict?)
-          coerced_value = Utils.coerce(Symbol, value)
+          return value if values.include?(value)
 
-          return coerced_value if values.include?(coerced_value)
+          if value.is_a?(::String) || value.is_a?(::Symbol)
+            candidate = value.to_s
+            match = values.find do |member|
+              (member.is_a?(::String) || member.is_a?(::Symbol)) && member.to_s.casecmp?(candidate)
+            end
+            return match unless match.nil?
+          end
 
           raise Errors::TypeError, "`#{value}` not in enum #{self}" if strict
 

--- a/seed/ruby-sdk-v2/public-object/test/unit/internal/types/test_enum.rb
+++ b/seed/ruby-sdk-v2/public-object/test/unit/internal/types/test_enum.rb
@@ -12,6 +12,16 @@ describe Seed::Internal::Types::Enum do
 
       finalize!
     end
+
+    module StringEnum
+      extend Seed::Internal::Types::Enum
+
+      ACTIVE = "ACTIVE"
+      CLOSED = "CLOSED"
+      GROUP_BY_PROFILE = "GROUP_BY_PROFILE"
+
+      finalize!
+    end
   end
 
   describe "#values" do
@@ -27,6 +37,19 @@ describe Seed::Internal::Types::Enum do
 
     it "coerces a string version of a member" do
       assert_equal :foo, EnumTest::ExampleEnum.coerce("foo")
+    end
+
+    it "coerces an existing string member" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce("CLOSED")
+    end
+
+    it "normalizes casing to the wire format" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce("closed")
+      assert_equal "GROUP_BY_PROFILE", EnumTest::StringEnum.coerce("group_by_profile")
+    end
+
+    it "coerces a symbol to the string member" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce(:closed)
     end
 
     it "returns the value if not a member with strictness off" do

--- a/seed/ruby-sdk-v2/query-param-name-conflict/lib/seed/internal/types/enum.rb
+++ b/seed/ruby-sdk-v2/query-param-name-conflict/lib/seed/internal/types/enum.rb
@@ -30,9 +30,15 @@ module Seed
         end
 
         def coerce(value, strict: strict?)
-          coerced_value = Utils.coerce(Symbol, value)
+          return value if values.include?(value)
 
-          return coerced_value if values.include?(coerced_value)
+          if value.is_a?(::String) || value.is_a?(::Symbol)
+            candidate = value.to_s
+            match = values.find do |member|
+              (member.is_a?(::String) || member.is_a?(::Symbol)) && member.to_s.casecmp?(candidate)
+            end
+            return match unless match.nil?
+          end
 
           raise Errors::TypeError, "`#{value}` not in enum #{self}" if strict
 

--- a/seed/ruby-sdk-v2/query-param-name-conflict/test/unit/internal/types/test_enum.rb
+++ b/seed/ruby-sdk-v2/query-param-name-conflict/test/unit/internal/types/test_enum.rb
@@ -12,6 +12,16 @@ describe Seed::Internal::Types::Enum do
 
       finalize!
     end
+
+    module StringEnum
+      extend Seed::Internal::Types::Enum
+
+      ACTIVE = "ACTIVE"
+      CLOSED = "CLOSED"
+      GROUP_BY_PROFILE = "GROUP_BY_PROFILE"
+
+      finalize!
+    end
   end
 
   describe "#values" do
@@ -27,6 +37,19 @@ describe Seed::Internal::Types::Enum do
 
     it "coerces a string version of a member" do
       assert_equal :foo, EnumTest::ExampleEnum.coerce("foo")
+    end
+
+    it "coerces an existing string member" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce("CLOSED")
+    end
+
+    it "normalizes casing to the wire format" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce("closed")
+      assert_equal "GROUP_BY_PROFILE", EnumTest::StringEnum.coerce("group_by_profile")
+    end
+
+    it "coerces a symbol to the string member" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce(:closed)
     end
 
     it "returns the value if not a member with strictness off" do

--- a/seed/ruby-sdk-v2/query-parameters-openapi-as-objects/lib/seed/internal/types/enum.rb
+++ b/seed/ruby-sdk-v2/query-parameters-openapi-as-objects/lib/seed/internal/types/enum.rb
@@ -30,9 +30,15 @@ module Seed
         end
 
         def coerce(value, strict: strict?)
-          coerced_value = Utils.coerce(Symbol, value)
+          return value if values.include?(value)
 
-          return coerced_value if values.include?(coerced_value)
+          if value.is_a?(::String) || value.is_a?(::Symbol)
+            candidate = value.to_s
+            match = values.find do |member|
+              (member.is_a?(::String) || member.is_a?(::Symbol)) && member.to_s.casecmp?(candidate)
+            end
+            return match unless match.nil?
+          end
 
           raise Errors::TypeError, "`#{value}` not in enum #{self}" if strict
 

--- a/seed/ruby-sdk-v2/query-parameters-openapi-as-objects/test/unit/internal/types/test_enum.rb
+++ b/seed/ruby-sdk-v2/query-parameters-openapi-as-objects/test/unit/internal/types/test_enum.rb
@@ -12,6 +12,16 @@ describe Seed::Internal::Types::Enum do
 
       finalize!
     end
+
+    module StringEnum
+      extend Seed::Internal::Types::Enum
+
+      ACTIVE = "ACTIVE"
+      CLOSED = "CLOSED"
+      GROUP_BY_PROFILE = "GROUP_BY_PROFILE"
+
+      finalize!
+    end
   end
 
   describe "#values" do
@@ -27,6 +37,19 @@ describe Seed::Internal::Types::Enum do
 
     it "coerces a string version of a member" do
       assert_equal :foo, EnumTest::ExampleEnum.coerce("foo")
+    end
+
+    it "coerces an existing string member" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce("CLOSED")
+    end
+
+    it "normalizes casing to the wire format" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce("closed")
+      assert_equal "GROUP_BY_PROFILE", EnumTest::StringEnum.coerce("group_by_profile")
+    end
+
+    it "coerces a symbol to the string member" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce(:closed)
     end
 
     it "returns the value if not a member with strictness off" do

--- a/seed/ruby-sdk-v2/query-parameters-openapi/lib/seed/internal/types/enum.rb
+++ b/seed/ruby-sdk-v2/query-parameters-openapi/lib/seed/internal/types/enum.rb
@@ -30,9 +30,15 @@ module Seed
         end
 
         def coerce(value, strict: strict?)
-          coerced_value = Utils.coerce(Symbol, value)
+          return value if values.include?(value)
 
-          return coerced_value if values.include?(coerced_value)
+          if value.is_a?(::String) || value.is_a?(::Symbol)
+            candidate = value.to_s
+            match = values.find do |member|
+              (member.is_a?(::String) || member.is_a?(::Symbol)) && member.to_s.casecmp?(candidate)
+            end
+            return match unless match.nil?
+          end
 
           raise Errors::TypeError, "`#{value}` not in enum #{self}" if strict
 

--- a/seed/ruby-sdk-v2/query-parameters-openapi/test/unit/internal/types/test_enum.rb
+++ b/seed/ruby-sdk-v2/query-parameters-openapi/test/unit/internal/types/test_enum.rb
@@ -12,6 +12,16 @@ describe Seed::Internal::Types::Enum do
 
       finalize!
     end
+
+    module StringEnum
+      extend Seed::Internal::Types::Enum
+
+      ACTIVE = "ACTIVE"
+      CLOSED = "CLOSED"
+      GROUP_BY_PROFILE = "GROUP_BY_PROFILE"
+
+      finalize!
+    end
   end
 
   describe "#values" do
@@ -27,6 +37,19 @@ describe Seed::Internal::Types::Enum do
 
     it "coerces a string version of a member" do
       assert_equal :foo, EnumTest::ExampleEnum.coerce("foo")
+    end
+
+    it "coerces an existing string member" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce("CLOSED")
+    end
+
+    it "normalizes casing to the wire format" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce("closed")
+      assert_equal "GROUP_BY_PROFILE", EnumTest::StringEnum.coerce("group_by_profile")
+    end
+
+    it "coerces a symbol to the string member" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce(:closed)
     end
 
     it "returns the value if not a member with strictness off" do

--- a/seed/ruby-sdk-v2/query-parameters/lib/seed/internal/types/enum.rb
+++ b/seed/ruby-sdk-v2/query-parameters/lib/seed/internal/types/enum.rb
@@ -30,9 +30,15 @@ module Seed
         end
 
         def coerce(value, strict: strict?)
-          coerced_value = Utils.coerce(Symbol, value)
+          return value if values.include?(value)
 
-          return coerced_value if values.include?(coerced_value)
+          if value.is_a?(::String) || value.is_a?(::Symbol)
+            candidate = value.to_s
+            match = values.find do |member|
+              (member.is_a?(::String) || member.is_a?(::Symbol)) && member.to_s.casecmp?(candidate)
+            end
+            return match unless match.nil?
+          end
 
           raise Errors::TypeError, "`#{value}` not in enum #{self}" if strict
 

--- a/seed/ruby-sdk-v2/query-parameters/test/unit/internal/types/test_enum.rb
+++ b/seed/ruby-sdk-v2/query-parameters/test/unit/internal/types/test_enum.rb
@@ -12,6 +12,16 @@ describe Seed::Internal::Types::Enum do
 
       finalize!
     end
+
+    module StringEnum
+      extend Seed::Internal::Types::Enum
+
+      ACTIVE = "ACTIVE"
+      CLOSED = "CLOSED"
+      GROUP_BY_PROFILE = "GROUP_BY_PROFILE"
+
+      finalize!
+    end
   end
 
   describe "#values" do
@@ -27,6 +37,19 @@ describe Seed::Internal::Types::Enum do
 
     it "coerces a string version of a member" do
       assert_equal :foo, EnumTest::ExampleEnum.coerce("foo")
+    end
+
+    it "coerces an existing string member" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce("CLOSED")
+    end
+
+    it "normalizes casing to the wire format" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce("closed")
+      assert_equal "GROUP_BY_PROFILE", EnumTest::StringEnum.coerce("group_by_profile")
+    end
+
+    it "coerces a symbol to the string member" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce(:closed)
     end
 
     it "returns the value if not a member with strictness off" do

--- a/seed/ruby-sdk-v2/request-parameters/lib/seed/internal/types/enum.rb
+++ b/seed/ruby-sdk-v2/request-parameters/lib/seed/internal/types/enum.rb
@@ -30,9 +30,15 @@ module Seed
         end
 
         def coerce(value, strict: strict?)
-          coerced_value = Utils.coerce(Symbol, value)
+          return value if values.include?(value)
 
-          return coerced_value if values.include?(coerced_value)
+          if value.is_a?(::String) || value.is_a?(::Symbol)
+            candidate = value.to_s
+            match = values.find do |member|
+              (member.is_a?(::String) || member.is_a?(::Symbol)) && member.to_s.casecmp?(candidate)
+            end
+            return match unless match.nil?
+          end
 
           raise Errors::TypeError, "`#{value}` not in enum #{self}" if strict
 

--- a/seed/ruby-sdk-v2/request-parameters/test/unit/internal/types/test_enum.rb
+++ b/seed/ruby-sdk-v2/request-parameters/test/unit/internal/types/test_enum.rb
@@ -12,6 +12,16 @@ describe Seed::Internal::Types::Enum do
 
       finalize!
     end
+
+    module StringEnum
+      extend Seed::Internal::Types::Enum
+
+      ACTIVE = "ACTIVE"
+      CLOSED = "CLOSED"
+      GROUP_BY_PROFILE = "GROUP_BY_PROFILE"
+
+      finalize!
+    end
   end
 
   describe "#values" do
@@ -27,6 +37,19 @@ describe Seed::Internal::Types::Enum do
 
     it "coerces a string version of a member" do
       assert_equal :foo, EnumTest::ExampleEnum.coerce("foo")
+    end
+
+    it "coerces an existing string member" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce("CLOSED")
+    end
+
+    it "normalizes casing to the wire format" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce("closed")
+      assert_equal "GROUP_BY_PROFILE", EnumTest::StringEnum.coerce("group_by_profile")
+    end
+
+    it "coerces a symbol to the string member" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce(:closed)
     end
 
     it "returns the value if not a member with strictness off" do

--- a/seed/ruby-sdk-v2/required-nullable/lib/seed/internal/types/enum.rb
+++ b/seed/ruby-sdk-v2/required-nullable/lib/seed/internal/types/enum.rb
@@ -30,9 +30,15 @@ module Seed
         end
 
         def coerce(value, strict: strict?)
-          coerced_value = Utils.coerce(Symbol, value)
+          return value if values.include?(value)
 
-          return coerced_value if values.include?(coerced_value)
+          if value.is_a?(::String) || value.is_a?(::Symbol)
+            candidate = value.to_s
+            match = values.find do |member|
+              (member.is_a?(::String) || member.is_a?(::Symbol)) && member.to_s.casecmp?(candidate)
+            end
+            return match unless match.nil?
+          end
 
           raise Errors::TypeError, "`#{value}` not in enum #{self}" if strict
 

--- a/seed/ruby-sdk-v2/required-nullable/test/unit/internal/types/test_enum.rb
+++ b/seed/ruby-sdk-v2/required-nullable/test/unit/internal/types/test_enum.rb
@@ -12,6 +12,16 @@ describe Seed::Internal::Types::Enum do
 
       finalize!
     end
+
+    module StringEnum
+      extend Seed::Internal::Types::Enum
+
+      ACTIVE = "ACTIVE"
+      CLOSED = "CLOSED"
+      GROUP_BY_PROFILE = "GROUP_BY_PROFILE"
+
+      finalize!
+    end
   end
 
   describe "#values" do
@@ -27,6 +37,19 @@ describe Seed::Internal::Types::Enum do
 
     it "coerces a string version of a member" do
       assert_equal :foo, EnumTest::ExampleEnum.coerce("foo")
+    end
+
+    it "coerces an existing string member" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce("CLOSED")
+    end
+
+    it "normalizes casing to the wire format" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce("closed")
+      assert_equal "GROUP_BY_PROFILE", EnumTest::StringEnum.coerce("group_by_profile")
+    end
+
+    it "coerces a symbol to the string member" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce(:closed)
     end
 
     it "returns the value if not a member with strictness off" do

--- a/seed/ruby-sdk-v2/reserved-keywords/lib/seed/internal/types/enum.rb
+++ b/seed/ruby-sdk-v2/reserved-keywords/lib/seed/internal/types/enum.rb
@@ -30,9 +30,15 @@ module Seed
         end
 
         def coerce(value, strict: strict?)
-          coerced_value = Utils.coerce(Symbol, value)
+          return value if values.include?(value)
 
-          return coerced_value if values.include?(coerced_value)
+          if value.is_a?(::String) || value.is_a?(::Symbol)
+            candidate = value.to_s
+            match = values.find do |member|
+              (member.is_a?(::String) || member.is_a?(::Symbol)) && member.to_s.casecmp?(candidate)
+            end
+            return match unless match.nil?
+          end
 
           raise Errors::TypeError, "`#{value}` not in enum #{self}" if strict
 

--- a/seed/ruby-sdk-v2/reserved-keywords/test/unit/internal/types/test_enum.rb
+++ b/seed/ruby-sdk-v2/reserved-keywords/test/unit/internal/types/test_enum.rb
@@ -12,6 +12,16 @@ describe Seed::Internal::Types::Enum do
 
       finalize!
     end
+
+    module StringEnum
+      extend Seed::Internal::Types::Enum
+
+      ACTIVE = "ACTIVE"
+      CLOSED = "CLOSED"
+      GROUP_BY_PROFILE = "GROUP_BY_PROFILE"
+
+      finalize!
+    end
   end
 
   describe "#values" do
@@ -27,6 +37,19 @@ describe Seed::Internal::Types::Enum do
 
     it "coerces a string version of a member" do
       assert_equal :foo, EnumTest::ExampleEnum.coerce("foo")
+    end
+
+    it "coerces an existing string member" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce("CLOSED")
+    end
+
+    it "normalizes casing to the wire format" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce("closed")
+      assert_equal "GROUP_BY_PROFILE", EnumTest::StringEnum.coerce("group_by_profile")
+    end
+
+    it "coerces a symbol to the string member" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce(:closed)
     end
 
     it "returns the value if not a member with strictness off" do

--- a/seed/ruby-sdk-v2/response-property/lib/seed/internal/types/enum.rb
+++ b/seed/ruby-sdk-v2/response-property/lib/seed/internal/types/enum.rb
@@ -30,9 +30,15 @@ module Seed
         end
 
         def coerce(value, strict: strict?)
-          coerced_value = Utils.coerce(Symbol, value)
+          return value if values.include?(value)
 
-          return coerced_value if values.include?(coerced_value)
+          if value.is_a?(::String) || value.is_a?(::Symbol)
+            candidate = value.to_s
+            match = values.find do |member|
+              (member.is_a?(::String) || member.is_a?(::Symbol)) && member.to_s.casecmp?(candidate)
+            end
+            return match unless match.nil?
+          end
 
           raise Errors::TypeError, "`#{value}` not in enum #{self}" if strict
 

--- a/seed/ruby-sdk-v2/response-property/test/unit/internal/types/test_enum.rb
+++ b/seed/ruby-sdk-v2/response-property/test/unit/internal/types/test_enum.rb
@@ -12,6 +12,16 @@ describe Seed::Internal::Types::Enum do
 
       finalize!
     end
+
+    module StringEnum
+      extend Seed::Internal::Types::Enum
+
+      ACTIVE = "ACTIVE"
+      CLOSED = "CLOSED"
+      GROUP_BY_PROFILE = "GROUP_BY_PROFILE"
+
+      finalize!
+    end
   end
 
   describe "#values" do
@@ -27,6 +37,19 @@ describe Seed::Internal::Types::Enum do
 
     it "coerces a string version of a member" do
       assert_equal :foo, EnumTest::ExampleEnum.coerce("foo")
+    end
+
+    it "coerces an existing string member" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce("CLOSED")
+    end
+
+    it "normalizes casing to the wire format" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce("closed")
+      assert_equal "GROUP_BY_PROFILE", EnumTest::StringEnum.coerce("group_by_profile")
+    end
+
+    it "coerces a symbol to the string member" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce(:closed)
     end
 
     it "returns the value if not a member with strictness off" do

--- a/seed/ruby-sdk-v2/ruby-alias-request-body/lib/seed/internal/types/enum.rb
+++ b/seed/ruby-sdk-v2/ruby-alias-request-body/lib/seed/internal/types/enum.rb
@@ -30,9 +30,15 @@ module Seed
         end
 
         def coerce(value, strict: strict?)
-          coerced_value = Utils.coerce(Symbol, value)
+          return value if values.include?(value)
 
-          return coerced_value if values.include?(coerced_value)
+          if value.is_a?(::String) || value.is_a?(::Symbol)
+            candidate = value.to_s
+            match = values.find do |member|
+              (member.is_a?(::String) || member.is_a?(::Symbol)) && member.to_s.casecmp?(candidate)
+            end
+            return match unless match.nil?
+          end
 
           raise Errors::TypeError, "`#{value}` not in enum #{self}" if strict
 

--- a/seed/ruby-sdk-v2/ruby-alias-request-body/test/unit/internal/types/test_enum.rb
+++ b/seed/ruby-sdk-v2/ruby-alias-request-body/test/unit/internal/types/test_enum.rb
@@ -12,6 +12,16 @@ describe Seed::Internal::Types::Enum do
 
       finalize!
     end
+
+    module StringEnum
+      extend Seed::Internal::Types::Enum
+
+      ACTIVE = "ACTIVE"
+      CLOSED = "CLOSED"
+      GROUP_BY_PROFILE = "GROUP_BY_PROFILE"
+
+      finalize!
+    end
   end
 
   describe "#values" do
@@ -27,6 +37,19 @@ describe Seed::Internal::Types::Enum do
 
     it "coerces a string version of a member" do
       assert_equal :foo, EnumTest::ExampleEnum.coerce("foo")
+    end
+
+    it "coerces an existing string member" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce("CLOSED")
+    end
+
+    it "normalizes casing to the wire format" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce("closed")
+      assert_equal "GROUP_BY_PROFILE", EnumTest::StringEnum.coerce("group_by_profile")
+    end
+
+    it "coerces a symbol to the string member" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce(:closed)
     end
 
     it "returns the value if not a member with strictness off" do

--- a/seed/ruby-sdk-v2/ruby-endpoint-security-optional-credentials/lib/seed/internal/types/enum.rb
+++ b/seed/ruby-sdk-v2/ruby-endpoint-security-optional-credentials/lib/seed/internal/types/enum.rb
@@ -30,9 +30,15 @@ module Seed
         end
 
         def coerce(value, strict: strict?)
-          coerced_value = Utils.coerce(Symbol, value)
+          return value if values.include?(value)
 
-          return coerced_value if values.include?(coerced_value)
+          if value.is_a?(::String) || value.is_a?(::Symbol)
+            candidate = value.to_s
+            match = values.find do |member|
+              (member.is_a?(::String) || member.is_a?(::Symbol)) && member.to_s.casecmp?(candidate)
+            end
+            return match unless match.nil?
+          end
 
           raise Errors::TypeError, "`#{value}` not in enum #{self}" if strict
 

--- a/seed/ruby-sdk-v2/ruby-endpoint-security-optional-credentials/test/unit/internal/types/test_enum.rb
+++ b/seed/ruby-sdk-v2/ruby-endpoint-security-optional-credentials/test/unit/internal/types/test_enum.rb
@@ -12,6 +12,16 @@ describe Seed::Internal::Types::Enum do
 
       finalize!
     end
+
+    module StringEnum
+      extend Seed::Internal::Types::Enum
+
+      ACTIVE = "ACTIVE"
+      CLOSED = "CLOSED"
+      GROUP_BY_PROFILE = "GROUP_BY_PROFILE"
+
+      finalize!
+    end
   end
 
   describe "#values" do
@@ -27,6 +37,19 @@ describe Seed::Internal::Types::Enum do
 
     it "coerces a string version of a member" do
       assert_equal :foo, EnumTest::ExampleEnum.coerce("foo")
+    end
+
+    it "coerces an existing string member" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce("CLOSED")
+    end
+
+    it "normalizes casing to the wire format" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce("closed")
+      assert_equal "GROUP_BY_PROFILE", EnumTest::StringEnum.coerce("group_by_profile")
+    end
+
+    it "coerces a symbol to the string member" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce(:closed)
     end
 
     it "returns the value if not a member with strictness off" do

--- a/seed/ruby-sdk-v2/ruby-global-header-env/lib/seed/internal/types/enum.rb
+++ b/seed/ruby-sdk-v2/ruby-global-header-env/lib/seed/internal/types/enum.rb
@@ -30,9 +30,15 @@ module Seed
         end
 
         def coerce(value, strict: strict?)
-          coerced_value = Utils.coerce(Symbol, value)
+          return value if values.include?(value)
 
-          return coerced_value if values.include?(coerced_value)
+          if value.is_a?(::String) || value.is_a?(::Symbol)
+            candidate = value.to_s
+            match = values.find do |member|
+              (member.is_a?(::String) || member.is_a?(::Symbol)) && member.to_s.casecmp?(candidate)
+            end
+            return match unless match.nil?
+          end
 
           raise Errors::TypeError, "`#{value}` not in enum #{self}" if strict
 

--- a/seed/ruby-sdk-v2/ruby-global-header-env/test/unit/internal/types/test_enum.rb
+++ b/seed/ruby-sdk-v2/ruby-global-header-env/test/unit/internal/types/test_enum.rb
@@ -12,6 +12,16 @@ describe Seed::Internal::Types::Enum do
 
       finalize!
     end
+
+    module StringEnum
+      extend Seed::Internal::Types::Enum
+
+      ACTIVE = "ACTIVE"
+      CLOSED = "CLOSED"
+      GROUP_BY_PROFILE = "GROUP_BY_PROFILE"
+
+      finalize!
+    end
   end
 
   describe "#values" do
@@ -27,6 +37,19 @@ describe Seed::Internal::Types::Enum do
 
     it "coerces a string version of a member" do
       assert_equal :foo, EnumTest::ExampleEnum.coerce("foo")
+    end
+
+    it "coerces an existing string member" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce("CLOSED")
+    end
+
+    it "normalizes casing to the wire format" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce("closed")
+      assert_equal "GROUP_BY_PROFILE", EnumTest::StringEnum.coerce("group_by_profile")
+    end
+
+    it "coerces a symbol to the string member" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce(:closed)
     end
 
     it "returns the value if not a member with strictness off" do

--- a/seed/ruby-sdk-v2/ruby-multi-env-url-templating/no-custom-config/lib/seed/internal/types/enum.rb
+++ b/seed/ruby-sdk-v2/ruby-multi-env-url-templating/no-custom-config/lib/seed/internal/types/enum.rb
@@ -30,9 +30,15 @@ module Seed
         end
 
         def coerce(value, strict: strict?)
-          coerced_value = Utils.coerce(Symbol, value)
+          return value if values.include?(value)
 
-          return coerced_value if values.include?(coerced_value)
+          if value.is_a?(::String) || value.is_a?(::Symbol)
+            candidate = value.to_s
+            match = values.find do |member|
+              (member.is_a?(::String) || member.is_a?(::Symbol)) && member.to_s.casecmp?(candidate)
+            end
+            return match unless match.nil?
+          end
 
           raise Errors::TypeError, "`#{value}` not in enum #{self}" if strict
 

--- a/seed/ruby-sdk-v2/ruby-multi-env-url-templating/no-custom-config/test/unit/internal/types/test_enum.rb
+++ b/seed/ruby-sdk-v2/ruby-multi-env-url-templating/no-custom-config/test/unit/internal/types/test_enum.rb
@@ -12,6 +12,16 @@ describe Seed::Internal::Types::Enum do
 
       finalize!
     end
+
+    module StringEnum
+      extend Seed::Internal::Types::Enum
+
+      ACTIVE = "ACTIVE"
+      CLOSED = "CLOSED"
+      GROUP_BY_PROFILE = "GROUP_BY_PROFILE"
+
+      finalize!
+    end
   end
 
   describe "#values" do
@@ -27,6 +37,19 @@ describe Seed::Internal::Types::Enum do
 
     it "coerces a string version of a member" do
       assert_equal :foo, EnumTest::ExampleEnum.coerce("foo")
+    end
+
+    it "coerces an existing string member" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce("CLOSED")
+    end
+
+    it "normalizes casing to the wire format" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce("closed")
+      assert_equal "GROUP_BY_PROFILE", EnumTest::StringEnum.coerce("group_by_profile")
+    end
+
+    it "coerces a symbol to the string member" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce(:closed)
     end
 
     it "returns the value if not a member with strictness off" do

--- a/seed/ruby-sdk-v2/ruby-reserved-word-properties/lib/seed/internal/types/enum.rb
+++ b/seed/ruby-sdk-v2/ruby-reserved-word-properties/lib/seed/internal/types/enum.rb
@@ -30,9 +30,15 @@ module Seed
         end
 
         def coerce(value, strict: strict?)
-          coerced_value = Utils.coerce(Symbol, value)
+          return value if values.include?(value)
 
-          return coerced_value if values.include?(coerced_value)
+          if value.is_a?(::String) || value.is_a?(::Symbol)
+            candidate = value.to_s
+            match = values.find do |member|
+              (member.is_a?(::String) || member.is_a?(::Symbol)) && member.to_s.casecmp?(candidate)
+            end
+            return match unless match.nil?
+          end
 
           raise Errors::TypeError, "`#{value}` not in enum #{self}" if strict
 

--- a/seed/ruby-sdk-v2/ruby-reserved-word-properties/test/unit/internal/types/test_enum.rb
+++ b/seed/ruby-sdk-v2/ruby-reserved-word-properties/test/unit/internal/types/test_enum.rb
@@ -12,6 +12,16 @@ describe Seed::Internal::Types::Enum do
 
       finalize!
     end
+
+    module StringEnum
+      extend Seed::Internal::Types::Enum
+
+      ACTIVE = "ACTIVE"
+      CLOSED = "CLOSED"
+      GROUP_BY_PROFILE = "GROUP_BY_PROFILE"
+
+      finalize!
+    end
   end
 
   describe "#values" do
@@ -27,6 +37,19 @@ describe Seed::Internal::Types::Enum do
 
     it "coerces a string version of a member" do
       assert_equal :foo, EnumTest::ExampleEnum.coerce("foo")
+    end
+
+    it "coerces an existing string member" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce("CLOSED")
+    end
+
+    it "normalizes casing to the wire format" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce("closed")
+      assert_equal "GROUP_BY_PROFILE", EnumTest::StringEnum.coerce("group_by_profile")
+    end
+
+    it "coerces a symbol to the string member" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce(:closed)
     end
 
     it "returns the value if not a member with strictness off" do

--- a/seed/ruby-sdk-v2/schemaless-request-body-examples/lib/seed/internal/types/enum.rb
+++ b/seed/ruby-sdk-v2/schemaless-request-body-examples/lib/seed/internal/types/enum.rb
@@ -30,9 +30,15 @@ module Seed
         end
 
         def coerce(value, strict: strict?)
-          coerced_value = Utils.coerce(Symbol, value)
+          return value if values.include?(value)
 
-          return coerced_value if values.include?(coerced_value)
+          if value.is_a?(::String) || value.is_a?(::Symbol)
+            candidate = value.to_s
+            match = values.find do |member|
+              (member.is_a?(::String) || member.is_a?(::Symbol)) && member.to_s.casecmp?(candidate)
+            end
+            return match unless match.nil?
+          end
 
           raise Errors::TypeError, "`#{value}` not in enum #{self}" if strict
 

--- a/seed/ruby-sdk-v2/schemaless-request-body-examples/test/unit/internal/types/test_enum.rb
+++ b/seed/ruby-sdk-v2/schemaless-request-body-examples/test/unit/internal/types/test_enum.rb
@@ -12,6 +12,16 @@ describe Seed::Internal::Types::Enum do
 
       finalize!
     end
+
+    module StringEnum
+      extend Seed::Internal::Types::Enum
+
+      ACTIVE = "ACTIVE"
+      CLOSED = "CLOSED"
+      GROUP_BY_PROFILE = "GROUP_BY_PROFILE"
+
+      finalize!
+    end
   end
 
   describe "#values" do
@@ -27,6 +37,19 @@ describe Seed::Internal::Types::Enum do
 
     it "coerces a string version of a member" do
       assert_equal :foo, EnumTest::ExampleEnum.coerce("foo")
+    end
+
+    it "coerces an existing string member" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce("CLOSED")
+    end
+
+    it "normalizes casing to the wire format" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce("closed")
+      assert_equal "GROUP_BY_PROFILE", EnumTest::StringEnum.coerce("group_by_profile")
+    end
+
+    it "coerces a symbol to the string member" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce(:closed)
     end
 
     it "returns the value if not a member with strictness off" do

--- a/seed/ruby-sdk-v2/server-sent-event-examples/lib/seed/internal/types/enum.rb
+++ b/seed/ruby-sdk-v2/server-sent-event-examples/lib/seed/internal/types/enum.rb
@@ -30,9 +30,15 @@ module Seed
         end
 
         def coerce(value, strict: strict?)
-          coerced_value = Utils.coerce(Symbol, value)
+          return value if values.include?(value)
 
-          return coerced_value if values.include?(coerced_value)
+          if value.is_a?(::String) || value.is_a?(::Symbol)
+            candidate = value.to_s
+            match = values.find do |member|
+              (member.is_a?(::String) || member.is_a?(::Symbol)) && member.to_s.casecmp?(candidate)
+            end
+            return match unless match.nil?
+          end
 
           raise Errors::TypeError, "`#{value}` not in enum #{self}" if strict
 

--- a/seed/ruby-sdk-v2/server-sent-event-examples/test/unit/internal/types/test_enum.rb
+++ b/seed/ruby-sdk-v2/server-sent-event-examples/test/unit/internal/types/test_enum.rb
@@ -12,6 +12,16 @@ describe Seed::Internal::Types::Enum do
 
       finalize!
     end
+
+    module StringEnum
+      extend Seed::Internal::Types::Enum
+
+      ACTIVE = "ACTIVE"
+      CLOSED = "CLOSED"
+      GROUP_BY_PROFILE = "GROUP_BY_PROFILE"
+
+      finalize!
+    end
   end
 
   describe "#values" do
@@ -27,6 +37,19 @@ describe Seed::Internal::Types::Enum do
 
     it "coerces a string version of a member" do
       assert_equal :foo, EnumTest::ExampleEnum.coerce("foo")
+    end
+
+    it "coerces an existing string member" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce("CLOSED")
+    end
+
+    it "normalizes casing to the wire format" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce("closed")
+      assert_equal "GROUP_BY_PROFILE", EnumTest::StringEnum.coerce("group_by_profile")
+    end
+
+    it "coerces a symbol to the string member" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce(:closed)
     end
 
     it "returns the value if not a member with strictness off" do

--- a/seed/ruby-sdk-v2/server-sent-events-openapi/lib/seed/internal/types/enum.rb
+++ b/seed/ruby-sdk-v2/server-sent-events-openapi/lib/seed/internal/types/enum.rb
@@ -30,9 +30,15 @@ module Seed
         end
 
         def coerce(value, strict: strict?)
-          coerced_value = Utils.coerce(Symbol, value)
+          return value if values.include?(value)
 
-          return coerced_value if values.include?(coerced_value)
+          if value.is_a?(::String) || value.is_a?(::Symbol)
+            candidate = value.to_s
+            match = values.find do |member|
+              (member.is_a?(::String) || member.is_a?(::Symbol)) && member.to_s.casecmp?(candidate)
+            end
+            return match unless match.nil?
+          end
 
           raise Errors::TypeError, "`#{value}` not in enum #{self}" if strict
 

--- a/seed/ruby-sdk-v2/server-sent-events-openapi/test/unit/internal/types/test_enum.rb
+++ b/seed/ruby-sdk-v2/server-sent-events-openapi/test/unit/internal/types/test_enum.rb
@@ -12,6 +12,16 @@ describe Seed::Internal::Types::Enum do
 
       finalize!
     end
+
+    module StringEnum
+      extend Seed::Internal::Types::Enum
+
+      ACTIVE = "ACTIVE"
+      CLOSED = "CLOSED"
+      GROUP_BY_PROFILE = "GROUP_BY_PROFILE"
+
+      finalize!
+    end
   end
 
   describe "#values" do
@@ -27,6 +37,19 @@ describe Seed::Internal::Types::Enum do
 
     it "coerces a string version of a member" do
       assert_equal :foo, EnumTest::ExampleEnum.coerce("foo")
+    end
+
+    it "coerces an existing string member" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce("CLOSED")
+    end
+
+    it "normalizes casing to the wire format" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce("closed")
+      assert_equal "GROUP_BY_PROFILE", EnumTest::StringEnum.coerce("group_by_profile")
+    end
+
+    it "coerces a symbol to the string member" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce(:closed)
     end
 
     it "returns the value if not a member with strictness off" do

--- a/seed/ruby-sdk-v2/server-sent-events-resumable/lib/seed/internal/types/enum.rb
+++ b/seed/ruby-sdk-v2/server-sent-events-resumable/lib/seed/internal/types/enum.rb
@@ -30,9 +30,15 @@ module Seed
         end
 
         def coerce(value, strict: strict?)
-          coerced_value = Utils.coerce(Symbol, value)
+          return value if values.include?(value)
 
-          return coerced_value if values.include?(coerced_value)
+          if value.is_a?(::String) || value.is_a?(::Symbol)
+            candidate = value.to_s
+            match = values.find do |member|
+              (member.is_a?(::String) || member.is_a?(::Symbol)) && member.to_s.casecmp?(candidate)
+            end
+            return match unless match.nil?
+          end
 
           raise Errors::TypeError, "`#{value}` not in enum #{self}" if strict
 

--- a/seed/ruby-sdk-v2/server-sent-events-resumable/test/unit/internal/types/test_enum.rb
+++ b/seed/ruby-sdk-v2/server-sent-events-resumable/test/unit/internal/types/test_enum.rb
@@ -12,6 +12,16 @@ describe Seed::Internal::Types::Enum do
 
       finalize!
     end
+
+    module StringEnum
+      extend Seed::Internal::Types::Enum
+
+      ACTIVE = "ACTIVE"
+      CLOSED = "CLOSED"
+      GROUP_BY_PROFILE = "GROUP_BY_PROFILE"
+
+      finalize!
+    end
   end
 
   describe "#values" do
@@ -27,6 +37,19 @@ describe Seed::Internal::Types::Enum do
 
     it "coerces a string version of a member" do
       assert_equal :foo, EnumTest::ExampleEnum.coerce("foo")
+    end
+
+    it "coerces an existing string member" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce("CLOSED")
+    end
+
+    it "normalizes casing to the wire format" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce("closed")
+      assert_equal "GROUP_BY_PROFILE", EnumTest::StringEnum.coerce("group_by_profile")
+    end
+
+    it "coerces a symbol to the string member" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce(:closed)
     end
 
     it "returns the value if not a member with strictness off" do

--- a/seed/ruby-sdk-v2/server-sent-events/lib/seed/internal/types/enum.rb
+++ b/seed/ruby-sdk-v2/server-sent-events/lib/seed/internal/types/enum.rb
@@ -30,9 +30,15 @@ module Seed
         end
 
         def coerce(value, strict: strict?)
-          coerced_value = Utils.coerce(Symbol, value)
+          return value if values.include?(value)
 
-          return coerced_value if values.include?(coerced_value)
+          if value.is_a?(::String) || value.is_a?(::Symbol)
+            candidate = value.to_s
+            match = values.find do |member|
+              (member.is_a?(::String) || member.is_a?(::Symbol)) && member.to_s.casecmp?(candidate)
+            end
+            return match unless match.nil?
+          end
 
           raise Errors::TypeError, "`#{value}` not in enum #{self}" if strict
 

--- a/seed/ruby-sdk-v2/server-sent-events/test/unit/internal/types/test_enum.rb
+++ b/seed/ruby-sdk-v2/server-sent-events/test/unit/internal/types/test_enum.rb
@@ -12,6 +12,16 @@ describe Seed::Internal::Types::Enum do
 
       finalize!
     end
+
+    module StringEnum
+      extend Seed::Internal::Types::Enum
+
+      ACTIVE = "ACTIVE"
+      CLOSED = "CLOSED"
+      GROUP_BY_PROFILE = "GROUP_BY_PROFILE"
+
+      finalize!
+    end
   end
 
   describe "#values" do
@@ -27,6 +37,19 @@ describe Seed::Internal::Types::Enum do
 
     it "coerces a string version of a member" do
       assert_equal :foo, EnumTest::ExampleEnum.coerce("foo")
+    end
+
+    it "coerces an existing string member" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce("CLOSED")
+    end
+
+    it "normalizes casing to the wire format" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce("closed")
+      assert_equal "GROUP_BY_PROFILE", EnumTest::StringEnum.coerce("group_by_profile")
+    end
+
+    it "coerces a symbol to the string member" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce(:closed)
     end
 
     it "returns the value if not a member with strictness off" do

--- a/seed/ruby-sdk-v2/server-url-templating-single-url/no-custom-config/lib/seed/internal/types/enum.rb
+++ b/seed/ruby-sdk-v2/server-url-templating-single-url/no-custom-config/lib/seed/internal/types/enum.rb
@@ -30,9 +30,15 @@ module Seed
         end
 
         def coerce(value, strict: strict?)
-          coerced_value = Utils.coerce(Symbol, value)
+          return value if values.include?(value)
 
-          return coerced_value if values.include?(coerced_value)
+          if value.is_a?(::String) || value.is_a?(::Symbol)
+            candidate = value.to_s
+            match = values.find do |member|
+              (member.is_a?(::String) || member.is_a?(::Symbol)) && member.to_s.casecmp?(candidate)
+            end
+            return match unless match.nil?
+          end
 
           raise Errors::TypeError, "`#{value}` not in enum #{self}" if strict
 

--- a/seed/ruby-sdk-v2/server-url-templating-single-url/no-custom-config/test/unit/internal/types/test_enum.rb
+++ b/seed/ruby-sdk-v2/server-url-templating-single-url/no-custom-config/test/unit/internal/types/test_enum.rb
@@ -12,6 +12,16 @@ describe Seed::Internal::Types::Enum do
 
       finalize!
     end
+
+    module StringEnum
+      extend Seed::Internal::Types::Enum
+
+      ACTIVE = "ACTIVE"
+      CLOSED = "CLOSED"
+      GROUP_BY_PROFILE = "GROUP_BY_PROFILE"
+
+      finalize!
+    end
   end
 
   describe "#values" do
@@ -27,6 +37,19 @@ describe Seed::Internal::Types::Enum do
 
     it "coerces a string version of a member" do
       assert_equal :foo, EnumTest::ExampleEnum.coerce("foo")
+    end
+
+    it "coerces an existing string member" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce("CLOSED")
+    end
+
+    it "normalizes casing to the wire format" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce("closed")
+      assert_equal "GROUP_BY_PROFILE", EnumTest::StringEnum.coerce("group_by_profile")
+    end
+
+    it "coerces a symbol to the string member" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce(:closed)
     end
 
     it "returns the value if not a member with strictness off" do

--- a/seed/ruby-sdk-v2/server-url-templating/no-custom-config/lib/seed/internal/types/enum.rb
+++ b/seed/ruby-sdk-v2/server-url-templating/no-custom-config/lib/seed/internal/types/enum.rb
@@ -30,9 +30,15 @@ module Seed
         end
 
         def coerce(value, strict: strict?)
-          coerced_value = Utils.coerce(Symbol, value)
+          return value if values.include?(value)
 
-          return coerced_value if values.include?(coerced_value)
+          if value.is_a?(::String) || value.is_a?(::Symbol)
+            candidate = value.to_s
+            match = values.find do |member|
+              (member.is_a?(::String) || member.is_a?(::Symbol)) && member.to_s.casecmp?(candidate)
+            end
+            return match unless match.nil?
+          end
 
           raise Errors::TypeError, "`#{value}` not in enum #{self}" if strict
 

--- a/seed/ruby-sdk-v2/server-url-templating/no-custom-config/test/unit/internal/types/test_enum.rb
+++ b/seed/ruby-sdk-v2/server-url-templating/no-custom-config/test/unit/internal/types/test_enum.rb
@@ -12,6 +12,16 @@ describe Seed::Internal::Types::Enum do
 
       finalize!
     end
+
+    module StringEnum
+      extend Seed::Internal::Types::Enum
+
+      ACTIVE = "ACTIVE"
+      CLOSED = "CLOSED"
+      GROUP_BY_PROFILE = "GROUP_BY_PROFILE"
+
+      finalize!
+    end
   end
 
   describe "#values" do
@@ -27,6 +37,19 @@ describe Seed::Internal::Types::Enum do
 
     it "coerces a string version of a member" do
       assert_equal :foo, EnumTest::ExampleEnum.coerce("foo")
+    end
+
+    it "coerces an existing string member" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce("CLOSED")
+    end
+
+    it "normalizes casing to the wire format" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce("closed")
+      assert_equal "GROUP_BY_PROFILE", EnumTest::StringEnum.coerce("group_by_profile")
+    end
+
+    it "coerces a symbol to the string member" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce(:closed)
     end
 
     it "returns the value if not a member with strictness off" do

--- a/seed/ruby-sdk-v2/simple-api/lib/seed/internal/types/enum.rb
+++ b/seed/ruby-sdk-v2/simple-api/lib/seed/internal/types/enum.rb
@@ -30,9 +30,15 @@ module Seed
         end
 
         def coerce(value, strict: strict?)
-          coerced_value = Utils.coerce(Symbol, value)
+          return value if values.include?(value)
 
-          return coerced_value if values.include?(coerced_value)
+          if value.is_a?(::String) || value.is_a?(::Symbol)
+            candidate = value.to_s
+            match = values.find do |member|
+              (member.is_a?(::String) || member.is_a?(::Symbol)) && member.to_s.casecmp?(candidate)
+            end
+            return match unless match.nil?
+          end
 
           raise Errors::TypeError, "`#{value}` not in enum #{self}" if strict
 

--- a/seed/ruby-sdk-v2/simple-api/test/unit/internal/types/test_enum.rb
+++ b/seed/ruby-sdk-v2/simple-api/test/unit/internal/types/test_enum.rb
@@ -12,6 +12,16 @@ describe Seed::Internal::Types::Enum do
 
       finalize!
     end
+
+    module StringEnum
+      extend Seed::Internal::Types::Enum
+
+      ACTIVE = "ACTIVE"
+      CLOSED = "CLOSED"
+      GROUP_BY_PROFILE = "GROUP_BY_PROFILE"
+
+      finalize!
+    end
   end
 
   describe "#values" do
@@ -27,6 +37,19 @@ describe Seed::Internal::Types::Enum do
 
     it "coerces a string version of a member" do
       assert_equal :foo, EnumTest::ExampleEnum.coerce("foo")
+    end
+
+    it "coerces an existing string member" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce("CLOSED")
+    end
+
+    it "normalizes casing to the wire format" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce("closed")
+      assert_equal "GROUP_BY_PROFILE", EnumTest::StringEnum.coerce("group_by_profile")
+    end
+
+    it "coerces a symbol to the string member" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce(:closed)
     end
 
     it "returns the value if not a member with strictness off" do

--- a/seed/ruby-sdk-v2/simple-fhir/lib/seed/internal/types/enum.rb
+++ b/seed/ruby-sdk-v2/simple-fhir/lib/seed/internal/types/enum.rb
@@ -30,9 +30,15 @@ module Seed
         end
 
         def coerce(value, strict: strict?)
-          coerced_value = Utils.coerce(Symbol, value)
+          return value if values.include?(value)
 
-          return coerced_value if values.include?(coerced_value)
+          if value.is_a?(::String) || value.is_a?(::Symbol)
+            candidate = value.to_s
+            match = values.find do |member|
+              (member.is_a?(::String) || member.is_a?(::Symbol)) && member.to_s.casecmp?(candidate)
+            end
+            return match unless match.nil?
+          end
 
           raise Errors::TypeError, "`#{value}` not in enum #{self}" if strict
 

--- a/seed/ruby-sdk-v2/simple-fhir/test/unit/internal/types/test_enum.rb
+++ b/seed/ruby-sdk-v2/simple-fhir/test/unit/internal/types/test_enum.rb
@@ -12,6 +12,16 @@ describe Seed::Internal::Types::Enum do
 
       finalize!
     end
+
+    module StringEnum
+      extend Seed::Internal::Types::Enum
+
+      ACTIVE = "ACTIVE"
+      CLOSED = "CLOSED"
+      GROUP_BY_PROFILE = "GROUP_BY_PROFILE"
+
+      finalize!
+    end
   end
 
   describe "#values" do
@@ -27,6 +37,19 @@ describe Seed::Internal::Types::Enum do
 
     it "coerces a string version of a member" do
       assert_equal :foo, EnumTest::ExampleEnum.coerce("foo")
+    end
+
+    it "coerces an existing string member" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce("CLOSED")
+    end
+
+    it "normalizes casing to the wire format" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce("closed")
+      assert_equal "GROUP_BY_PROFILE", EnumTest::StringEnum.coerce("group_by_profile")
+    end
+
+    it "coerces a symbol to the string member" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce(:closed)
     end
 
     it "returns the value if not a member with strictness off" do

--- a/seed/ruby-sdk-v2/single-url-environment-default/lib/seed/internal/types/enum.rb
+++ b/seed/ruby-sdk-v2/single-url-environment-default/lib/seed/internal/types/enum.rb
@@ -30,9 +30,15 @@ module Seed
         end
 
         def coerce(value, strict: strict?)
-          coerced_value = Utils.coerce(Symbol, value)
+          return value if values.include?(value)
 
-          return coerced_value if values.include?(coerced_value)
+          if value.is_a?(::String) || value.is_a?(::Symbol)
+            candidate = value.to_s
+            match = values.find do |member|
+              (member.is_a?(::String) || member.is_a?(::Symbol)) && member.to_s.casecmp?(candidate)
+            end
+            return match unless match.nil?
+          end
 
           raise Errors::TypeError, "`#{value}` not in enum #{self}" if strict
 

--- a/seed/ruby-sdk-v2/single-url-environment-default/test/unit/internal/types/test_enum.rb
+++ b/seed/ruby-sdk-v2/single-url-environment-default/test/unit/internal/types/test_enum.rb
@@ -12,6 +12,16 @@ describe Seed::Internal::Types::Enum do
 
       finalize!
     end
+
+    module StringEnum
+      extend Seed::Internal::Types::Enum
+
+      ACTIVE = "ACTIVE"
+      CLOSED = "CLOSED"
+      GROUP_BY_PROFILE = "GROUP_BY_PROFILE"
+
+      finalize!
+    end
   end
 
   describe "#values" do
@@ -27,6 +37,19 @@ describe Seed::Internal::Types::Enum do
 
     it "coerces a string version of a member" do
       assert_equal :foo, EnumTest::ExampleEnum.coerce("foo")
+    end
+
+    it "coerces an existing string member" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce("CLOSED")
+    end
+
+    it "normalizes casing to the wire format" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce("closed")
+      assert_equal "GROUP_BY_PROFILE", EnumTest::StringEnum.coerce("group_by_profile")
+    end
+
+    it "coerces a symbol to the string member" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce(:closed)
     end
 
     it "returns the value if not a member with strictness off" do

--- a/seed/ruby-sdk-v2/single-url-environment-no-default/lib/seed/internal/types/enum.rb
+++ b/seed/ruby-sdk-v2/single-url-environment-no-default/lib/seed/internal/types/enum.rb
@@ -30,9 +30,15 @@ module Seed
         end
 
         def coerce(value, strict: strict?)
-          coerced_value = Utils.coerce(Symbol, value)
+          return value if values.include?(value)
 
-          return coerced_value if values.include?(coerced_value)
+          if value.is_a?(::String) || value.is_a?(::Symbol)
+            candidate = value.to_s
+            match = values.find do |member|
+              (member.is_a?(::String) || member.is_a?(::Symbol)) && member.to_s.casecmp?(candidate)
+            end
+            return match unless match.nil?
+          end
 
           raise Errors::TypeError, "`#{value}` not in enum #{self}" if strict
 

--- a/seed/ruby-sdk-v2/single-url-environment-no-default/test/unit/internal/types/test_enum.rb
+++ b/seed/ruby-sdk-v2/single-url-environment-no-default/test/unit/internal/types/test_enum.rb
@@ -12,6 +12,16 @@ describe Seed::Internal::Types::Enum do
 
       finalize!
     end
+
+    module StringEnum
+      extend Seed::Internal::Types::Enum
+
+      ACTIVE = "ACTIVE"
+      CLOSED = "CLOSED"
+      GROUP_BY_PROFILE = "GROUP_BY_PROFILE"
+
+      finalize!
+    end
   end
 
   describe "#values" do
@@ -27,6 +37,19 @@ describe Seed::Internal::Types::Enum do
 
     it "coerces a string version of a member" do
       assert_equal :foo, EnumTest::ExampleEnum.coerce("foo")
+    end
+
+    it "coerces an existing string member" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce("CLOSED")
+    end
+
+    it "normalizes casing to the wire format" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce("closed")
+      assert_equal "GROUP_BY_PROFILE", EnumTest::StringEnum.coerce("group_by_profile")
+    end
+
+    it "coerces a symbol to the string member" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce(:closed)
     end
 
     it "returns the value if not a member with strictness off" do

--- a/seed/ruby-sdk-v2/streaming-parameter/lib/seed/internal/types/enum.rb
+++ b/seed/ruby-sdk-v2/streaming-parameter/lib/seed/internal/types/enum.rb
@@ -30,9 +30,15 @@ module Seed
         end
 
         def coerce(value, strict: strict?)
-          coerced_value = Utils.coerce(Symbol, value)
+          return value if values.include?(value)
 
-          return coerced_value if values.include?(coerced_value)
+          if value.is_a?(::String) || value.is_a?(::Symbol)
+            candidate = value.to_s
+            match = values.find do |member|
+              (member.is_a?(::String) || member.is_a?(::Symbol)) && member.to_s.casecmp?(candidate)
+            end
+            return match unless match.nil?
+          end
 
           raise Errors::TypeError, "`#{value}` not in enum #{self}" if strict
 

--- a/seed/ruby-sdk-v2/streaming-parameter/test/unit/internal/types/test_enum.rb
+++ b/seed/ruby-sdk-v2/streaming-parameter/test/unit/internal/types/test_enum.rb
@@ -12,6 +12,16 @@ describe Seed::Internal::Types::Enum do
 
       finalize!
     end
+
+    module StringEnum
+      extend Seed::Internal::Types::Enum
+
+      ACTIVE = "ACTIVE"
+      CLOSED = "CLOSED"
+      GROUP_BY_PROFILE = "GROUP_BY_PROFILE"
+
+      finalize!
+    end
   end
 
   describe "#values" do
@@ -27,6 +37,19 @@ describe Seed::Internal::Types::Enum do
 
     it "coerces a string version of a member" do
       assert_equal :foo, EnumTest::ExampleEnum.coerce("foo")
+    end
+
+    it "coerces an existing string member" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce("CLOSED")
+    end
+
+    it "normalizes casing to the wire format" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce("closed")
+      assert_equal "GROUP_BY_PROFILE", EnumTest::StringEnum.coerce("group_by_profile")
+    end
+
+    it "coerces a symbol to the string member" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce(:closed)
     end
 
     it "returns the value if not a member with strictness off" do

--- a/seed/ruby-sdk-v2/streaming/lib/seed/internal/types/enum.rb
+++ b/seed/ruby-sdk-v2/streaming/lib/seed/internal/types/enum.rb
@@ -30,9 +30,15 @@ module Seed
         end
 
         def coerce(value, strict: strict?)
-          coerced_value = Utils.coerce(Symbol, value)
+          return value if values.include?(value)
 
-          return coerced_value if values.include?(coerced_value)
+          if value.is_a?(::String) || value.is_a?(::Symbol)
+            candidate = value.to_s
+            match = values.find do |member|
+              (member.is_a?(::String) || member.is_a?(::Symbol)) && member.to_s.casecmp?(candidate)
+            end
+            return match unless match.nil?
+          end
 
           raise Errors::TypeError, "`#{value}` not in enum #{self}" if strict
 

--- a/seed/ruby-sdk-v2/streaming/test/unit/internal/types/test_enum.rb
+++ b/seed/ruby-sdk-v2/streaming/test/unit/internal/types/test_enum.rb
@@ -12,6 +12,16 @@ describe Seed::Internal::Types::Enum do
 
       finalize!
     end
+
+    module StringEnum
+      extend Seed::Internal::Types::Enum
+
+      ACTIVE = "ACTIVE"
+      CLOSED = "CLOSED"
+      GROUP_BY_PROFILE = "GROUP_BY_PROFILE"
+
+      finalize!
+    end
   end
 
   describe "#values" do
@@ -27,6 +37,19 @@ describe Seed::Internal::Types::Enum do
 
     it "coerces a string version of a member" do
       assert_equal :foo, EnumTest::ExampleEnum.coerce("foo")
+    end
+
+    it "coerces an existing string member" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce("CLOSED")
+    end
+
+    it "normalizes casing to the wire format" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce("closed")
+      assert_equal "GROUP_BY_PROFILE", EnumTest::StringEnum.coerce("group_by_profile")
+    end
+
+    it "coerces a symbol to the string member" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce(:closed)
     end
 
     it "returns the value if not a member with strictness off" do

--- a/seed/ruby-sdk-v2/trace/lib/seed/internal/types/enum.rb
+++ b/seed/ruby-sdk-v2/trace/lib/seed/internal/types/enum.rb
@@ -30,9 +30,15 @@ module Seed
         end
 
         def coerce(value, strict: strict?)
-          coerced_value = Utils.coerce(Symbol, value)
+          return value if values.include?(value)
 
-          return coerced_value if values.include?(coerced_value)
+          if value.is_a?(::String) || value.is_a?(::Symbol)
+            candidate = value.to_s
+            match = values.find do |member|
+              (member.is_a?(::String) || member.is_a?(::Symbol)) && member.to_s.casecmp?(candidate)
+            end
+            return match unless match.nil?
+          end
 
           raise Errors::TypeError, "`#{value}` not in enum #{self}" if strict
 

--- a/seed/ruby-sdk-v2/trace/test/unit/internal/types/test_enum.rb
+++ b/seed/ruby-sdk-v2/trace/test/unit/internal/types/test_enum.rb
@@ -12,6 +12,16 @@ describe Seed::Internal::Types::Enum do
 
       finalize!
     end
+
+    module StringEnum
+      extend Seed::Internal::Types::Enum
+
+      ACTIVE = "ACTIVE"
+      CLOSED = "CLOSED"
+      GROUP_BY_PROFILE = "GROUP_BY_PROFILE"
+
+      finalize!
+    end
   end
 
   describe "#values" do
@@ -27,6 +37,19 @@ describe Seed::Internal::Types::Enum do
 
     it "coerces a string version of a member" do
       assert_equal :foo, EnumTest::ExampleEnum.coerce("foo")
+    end
+
+    it "coerces an existing string member" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce("CLOSED")
+    end
+
+    it "normalizes casing to the wire format" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce("closed")
+      assert_equal "GROUP_BY_PROFILE", EnumTest::StringEnum.coerce("group_by_profile")
+    end
+
+    it "coerces a symbol to the string member" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce(:closed)
     end
 
     it "returns the value if not a member with strictness off" do

--- a/seed/ruby-sdk-v2/undiscriminated-union-with-response-property/lib/seed/internal/types/enum.rb
+++ b/seed/ruby-sdk-v2/undiscriminated-union-with-response-property/lib/seed/internal/types/enum.rb
@@ -30,9 +30,15 @@ module Seed
         end
 
         def coerce(value, strict: strict?)
-          coerced_value = Utils.coerce(Symbol, value)
+          return value if values.include?(value)
 
-          return coerced_value if values.include?(coerced_value)
+          if value.is_a?(::String) || value.is_a?(::Symbol)
+            candidate = value.to_s
+            match = values.find do |member|
+              (member.is_a?(::String) || member.is_a?(::Symbol)) && member.to_s.casecmp?(candidate)
+            end
+            return match unless match.nil?
+          end
 
           raise Errors::TypeError, "`#{value}` not in enum #{self}" if strict
 

--- a/seed/ruby-sdk-v2/undiscriminated-union-with-response-property/test/unit/internal/types/test_enum.rb
+++ b/seed/ruby-sdk-v2/undiscriminated-union-with-response-property/test/unit/internal/types/test_enum.rb
@@ -12,6 +12,16 @@ describe Seed::Internal::Types::Enum do
 
       finalize!
     end
+
+    module StringEnum
+      extend Seed::Internal::Types::Enum
+
+      ACTIVE = "ACTIVE"
+      CLOSED = "CLOSED"
+      GROUP_BY_PROFILE = "GROUP_BY_PROFILE"
+
+      finalize!
+    end
   end
 
   describe "#values" do
@@ -27,6 +37,19 @@ describe Seed::Internal::Types::Enum do
 
     it "coerces a string version of a member" do
       assert_equal :foo, EnumTest::ExampleEnum.coerce("foo")
+    end
+
+    it "coerces an existing string member" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce("CLOSED")
+    end
+
+    it "normalizes casing to the wire format" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce("closed")
+      assert_equal "GROUP_BY_PROFILE", EnumTest::StringEnum.coerce("group_by_profile")
+    end
+
+    it "coerces a symbol to the string member" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce(:closed)
     end
 
     it "returns the value if not a member with strictness off" do

--- a/seed/ruby-sdk-v2/undiscriminated-unions/lib/seed/internal/types/enum.rb
+++ b/seed/ruby-sdk-v2/undiscriminated-unions/lib/seed/internal/types/enum.rb
@@ -30,9 +30,15 @@ module Seed
         end
 
         def coerce(value, strict: strict?)
-          coerced_value = Utils.coerce(Symbol, value)
+          return value if values.include?(value)
 
-          return coerced_value if values.include?(coerced_value)
+          if value.is_a?(::String) || value.is_a?(::Symbol)
+            candidate = value.to_s
+            match = values.find do |member|
+              (member.is_a?(::String) || member.is_a?(::Symbol)) && member.to_s.casecmp?(candidate)
+            end
+            return match unless match.nil?
+          end
 
           raise Errors::TypeError, "`#{value}` not in enum #{self}" if strict
 

--- a/seed/ruby-sdk-v2/undiscriminated-unions/test/unit/internal/types/test_enum.rb
+++ b/seed/ruby-sdk-v2/undiscriminated-unions/test/unit/internal/types/test_enum.rb
@@ -12,6 +12,16 @@ describe Seed::Internal::Types::Enum do
 
       finalize!
     end
+
+    module StringEnum
+      extend Seed::Internal::Types::Enum
+
+      ACTIVE = "ACTIVE"
+      CLOSED = "CLOSED"
+      GROUP_BY_PROFILE = "GROUP_BY_PROFILE"
+
+      finalize!
+    end
   end
 
   describe "#values" do
@@ -27,6 +37,19 @@ describe Seed::Internal::Types::Enum do
 
     it "coerces a string version of a member" do
       assert_equal :foo, EnumTest::ExampleEnum.coerce("foo")
+    end
+
+    it "coerces an existing string member" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce("CLOSED")
+    end
+
+    it "normalizes casing to the wire format" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce("closed")
+      assert_equal "GROUP_BY_PROFILE", EnumTest::StringEnum.coerce("group_by_profile")
+    end
+
+    it "coerces a symbol to the string member" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce(:closed)
     end
 
     it "returns the value if not a member with strictness off" do

--- a/seed/ruby-sdk-v2/union-query-parameters/lib/seed/internal/types/enum.rb
+++ b/seed/ruby-sdk-v2/union-query-parameters/lib/seed/internal/types/enum.rb
@@ -30,9 +30,15 @@ module Seed
         end
 
         def coerce(value, strict: strict?)
-          coerced_value = Utils.coerce(Symbol, value)
+          return value if values.include?(value)
 
-          return coerced_value if values.include?(coerced_value)
+          if value.is_a?(::String) || value.is_a?(::Symbol)
+            candidate = value.to_s
+            match = values.find do |member|
+              (member.is_a?(::String) || member.is_a?(::Symbol)) && member.to_s.casecmp?(candidate)
+            end
+            return match unless match.nil?
+          end
 
           raise Errors::TypeError, "`#{value}` not in enum #{self}" if strict
 

--- a/seed/ruby-sdk-v2/union-query-parameters/test/unit/internal/types/test_enum.rb
+++ b/seed/ruby-sdk-v2/union-query-parameters/test/unit/internal/types/test_enum.rb
@@ -12,6 +12,16 @@ describe Seed::Internal::Types::Enum do
 
       finalize!
     end
+
+    module StringEnum
+      extend Seed::Internal::Types::Enum
+
+      ACTIVE = "ACTIVE"
+      CLOSED = "CLOSED"
+      GROUP_BY_PROFILE = "GROUP_BY_PROFILE"
+
+      finalize!
+    end
   end
 
   describe "#values" do
@@ -27,6 +37,19 @@ describe Seed::Internal::Types::Enum do
 
     it "coerces a string version of a member" do
       assert_equal :foo, EnumTest::ExampleEnum.coerce("foo")
+    end
+
+    it "coerces an existing string member" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce("CLOSED")
+    end
+
+    it "normalizes casing to the wire format" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce("closed")
+      assert_equal "GROUP_BY_PROFILE", EnumTest::StringEnum.coerce("group_by_profile")
+    end
+
+    it "coerces a symbol to the string member" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce(:closed)
     end
 
     it "returns the value if not a member with strictness off" do

--- a/seed/ruby-sdk-v2/unions-with-local-date/lib/seed/internal/types/enum.rb
+++ b/seed/ruby-sdk-v2/unions-with-local-date/lib/seed/internal/types/enum.rb
@@ -30,9 +30,15 @@ module Seed
         end
 
         def coerce(value, strict: strict?)
-          coerced_value = Utils.coerce(Symbol, value)
+          return value if values.include?(value)
 
-          return coerced_value if values.include?(coerced_value)
+          if value.is_a?(::String) || value.is_a?(::Symbol)
+            candidate = value.to_s
+            match = values.find do |member|
+              (member.is_a?(::String) || member.is_a?(::Symbol)) && member.to_s.casecmp?(candidate)
+            end
+            return match unless match.nil?
+          end
 
           raise Errors::TypeError, "`#{value}` not in enum #{self}" if strict
 

--- a/seed/ruby-sdk-v2/unions-with-local-date/test/unit/internal/types/test_enum.rb
+++ b/seed/ruby-sdk-v2/unions-with-local-date/test/unit/internal/types/test_enum.rb
@@ -12,6 +12,16 @@ describe Seed::Internal::Types::Enum do
 
       finalize!
     end
+
+    module StringEnum
+      extend Seed::Internal::Types::Enum
+
+      ACTIVE = "ACTIVE"
+      CLOSED = "CLOSED"
+      GROUP_BY_PROFILE = "GROUP_BY_PROFILE"
+
+      finalize!
+    end
   end
 
   describe "#values" do
@@ -27,6 +37,19 @@ describe Seed::Internal::Types::Enum do
 
     it "coerces a string version of a member" do
       assert_equal :foo, EnumTest::ExampleEnum.coerce("foo")
+    end
+
+    it "coerces an existing string member" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce("CLOSED")
+    end
+
+    it "normalizes casing to the wire format" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce("closed")
+      assert_equal "GROUP_BY_PROFILE", EnumTest::StringEnum.coerce("group_by_profile")
+    end
+
+    it "coerces a symbol to the string member" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce(:closed)
     end
 
     it "returns the value if not a member with strictness off" do

--- a/seed/ruby-sdk-v2/unions/lib/seed/internal/types/enum.rb
+++ b/seed/ruby-sdk-v2/unions/lib/seed/internal/types/enum.rb
@@ -30,9 +30,15 @@ module Seed
         end
 
         def coerce(value, strict: strict?)
-          coerced_value = Utils.coerce(Symbol, value)
+          return value if values.include?(value)
 
-          return coerced_value if values.include?(coerced_value)
+          if value.is_a?(::String) || value.is_a?(::Symbol)
+            candidate = value.to_s
+            match = values.find do |member|
+              (member.is_a?(::String) || member.is_a?(::Symbol)) && member.to_s.casecmp?(candidate)
+            end
+            return match unless match.nil?
+          end
 
           raise Errors::TypeError, "`#{value}` not in enum #{self}" if strict
 

--- a/seed/ruby-sdk-v2/unions/test/unit/internal/types/test_enum.rb
+++ b/seed/ruby-sdk-v2/unions/test/unit/internal/types/test_enum.rb
@@ -12,6 +12,16 @@ describe Seed::Internal::Types::Enum do
 
       finalize!
     end
+
+    module StringEnum
+      extend Seed::Internal::Types::Enum
+
+      ACTIVE = "ACTIVE"
+      CLOSED = "CLOSED"
+      GROUP_BY_PROFILE = "GROUP_BY_PROFILE"
+
+      finalize!
+    end
   end
 
   describe "#values" do
@@ -27,6 +37,19 @@ describe Seed::Internal::Types::Enum do
 
     it "coerces a string version of a member" do
       assert_equal :foo, EnumTest::ExampleEnum.coerce("foo")
+    end
+
+    it "coerces an existing string member" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce("CLOSED")
+    end
+
+    it "normalizes casing to the wire format" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce("closed")
+      assert_equal "GROUP_BY_PROFILE", EnumTest::StringEnum.coerce("group_by_profile")
+    end
+
+    it "coerces a symbol to the string member" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce(:closed)
     end
 
     it "returns the value if not a member with strictness off" do

--- a/seed/ruby-sdk-v2/unknown/lib/seed/internal/types/enum.rb
+++ b/seed/ruby-sdk-v2/unknown/lib/seed/internal/types/enum.rb
@@ -30,9 +30,15 @@ module Seed
         end
 
         def coerce(value, strict: strict?)
-          coerced_value = Utils.coerce(Symbol, value)
+          return value if values.include?(value)
 
-          return coerced_value if values.include?(coerced_value)
+          if value.is_a?(::String) || value.is_a?(::Symbol)
+            candidate = value.to_s
+            match = values.find do |member|
+              (member.is_a?(::String) || member.is_a?(::Symbol)) && member.to_s.casecmp?(candidate)
+            end
+            return match unless match.nil?
+          end
 
           raise Errors::TypeError, "`#{value}` not in enum #{self}" if strict
 

--- a/seed/ruby-sdk-v2/unknown/test/unit/internal/types/test_enum.rb
+++ b/seed/ruby-sdk-v2/unknown/test/unit/internal/types/test_enum.rb
@@ -12,6 +12,16 @@ describe Seed::Internal::Types::Enum do
 
       finalize!
     end
+
+    module StringEnum
+      extend Seed::Internal::Types::Enum
+
+      ACTIVE = "ACTIVE"
+      CLOSED = "CLOSED"
+      GROUP_BY_PROFILE = "GROUP_BY_PROFILE"
+
+      finalize!
+    end
   end
 
   describe "#values" do
@@ -27,6 +37,19 @@ describe Seed::Internal::Types::Enum do
 
     it "coerces a string version of a member" do
       assert_equal :foo, EnumTest::ExampleEnum.coerce("foo")
+    end
+
+    it "coerces an existing string member" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce("CLOSED")
+    end
+
+    it "normalizes casing to the wire format" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce("closed")
+      assert_equal "GROUP_BY_PROFILE", EnumTest::StringEnum.coerce("group_by_profile")
+    end
+
+    it "coerces a symbol to the string member" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce(:closed)
     end
 
     it "returns the value if not a member with strictness off" do

--- a/seed/ruby-sdk-v2/url-form-encoded/lib/seed/internal/types/enum.rb
+++ b/seed/ruby-sdk-v2/url-form-encoded/lib/seed/internal/types/enum.rb
@@ -30,9 +30,15 @@ module Seed
         end
 
         def coerce(value, strict: strict?)
-          coerced_value = Utils.coerce(Symbol, value)
+          return value if values.include?(value)
 
-          return coerced_value if values.include?(coerced_value)
+          if value.is_a?(::String) || value.is_a?(::Symbol)
+            candidate = value.to_s
+            match = values.find do |member|
+              (member.is_a?(::String) || member.is_a?(::Symbol)) && member.to_s.casecmp?(candidate)
+            end
+            return match unless match.nil?
+          end
 
           raise Errors::TypeError, "`#{value}` not in enum #{self}" if strict
 

--- a/seed/ruby-sdk-v2/url-form-encoded/test/unit/internal/types/test_enum.rb
+++ b/seed/ruby-sdk-v2/url-form-encoded/test/unit/internal/types/test_enum.rb
@@ -12,6 +12,16 @@ describe Seed::Internal::Types::Enum do
 
       finalize!
     end
+
+    module StringEnum
+      extend Seed::Internal::Types::Enum
+
+      ACTIVE = "ACTIVE"
+      CLOSED = "CLOSED"
+      GROUP_BY_PROFILE = "GROUP_BY_PROFILE"
+
+      finalize!
+    end
   end
 
   describe "#values" do
@@ -27,6 +37,19 @@ describe Seed::Internal::Types::Enum do
 
     it "coerces a string version of a member" do
       assert_equal :foo, EnumTest::ExampleEnum.coerce("foo")
+    end
+
+    it "coerces an existing string member" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce("CLOSED")
+    end
+
+    it "normalizes casing to the wire format" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce("closed")
+      assert_equal "GROUP_BY_PROFILE", EnumTest::StringEnum.coerce("group_by_profile")
+    end
+
+    it "coerces a symbol to the string member" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce(:closed)
     end
 
     it "returns the value if not a member with strictness off" do

--- a/seed/ruby-sdk-v2/validation/lib/seed/internal/types/enum.rb
+++ b/seed/ruby-sdk-v2/validation/lib/seed/internal/types/enum.rb
@@ -30,9 +30,15 @@ module Seed
         end
 
         def coerce(value, strict: strict?)
-          coerced_value = Utils.coerce(Symbol, value)
+          return value if values.include?(value)
 
-          return coerced_value if values.include?(coerced_value)
+          if value.is_a?(::String) || value.is_a?(::Symbol)
+            candidate = value.to_s
+            match = values.find do |member|
+              (member.is_a?(::String) || member.is_a?(::Symbol)) && member.to_s.casecmp?(candidate)
+            end
+            return match unless match.nil?
+          end
 
           raise Errors::TypeError, "`#{value}` not in enum #{self}" if strict
 

--- a/seed/ruby-sdk-v2/validation/test/unit/internal/types/test_enum.rb
+++ b/seed/ruby-sdk-v2/validation/test/unit/internal/types/test_enum.rb
@@ -12,6 +12,16 @@ describe Seed::Internal::Types::Enum do
 
       finalize!
     end
+
+    module StringEnum
+      extend Seed::Internal::Types::Enum
+
+      ACTIVE = "ACTIVE"
+      CLOSED = "CLOSED"
+      GROUP_BY_PROFILE = "GROUP_BY_PROFILE"
+
+      finalize!
+    end
   end
 
   describe "#values" do
@@ -27,6 +37,19 @@ describe Seed::Internal::Types::Enum do
 
     it "coerces a string version of a member" do
       assert_equal :foo, EnumTest::ExampleEnum.coerce("foo")
+    end
+
+    it "coerces an existing string member" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce("CLOSED")
+    end
+
+    it "normalizes casing to the wire format" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce("closed")
+      assert_equal "GROUP_BY_PROFILE", EnumTest::StringEnum.coerce("group_by_profile")
+    end
+
+    it "coerces a symbol to the string member" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce(:closed)
     end
 
     it "returns the value if not a member with strictness off" do

--- a/seed/ruby-sdk-v2/variables/lib/seed/internal/types/enum.rb
+++ b/seed/ruby-sdk-v2/variables/lib/seed/internal/types/enum.rb
@@ -30,9 +30,15 @@ module Seed
         end
 
         def coerce(value, strict: strict?)
-          coerced_value = Utils.coerce(Symbol, value)
+          return value if values.include?(value)
 
-          return coerced_value if values.include?(coerced_value)
+          if value.is_a?(::String) || value.is_a?(::Symbol)
+            candidate = value.to_s
+            match = values.find do |member|
+              (member.is_a?(::String) || member.is_a?(::Symbol)) && member.to_s.casecmp?(candidate)
+            end
+            return match unless match.nil?
+          end
 
           raise Errors::TypeError, "`#{value}` not in enum #{self}" if strict
 

--- a/seed/ruby-sdk-v2/variables/test/unit/internal/types/test_enum.rb
+++ b/seed/ruby-sdk-v2/variables/test/unit/internal/types/test_enum.rb
@@ -12,6 +12,16 @@ describe Seed::Internal::Types::Enum do
 
       finalize!
     end
+
+    module StringEnum
+      extend Seed::Internal::Types::Enum
+
+      ACTIVE = "ACTIVE"
+      CLOSED = "CLOSED"
+      GROUP_BY_PROFILE = "GROUP_BY_PROFILE"
+
+      finalize!
+    end
   end
 
   describe "#values" do
@@ -27,6 +37,19 @@ describe Seed::Internal::Types::Enum do
 
     it "coerces a string version of a member" do
       assert_equal :foo, EnumTest::ExampleEnum.coerce("foo")
+    end
+
+    it "coerces an existing string member" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce("CLOSED")
+    end
+
+    it "normalizes casing to the wire format" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce("closed")
+      assert_equal "GROUP_BY_PROFILE", EnumTest::StringEnum.coerce("group_by_profile")
+    end
+
+    it "coerces a symbol to the string member" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce(:closed)
     end
 
     it "returns the value if not a member with strictness off" do

--- a/seed/ruby-sdk-v2/version-no-default/lib/seed/internal/types/enum.rb
+++ b/seed/ruby-sdk-v2/version-no-default/lib/seed/internal/types/enum.rb
@@ -30,9 +30,15 @@ module Seed
         end
 
         def coerce(value, strict: strict?)
-          coerced_value = Utils.coerce(Symbol, value)
+          return value if values.include?(value)
 
-          return coerced_value if values.include?(coerced_value)
+          if value.is_a?(::String) || value.is_a?(::Symbol)
+            candidate = value.to_s
+            match = values.find do |member|
+              (member.is_a?(::String) || member.is_a?(::Symbol)) && member.to_s.casecmp?(candidate)
+            end
+            return match unless match.nil?
+          end
 
           raise Errors::TypeError, "`#{value}` not in enum #{self}" if strict
 

--- a/seed/ruby-sdk-v2/version-no-default/test/unit/internal/types/test_enum.rb
+++ b/seed/ruby-sdk-v2/version-no-default/test/unit/internal/types/test_enum.rb
@@ -12,6 +12,16 @@ describe Seed::Internal::Types::Enum do
 
       finalize!
     end
+
+    module StringEnum
+      extend Seed::Internal::Types::Enum
+
+      ACTIVE = "ACTIVE"
+      CLOSED = "CLOSED"
+      GROUP_BY_PROFILE = "GROUP_BY_PROFILE"
+
+      finalize!
+    end
   end
 
   describe "#values" do
@@ -27,6 +37,19 @@ describe Seed::Internal::Types::Enum do
 
     it "coerces a string version of a member" do
       assert_equal :foo, EnumTest::ExampleEnum.coerce("foo")
+    end
+
+    it "coerces an existing string member" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce("CLOSED")
+    end
+
+    it "normalizes casing to the wire format" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce("closed")
+      assert_equal "GROUP_BY_PROFILE", EnumTest::StringEnum.coerce("group_by_profile")
+    end
+
+    it "coerces a symbol to the string member" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce(:closed)
     end
 
     it "returns the value if not a member with strictness off" do

--- a/seed/ruby-sdk-v2/version/lib/seed/internal/types/enum.rb
+++ b/seed/ruby-sdk-v2/version/lib/seed/internal/types/enum.rb
@@ -30,9 +30,15 @@ module Seed
         end
 
         def coerce(value, strict: strict?)
-          coerced_value = Utils.coerce(Symbol, value)
+          return value if values.include?(value)
 
-          return coerced_value if values.include?(coerced_value)
+          if value.is_a?(::String) || value.is_a?(::Symbol)
+            candidate = value.to_s
+            match = values.find do |member|
+              (member.is_a?(::String) || member.is_a?(::Symbol)) && member.to_s.casecmp?(candidate)
+            end
+            return match unless match.nil?
+          end
 
           raise Errors::TypeError, "`#{value}` not in enum #{self}" if strict
 

--- a/seed/ruby-sdk-v2/version/test/unit/internal/types/test_enum.rb
+++ b/seed/ruby-sdk-v2/version/test/unit/internal/types/test_enum.rb
@@ -12,6 +12,16 @@ describe Seed::Internal::Types::Enum do
 
       finalize!
     end
+
+    module StringEnum
+      extend Seed::Internal::Types::Enum
+
+      ACTIVE = "ACTIVE"
+      CLOSED = "CLOSED"
+      GROUP_BY_PROFILE = "GROUP_BY_PROFILE"
+
+      finalize!
+    end
   end
 
   describe "#values" do
@@ -27,6 +37,19 @@ describe Seed::Internal::Types::Enum do
 
     it "coerces a string version of a member" do
       assert_equal :foo, EnumTest::ExampleEnum.coerce("foo")
+    end
+
+    it "coerces an existing string member" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce("CLOSED")
+    end
+
+    it "normalizes casing to the wire format" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce("closed")
+      assert_equal "GROUP_BY_PROFILE", EnumTest::StringEnum.coerce("group_by_profile")
+    end
+
+    it "coerces a symbol to the string member" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce(:closed)
     end
 
     it "returns the value if not a member with strictness off" do

--- a/seed/ruby-sdk-v2/webhook-audience/lib/seed/internal/types/enum.rb
+++ b/seed/ruby-sdk-v2/webhook-audience/lib/seed/internal/types/enum.rb
@@ -30,9 +30,15 @@ module Seed
         end
 
         def coerce(value, strict: strict?)
-          coerced_value = Utils.coerce(Symbol, value)
+          return value if values.include?(value)
 
-          return coerced_value if values.include?(coerced_value)
+          if value.is_a?(::String) || value.is_a?(::Symbol)
+            candidate = value.to_s
+            match = values.find do |member|
+              (member.is_a?(::String) || member.is_a?(::Symbol)) && member.to_s.casecmp?(candidate)
+            end
+            return match unless match.nil?
+          end
 
           raise Errors::TypeError, "`#{value}` not in enum #{self}" if strict
 

--- a/seed/ruby-sdk-v2/webhook-audience/test/unit/internal/types/test_enum.rb
+++ b/seed/ruby-sdk-v2/webhook-audience/test/unit/internal/types/test_enum.rb
@@ -12,6 +12,16 @@ describe Seed::Internal::Types::Enum do
 
       finalize!
     end
+
+    module StringEnum
+      extend Seed::Internal::Types::Enum
+
+      ACTIVE = "ACTIVE"
+      CLOSED = "CLOSED"
+      GROUP_BY_PROFILE = "GROUP_BY_PROFILE"
+
+      finalize!
+    end
   end
 
   describe "#values" do
@@ -27,6 +37,19 @@ describe Seed::Internal::Types::Enum do
 
     it "coerces a string version of a member" do
       assert_equal :foo, EnumTest::ExampleEnum.coerce("foo")
+    end
+
+    it "coerces an existing string member" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce("CLOSED")
+    end
+
+    it "normalizes casing to the wire format" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce("closed")
+      assert_equal "GROUP_BY_PROFILE", EnumTest::StringEnum.coerce("group_by_profile")
+    end
+
+    it "coerces a symbol to the string member" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce(:closed)
     end
 
     it "returns the value if not a member with strictness off" do

--- a/seed/ruby-sdk-v2/webhooks/lib/seed/internal/types/enum.rb
+++ b/seed/ruby-sdk-v2/webhooks/lib/seed/internal/types/enum.rb
@@ -30,9 +30,15 @@ module Seed
         end
 
         def coerce(value, strict: strict?)
-          coerced_value = Utils.coerce(Symbol, value)
+          return value if values.include?(value)
 
-          return coerced_value if values.include?(coerced_value)
+          if value.is_a?(::String) || value.is_a?(::Symbol)
+            candidate = value.to_s
+            match = values.find do |member|
+              (member.is_a?(::String) || member.is_a?(::Symbol)) && member.to_s.casecmp?(candidate)
+            end
+            return match unless match.nil?
+          end
 
           raise Errors::TypeError, "`#{value}` not in enum #{self}" if strict
 

--- a/seed/ruby-sdk-v2/webhooks/test/unit/internal/types/test_enum.rb
+++ b/seed/ruby-sdk-v2/webhooks/test/unit/internal/types/test_enum.rb
@@ -12,6 +12,16 @@ describe Seed::Internal::Types::Enum do
 
       finalize!
     end
+
+    module StringEnum
+      extend Seed::Internal::Types::Enum
+
+      ACTIVE = "ACTIVE"
+      CLOSED = "CLOSED"
+      GROUP_BY_PROFILE = "GROUP_BY_PROFILE"
+
+      finalize!
+    end
   end
 
   describe "#values" do
@@ -27,6 +37,19 @@ describe Seed::Internal::Types::Enum do
 
     it "coerces a string version of a member" do
       assert_equal :foo, EnumTest::ExampleEnum.coerce("foo")
+    end
+
+    it "coerces an existing string member" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce("CLOSED")
+    end
+
+    it "normalizes casing to the wire format" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce("closed")
+      assert_equal "GROUP_BY_PROFILE", EnumTest::StringEnum.coerce("group_by_profile")
+    end
+
+    it "coerces a symbol to the string member" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce(:closed)
     end
 
     it "returns the value if not a member with strictness off" do

--- a/seed/ruby-sdk-v2/websocket-bearer-auth/lib/seed/internal/types/enum.rb
+++ b/seed/ruby-sdk-v2/websocket-bearer-auth/lib/seed/internal/types/enum.rb
@@ -30,9 +30,15 @@ module Seed
         end
 
         def coerce(value, strict: strict?)
-          coerced_value = Utils.coerce(Symbol, value)
+          return value if values.include?(value)
 
-          return coerced_value if values.include?(coerced_value)
+          if value.is_a?(::String) || value.is_a?(::Symbol)
+            candidate = value.to_s
+            match = values.find do |member|
+              (member.is_a?(::String) || member.is_a?(::Symbol)) && member.to_s.casecmp?(candidate)
+            end
+            return match unless match.nil?
+          end
 
           raise Errors::TypeError, "`#{value}` not in enum #{self}" if strict
 

--- a/seed/ruby-sdk-v2/websocket-bearer-auth/test/unit/internal/types/test_enum.rb
+++ b/seed/ruby-sdk-v2/websocket-bearer-auth/test/unit/internal/types/test_enum.rb
@@ -12,6 +12,16 @@ describe Seed::Internal::Types::Enum do
 
       finalize!
     end
+
+    module StringEnum
+      extend Seed::Internal::Types::Enum
+
+      ACTIVE = "ACTIVE"
+      CLOSED = "CLOSED"
+      GROUP_BY_PROFILE = "GROUP_BY_PROFILE"
+
+      finalize!
+    end
   end
 
   describe "#values" do
@@ -27,6 +37,19 @@ describe Seed::Internal::Types::Enum do
 
     it "coerces a string version of a member" do
       assert_equal :foo, EnumTest::ExampleEnum.coerce("foo")
+    end
+
+    it "coerces an existing string member" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce("CLOSED")
+    end
+
+    it "normalizes casing to the wire format" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce("closed")
+      assert_equal "GROUP_BY_PROFILE", EnumTest::StringEnum.coerce("group_by_profile")
+    end
+
+    it "coerces a symbol to the string member" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce(:closed)
     end
 
     it "returns the value if not a member with strictness off" do

--- a/seed/ruby-sdk-v2/websocket-inferred-auth/lib/seed/internal/types/enum.rb
+++ b/seed/ruby-sdk-v2/websocket-inferred-auth/lib/seed/internal/types/enum.rb
@@ -30,9 +30,15 @@ module Seed
         end
 
         def coerce(value, strict: strict?)
-          coerced_value = Utils.coerce(Symbol, value)
+          return value if values.include?(value)
 
-          return coerced_value if values.include?(coerced_value)
+          if value.is_a?(::String) || value.is_a?(::Symbol)
+            candidate = value.to_s
+            match = values.find do |member|
+              (member.is_a?(::String) || member.is_a?(::Symbol)) && member.to_s.casecmp?(candidate)
+            end
+            return match unless match.nil?
+          end
 
           raise Errors::TypeError, "`#{value}` not in enum #{self}" if strict
 

--- a/seed/ruby-sdk-v2/websocket-inferred-auth/test/unit/internal/types/test_enum.rb
+++ b/seed/ruby-sdk-v2/websocket-inferred-auth/test/unit/internal/types/test_enum.rb
@@ -12,6 +12,16 @@ describe Seed::Internal::Types::Enum do
 
       finalize!
     end
+
+    module StringEnum
+      extend Seed::Internal::Types::Enum
+
+      ACTIVE = "ACTIVE"
+      CLOSED = "CLOSED"
+      GROUP_BY_PROFILE = "GROUP_BY_PROFILE"
+
+      finalize!
+    end
   end
 
   describe "#values" do
@@ -27,6 +37,19 @@ describe Seed::Internal::Types::Enum do
 
     it "coerces a string version of a member" do
       assert_equal :foo, EnumTest::ExampleEnum.coerce("foo")
+    end
+
+    it "coerces an existing string member" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce("CLOSED")
+    end
+
+    it "normalizes casing to the wire format" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce("closed")
+      assert_equal "GROUP_BY_PROFILE", EnumTest::StringEnum.coerce("group_by_profile")
+    end
+
+    it "coerces a symbol to the string member" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce(:closed)
     end
 
     it "returns the value if not a member with strictness off" do

--- a/seed/ruby-sdk-v2/websocket-multi-url/lib/seed/internal/types/enum.rb
+++ b/seed/ruby-sdk-v2/websocket-multi-url/lib/seed/internal/types/enum.rb
@@ -30,9 +30,15 @@ module Seed
         end
 
         def coerce(value, strict: strict?)
-          coerced_value = Utils.coerce(Symbol, value)
+          return value if values.include?(value)
 
-          return coerced_value if values.include?(coerced_value)
+          if value.is_a?(::String) || value.is_a?(::Symbol)
+            candidate = value.to_s
+            match = values.find do |member|
+              (member.is_a?(::String) || member.is_a?(::Symbol)) && member.to_s.casecmp?(candidate)
+            end
+            return match unless match.nil?
+          end
 
           raise Errors::TypeError, "`#{value}` not in enum #{self}" if strict
 

--- a/seed/ruby-sdk-v2/websocket-multi-url/test/unit/internal/types/test_enum.rb
+++ b/seed/ruby-sdk-v2/websocket-multi-url/test/unit/internal/types/test_enum.rb
@@ -12,6 +12,16 @@ describe Seed::Internal::Types::Enum do
 
       finalize!
     end
+
+    module StringEnum
+      extend Seed::Internal::Types::Enum
+
+      ACTIVE = "ACTIVE"
+      CLOSED = "CLOSED"
+      GROUP_BY_PROFILE = "GROUP_BY_PROFILE"
+
+      finalize!
+    end
   end
 
   describe "#values" do
@@ -27,6 +37,19 @@ describe Seed::Internal::Types::Enum do
 
     it "coerces a string version of a member" do
       assert_equal :foo, EnumTest::ExampleEnum.coerce("foo")
+    end
+
+    it "coerces an existing string member" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce("CLOSED")
+    end
+
+    it "normalizes casing to the wire format" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce("closed")
+      assert_equal "GROUP_BY_PROFILE", EnumTest::StringEnum.coerce("group_by_profile")
+    end
+
+    it "coerces a symbol to the string member" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce(:closed)
     end
 
     it "returns the value if not a member with strictness off" do

--- a/seed/ruby-sdk-v2/websocket/lib/seed/internal/types/enum.rb
+++ b/seed/ruby-sdk-v2/websocket/lib/seed/internal/types/enum.rb
@@ -30,9 +30,15 @@ module Seed
         end
 
         def coerce(value, strict: strict?)
-          coerced_value = Utils.coerce(Symbol, value)
+          return value if values.include?(value)
 
-          return coerced_value if values.include?(coerced_value)
+          if value.is_a?(::String) || value.is_a?(::Symbol)
+            candidate = value.to_s
+            match = values.find do |member|
+              (member.is_a?(::String) || member.is_a?(::Symbol)) && member.to_s.casecmp?(candidate)
+            end
+            return match unless match.nil?
+          end
 
           raise Errors::TypeError, "`#{value}` not in enum #{self}" if strict
 

--- a/seed/ruby-sdk-v2/websocket/test/unit/internal/types/test_enum.rb
+++ b/seed/ruby-sdk-v2/websocket/test/unit/internal/types/test_enum.rb
@@ -12,6 +12,16 @@ describe Seed::Internal::Types::Enum do
 
       finalize!
     end
+
+    module StringEnum
+      extend Seed::Internal::Types::Enum
+
+      ACTIVE = "ACTIVE"
+      CLOSED = "CLOSED"
+      GROUP_BY_PROFILE = "GROUP_BY_PROFILE"
+
+      finalize!
+    end
   end
 
   describe "#values" do
@@ -27,6 +37,19 @@ describe Seed::Internal::Types::Enum do
 
     it "coerces a string version of a member" do
       assert_equal :foo, EnumTest::ExampleEnum.coerce("foo")
+    end
+
+    it "coerces an existing string member" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce("CLOSED")
+    end
+
+    it "normalizes casing to the wire format" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce("closed")
+      assert_equal "GROUP_BY_PROFILE", EnumTest::StringEnum.coerce("group_by_profile")
+    end
+
+    it "coerces a symbol to the string member" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce(:closed)
     end
 
     it "returns the value if not a member with strictness off" do

--- a/seed/ruby-sdk-v2/x-fern-default/lib/seed/internal/types/enum.rb
+++ b/seed/ruby-sdk-v2/x-fern-default/lib/seed/internal/types/enum.rb
@@ -30,9 +30,15 @@ module Seed
         end
 
         def coerce(value, strict: strict?)
-          coerced_value = Utils.coerce(Symbol, value)
+          return value if values.include?(value)
 
-          return coerced_value if values.include?(coerced_value)
+          if value.is_a?(::String) || value.is_a?(::Symbol)
+            candidate = value.to_s
+            match = values.find do |member|
+              (member.is_a?(::String) || member.is_a?(::Symbol)) && member.to_s.casecmp?(candidate)
+            end
+            return match unless match.nil?
+          end
 
           raise Errors::TypeError, "`#{value}` not in enum #{self}" if strict
 

--- a/seed/ruby-sdk-v2/x-fern-default/test/unit/internal/types/test_enum.rb
+++ b/seed/ruby-sdk-v2/x-fern-default/test/unit/internal/types/test_enum.rb
@@ -12,6 +12,16 @@ describe Seed::Internal::Types::Enum do
 
       finalize!
     end
+
+    module StringEnum
+      extend Seed::Internal::Types::Enum
+
+      ACTIVE = "ACTIVE"
+      CLOSED = "CLOSED"
+      GROUP_BY_PROFILE = "GROUP_BY_PROFILE"
+
+      finalize!
+    end
   end
 
   describe "#values" do
@@ -27,6 +37,19 @@ describe Seed::Internal::Types::Enum do
 
     it "coerces a string version of a member" do
       assert_equal :foo, EnumTest::ExampleEnum.coerce("foo")
+    end
+
+    it "coerces an existing string member" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce("CLOSED")
+    end
+
+    it "normalizes casing to the wire format" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce("closed")
+      assert_equal "GROUP_BY_PROFILE", EnumTest::StringEnum.coerce("group_by_profile")
+    end
+
+    it "coerces a symbol to the string member" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce(:closed)
     end
 
     it "returns the value if not a member with strictness off" do

--- a/seed/ruby-sdk-v2/x-fern-global-parameters/lib/seed/internal/types/enum.rb
+++ b/seed/ruby-sdk-v2/x-fern-global-parameters/lib/seed/internal/types/enum.rb
@@ -30,9 +30,15 @@ module Seed
         end
 
         def coerce(value, strict: strict?)
-          coerced_value = Utils.coerce(Symbol, value)
+          return value if values.include?(value)
 
-          return coerced_value if values.include?(coerced_value)
+          if value.is_a?(::String) || value.is_a?(::Symbol)
+            candidate = value.to_s
+            match = values.find do |member|
+              (member.is_a?(::String) || member.is_a?(::Symbol)) && member.to_s.casecmp?(candidate)
+            end
+            return match unless match.nil?
+          end
 
           raise Errors::TypeError, "`#{value}` not in enum #{self}" if strict
 

--- a/seed/ruby-sdk-v2/x-fern-global-parameters/test/unit/internal/types/test_enum.rb
+++ b/seed/ruby-sdk-v2/x-fern-global-parameters/test/unit/internal/types/test_enum.rb
@@ -12,6 +12,16 @@ describe Seed::Internal::Types::Enum do
 
       finalize!
     end
+
+    module StringEnum
+      extend Seed::Internal::Types::Enum
+
+      ACTIVE = "ACTIVE"
+      CLOSED = "CLOSED"
+      GROUP_BY_PROFILE = "GROUP_BY_PROFILE"
+
+      finalize!
+    end
   end
 
   describe "#values" do
@@ -27,6 +37,19 @@ describe Seed::Internal::Types::Enum do
 
     it "coerces a string version of a member" do
       assert_equal :foo, EnumTest::ExampleEnum.coerce("foo")
+    end
+
+    it "coerces an existing string member" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce("CLOSED")
+    end
+
+    it "normalizes casing to the wire format" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce("closed")
+      assert_equal "GROUP_BY_PROFILE", EnumTest::StringEnum.coerce("group_by_profile")
+    end
+
+    it "coerces a symbol to the string member" do
+      assert_equal "CLOSED", EnumTest::StringEnum.coerce(:closed)
     end
 
     it "returns the value if not a member with strictness off" do


### PR DESCRIPTION
## Description
Fixes Ruby SDK enum serialization sending user input as-is instead of the API's wire format (reported against Twilio Ruby SDK 1.18.2):

```ruby
client.conversations.update_conversation_by_id(id: conv_id, status: "closed")
# sent: {"status": "closed"}  — API rejects: must be one of [ACTIVE, INACTIVE, CLOSED]
```

Root cause: `Enum.coerce` in the as-is `internal/types/enum.rb` did `Utils.coerce(Symbol, value)` and checked `values.include?(coerced_value)`. Generated enums have **String** members (`CLOSED = "CLOSED"`), so the symbolized input never matched and every value fell through to the non-strict passthrough — no normalization ever happened.

New behavior:

```ruby
def coerce(value, strict: strict?)
  return value if values.include?(value)          # exact member match (String or Symbol enums)

  if value.is_a?(::String) || value.is_a?(::Symbol)
    match = values.find { |m| m.to_s.casecmp?(value.to_s) }  # case-insensitive → canonical member
    return match unless match.nil?
  end

  raise Errors::TypeError, ... if strict
  value                                            # non-strict passthrough for unknown values
end
```

So `"closed"`, `:closed`, and `"CLOSED"` all serialize as `"CLOSED"`; `"group_by_profile"` → `"GROUP_BY_PROFILE"`. Unknown values still pass through (non-strict) for forward compatibility. Enum constants (e.g. `Twilio::Conversations::Types::ConversationStatus::CLOSED`) already exist and continue to work.

## Changes Made
- `generators/ruby-v2/base/src/asIs/internal/types/enum.Template.rb`: rewrote `coerce` as above
- `generators/ruby-v2/base/src/asIs/test/unit/internal/types/test_enum.Template.rb`: added string-member enum tests covering exact match, case normalization, and symbol input
- Regenerated the 144 `seed/ruby-sdk-v2/**` copies of `enum.rb` and `test_enum.rb`
- Changelog entry under `generators/ruby-v2/sdk/changes/unreleased/`

## Testing
- [x] Unit tests added/updated — `seed/ruby-sdk-v2/enum` unit suite passes (572 runs, 0 failures) incl. new enum casing tests
- [x] Manual testing completed — patched the Twilio Ruby SDK locally; `status: "closed"` now serializes to `{"status": "CLOSED"}` and `conversation_grouping_type: "group_by_profile"` to `"GROUP_BY_PROFILE"` (before: sent as-is)


Link to Devin session: https://app.devin.ai/sessions/5b0055099b614e4691a5fce4a946df42
Requested by: @iamnamananand996
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/17252" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->