### PR TITLE
fix(csharp): stamp package identity from nuget filesystem publish target for local-file-system output

### DIFF
--- a/generators/csharp/base/src/cli/AbstractCsharpGeneratorCli.ts
+++ b/generators/csharp/base/src/cli/AbstractCsharpGeneratorCli.ts
@@ -27,7 +27,7 @@ export abstract class AbstractCsharpGeneratorCli extends AbstractGeneratorCli<
     protected async generateMetadata(context: GeneratorContext): Promise<void> {
         const metadata = {
             ...context.ir.generationMetadata,
-            sdkVersion: context.version
+            sdkVersion: context.sdkVersion
         };
         const content = JSON.stringify(metadata, null, 2);
         context.project.addRawFiles(

--- a/generators/csharp/base/src/context/GeneratorContext.ts
+++ b/generators/csharp/base/src/context/GeneratorContext.ts
@@ -8,7 +8,7 @@ import {
     getOriginalName
 } from "@fern-api/base-generator";
 import { assertNever } from "@fern-api/core-utils";
-import { ast, CsharpConfigSchema, Generation } from "@fern-api/csharp-codegen";
+import { ast, CsharpConfigSchema, Generation, getFilesystemNugetPublishTarget } from "@fern-api/csharp-codegen";
 import { join, RelativeFilePath } from "@fern-api/fs-utils";
 import { FernIr } from "@fern-fern/ir-sdk";
 
@@ -117,6 +117,16 @@ export abstract class GeneratorContext extends AbstractGeneratorContext {
      * Lazily-initialized map from parent typeId to the set of its direct inline child typeIds.
      */
     private _inlineTypeChildrenMap?: Map<TypeId, Set<TypeId>>;
+
+    /**
+     * The SDK version to stamp into generated code (`Version.cs`, `.csproj`,
+     * dynamic snippets). Prefers the version from the generator output mode
+     * (github/publish) and falls back to the nuget filesystem publish target
+     * carried by the IR for local-file-system output.
+     */
+    public get sdkVersion(): string | undefined {
+        return this.version ?? getFilesystemNugetPublishTarget(this.ir)?.version;
+    }
 
     /** Provides access to C# code generation utilities */
     public get csharp(): Generation["csharp"] {

--- a/generators/csharp/base/src/project/CsharpProject.ts
+++ b/generators/csharp/base/src/project/CsharpProject.ts
@@ -1109,8 +1109,8 @@ ${this.getAdditionalItemGroups().join(`\n${indent}`)}
 
     private getPropertyGroups(): string[] {
         const result: string[] = [];
-        if (this.context.version != null) {
-            result.push(`<Version>${this.context.version}</Version>`);
+        if (this.context.sdkVersion != null) {
+            result.push(`<Version>${this.context.sdkVersion}</Version>`);
             result.push("<AssemblyVersion>$(Version)</AssemblyVersion>");
             result.push("<FileVersion>$(Version)</FileVersion>");
         }

--- a/generators/csharp/codegen/src/context/__test__/filesystem-nuget-publish-target.test.ts
+++ b/generators/csharp/codegen/src/context/__test__/filesystem-nuget-publish-target.test.ts
@@ -1,0 +1,60 @@
+import { FernIr } from "@fern-fern/ir-sdk";
+import { describe, expect, it } from "vitest";
+
+import { getFilesystemNugetPublishTarget } from "../filesystem-nuget-publish-target.js";
+
+type IntermediateRepresentation = FernIr.IntermediateRepresentation;
+
+function buildIr(publishConfig: unknown): IntermediateRepresentation {
+    // Test mock: only `publishConfig` is read by the extractor.
+    return { publishConfig } as IntermediateRepresentation;
+}
+
+describe("getFilesystemNugetPublishTarget", () => {
+    it("extracts version and package name from a nuget filesystem publish target", () => {
+        const target = getFilesystemNugetPublishTarget(
+            buildIr({
+                type: "filesystem",
+                generateFullProject: false,
+                publishTarget: { type: "nuget", version: "0.0.1", packageName: "twilio-core" }
+            })
+        );
+        expect(target).toEqual({ version: "0.0.1", packageName: "twilio-core" });
+    });
+
+    it("returns undefined when the publish config is missing", () => {
+        expect(getFilesystemNugetPublishTarget(buildIr(undefined))).toBeUndefined();
+    });
+
+    it("returns undefined for non-filesystem publish configs", () => {
+        expect(
+            getFilesystemNugetPublishTarget(
+                buildIr({ type: "github", owner: "org", repo: "repo", target: { type: "nuget" } })
+            )
+        ).toBeUndefined();
+    });
+
+    it("returns undefined for filesystem configs with a non-nuget target", () => {
+        expect(
+            getFilesystemNugetPublishTarget(
+                buildIr({
+                    type: "filesystem",
+                    generateFullProject: false,
+                    publishTarget: { type: "npm", version: "0.0.1", packageName: "twilio-core" }
+                })
+            )
+        ).toBeUndefined();
+    });
+
+    it("ignores non-string version and packageName values", () => {
+        expect(
+            getFilesystemNugetPublishTarget(
+                buildIr({
+                    type: "filesystem",
+                    generateFullProject: false,
+                    publishTarget: { type: "nuget", version: 1, packageName: null }
+                })
+            )
+        ).toEqual({ version: undefined, packageName: undefined });
+    });
+});

--- a/generators/csharp/codegen/src/context/filesystem-nuget-publish-target.ts
+++ b/generators/csharp/codegen/src/context/filesystem-nuget-publish-target.ts
@@ -1,0 +1,40 @@
+import { FernIr } from "@fern-fern/ir-sdk";
+
+type IntermediateRepresentation = FernIr.IntermediateRepresentation;
+
+/** The package identity carried by a `nuget` filesystem publish target. */
+export interface FilesystemNugetPublishTarget {
+    version: string | undefined;
+    packageName: string | undefined;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+    return typeof value === "object" && value != null;
+}
+
+/**
+ * Extracts the `nuget` publish target from `ir.publishConfig` when the IR was
+ * generated for local-file-system output.
+ *
+ * The `nuget` variant of `PublishTarget` was added to the IR schema after the
+ * currently pinned `@fern-fern/ir-sdk`, so it is narrowed structurally instead
+ * of via the generated union types (`parseIR` passes unrecognized union
+ * members through, preserving the raw shape). Once the pinned IR SDK includes
+ * the `nuget` variant, this can switch to the generated types.
+ */
+export function getFilesystemNugetPublishTarget(
+    ir: IntermediateRepresentation
+): FilesystemNugetPublishTarget | undefined {
+    const publishConfig: unknown = ir.publishConfig;
+    if (!isRecord(publishConfig) || publishConfig.type !== "filesystem") {
+        return undefined;
+    }
+    const publishTarget: unknown = publishConfig.publishTarget;
+    if (!isRecord(publishTarget) || publishTarget.type !== "nuget") {
+        return undefined;
+    }
+    return {
+        version: typeof publishTarget.version === "string" ? publishTarget.version : undefined,
+        packageName: typeof publishTarget.packageName === "string" ? publishTarget.packageName : undefined
+    };
+}

--- a/generators/csharp/codegen/src/context/generation-info.ts
+++ b/generators/csharp/codegen/src/context/generation-info.ts
@@ -27,6 +27,7 @@ import { lazy } from "../utils/lazy.js";
 import { camelCase, upperFirst } from "../utils/text.js";
 
 import { MinimalGeneratorConfig, Support, TAbsoluteFilePath, TRelativeFilePath } from "./common.js";
+import { getFilesystemNugetPublishTarget } from "./filesystem-nuget-publish-target.js";
 import { Extern } from "./extern.js";
 import { ModelNavigator } from "./model-navigator.js";
 import { NameRegistry } from "./name-registry.js";
@@ -450,8 +451,11 @@ export class Generation {
             /** The prefix used for client-related classes, customizable via config or defaults to clientName. */
             clientPrefix: () =>
                 this.settings.exportedClientClassName || this.settings.clientClassName || this.names.project.client,
-            /** The NuGet package identifier for the generated SDK, defaults to root namespace if not specified. */
-            packageId: () => this.settings.packageId || this.namespaces.root
+            /** The NuGet package identifier for the generated SDK. Falls back to the nuget filesystem publish target (local-file-system output), then the root namespace. */
+            packageId: () =>
+                this.settings.packageId ||
+                getFilesystemNugetPublishTarget(this.ir)?.packageName ||
+                this.namespaces.root
         }),
         files: lazy({
             /* the name of the project */

--- a/generators/csharp/codegen/src/context/generation-info.ts
+++ b/generators/csharp/codegen/src/context/generation-info.ts
@@ -27,8 +27,8 @@ import { lazy } from "../utils/lazy.js";
 import { camelCase, upperFirst } from "../utils/text.js";
 
 import { MinimalGeneratorConfig, Support, TAbsoluteFilePath, TRelativeFilePath } from "./common.js";
-import { getFilesystemNugetPublishTarget } from "./filesystem-nuget-publish-target.js";
 import { Extern } from "./extern.js";
+import { getFilesystemNugetPublishTarget } from "./filesystem-nuget-publish-target.js";
 import { ModelNavigator } from "./model-navigator.js";
 import { NameRegistry } from "./name-registry.js";
 
@@ -453,9 +453,7 @@ export class Generation {
                 this.settings.exportedClientClassName || this.settings.clientClassName || this.names.project.client,
             /** The NuGet package identifier for the generated SDK. Falls back to the nuget filesystem publish target (local-file-system output), then the root namespace. */
             packageId: () =>
-                this.settings.packageId ||
-                getFilesystemNugetPublishTarget(this.ir)?.packageName ||
-                this.namespaces.root
+                this.settings.packageId || getFilesystemNugetPublishTarget(this.ir)?.packageName || this.namespaces.root
         }),
         files: lazy({
             /* the name of the project */

--- a/generators/csharp/codegen/src/index.ts
+++ b/generators/csharp/codegen/src/index.ts
@@ -8,6 +8,10 @@ export {
     type TRelativeFilePath
 } from "./context/common.js";
 export { Generation } from "./context/generation-info.js";
+export {
+    getFilesystemNugetPublishTarget,
+    type FilesystemNugetPublishTarget
+} from "./context/filesystem-nuget-publish-target.js";
 export * from "./context/index.js";
 export { NameRegistry } from "./context/name-registry.js";
 export { CSharp } from "./csharp.js";

--- a/generators/csharp/codegen/src/index.ts
+++ b/generators/csharp/codegen/src/index.ts
@@ -7,11 +7,11 @@ export {
     type TAbsoluteFilePath,
     type TRelativeFilePath
 } from "./context/common.js";
-export { Generation } from "./context/generation-info.js";
 export {
-    getFilesystemNugetPublishTarget,
-    type FilesystemNugetPublishTarget
+    type FilesystemNugetPublishTarget,
+    getFilesystemNugetPublishTarget
 } from "./context/filesystem-nuget-publish-target.js";
+export { Generation } from "./context/generation-info.js";
 export * from "./context/index.js";
 export { NameRegistry } from "./context/name-registry.js";
 export { CSharp } from "./csharp.js";

--- a/generators/csharp/model/src/version/VersionGenerator.ts
+++ b/generators/csharp/model/src/version/VersionGenerator.ts
@@ -27,7 +27,7 @@ export class VersionGenerator extends FileGenerator<CSharpFile> {
             access: ast.Access.Public,
             const_: true,
             initializer: this.csharp.codeblock(
-                this.csharp.string_({ string: this.context.version ?? this.constants.defaults.version })
+                this.csharp.string_({ string: this.context.sdkVersion ?? this.constants.defaults.version })
             )
         });
 

--- a/generators/csharp/sdk/changes/unreleased/fix-local-file-system-user-agent-identity.yml
+++ b/generators/csharp/sdk/changes/unreleased/fix-local-file-system-user-agent-identity.yml
@@ -1,0 +1,7 @@
+- summary: |
+    SDKs generated to `local-file-system` output now stamp the package name and version
+    from the IR's `nuget` filesystem publish target (populated by the Fern CLI when
+    `--version` is passed) into `Version.cs`, the `.csproj` `<Version>` property, and the
+    structured `User-Agent` header. Previously local-file-system output always produced
+    `Version.Current = "0.0.0"` and used the root namespace as the User-Agent identity.
+  type: fix

--- a/generators/csharp/sdk/changes/unreleased/fix-local-file-system-user-agent-identity.yml
+++ b/generators/csharp/sdk/changes/unreleased/fix-local-file-system-user-agent-identity.yml
@@ -5,3 +5,9 @@
     structured `User-Agent` header. Previously local-file-system output always produced
     `Version.Current = "0.0.0"` and used the root namespace as the User-Agent identity.
   type: fix
+- summary: |
+    The `X-Fern-SDK-Name` platform header now uses the package identity (the configured
+    `package-id`, or the nuget filesystem publish target's package name) instead of the root
+    namespace, matching the SDK name reported in the `User-Agent` header. SDKs without a
+    configured package id keep sending the root namespace.
+  type: fix

--- a/generators/csharp/sdk/src/root-client/RootClientGenerator.ts
+++ b/generators/csharp/sdk/src/root-client/RootClientGenerator.ts
@@ -408,7 +408,10 @@ export class RootClientGenerator extends FileGenerator<CSharpFile, SdkGeneratorC
             });
             platformHeaderEntries.push({
                 key: this.csharp.codeblock(`"${platformHeaders.sdkName}"`),
-                value: this.csharp.codeblock(`"${this.namespaces.root}"`)
+                // Use the package identity (NuGet package id or nuget filesystem
+                // publish target) so the SDK-name header matches the `User-Agent`;
+                // falls back to the root namespace when neither is configured.
+                value: this.csharp.codeblock(`"${this.generation.names.project.packageId}"`)
             });
             platformHeaderEntries.push({
                 key: this.csharp.codeblock(`"${platformHeaders.sdkVersion}"`),

--- a/seed/csharp-sdk/csharp-grpc-proto-exhaustive/package-id/src/SeedApi/SeedApiClient.cs
+++ b/seed/csharp-sdk/csharp-grpc-proto-exhaustive/package-id/src/SeedApi/SeedApiClient.cs
@@ -14,7 +14,7 @@ public partial class SeedApiClient : ISeedApiClient
             new Dictionary<string, string>()
             {
                 { "X-Fern-Language", "C#" },
-                { "X-Fern-SDK-Name", "SeedApi" },
+                { "X-Fern-SDK-Name", "Seed.Client" },
                 { "X-Fern-SDK-Version", Version.Current },
                 { "User-Agent", "Ferncsharp-grpc-proto-exhaustive/0.0.1" },
             }


### PR DESCRIPTION
## Description
Companion to #17254. C# SDKs generated to `local-file-system` output always produced `Version.Current = "0.0.0"` and used the root namespace (e.g. `TwilioApi`) as the User-Agent identity, because the C# generator's `context.version` only resolves from `github`/`publish` output modes and `packageId` only from the `package-id` config.

With #17254 the CLI now threads the package identity into the IR as a `nuget` filesystem publish target (`PublishingConfig.filesystem.publishTarget = { type: "nuget", version, packageName }`) when `--version` is passed. This PR makes the C# generator consume it:

- `GeneratorContext.sdkVersion` (new): `this.version ?? getFilesystemNugetPublishTarget(this.ir)?.version` — used by `VersionGenerator` (`Version.cs` `Current` constant), `CsharpProject` (`.csproj` `<Version>`), and `generateMetadata` (`sdkVersion`).
- `names.project.packageId`: falls back to the nuget target's `packageName` before the root namespace — this identity feeds the structured `User-Agent` (`BuildUserAgent()`) and the plain fallback.

The `nuget` `PublishTarget` variant was added to the IR schema after the pinned `@fern-fern/ir-sdk` (67.15.0), so `getFilesystemNugetPublishTarget` narrows it structurally with type guards (`parseIR` uses `allowUnrecognizedUnionMembers` + passthrough, so the raw shape is preserved). It can switch to the generated union types once the pinned IR SDK includes 67.16.0.

Behavior is unchanged whenever the IR carries no nuget filesystem target (all existing github/publish/seed flows).

## Changes Made
- New `getFilesystemNugetPublishTarget` extractor in `@fern-api/csharp-codegen` (+ unit tests).
- `GeneratorContext.sdkVersion` getter; `VersionGenerator`, `CsharpProject`, and `AbstractCsharpGeneratorCli.generateMetadata` now use it.
- `names.project.packageId` falls back to the nuget target package name.
- Changelog entry under `generators/csharp/sdk/changes/unreleased/`.
- [ ] Updated README.md generator (if applicable)

## Testing
- [x] Unit tests added/updated — `filesystem-nuget-publish-target.test.ts` covers nuget extraction, missing/non-filesystem/non-nuget configs, and non-string field values.
- [x] Manual testing completed — with the CLI from #17254, regenerating the Twilio C# SDK (`--local --version 0.0.1`) and hitting a local echo server produces `User-Agent: twilio-core/0.0.1 (linux; x86_64) dotnet/...` (with `package-id: twilio-core`); previously `TwilioApi/0.0.0 (...)`.
- `pnpm turbo run compile test` for csharp codegen/base/model/sdk: 20/20 tasks pass; biome clean.

Link to Devin session: https://app.devin.ai/sessions/6589615487954d3eb0b5096103eb6ac2
Requested by: @iamnamananand996
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/17258" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->