### PR TITLE
fix(typescript): OAuth client-credentials codegen (strict-mode canCreate + README credential shape)

### DIFF
--- a/generators/typescript/sdk/changes/unreleased/oauth-client-credentials-codegen.yml
+++ b/generators/typescript/sdk/changes/unreleased/oauth-client-credentials-codegen.yml
@@ -1,0 +1,21 @@
+# yaml-language-server: $schema=../../../../../fern-changes-yml.schema.json
+
+- summary: |
+    Fix two OAuth client-credentials codegen issues in the multi-scheme (wrapper) case.
+
+    1. `OAuthAuthProvider.canCreate` now satisfies the `InstantiatableAuthProvider`
+       contract used by `AnyAuthProvider.createInstance`. When OAuth is combined with
+       another auth scheme (and OAuth has no client-id/secret env-var fallback, so the
+       nested credentials are required), the generated `BaseClient.ts` previously failed
+       `tsc --strict` with TS2322 because `canCreate`'s parameter type was narrower than
+       `(opts: NormalizedClientOptions) => boolean`. The parameter is now widened in the
+       wrapper case so the assignment type-checks; runtime behavior is unchanged.
+
+    2. The generated README OAuth quickstart now nests `clientId`/`clientSecret` (and the
+       token override) under the OAuth wrapper property (e.g. `oauth: { ... }`) whenever the
+       auth requirement is `any` or endpoint-scoped, matching the shape the generated auth
+       provider actually reads. Previously the README documented top-level credentials that
+       the provider ignored, so the documented usage never authenticated.
+
+    Single-scheme OAuth output (top-level credentials) is unchanged.
+  type: fix

--- a/generators/typescript/sdk/client-class-generator/src/__test__/AuthProviders.test.ts
+++ b/generators/typescript/sdk/client-class-generator/src/__test__/AuthProviders.test.ts
@@ -838,4 +838,107 @@ export type BaseClientOptions = {
             expect(diagnostics.some((d) => d.includes("nonsense"))).toBe(true);
         });
     });
