### PR TITLE
fix(openapi): scope error schema consistency checks per namespace

### DIFF
--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir/namespaced-error-schemas.json
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir/namespaced-error-schemas.json
@@ -1,0 +1,615 @@
+{
+  "specVersion": "1.0.0",
+  "title": "Users API",
+  "servers": [
+    {
+      "url": "https://api.example.com"
+    },
+    {
+      "url": "https://api.example.com"
+    }
+  ],
+  "websocketServers": [],
+  "tags": {
+    "tagsById": {}
+  },
+  "hasEndpointsMarkedInternal": false,
+  "endpoints": [
+    {
+      "audiences": [],
+      "operationId": "listUsers",
+      "tags": [
+        "users"
+      ],
+      "namespace": "users",
+      "pathParameters": [],
+      "queryParameters": [],
+      "headers": [],
+      "generatedRequestName": "ListUsersRequest",
+      "response": {
+        "description": "OK",
+        "schema": {
+          "value": {
+            "generatedName": "ListUsersResponseItem",
+            "schema": "User",
+            "namespace": "users",
+            "source": {
+              "file": "../users-api.yml",
+              "type": "openapi"
+            },
+            "type": "reference"
+          },
+          "generatedName": "ListUsersResponse",
+          "namespace": "users",
+          "groupName": [
+            {
+              "type": "namespace",
+              "name": "users"
+            }
+          ],
+          "type": "array"
+        },
+        "fullExamples": [],
+        "source": {
+          "file": "../users-api.yml",
+          "type": "openapi"
+        },
+        "statusCode": 200,
+        "type": "json"
+      },
+      "errors": {
+        "400": {
+          "generatedName": "BadRequestError",
+          "schema": {
+            "generatedName": "BadRequestErrorBody",
+            "schema": "UsersError",
+            "namespace": "users",
+            "source": {
+              "file": "../users-api.yml",
+              "type": "openapi"
+            },
+            "type": "reference"
+          },
+          "description": "Bad request",
+          "source": {
+            "file": "../users-api.yml",
+            "type": "openapi"
+          },
+          "examples": [
+            {
+              "example": {
+                "properties": {
+                  "code": {
+                    "value": {
+                      "value": 1,
+                      "type": "int"
+                    },
+                    "type": "primitive"
+                  }
+                },
+                "type": "object"
+              }
+            }
+          ]
+        }
+      },
+      "servers": [],
+      "authed": false,
+      "method": "GET",
+      "path": "/users",
+      "examples": [
+        {
+          "pathParameters": [],
+          "queryParameters": [],
+          "headers": [],
+          "response": {
+            "value": {
+              "value": [
+                {
+                  "properties": {
+                    "id": {
+                      "value": {
+                        "value": "id",
+                        "type": "string"
+                      },
+                      "type": "primitive"
+                    },
+                    "name": {
+                      "value": {
+                        "value": "name",
+                        "type": "string"
+                      },
+                      "type": "primitive"
+                    }
+                  },
+                  "type": "object"
+                }
+              ],
+              "type": "array"
+            },
+            "type": "withoutStreaming"
+          },
+          "codeSamples": [],
+          "type": "full"
+        }
+      ],
+      "source": {
+        "file": "../users-api.yml",
+        "type": "openapi"
+      }
+    },
+    {
+      "audiences": [],
+      "operationId": "listPayments",
+      "tags": [
+        "payments"
+      ],
+      "namespace": "payments",
+      "pathParameters": [],
+      "queryParameters": [],
+      "headers": [],
+      "generatedRequestName": "ListPaymentsRequest",
+      "response": {
+        "description": "OK",
+        "schema": {
+          "value": {
+            "generatedName": "ListPaymentsResponseItem",
+            "schema": "Payment",
+            "namespace": "payments",
+            "source": {
+              "file": "../payments-api.yml",
+              "type": "openapi"
+            },
+            "type": "reference"
+          },
+          "generatedName": "ListPaymentsResponse",
+          "namespace": "payments",
+          "groupName": [
+            {
+              "type": "namespace",
+              "name": "payments"
+            }
+          ],
+          "type": "array"
+        },
+        "fullExamples": [],
+        "source": {
+          "file": "../payments-api.yml",
+          "type": "openapi"
+        },
+        "statusCode": 200,
+        "type": "json"
+      },
+      "errors": {
+        "400": {
+          "generatedName": "BadRequestError",
+          "schema": {
+            "generatedName": "BadRequestErrorBody",
+            "schema": "PaymentsError",
+            "namespace": "payments",
+            "source": {
+              "file": "../payments-api.yml",
+              "type": "openapi"
+            },
+            "type": "reference"
+          },
+          "description": "Bad request",
+          "source": {
+            "file": "../payments-api.yml",
+            "type": "openapi"
+          },
+          "examples": [
+            {
+              "example": {
+                "properties": {
+                  "type": {
+                    "value": {
+                      "value": "type",
+                      "type": "string"
+                    },
+                    "type": "primitive"
+                  },
+                  "title": {
+                    "value": {
+                      "value": "title",
+                      "type": "string"
+                    },
+                    "type": "primitive"
+                  }
+                },
+                "type": "object"
+              }
+            }
+          ]
+        }
+      },
+      "servers": [],
+      "authed": false,
+      "method": "GET",
+      "path": "/payments",
+      "examples": [
+        {
+          "pathParameters": [],
+          "queryParameters": [],
+          "headers": [],
+          "response": {
+            "value": {
+              "value": [
+                {
+                  "properties": {
+                    "id": {
+                      "value": {
+                        "value": "id",
+                        "type": "string"
+                      },
+                      "type": "primitive"
+                    },
+                    "amount": {
+                      "value": {
+                        "value": 1,
+                        "type": "int"
+                      },
+                      "type": "primitive"
+                    }
+                  },
+                  "type": "object"
+                }
+              ],
+              "type": "array"
+            },
+            "type": "withoutStreaming"
+          },
+          "codeSamples": [],
+          "type": "full"
+        }
+      ],
+      "source": {
+        "file": "../payments-api.yml",
+        "type": "openapi"
+      }
+    }
+  ],
+  "webhooks": [],
+  "channels": {},
+  "groupedSchemas": {
+    "rootSchemas": {},
+    "namespacedSchemas": {
+      "users": {
+        "User": {
+          "allOf": [],
+          "properties": [
+            {
+              "conflict": {},
+              "generatedName": "userId",
+              "key": "id",
+              "schema": {
+                "generatedName": "UserId",
+                "value": {
+                  "schema": {
+                    "type": "string"
+                  },
+                  "generatedName": "UserId",
+                  "namespace": "users",
+                  "groupName": [
+                    {
+                      "type": "namespace",
+                      "name": "users"
+                    }
+                  ],
+                  "type": "primitive"
+                },
+                "namespace": "users",
+                "groupName": [
+                  {
+                    "type": "namespace",
+                    "name": "users"
+                  }
+                ],
+                "type": "optional"
+              },
+              "audiences": []
+            },
+            {
+              "conflict": {},
+              "generatedName": "userName",
+              "key": "name",
+              "schema": {
+                "generatedName": "UserName",
+                "value": {
+                  "schema": {
+                    "type": "string"
+                  },
+                  "generatedName": "UserName",
+                  "namespace": "users",
+                  "groupName": [
+                    {
+                      "type": "namespace",
+                      "name": "users"
+                    }
+                  ],
+                  "type": "primitive"
+                },
+                "namespace": "users",
+                "groupName": [
+                  {
+                    "type": "namespace",
+                    "name": "users"
+                  }
+                ],
+                "type": "optional"
+              },
+              "audiences": []
+            }
+          ],
+          "allOfPropertyConflicts": [],
+          "generatedName": "User",
+          "namespace": "users",
+          "groupName": [
+            {
+              "type": "namespace",
+              "name": "users"
+            }
+          ],
+          "additionalProperties": false,
+          "source": {
+            "file": "../users-api.yml",
+            "type": "openapi"
+          },
+          "type": "object"
+        },
+        "UsersError": {
+          "allOf": [],
+          "properties": [
+            {
+              "conflict": {},
+              "generatedName": "usersErrorCode",
+              "key": "code",
+              "schema": {
+                "schema": {
+                  "type": "int"
+                },
+                "generatedName": "UsersErrorCode",
+                "namespace": "users",
+                "groupName": [
+                  {
+                    "type": "namespace",
+                    "name": "users"
+                  }
+                ],
+                "type": "primitive"
+              },
+              "audiences": []
+            },
+            {
+              "conflict": {},
+              "generatedName": "usersErrorMessage",
+              "key": "message",
+              "schema": {
+                "generatedName": "UsersErrorMessage",
+                "value": {
+                  "schema": {
+                    "type": "string"
+                  },
+                  "generatedName": "UsersErrorMessage",
+                  "namespace": "users",
+                  "groupName": [
+                    {
+                      "type": "namespace",
+                      "name": "users"
+                    }
+                  ],
+                  "type": "primitive"
+                },
+                "namespace": "users",
+                "groupName": [
+                  {
+                    "type": "namespace",
+                    "name": "users"
+                  }
+                ],
+                "type": "optional"
+              },
+              "audiences": []
+            }
+          ],
+          "allOfPropertyConflicts": [],
+          "generatedName": "UsersError",
+          "namespace": "users",
+          "groupName": [
+            {
+              "type": "namespace",
+              "name": "users"
+            }
+          ],
+          "additionalProperties": false,
+          "source": {
+            "file": "../users-api.yml",
+            "type": "openapi"
+          },
+          "type": "object"
+        }
+      },
+      "payments": {
+        "Payment": {
+          "allOf": [],
+          "properties": [
+            {
+              "conflict": {},
+              "generatedName": "paymentId",
+              "key": "id",
+              "schema": {
+                "generatedName": "PaymentId",
+                "value": {
+                  "schema": {
+                    "type": "string"
+                  },
+                  "generatedName": "PaymentId",
+                  "namespace": "payments",
+                  "groupName": [
+                    {
+                      "type": "namespace",
+                      "name": "payments"
+                    }
+                  ],
+                  "type": "primitive"
+                },
+                "namespace": "payments",
+                "groupName": [
+                  {
+                    "type": "namespace",
+                    "name": "payments"
+                  }
+                ],
+                "type": "optional"
+              },
+              "audiences": []
+            },
+            {
+              "conflict": {},
+              "generatedName": "paymentAmount",
+              "key": "amount",
+              "schema": {
+                "generatedName": "PaymentAmount",
+                "value": {
+                  "schema": {
+                    "type": "int"
+                  },
+                  "generatedName": "PaymentAmount",
+                  "namespace": "payments",
+                  "groupName": [
+                    {
+                      "type": "namespace",
+                      "name": "payments"
+                    }
+                  ],
+                  "type": "primitive"
+                },
+                "namespace": "payments",
+                "groupName": [
+                  {
+                    "type": "namespace",
+                    "name": "payments"
+                  }
+                ],
+                "type": "optional"
+              },
+              "audiences": []
+            }
+          ],
+          "allOfPropertyConflicts": [],
+          "generatedName": "Payment",
+          "namespace": "payments",
+          "groupName": [
+            {
+              "type": "namespace",
+              "name": "payments"
+            }
+          ],
+          "additionalProperties": false,
+          "source": {
+            "file": "../payments-api.yml",
+            "type": "openapi"
+          },
+          "type": "object"
+        },
+        "PaymentsError": {
+          "allOf": [],
+          "properties": [
+            {
+              "conflict": {},
+              "generatedName": "paymentsErrorType",
+              "key": "type",
+              "schema": {
+                "schema": {
+                  "type": "string"
+                },
+                "generatedName": "PaymentsErrorType",
+                "namespace": "payments",
+                "groupName": [
+                  {
+                    "type": "namespace",
+                    "name": "payments"
+                  }
+                ],
+                "type": "primitive"
+              },
+              "audiences": []
+            },
+            {
+              "conflict": {},
+              "generatedName": "paymentsErrorTitle",
+              "key": "title",
+              "schema": {
+                "schema": {
+                  "type": "string"
+                },
+                "generatedName": "PaymentsErrorTitle",
+                "namespace": "payments",
+                "groupName": [
+                  {
+                    "type": "namespace",
+                    "name": "payments"
+                  }
+                ],
+                "type": "primitive"
+              },
+              "audiences": []
+            },
+            {
+              "conflict": {},
+              "generatedName": "paymentsErrorDetail",
+              "key": "detail",
+              "schema": {
+                "generatedName": "PaymentsErrorDetail",
+                "value": {
+                  "schema": {
+                    "type": "string"
+                  },
+                  "generatedName": "PaymentsErrorDetail",
+                  "namespace": "payments",
+                  "groupName": [
+                    {
+                      "type": "namespace",
+                      "name": "payments"
+                    }
+                  ],
+                  "type": "primitive"
+                },
+                "namespace": "payments",
+                "groupName": [
+                  {
+                    "type": "namespace",
+                    "name": "payments"
+                  }
+                ],
+                "type": "optional"
+              },
+              "audiences": []
+            }
+          ],
+          "allOfPropertyConflicts": [],
+          "generatedName": "PaymentsError",
+          "namespace": "payments",
+          "groupName": [
+            {
+              "type": "namespace",
+              "name": "payments"
+            }
+          ],
+          "additionalProperties": false,
+          "source": {
+            "file": "../payments-api.yml",
+            "type": "openapi"
+          },
+          "type": "object"
+        }
+      }
+    }
+  },
+  "variables": {},
+  "nonRequestReferencedSchemas": {},
+  "securitySchemes": {},
+  "globalHeaders": [],
+  "idempotencyHeaders": [],
+  "groups": {}
+}

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi/namespaced-error-schemas.json
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi/namespaced-error-schemas.json
@@ -1,0 +1,296 @@
+{
+  "absoluteFilePath": "/DUMMY_PATH",
+  "importedDefinitions": {},
+  "namedDefinitionFiles": {
+    "__package__.yml": {
+      "absoluteFilepath": "/DUMMY_PATH",
+      "contents": {},
+      "rawContents": "{}
+",
+    },
+    "payments/__package__.yml": {
+      "absoluteFilepath": "/DUMMY_PATH",
+      "contents": {
+        "errors": {
+          "BadRequestError": {
+            "docs": "Bad request",
+            "examples": [
+              {
+                "docs": undefined,
+                "name": undefined,
+                "value": {
+                  "title": "title",
+                  "type": "type",
+                },
+              },
+            ],
+            "status-code": 400,
+            "type": "PaymentsError",
+          },
+        },
+        "service": {
+          "auth": false,
+          "base-path": "",
+          "endpoints": {
+            "listPayments": {
+              "auth": undefined,
+              "docs": undefined,
+              "errors": [
+                "BadRequestError",
+              ],
+              "examples": [
+                {
+                  "response": {
+                    "body": [
+                      {
+                        "amount": 1,
+                        "id": "id",
+                      },
+                    ],
+                  },
+                },
+              ],
+              "method": "GET",
+              "pagination": undefined,
+              "path": "/payments",
+              "response": {
+                "docs": "OK",
+                "status-code": 200,
+                "type": "list<Payment>",
+              },
+              "source": {
+                "openapi": "../payments-api.yml",
+              },
+            },
+          },
+          "source": {
+            "openapi": "../payments-api.yml",
+          },
+        },
+        "types": {
+          "Payment": {
+            "docs": undefined,
+            "inline": undefined,
+            "properties": {
+              "amount": "optional<integer>",
+              "id": "optional<string>",
+            },
+            "source": {
+              "openapi": "../payments-api.yml",
+            },
+          },
+          "PaymentsError": {
+            "docs": undefined,
+            "inline": undefined,
+            "properties": {
+              "detail": "optional<string>",
+              "title": "string",
+              "type": "string",
+            },
+            "source": {
+              "openapi": "../payments-api.yml",
+            },
+          },
+        },
+      },
+      "rawContents": "errors:
+  BadRequestError:
+    status-code: 400
+    type: PaymentsError
+    docs: Bad request
+    examples:
+      - value:
+          type: type
+          title: title
+service:
+  auth: false
+  base-path: ''
+  endpoints:
+    listPayments:
+      path: /payments
+      method: GET
+      source:
+        openapi: ../payments-api.yml
+      response:
+        docs: OK
+        type: list<Payment>
+        status-code: 200
+      errors:
+        - BadRequestError
+      examples:
+        - response:
+            body:
+              - id: id
+                amount: 1
+  source:
+    openapi: ../payments-api.yml
+types:
+  Payment:
+    properties:
+      id: optional<string>
+      amount: optional<integer>
+    source:
+      openapi: ../payments-api.yml
+  PaymentsError:
+    properties:
+      type: string
+      title: string
+      detail: optional<string>
+    source:
+      openapi: ../payments-api.yml
+",
+    },
+    "users/__package__.yml": {
+      "absoluteFilepath": "/DUMMY_PATH",
+      "contents": {
+        "errors": {
+          "BadRequestError": {
+            "docs": "Bad request",
+            "examples": [
+              {
+                "docs": undefined,
+                "name": undefined,
+                "value": {
+                  "code": 1,
+                },
+              },
+            ],
+            "status-code": 400,
+            "type": "UsersError",
+          },
+        },
+        "service": {
+          "auth": false,
+          "base-path": "",
+          "endpoints": {
+            "listUsers": {
+              "auth": undefined,
+              "docs": undefined,
+              "errors": [
+                "BadRequestError",
+              ],
+              "examples": [
+                {
+                  "response": {
+                    "body": [
+                      {
+                        "id": "id",
+                        "name": "name",
+                      },
+                    ],
+                  },
+                },
+              ],
+              "method": "GET",
+              "pagination": undefined,
+              "path": "/users",
+              "response": {
+                "docs": "OK",
+                "status-code": 200,
+                "type": "list<User>",
+              },
+              "source": {
+                "openapi": "../users-api.yml",
+              },
+            },
+          },
+          "source": {
+            "openapi": "../users-api.yml",
+          },
+        },
+        "types": {
+          "User": {
+            "docs": undefined,
+            "inline": undefined,
+            "properties": {
+              "id": "optional<string>",
+              "name": "optional<string>",
+            },
+            "source": {
+              "openapi": "../users-api.yml",
+            },
+          },
+          "UsersError": {
+            "docs": undefined,
+            "inline": undefined,
+            "properties": {
+              "code": "integer",
+              "message": "optional<string>",
+            },
+            "source": {
+              "openapi": "../users-api.yml",
+            },
+          },
+        },
+      },
+      "rawContents": "errors:
+  BadRequestError:
+    status-code: 400
+    type: UsersError
+    docs: Bad request
+    examples:
+      - value:
+          code: 1
+service:
+  auth: false
+  base-path: ''
+  endpoints:
+    listUsers:
+      path: /users
+      method: GET
+      source:
+        openapi: ../users-api.yml
+      response:
+        docs: OK
+        type: list<User>
+        status-code: 200
+      errors:
+        - BadRequestError
+      examples:
+        - response:
+            body:
+              - id: id
+                name: name
+  source:
+    openapi: ../users-api.yml
+types:
+  User:
+    properties:
+      id: optional<string>
+      name: optional<string>
+    source:
+      openapi: ../users-api.yml
+  UsersError:
+    properties:
+      code: integer
+      message: optional<string>
+    source:
+      openapi: ../users-api.yml
+",
+    },
+  },
+  "packageMarkers": {},
+  "rootApiFile": {
+    "contents": {
+      "default-environment": "Default",
+      "display-name": "Users API",
+      "environments": {
+        "Default": "https://api.example.com",
+      },
+      "error-discrimination": {
+        "strategy": "status-code",
+      },
+      "name": "api",
+    },
+    "defaultUrl": undefined,
+    "rawContents": "name: api
+error-discrimination:
+  strategy: status-code
+display-name: Users API
+environments:
+  Default: https://api.example.com
+default-environment: Default
+",
+  },
+  "specVersion": "1.0.0",
+}

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/fixtures/namespaced-error-schemas/fern/generators.yml
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/fixtures/namespaced-error-schemas/fern/generators.yml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://schema.buildwithfern.dev/generators-yml.json
+api:
+  specs:
+    - openapi: ../users-api.yml
+      namespace: users
+    - openapi: ../payments-api.yml
+      namespace: payments

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/fixtures/namespaced-error-schemas/payments-api.yml
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/fixtures/namespaced-error-schemas/payments-api.yml
@@ -1,0 +1,46 @@
+openapi: 3.0.1
+info:
+  title: Payments API
+  version: 1.0.0
+servers:
+  - url: https://api.example.com
+paths:
+  /payments:
+    get:
+      operationId: listPayments
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Payment'
+        '400':
+          description: Bad request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PaymentsError'
+components:
+  schemas:
+    Payment:
+      type: object
+      properties:
+        id:
+          type: string
+        amount:
+          type: integer
+    PaymentsError:
+      type: object
+      required:
+        - type
+        - title
+      properties:
+        type:
+          type: string
+        title:
+          type: string
+        detail:
+          type: string

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/fixtures/namespaced-error-schemas/users-api.yml
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/fixtures/namespaced-error-schemas/users-api.yml
@@ -1,0 +1,43 @@
+openapi: 3.0.1
+info:
+  title: Users API
+  version: 1.0.0
+servers:
+  - url: https://api.example.com
+paths:
+  /users:
+    get:
+      operationId: listUsers
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/User'
+        '400':
+          description: Bad request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UsersError'
+components:
+  schemas:
+    User:
+      type: object
+      properties:
+        id:
+          type: string
+        name:
+          type: string
+    UsersError:
+      type: object
+      required:
+        - code
+      properties:
+        code:
+          type: integer
+        message:
+          type: string

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern/src/OpenApiIrConverterContext.ts
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern/src/OpenApiIrConverterContext.ts
@@ -38,7 +38,7 @@ export class OpenApiIrConverterContext {
 
     private enableUniqueErrorsPerEndpoint: boolean;
     private defaultServerName: string | undefined = undefined;
-    private unknownSchema: Set<number> = new Set();
+    private unknownSchema: Set<string> = new Set();
 
     /**
      * The set of referenced schema ids to include in the generated definition.
@@ -109,14 +109,15 @@ export class OpenApiIrConverterContext {
             this.builder.setDisplayName({ displayName: ir.title });
         }
 
-        const schemaByStatusCode: Record<number, Schema> = {};
+        const schemaByErrorKey: Record<string, Schema> = {};
         if (!this.enableUniqueErrorsPerEndpoint) {
             for (const endpoint of ir.endpoints) {
                 for (const [statusCodeString, error] of Object.entries(endpoint.errors)) {
                     const statusCode = parseInt(statusCodeString);
-                    const existingSchema = schemaByStatusCode[statusCode];
+                    const errorKey = getErrorSchemaKey({ statusCode, namespace: endpoint.namespace });
+                    const existingSchema = schemaByErrorKey[errorKey];
                     if (existingSchema == null && error.schema != null) {
-                        schemaByStatusCode[statusCode] = error.schema;
+                        schemaByErrorKey[errorKey] = error.schema;
                     } else if (
                         existingSchema != null &&
                         error.schema != null &&
@@ -124,7 +125,7 @@ export class OpenApiIrConverterContext {
                     ) {
                         // pass
                     } else {
-                        this.unknownSchema.add(statusCode);
+                        this.unknownSchema.add(errorKey);
                     }
                 }
             }
@@ -176,8 +177,14 @@ export class OpenApiIrConverterContext {
     /**
      * Is error an unknown schema
      */
-    public isErrorUnknownSchema(statusCode: number): boolean {
-        return this.unknownSchema.has(statusCode);
+    public isErrorUnknownSchema({
+        statusCode,
+        namespace
+    }: {
+        statusCode: number;
+        namespace: string | undefined;
+    }): boolean {
+        return this.unknownSchema.has(getErrorSchemaKey({ statusCode, namespace }));
     }
 
     /**
@@ -396,4 +403,8 @@ export class OpenApiIrConverterContext {
         }
         return this.schemaNameMapping.get(schemaId) ?? schemaId;
     }
+}
+
+function getErrorSchemaKey({ statusCode, namespace }: { statusCode: number; namespace: string | undefined }): string {
+    return namespace != null ? `${namespace}:${statusCode}` : `${statusCode}`;
 }

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern/src/buildEndpoint.ts
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern/src/buildEndpoint.ts
@@ -486,7 +486,7 @@ export function buildEndpoint({
 
         context.builder.addError(errorDeclarationFile, {
             name: errorName,
-            schema: context.isErrorUnknownSchema(parseInt(statusCode))
+            schema: context.isErrorUnknownSchema({ statusCode: parseInt(statusCode), namespace: endpoint.namespace })
                 ? { ...errorDeclaration, type: "unknown" }
                 : errorDeclaration
         });

--- a/packages/cli/cli/changes/unreleased/fix-namespace-scoped-error-schemas.yml
+++ b/packages/cli/cli/changes/unreleased/fix-namespace-scoped-error-schemas.yml
@@ -1,0 +1,8 @@
+- summary: |
+    Scope OpenAPI error schema consistency checks per namespace. Previously, if two
+    endpoints in different namespaces declared different body schemas for the same
+    HTTP status code, every error with that status code was generated with an
+    `unknown` body type across the entire workspace. Error schemas are now only
+    required to be consistent within their own namespace, so namespaced APIs keep
+    typed error bodies.
+  type: fix

--- a/packages/cli/ete-tests/src/tests/write-definition/__snapshots__/writeDefinition.test.ts.snap
+++ b/packages/cli/ete-tests/src/tests/write-definition/__snapshots__/writeDefinition.test.ts.snap
@@ -2149,14 +2149,14 @@ errors:
     examples:
       - value: {}
     status-code: 400
-    type: unknown
+    type: BadRequestErrorBody
   ClientClosedRequestError:
     docs: |
       This error is returned when a request is cancelled by the user.
     examples:
       - value: {}
     status-code: 499
-    type: unknown
+    type: ClientClosedRequestErrorBody
   ForbiddenError:
     docs: >
       This error indicates that the operation attempted to be performed is not
@@ -2166,7 +2166,7 @@ errors:
     examples:
       - value: {}
     status-code: 403
-    type: unknown
+    type: ForbiddenErrorBody
   GatewayTimeoutError:
     docs: >
       This error is returned when a request to the server times out. This could
@@ -2175,14 +2175,14 @@ errors:
     examples:
       - value: {}
     status-code: 504
-    type: unknown
+    type: GatewayTimeoutErrorBody
   InternalServerError:
     docs: |
       This error is returned when an uncategorized internal server error occurs.
     examples:
       - value: {}
     status-code: 500
-    type: unknown
+    type: InternalServerErrorBody
   InvalidTokenError:
     docs: >
       This error is returned when a request or response contains a deny-listed
@@ -2190,7 +2190,7 @@ errors:
     examples:
       - value: {}
     status-code: 498
-    type: unknown
+    type: InvalidTokenErrorBody
   NotFoundError:
     docs: >
       This error is returned when a resource is not found. This could be
@@ -2200,14 +2200,14 @@ errors:
     examples:
       - value: {}
     status-code: 404
-    type: unknown
+    type: NotFoundErrorBody
   NotImplementedError:
     docs: |
       This error is returned when the requested feature is not implemented.
     examples:
       - value: {}
     status-code: 501
-    type: unknown
+    type: NotImplementedErrorBody
   ServiceUnavailableError:
     docs: >
       This error is returned when the service is unavailable. This could be due
@@ -2216,13 +2216,13 @@ errors:
     examples:
       - value: {}
     status-code: 503
-    type: unknown
+    type: ServiceUnavailableErrorBody
   TooManyRequestsError:
     docs: Too many requests
     examples:
       - value: {}
     status-code: 429
-    type: unknown
+    type: TooManyRequestsErrorBody
   UnauthorizedError:
     docs: >
       This error indicates that the operation attempted to be performed is not
@@ -2232,7 +2232,7 @@ errors:
     examples:
       - value: {}
     status-code: 401
-    type: unknown
+    type: UnauthorizedErrorBody
   UnprocessableEntityError:
     docs: >
       This error is returned when the request is not well formed. This could be
@@ -2243,7 +2243,7 @@ errors:
     examples:
       - value: {}
     status-code: 422
-    type: unknown
+    type: UnprocessableEntityErrorBody
 service:
   auth: true
   base-path: ''
@@ -2548,14 +2548,14 @@ errors:
     examples:
       - value: {}
     status-code: 400
-    type: unknown
+    type: BadRequestErrorBody
   ClientClosedRequestError:
     docs: |
       This error is returned when a request is cancelled by the user.
     examples:
       - value: {}
     status-code: 499
-    type: unknown
+    type: ClientClosedRequestErrorBody
   ForbiddenError:
     docs: >
       This error indicates that the operation attempted to be performed is not
@@ -2565,7 +2565,7 @@ errors:
     examples:
       - value: {}
     status-code: 403
-    type: unknown
+    type: ForbiddenErrorBody
   GatewayTimeoutError:
     docs: >
       This error is returned when a request to the server times out. This could
@@ -2574,14 +2574,14 @@ errors:
     examples:
       - value: {}
     status-code: 504
-    type: unknown
+    type: GatewayTimeoutErrorBody
   InternalServerError:
     docs: |
       This error is returned when an uncategorized internal server error occurs.
     examples:
       - value: {}
     status-code: 500
-    type: unknown
+    type: InternalServerErrorBody
   InvalidTokenError:
     docs: >
       This error is returned when a request or response contains a deny-listed
@@ -2589,7 +2589,7 @@ errors:
     examples:
       - value: {}
     status-code: 498
-    type: unknown
+    type: InvalidTokenErrorBody
   NotFoundError:
     docs: >
       This error is returned when a resource is not found. This could be
@@ -2599,14 +2599,14 @@ errors:
     examples:
       - value: {}
     status-code: 404
-    type: unknown
+    type: NotFoundErrorBody
   NotImplementedError:
     docs: |
       This error is returned when the requested feature is not implemented.
     examples:
       - value: {}
     status-code: 501
-    type: unknown
+    type: NotImplementedErrorBody
   ServiceUnavailableError:
     docs: >
       This error is returned when the service is unavailable. This could be due
@@ -2615,13 +2615,13 @@ errors:
     examples:
       - value: {}
     status-code: 503
-    type: unknown
+    type: ServiceUnavailableErrorBody
   TooManyRequestsError:
     docs: Too many requests
     examples:
       - value: {}
     status-code: 429
-    type: unknown
+    type: TooManyRequestsErrorBody
   UnauthorizedError:
     docs: >
       This error indicates that the operation attempted to be performed is not
@@ -2631,7 +2631,7 @@ errors:
     examples:
       - value: {}
     status-code: 401
-    type: unknown
+    type: UnauthorizedErrorBody
   UnprocessableEntityError:
     docs: >
       This error is returned when the request is not well formed. This could be
@@ -2642,7 +2642,7 @@ errors:
     examples:
       - value: {}
     status-code: 422
-    type: unknown
+    type: UnprocessableEntityErrorBody
 ",
         "name": "__package__.yml",
         "type": "file",

--- a/packages/cli/ete-tests/src/tests/write-definition/fixtures/namespaced-fleshedout/fern/.definition/v1/__package__.yml
+++ b/packages/cli/ete-tests/src/tests/write-definition/fixtures/namespaced-fleshedout/fern/.definition/v1/__package__.yml
@@ -140,14 +140,14 @@ errors:
     examples:
       - value: {}
     status-code: 400
-    type: unknown
+    type: BadRequestErrorBody
   ClientClosedRequestError:
     docs: |
       This error is returned when a request is cancelled by the user.
     examples:
       - value: {}
     status-code: 499
-    type: unknown
+    type: ClientClosedRequestErrorBody
   ForbiddenError:
     docs: >
       This error indicates that the operation attempted to be performed is not
@@ -157,7 +157,7 @@ errors:
     examples:
       - value: {}
     status-code: 403
-    type: unknown
+    type: ForbiddenErrorBody
   GatewayTimeoutError:
     docs: >
       This error is returned when a request to the server times out. This could
@@ -166,14 +166,14 @@ errors:
     examples:
       - value: {}
     status-code: 504
-    type: unknown
+    type: GatewayTimeoutErrorBody
   InternalServerError:
     docs: |
       This error is returned when an uncategorized internal server error occurs.
     examples:
       - value: {}
     status-code: 500
-    type: unknown
+    type: InternalServerErrorBody
   InvalidTokenError:
     docs: >
       This error is returned when a request or response contains a deny-listed
@@ -181,7 +181,7 @@ errors:
     examples:
       - value: {}
     status-code: 498
-    type: unknown
+    type: InvalidTokenErrorBody
   NotFoundError:
     docs: >
       This error is returned when a resource is not found. This could be
@@ -191,14 +191,14 @@ errors:
     examples:
       - value: {}
     status-code: 404
-    type: unknown
+    type: NotFoundErrorBody
   NotImplementedError:
     docs: |
       This error is returned when the requested feature is not implemented.
     examples:
       - value: {}
     status-code: 501
-    type: unknown
+    type: NotImplementedErrorBody
   ServiceUnavailableError:
     docs: >
       This error is returned when the service is unavailable. This could be due
@@ -207,13 +207,13 @@ errors:
     examples:
       - value: {}
     status-code: 503
-    type: unknown
+    type: ServiceUnavailableErrorBody
   TooManyRequestsError:
     docs: Too many requests
     examples:
       - value: {}
     status-code: 429
-    type: unknown
+    type: TooManyRequestsErrorBody
   UnauthorizedError:
     docs: >
       This error indicates that the operation attempted to be performed is not
@@ -223,7 +223,7 @@ errors:
     examples:
       - value: {}
     status-code: 401
-    type: unknown
+    type: UnauthorizedErrorBody
   UnprocessableEntityError:
     docs: >
       This error is returned when the request is not well formed. This could be
@@ -234,7 +234,7 @@ errors:
     examples:
       - value: {}
     status-code: 422
-    type: unknown
+    type: UnprocessableEntityErrorBody
 service:
   auth: true
   base-path: ''

--- a/packages/cli/ete-tests/src/tests/write-definition/fixtures/namespaced-fleshedout/fern/.definition/v2/__package__.yml
+++ b/packages/cli/ete-tests/src/tests/write-definition/fixtures/namespaced-fleshedout/fern/.definition/v2/__package__.yml
@@ -70,14 +70,14 @@ errors:
     examples:
       - value: {}
     status-code: 400
-    type: unknown
+    type: BadRequestErrorBody
   ClientClosedRequestError:
     docs: |
       This error is returned when a request is cancelled by the user.
     examples:
       - value: {}
     status-code: 499
-    type: unknown
+    type: ClientClosedRequestErrorBody
   ForbiddenError:
     docs: >
       This error indicates that the operation attempted to be performed is not
@@ -87,7 +87,7 @@ errors:
     examples:
       - value: {}
     status-code: 403
-    type: unknown
+    type: ForbiddenErrorBody
   GatewayTimeoutError:
     docs: >
       This error is returned when a request to the server times out. This could
@@ -96,14 +96,14 @@ errors:
     examples:
       - value: {}
     status-code: 504
-    type: unknown
+    type: GatewayTimeoutErrorBody
   InternalServerError:
     docs: |
       This error is returned when an uncategorized internal server error occurs.
     examples:
       - value: {}
     status-code: 500
-    type: unknown
+    type: InternalServerErrorBody
   InvalidTokenError:
     docs: >
       This error is returned when a request or response contains a deny-listed
@@ -111,7 +111,7 @@ errors:
     examples:
       - value: {}
     status-code: 498
-    type: unknown
+    type: InvalidTokenErrorBody
   NotFoundError:
     docs: >
       This error is returned when a resource is not found. This could be
@@ -121,14 +121,14 @@ errors:
     examples:
       - value: {}
     status-code: 404
-    type: unknown
+    type: NotFoundErrorBody
   NotImplementedError:
     docs: |
       This error is returned when the requested feature is not implemented.
     examples:
       - value: {}
     status-code: 501
-    type: unknown
+    type: NotImplementedErrorBody
   ServiceUnavailableError:
     docs: >
       This error is returned when the service is unavailable. This could be due
@@ -137,13 +137,13 @@ errors:
     examples:
       - value: {}
     status-code: 503
-    type: unknown
+    type: ServiceUnavailableErrorBody
   TooManyRequestsError:
     docs: Too many requests
     examples:
       - value: {}
     status-code: 429
-    type: unknown
+    type: TooManyRequestsErrorBody
   UnauthorizedError:
     docs: >
       This error indicates that the operation attempted to be performed is not
@@ -153,7 +153,7 @@ errors:
     examples:
       - value: {}
     status-code: 401
-    type: unknown
+    type: UnauthorizedErrorBody
   UnprocessableEntityError:
     docs: >
       This error is returned when the request is not well formed. This could be
@@ -164,4 +164,4 @@ errors:
     examples:
       - value: {}
     status-code: 422
-    type: unknown
+    type: UnprocessableEntityErrorBody


### PR DESCRIPTION
## Description
<!-- no Linear ticket -->
When importing a multi-namespace OpenAPI workspace, `OpenApiIrConverterContext` tracked error body schemas in a single `schemaByStatusCode` map keyed only by status code. If two endpoints in *different* namespaces declared non-equal schemas for the same status code, the status code was added to `unknownSchema` and **every** error with that status across the whole workspace was emitted with `type: "unknown"` — even though namespaced errors are declared per namespace (`error_<ns>:BadRequestError`) and never shared across namespaces.

This change scopes the consistency check per namespace:

```diff
- private unknownSchema: Set<number>
+ private unknownSchema: Set<string>   // key = `${namespace}:${statusCode}` (or `${statusCode}` when un-namespaced)

- context.isErrorUnknownSchema(parseInt(statusCode))
+ context.isErrorUnknownSchema({ statusCode: parseInt(statusCode), namespace: endpoint.namespace })
```

Behavior for single-namespace / un-namespaced workspaces is unchanged.

Observed in the wild: a Twilio multi-namespace config where one namespace's RFC-9457 error schema differed from another namespace's legacy error schema caused all generated SDK error classes (400/401/403/404/429/500/503) to have `body?: unknown` instead of typed bodies.

## Changes Made
- `OpenApiIrConverterContext`: key `unknownSchema`/`schemaByErrorKey` by namespace + status code (`getErrorSchemaKey`)
- `buildEndpoint`: pass `endpoint.namespace` to `isErrorUnknownSchema`
- New fixture `namespaced-error-schemas` (two namespaces, both with a 400 of different shapes) — snapshot shows both errors keep typed bodies (`type: UsersError` / `type: PaymentsError`)
- CLI changelog entry `packages/cli/cli/changes/unreleased/fix-namespace-scoped-error-schemas.yml`
- [ ] Updated README.md generator (if applicable)

## Testing
- [x] Unit tests added/updated — `@fern-api/openapi-ir-to-fern-tests`: 305 existing tests pass unchanged (no snapshot churn) + 2 new snapshot tests for the fixture
- [x] Manual testing completed — verified against the Twilio multi-namespace config: errors previously `unknown` are now `named`

Link to Devin session: https://app.devin.ai/sessions/0599f25ee1c94a199bfebc8fec336f15
Requested by: @iamnamananand996
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/17264" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->