+
+    // ──────────────────────────────────────────────────────────────────────────
+    // Regression: strict-mode `OAuthAuthProvider.canCreate` assignability.
+    //
+    // Under multi-scheme `auth: any` combining OAuth (WITHOUT env vars, so nested
+    // clientId/clientSecret are REQUIRED) with another scheme, `NormalizedClientOptions`
+    // collapses the OAuth wrapper property to the token-override shape ({ token? })
+    // via AtLeastOneOf / UnionToIntersection. The generated
+    // `OAuthAuthProvider.canCreate` is passed to `AnyAuthProvider.createInstance`,
+    // whose contract is `(opts: NormalizedClientOptions) => boolean`. If canCreate's
+    // parameter is the narrow `Partial<ClientCredentials & BaseClientOptions>`, strict
+    // function-parameter contravariance rejects the assignment (BaseClient.ts TS2322).
+    //
+    // These tests pin the parameter type emitted in the wrapper case so the provider
+    // stays assignable to the InstantiatableAuthProvider contract.
+    // ──────────────────────────────────────────────────────────────────────────
+    describe("wrapper-case OAuth canCreate satisfies AnyAuthProvider contract", () => {
+        // Reconstructs the emitted types for `auth: any: [OAuth (no env vars), ApiKey]`
+        // where the OAuth wrapper key is `oauth` and nested clientId/clientSecret are
+        // REQUIRED (no env var fallback).
+        const CONTRACT_SOURCE = `
+type Supplier<T> = T | Promise<T> | (() => T | Promise<T>);
+
+type UnionToIntersection<U> = (U extends any ? (x: U) => void : never) extends (x: infer I) => void ? I : never;
+type AtLeastOneOf<T extends readonly any[]> = {
+    [K in keyof T]: T[K] & Partial<UnionToIntersection<Exclude<T[number], T[K]>>>;
+}[number];
+
+export type BaseClientOptions = { environment: Supplier<string> };
+
+const WRAPPER_PROPERTY = "oauth" as const;
+const CLIENT_ID_PARAM = "clientId" as const;
+const CLIENT_SECRET_PARAM = "clientSecret" as const;
+const TOKEN_PARAM = "token" as const;
+
+// OAuth with REQUIRED nested creds (no env var fallback).
+type OAuthClientCredentials = {
+    [WRAPPER_PROPERTY]?: { [CLIENT_ID_PARAM]: Supplier<string>; [CLIENT_SECRET_PARAM]: Supplier<string> };
+};
+type OAuthTokenOverride = { [WRAPPER_PROPERTY]?: { [TOKEN_PARAM]?: Supplier<string> } };
+type OAuthAuthOptions = OAuthClientCredentials | OAuthTokenOverride;
+type HeaderAuthOptions = { apiKeyAuth?: { apiKey?: Supplier<string> } };
+
+type AnyAuthOptions = AtLeastOneOf<[OAuthAuthOptions, HeaderAuthOptions]>;
+export type NormalizedClientOptions = BaseClientOptions & AnyAuthOptions & { logging: unknown };
+
+export type InstantiatableAuthProvider = {
+    canCreate: (opts: NormalizedClientOptions) => boolean;
+};
+`;
+
+        function diagnosticsForCanCreateType(canCreateParamType: string): string[] {
+            const project = new Project({
+                useInMemoryFileSystem: true,
+                compilerOptions: {
+                    strict: true,
+                    noEmit: true,
+                    skipLibCheck: true,
+                    target: ts.ScriptTarget.ES2020,
+                    lib: ["lib.es2020.d.ts"]
+                }
+            });
+            project.createSourceFile("contract.ts", CONTRACT_SOURCE);
+            project.createSourceFile(
+                "usage.ts",
+                [
+                    `import type { InstantiatableAuthProvider, BaseClientOptions } from "./contract";`,
+                    `const WRAPPER_PROPERTY = "oauth" as const;`,
+                    `const CLIENT_ID_PARAM = "clientId" as const;`,
+                    `const CLIENT_SECRET_PARAM = "clientSecret" as const;`,
+                    `const TOKEN_PARAM = "token" as const;`,
+                    `type Supplier<T> = T | Promise<T> | (() => T | Promise<T>);`,
+                    `const OAuthAuthProviderClass = {`,
+                    `    canCreate(options?: ${canCreateParamType}): boolean {`,
+                    `        return options?.[WRAPPER_PROPERTY]?.[CLIENT_ID_PARAM] != null && options?.[WRAPPER_PROPERTY]?.[CLIENT_SECRET_PARAM] != null;`,
+                    `    }`,
+                    `};`,
+                    `const list: InstantiatableAuthProvider[] = [OAuthAuthProviderClass];`
+                ].join("\n")
+            );
+            return project.getPreEmitDiagnostics().map((d) => {
+                const message = d.getMessageText();
+                return typeof message === "string" ? message : message.getMessageText();
+            });
+        }
+
+        it("the OLD narrow parameter type fails the contract (documents the bug)", () => {
+            // Partial<ClientCredentials & BaseClientOptions> with required nested creds.
+            const diagnostics = diagnosticsForCanCreateType(
+                `Partial<{ [WRAPPER_PROPERTY]?: { [CLIENT_ID_PARAM]: Supplier<string>; [CLIENT_SECRET_PARAM]: Supplier<string> } } & BaseClientOptions>`
+            );
+            expect(diagnostics.length).toBeGreaterThan(0);
+            expect(diagnostics.some((d) => d.includes("InstantiatableAuthProvider"))).toBe(true);
+        });
+
+        it("the widened parameter type (as generated) satisfies the contract", () => {
+            // Matches OAuthAuthProviderGenerator.getCanCreateParameterType() wrapper output.
+            const diagnostics = diagnosticsForCanCreateType(
+                `Partial<BaseClientOptions> & { [WRAPPER_PROPERTY]?: { [CLIENT_ID_PARAM]?: Supplier<string>; [CLIENT_SECRET_PARAM]?: Supplier<string>; [TOKEN_PARAM]?: Supplier<string> } }`
+            );
+            expect(diagnostics).toEqual([]);
+        });
+    });
 });

--- a/generators/typescript/sdk/client-class-generator/src/auth-provider/OAuthAuthProviderGenerator.ts
+++ b/generators/typescript/sdk/client-class-generator/src/auth-provider/OAuthAuthProviderGenerator.ts
@@ -415,6 +415,7 @@ export class OAuthAuthProviderGenerator implements AuthProviderGenerator {
         );
 
         const canCreateReturnType = "boolean";
+        const canCreateParameterType = this.getCanCreateParameterType(context);
 
         const clientIdSupplierStatements = this.generateClientIdSupplierStatements(oauthConfig.clientIdEnvVar, context);
         const clientSecretSupplierStatements = this.generateClientSecretSupplierStatements(
@@ -443,7 +444,7 @@ export class OAuthAuthProviderGenerator implements AuthProviderGenerator {
                 parameters: [
                     {
                         name: "options?",
-                        type: `Partial<${CLASS_NAME}.ClientCredentials & BaseClientOptions>`
+                        type: canCreateParameterType
                     }
                 ]
             },
@@ -752,6 +753,46 @@ export class OAuthAuthProviderGenerator implements AuthProviderGenerator {
         return `if (!tokenResponse.ok) {
                 throw new ${errorType}({ body: tokenResponse.error });
             }`;
+    }
+
+    /**
+     * The parameter type for the static `canCreate` method.
+     *
+     * In the single-scheme case (no wrapper) the options are top-level, so
+     * `Partial<ClientCredentials & BaseClientOptions>` is both correct and the
+     * type the runtime body indexes into.
+     *
+     * In the wrapper case (multi-scheme / endpoint-security), `canCreate` must
+     * satisfy `AnyAuthProvider.InstantiatableAuthProvider`'s contract of
+     * `(opts: NormalizedClientOptions) => boolean`. `NormalizedClientOptions`
+     * derives the wrapper property through `AtLeastOneOf`/`UnionToIntersection`,
+     * which can collapse it to the `TokenOverride` shape (`{ token?: ... }`) that
+     * lacks `clientId`/`clientSecret`. Under strict-mode function-parameter
+     * contravariance, a narrow `Partial<ClientCredentials & BaseClientOptions>`
+     * parameter is therefore not assignable to the contract. We widen the
+     * wrapper property to an all-optional shape that unifies the client-credentials
+     * and token-override members so the assignment type-checks while the runtime
+     * body (which only reads `clientId`/`clientSecret`) is unchanged.
+     */
+    private getCanCreateParameterType(context: FileContext): string {
+        if (this.keepIfWrapper("x") === "") {
+            // Single-scheme: options are top-level; keep the existing (byte-identical) type.
+            return `Partial<${CLASS_NAME}.ClientCredentials & BaseClientOptions>`;
+        }
+
+        // Use the same supplier type the emitted ClientCredentials/TokenOverride use
+        // (Supplier | EndpointSupplier), so the parameter is a supertype of the
+        // wrapper property in NormalizedClientOptions regardless of endpoint metadata.
+        const supplierType = getTextOfTsNode(
+            context.coreUtilities.fetcher.SupplierOrEndpointSupplier._getReferenceToType(
+                ts.factory.createKeywordTypeNode(ts.SyntaxKind.StringKeyword)
+            )
+        );
+
+        // Wrapper case: unify ClientCredentials + TokenOverride into an all-optional
+        // wrapper shape so the parameter is a supertype of the collapsed
+        // NormalizedClientOptions wrapper property.
+        return `Partial<BaseClientOptions> & { [WRAPPER_PROPERTY]?: { [CLIENT_ID_PARAM]?: ${supplierType}; [CLIENT_SECRET_PARAM]?: ${supplierType}; [TOKEN_PARAM]?: ${supplierType} } }`;
     }
 
     private generateCanCreateStatements(

--- a/generators/typescript/sdk/client-class-generator/src/auth-provider/OAuthAuthProviderGenerator.ts
+++ b/generators/typescript/sdk/client-class-generator/src/auth-provider/OAuthAuthProviderGenerator.ts
@@ -1,6 +1,11 @@
 import { getOriginalName } from "@fern-api/base-generator";
 import type { FernIr } from "@fern-fern/ir-sdk";
-import { type ExportedFilePath, getPropertyKey, getTextOfTsNode, toCamelCase } from "@fern-typescript/commons";
+import {
+    type ExportedFilePath,
+    getOAuthWrapperPropertyName,
+    getPropertyKey,
+    getTextOfTsNode
+} from "@fern-typescript/commons";
 import type { FileContext } from "@fern-typescript/contexts";
 import { type OptionalKind, type PropertySignatureStructure, Scope, StructureKind, ts } from "ts-morph";
 
@@ -43,6 +48,7 @@ export class OAuthAuthProviderGenerator implements AuthProviderGenerator {
     private readonly authScheme: FernIr.OAuthScheme;
     private readonly neverThrowErrors: boolean;
     private readonly includeSerdeLayer: boolean;
+    private readonly shouldUseWrapper: boolean;
     private readonly keepIfWrapper: (str: string) => string;
 
     constructor(init: OAuthAuthProviderGenerator.Init) {
@@ -50,6 +56,7 @@ export class OAuthAuthProviderGenerator implements AuthProviderGenerator {
         this.authScheme = init.authScheme;
         this.neverThrowErrors = init.neverThrowErrors;
         this.includeSerdeLayer = init.includeSerdeLayer;
+        this.shouldUseWrapper = init.shouldUseWrapper;
         this.keepIfWrapper = init.shouldUseWrapper ? (str: string) => str : () => "";
     }
 
@@ -59,7 +66,7 @@ export class OAuthAuthProviderGenerator implements AuthProviderGenerator {
      * e.g., "OAuth" -> "oauth", "magical_auth" -> "magicalAuth"
      */
     public getWrapperPropertyName(): string {
-        return toCamelCase(this.authScheme.key);
+        return getOAuthWrapperPropertyName(this.authScheme.key);
     }
 
     public getFilePath(): ExportedFilePath {
@@ -775,7 +782,7 @@ export class OAuthAuthProviderGenerator implements AuthProviderGenerator {
      * body (which only reads `clientId`/`clientSecret`) is unchanged.
      */
     private getCanCreateParameterType(context: FileContext): string {
-        if (this.keepIfWrapper("x") === "") {
+        if (!this.shouldUseWrapper) {
             // Single-scheme: options are top-level; keep the existing (byte-identical) type.
             return `Partial<${CLASS_NAME}.ClientCredentials & BaseClientOptions>`;
         }
@@ -792,6 +799,12 @@ export class OAuthAuthProviderGenerator implements AuthProviderGenerator {
         // Wrapper case: unify ClientCredentials + TokenOverride into an all-optional
         // wrapper shape so the parameter is a supertype of the collapsed
         // NormalizedClientOptions wrapper property.
+        //
+        // The `WRAPPER_PROPERTY`, `CLIENT_ID_PARAM`, `CLIENT_SECRET_PARAM`, and `TOKEN_PARAM`
+        // identifiers below are emitted verbatim into the generated file: this type is only
+        // valid because those module-level consts are unconditionally emitted in the wrapper
+        // branch (see `getConstants` / `keepIfWrapper`). The single-scheme branch returns
+        // early above, so it never references the wrapper-only consts.
         return `Partial<BaseClientOptions> & { [WRAPPER_PROPERTY]?: { [CLIENT_ID_PARAM]?: ${supplierType}; [CLIENT_SECRET_PARAM]?: ${supplierType}; [TOKEN_PARAM]?: ${supplierType} } }`;
     }
 

--- a/generators/typescript/sdk/generator/src/__test__/ReadmeSnippetBuilder.test.ts
+++ b/generators/typescript/sdk/generator/src/__test__/ReadmeSnippetBuilder.test.ts
@@ -113,11 +113,13 @@ function createMockFileContext(overrides?: {
     packageName?: string;
     namespaceExport?: string;
     authSchemes?: FernIr.AuthScheme[];
+    authRequirement?: FernIr.AuthSchemesRequirement;
 }): FileContext {
     const services = overrides?.services ?? {};
     const subpackages = overrides?.subpackages ?? {};
     const readmeConfig = overrides?.readmeConfig;
     const authSchemes = overrides?.authSchemes ?? [];
+    const authRequirement = overrides?.authRequirement ?? "ALL";
 
     return {
         case: new CaseConverter({ generationLanguage: "typescript", keywords: undefined, smartCasing: false }),
@@ -130,7 +132,7 @@ function createMockFileContext(overrides?: {
             readmeConfig,
             auth: {
                 schemes: authSchemes,
-                requirement: "ALL",
+                requirement: authRequirement,
                 docs: undefined
             }
         },
@@ -1078,6 +1080,45 @@ describe("ReadmeSnippetBuilder", () => {
             expect(description).toContain("clientSecret");
             expect(description).toContain("MySDKClient");
             expect(description).toContain("@acme/sdk");
+            // Single-scheme (ALL requirement) => credentials are top-level, not nested.
+            expect(description).not.toContain("oauth: {");
+        });
+
+        it("nests credentials under the OAuth wrapper when auth requirement is ANY", () => {
+            const endpoint = createEndpoint("ep1", "createUser");
+            const service = createService("svc1", createFernFilepath([]), [endpoint]);
+            const endpointSnippet = createEndpointSnippet("ep1", "POST", "await client.createUser();");
+
+            const context = createMockFileContext({
+                services: { svc1: service },
+                packageName: "@acme/sdk",
+                authRequirement: "ANY",
+                authSchemes: [
+                    FernIr.AuthScheme.oauth({
+                        key: "OAuth",
+                        configuration: {
+                            type: "clientCredentials"
+                        } as FernIr.OAuthConfiguration
+                        // biome-ignore lint/suspicious/noExplicitAny: IR mock
+                    } as any)
+                ]
+            });
+            const builder = new ReadmeSnippetBuilder({
+                context,
+                endpointSnippets: [endpointSnippet],
+                fileResponseType: "stream",
+                allowCustomFetcher: true,
+                generateSubpackageExports: false
+            });
+
+            const description = builder.buildAuthenticationDescription();
+            assert(description != null);
+            // Wrapper property matches OAuthAuthProvider's WRAPPER_PROPERTY ("oauth").
+            expect(description).toContain("oauth: {");
+            expect(description).toContain('clientId: "YOUR_CLIENT_ID"');
+            expect(description).toContain('clientSecret: "YOUR_CLIENT_SECRET"');
+            // Token override is also nested under the wrapper.
+            expect(description).toContain('token: "my-pre-generated-bearer-token"');
         });
 
         it("returns undefined when no OAuth scheme exists", () => {

--- a/generators/typescript/sdk/generator/src/readme/ReadmeSnippetBuilder.ts
+++ b/generators/typescript/sdk/generator/src/readme/ReadmeSnippetBuilder.ts
@@ -3,7 +3,7 @@ import { isNonNullish } from "@fern-api/core-utils";
 import { FernGeneratorCli } from "@fern-fern/generator-cli-sdk";
 import { FernGeneratorExec } from "@fern-fern/generator-exec-sdk";
 import { FernIr } from "@fern-fern/ir-sdk";
-import { getTextOfTsNode } from "@fern-typescript/commons";
+import { getTextOfTsNode, toCamelCase } from "@fern-typescript/commons";
 import { FileContext } from "@fern-typescript/contexts";
 import { readFileSync } from "fs";
 import { template } from "lodash-es";
@@ -529,6 +529,27 @@ const data = await response.json();
             return undefined;
         }
 
+        // When OAuth is combined with another scheme (ANY) or scoped per-endpoint
+        // (ENDPOINT_SECURITY), the generated client options nest OAuth credentials
+        // under a wrapper property (e.g. `oauth`). Emitting top-level `clientId`/
+        // `clientSecret` in that case would document a shape the auth provider does
+        // not read, so the client would never authenticate. Mirror the same signal
+        // used by the auth-provider and wire-test generators.
+        const wrapperPropertyName = this.getOAuthWrapperPropertyName(oauthScheme);
+
+        const clientCredentialsBody =
+            wrapperPropertyName != null
+                ? `    ${wrapperPropertyName}: {\n` +
+                  `        clientId: "YOUR_CLIENT_ID",\n` +
+                  `        clientSecret: "YOUR_CLIENT_SECRET",\n` +
+                  `    },\n`
+                : `    clientId: "YOUR_CLIENT_ID",\n` + `    clientSecret: "YOUR_CLIENT_SECRET",\n`;
+
+        const tokenOverrideBody =
+            wrapperPropertyName != null
+                ? `    ${wrapperPropertyName}: {\n` + `        token: "my-pre-generated-bearer-token",\n` + `    },\n`
+                : `    token: "my-pre-generated-bearer-token",\n`;
+
         return (
             "The SDK supports OAuth authentication with two options:\n\n" +
             "**Option 1: OAuth Client Credentials Flow**\n\n" +
@@ -536,8 +557,7 @@ const data = await response.json();
             "```typescript\n" +
             `import { ${this.rootClientConstructorName} } from "${this.rootPackageName}";\n\n` +
             `const ${this.clientVariableName} = new ${this.rootClientConstructorName}({\n` +
-            `    clientId: "YOUR_CLIENT_ID",\n` +
-            `    clientSecret: "YOUR_CLIENT_SECRET",\n` +
+            clientCredentialsBody +
             `    ...\n` +
             `});\n` +
             "```\n\n" +
@@ -546,11 +566,35 @@ const data = await response.json();
             "```typescript\n" +
             `import { ${this.rootClientConstructorName} } from "${this.rootPackageName}";\n\n` +
             `const ${this.clientVariableName} = new ${this.rootClientConstructorName}({\n` +
-            `    token: "my-pre-generated-bearer-token",\n` +
+            tokenOverrideBody +
             `    ...\n` +
             `});\n` +
             "```"
         );
+    }
+
+    /**
+     * Returns the wrapper property name under which OAuth credentials must be nested
+     * (e.g. `oauth`), or `undefined` when credentials are top-level (single-scheme).
+     *
+     * OAuth credentials are nested when the auth requirement is ANY (multiple schemes)
+     * or ENDPOINT_SECURITY (per-endpoint auth) — the same condition the auth-provider
+     * and wire-test generators use to switch on the wrapper.
+     */
+    private getOAuthWrapperPropertyName(oauthScheme: FernIr.AuthScheme.Oauth): string | undefined {
+        const requiresNestedAuth = FernIr.AuthSchemesRequirement._visit(this.context.ir.auth.requirement, {
+            any: () => true,
+            all: () => false,
+            endpointSecurity: () => true,
+            _other: () => false
+        });
+        if (!requiresNestedAuth) {
+            return undefined;
+        }
+        // Mirror OAuthAuthProviderGenerator.getWrapperPropertyName (the source of
+        // truth for WRAPPER_PROPERTY) so the README nests under the exact key the
+        // auth provider reads.
+        return toCamelCase(oauthScheme.key);
     }
 
     private buildCustomFetcherSnippets(): string[] | false {

--- a/generators/typescript/sdk/generator/src/readme/ReadmeSnippetBuilder.ts
+++ b/generators/typescript/sdk/generator/src/readme/ReadmeSnippetBuilder.ts
@@ -3,7 +3,7 @@ import { isNonNullish } from "@fern-api/core-utils";
 import { FernGeneratorCli } from "@fern-fern/generator-cli-sdk";
 import { FernGeneratorExec } from "@fern-fern/generator-exec-sdk";
 import { FernIr } from "@fern-fern/ir-sdk";
-import { getTextOfTsNode, toCamelCase } from "@fern-typescript/commons";
+import { getOAuthWrapperPropertyName, getTextOfTsNode } from "@fern-typescript/commons";
 import { FileContext } from "@fern-typescript/contexts";
 import { readFileSync } from "fs";
 import { template } from "lodash-es";
@@ -591,10 +591,10 @@ const data = await response.json();
         if (!requiresNestedAuth) {
             return undefined;
         }
-        // Mirror OAuthAuthProviderGenerator.getWrapperPropertyName (the source of
-        // truth for WRAPPER_PROPERTY) so the README nests under the exact key the
-        // auth provider reads.
-        return toCamelCase(oauthScheme.key);
+        // Use the shared helper that OAuthAuthProviderGenerator.getWrapperPropertyName
+        // also calls (the source of truth for WRAPPER_PROPERTY), so the README nests
+        // under the exact key the auth provider reads and the two cannot drift.
+        return getOAuthWrapperPropertyName(oauthScheme.key);
     }
 
     private buildCustomFetcherSnippets(): string[] | false {

--- a/generators/typescript/utils/commons/src/codegen-utils/getOAuthWrapperPropertyName.ts
+++ b/generators/typescript/utils/commons/src/codegen-utils/getOAuthWrapperPropertyName.ts
@@ -1,0 +1,18 @@
+import { toCamelCase } from "./toCamelCase.js";
+
+/**
+ * Derives the wrapper property name under which OAuth credentials are nested when
+ * multiple auth schemes are present (e.g. `OAuth` -> `oauth`, `magical_auth` -> `magicalAuth`).
+ *
+ * This is the single source of truth for the OAuth wrapper key. Both
+ * `OAuthAuthProviderGenerator` (which emits `WRAPPER_PROPERTY` into the generated
+ * SDK) and `ReadmeSnippetBuilder` (which documents the key users must nest under)
+ * call this helper so their derivations cannot drift apart — any change to casing,
+ * keyword escaping, or smart-casing lives here and applies to both.
+ *
+ * @param oauthSchemeKey The `key` of the OAuth `AuthScheme`.
+ * @returns The camelCased wrapper property name.
+ */
+export function getOAuthWrapperPropertyName(oauthSchemeKey: string): string {
+    return toCamelCase(oauthSchemeKey);
+}

--- a/generators/typescript/utils/commons/src/index.ts
+++ b/generators/typescript/utils/commons/src/index.ts
@@ -8,6 +8,7 @@ export {
 export { deduplicateExamples } from "./codegen-utils/deduplicateExamples.js";
 export { generateInlineAliasModule, generateInlinePropertiesModule } from "./codegen-utils/generateInlineModule.js";
 export { getExampleEndpointCalls, getExampleEndpointCallsForTests } from "./codegen-utils/getExampleEndpointCalls.js";
+export { getOAuthWrapperPropertyName } from "./codegen-utils/getOAuthWrapperPropertyName.js";
 export {
     getParameterNameForPositionalPathParameter,
     getParameterNameForPropertyPathParameter,

--- a/seed/ts-sdk/any-auth/always-send-auth/README.md
+++ b/seed/ts-sdk/any-auth/always-send-auth/README.md
@@ -62,8 +62,10 @@ Use this when you want the SDK to automatically handle OAuth token retrieval and
 import { SeedAnyAuthClient } from "@fern/any-auth";
 
 const client = new SeedAnyAuthClient({
-    clientId: "YOUR_CLIENT_ID",
-    clientSecret: "YOUR_CLIENT_SECRET",
+    oauth: {
+        clientId: "YOUR_CLIENT_ID",
+        clientSecret: "YOUR_CLIENT_SECRET",
+    },
     ...
 });
 ```
@@ -76,7 +78,9 @@ Use this when you already have a valid bearer token and want to skip the OAuth f
 import { SeedAnyAuthClient } from "@fern/any-auth";
 
 const client = new SeedAnyAuthClient({
-    token: "my-pre-generated-bearer-token",
+    oauth: {
+        token: "my-pre-generated-bearer-token",
+    },
     ...
 });
 ```

--- a/seed/ts-sdk/any-auth/always-send-auth/src/auth/OAuthAuthProvider.ts
+++ b/seed/ts-sdk/any-auth/always-send-auth/src/auth/OAuthAuthProvider.ts
@@ -31,7 +31,15 @@ export class OAuthAuthProvider implements core.AuthProvider {
         this.expiresAt = new Date();
     }
 
-    public static canCreate(options?: Partial<OAuthAuthProvider.ClientCredentials & BaseClientOptions>): boolean {
+    public static canCreate(
+        options?: Partial<BaseClientOptions> & {
+            [WRAPPER_PROPERTY]?: {
+                [CLIENT_ID_PARAM]?: core.Supplier<string>;
+                [CLIENT_SECRET_PARAM]?: core.Supplier<string>;
+                [TOKEN_PARAM]?: core.Supplier<string>;
+            };
+        },
+    ): boolean {
         return (
             (options?.[WRAPPER_PROPERTY]?.[CLIENT_ID_PARAM] != null || process.env?.[ENV_CLIENT_ID] != null) &&
             (options?.[WRAPPER_PROPERTY]?.[CLIENT_SECRET_PARAM] != null || process.env?.[ENV_CLIENT_SECRET] != null)

--- a/seed/ts-sdk/any-auth/generate-endpoint-metadata/README.md
+++ b/seed/ts-sdk/any-auth/generate-endpoint-metadata/README.md
@@ -62,8 +62,10 @@ Use this when you want the SDK to automatically handle OAuth token retrieval and
 import { SeedAnyAuthClient } from "@fern/any-auth";
 
 const client = new SeedAnyAuthClient({
-    clientId: "YOUR_CLIENT_ID",
-    clientSecret: "YOUR_CLIENT_SECRET",
+    oauth: {
+        clientId: "YOUR_CLIENT_ID",
+        clientSecret: "YOUR_CLIENT_SECRET",
+    },
     ...
 });
 ```
@@ -76,7 +78,9 @@ Use this when you already have a valid bearer token and want to skip the OAuth f
 import { SeedAnyAuthClient } from "@fern/any-auth";
 
 const client = new SeedAnyAuthClient({
-    token: "my-pre-generated-bearer-token",
+    oauth: {
+        token: "my-pre-generated-bearer-token",
+    },
     ...
 });
 ```

--- a/seed/ts-sdk/any-auth/generate-endpoint-metadata/src/auth/OAuthAuthProvider.ts
+++ b/seed/ts-sdk/any-auth/generate-endpoint-metadata/src/auth/OAuthAuthProvider.ts
@@ -31,7 +31,15 @@ export class OAuthAuthProvider implements core.AuthProvider {
         this.expiresAt = new Date();
     }
 
-    public static canCreate(options?: Partial<OAuthAuthProvider.ClientCredentials & BaseClientOptions>): boolean {
+    public static canCreate(
+        options?: Partial<BaseClientOptions> & {
+            [WRAPPER_PROPERTY]?: {
+                [CLIENT_ID_PARAM]?: core.EndpointSupplier<string>;
+                [CLIENT_SECRET_PARAM]?: core.EndpointSupplier<string>;
+                [TOKEN_PARAM]?: core.EndpointSupplier<string>;
+            };
+        },
+    ): boolean {
         return (
             (options?.[WRAPPER_PROPERTY]?.[CLIENT_ID_PARAM] != null || process.env?.[ENV_CLIENT_ID] != null) &&
             (options?.[WRAPPER_PROPERTY]?.[CLIENT_SECRET_PARAM] != null || process.env?.[ENV_CLIENT_SECRET] != null)

--- a/seed/ts-sdk/any-auth/no-custom-config/README.md
+++ b/seed/ts-sdk/any-auth/no-custom-config/README.md
@@ -62,8 +62,10 @@ Use this when you want the SDK to automatically handle OAuth token retrieval and
 import { SeedAnyAuthClient } from "@fern/any-auth";
 
 const client = new SeedAnyAuthClient({
-    clientId: "YOUR_CLIENT_ID",
-    clientSecret: "YOUR_CLIENT_SECRET",
+    oauth: {
+        clientId: "YOUR_CLIENT_ID",
+        clientSecret: "YOUR_CLIENT_SECRET",
+    },
     ...
 });
 ```
@@ -76,7 +78,9 @@ Use this when you already have a valid bearer token and want to skip the OAuth f
 import { SeedAnyAuthClient } from "@fern/any-auth";
 
 const client = new SeedAnyAuthClient({
-    token: "my-pre-generated-bearer-token",
+    oauth: {
+        token: "my-pre-generated-bearer-token",
+    },
     ...
 });
 ```

--- a/seed/ts-sdk/any-auth/no-custom-config/src/auth/OAuthAuthProvider.ts
+++ b/seed/ts-sdk/any-auth/no-custom-config/src/auth/OAuthAuthProvider.ts
@@ -31,7 +31,15 @@ export class OAuthAuthProvider implements core.AuthProvider {
         this.expiresAt = new Date();
     }
 
-    public static canCreate(options?: Partial<OAuthAuthProvider.ClientCredentials & BaseClientOptions>): boolean {
+    public static canCreate(
+        options?: Partial<BaseClientOptions> & {
+            [WRAPPER_PROPERTY]?: {
+                [CLIENT_ID_PARAM]?: core.Supplier<string>;
+                [CLIENT_SECRET_PARAM]?: core.Supplier<string>;
+                [TOKEN_PARAM]?: core.Supplier<string>;
+            };
+        },
+    ): boolean {
         return (
             (options?.[WRAPPER_PROPERTY]?.[CLIENT_ID_PARAM] != null || process.env?.[ENV_CLIENT_ID] != null) &&
             (options?.[WRAPPER_PROPERTY]?.[CLIENT_SECRET_PARAM] != null || process.env?.[ENV_CLIENT_SECRET] != null)

--- a/seed/ts-sdk/endpoint-security-auth/README.md
+++ b/seed/ts-sdk/endpoint-security-auth/README.md
@@ -62,8 +62,10 @@ Use this when you want the SDK to automatically handle OAuth token retrieval and
 import { SeedEndpointSecurityAuthClient } from "@fern/endpoint-security-auth";
 
 const client = new SeedEndpointSecurityAuthClient({
-    clientId: "YOUR_CLIENT_ID",
-    clientSecret: "YOUR_CLIENT_SECRET",
+    oauth: {
+        clientId: "YOUR_CLIENT_ID",
+        clientSecret: "YOUR_CLIENT_SECRET",
+    },
     ...
 });
 ```
@@ -76,7 +78,9 @@ Use this when you already have a valid bearer token and want to skip the OAuth f
 import { SeedEndpointSecurityAuthClient } from "@fern/endpoint-security-auth";
 
 const client = new SeedEndpointSecurityAuthClient({
-    token: "my-pre-generated-bearer-token",
+    oauth: {
+        token: "my-pre-generated-bearer-token",
+    },
     ...
 });
 ```

--- a/seed/ts-sdk/endpoint-security-auth/src/auth/OAuthAuthProvider.ts
+++ b/seed/ts-sdk/endpoint-security-auth/src/auth/OAuthAuthProvider.ts
@@ -31,7 +31,15 @@ export class OAuthAuthProvider implements core.AuthProvider {
         this.expiresAt = new Date();
     }
 
-    public static canCreate(options?: Partial<OAuthAuthProvider.ClientCredentials & BaseClientOptions>): boolean {
+    public static canCreate(
+        options?: Partial<BaseClientOptions> & {
+            [WRAPPER_PROPERTY]?: {
+                [CLIENT_ID_PARAM]?: core.EndpointSupplier<string>;
+                [CLIENT_SECRET_PARAM]?: core.EndpointSupplier<string>;
+                [TOKEN_PARAM]?: core.EndpointSupplier<string>;
+            };
+        },
+    ): boolean {
         return (
             (options?.[WRAPPER_PROPERTY]?.[CLIENT_ID_PARAM] != null || process.env?.[ENV_CLIENT_ID] != null) &&
             (options?.[WRAPPER_PROPERTY]?.[CLIENT_SECRET_PARAM] != null || process.env?.[ENV_CLIENT_SECRET] != null)


### PR DESCRIPTION
## Description
Fixes two OAuth client-credentials codegen bugs in the TypeScript SDK generator, both of which only affect the **multi-scheme / wrapper** case (OAuth combined with another scheme via `auth: any`, or endpoint-scoped auth). Single-scheme OAuth output is byte-identical. Reported by a customer (perkss) against `fern-typescript-sdk 3.82.3`; both bugs still reproduced on current `main`.

## Changes Made

**Bug 1a — `tsc --strict` failure on multi-scheme OAuth**
- When OAuth is combined with another scheme and has no client-id/secret env-var fallback (so the nested `oauth.clientId`/`clientSecret` are *required*), the generated `BaseClient.ts` failed `tsc --strict` with `TS2322`: `OAuthAuthProvider.canCreate` was not assignable to `AnyAuthProvider`'s `InstantiatableAuthProvider` contract `(opts: NormalizedClientOptions) => boolean`. `NormalizedClientOptions` collapses the wrapper property to the token-override shape (`{ token? }`) via `AtLeastOneOf`/`UnionToIntersection`, so under function-parameter contravariance the narrow `Partial<ClientCredentials & BaseClientOptions>` parameter was rejected.
- Fix: `OAuthAuthProviderGenerator` now widens the `canCreate` parameter in the wrapper case to an all-optional wrapper shape (`{ [WRAPPER_PROPERTY]?: { clientId?; clientSecret?; token? } }`), using the same `Supplier | EndpointSupplier` type the emitted options use. Runtime body is unchanged.

**Bug 1b — README documented un-authenticating credentials**
- The generated README OAuth quickstart emitted top-level `clientId`/`clientSecret` (and token override), but in the wrapper case the auth provider only reads them nested under the wrapper property (e.g. `oauth: { ... }`) — so the documented usage never authenticated.
- Fix: `ReadmeSnippetBuilder.buildAuthenticationDescription()` now nests credentials under the wrapper when the auth requirement is `any` or endpoint-scoped, mirroring the same `requiresNestedAuth` signal used by the auth-provider and wire-test generators. The wrapper key is derived via `toCamelCase(oauthScheme.key)` — the exact source of truth for `WRAPPER_PROPERTY`.
- **The wire-test / `mockAuth` half of 1b was already correct on `main`** (`TestGenerator.getAuthClientOptions()` already branches on `requiresNestedAuth`), so only the README needed fixing.

- [x] Updated README.md generator

## Testing
- [x] Unit tests added/updated
  - `AuthProviders.test.ts`: new type-diagnostic suite that reproduces the 1a contravariance failure with the old narrow parameter and proves the widened parameter satisfies the contract.
  - `ReadmeSnippetBuilder.test.ts`: new test asserting nested `oauth: { ... }` for `ANY` requirement, plus an assertion that single-scheme (`ALL`) stays top-level.
- [x] Manual testing completed
  - Reproduced 1a in isolation (`tsc 5.9.3 --strict` → exact `TS2322`); confirmed fix type-checks.
  - Regenerated all `any-auth`, `endpoint-security-auth`, and single-scheme `oauth-client-credentials*` seed fixtures via local generator. All pass the validator's strict typecheck. Only the 4 wrapper fixtures' `README.md` + `OAuthAuthProvider.ts` changed; every single-scheme fixture is byte-identical (metadata-only churn reverted).
- Changelog: `fix` entry under `generators/typescript/sdk/changes/unreleased/`.

Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/17262" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->