### PR TITLE
fix(java): resolve X-Fern-SDK-Name from configured coordinate in GitHub output mode

### DIFF
--- a/generators/java/sdk/changes/unreleased/fix-sdk-name-header-github-output.yml
+++ b/generators/java/sdk/changes/unreleased/fix-sdk-name-header-github-output.yml
@@ -1,0 +1,12 @@
+# yaml-language-server: $schema=../../../../../fern-changes-yml.schema.json
+
+- summary: |
+    Resolve the `X-Fern-SDK-Name` header from the configured Maven coordinate in
+    GitHub output mode. Previously the header was read from the (Fiddle-synthesized)
+    publish config, so it emitted `com.<org>.fern:<workspace>-sdk` instead of the
+    coordinate the user configured under `output.coordinate`, leaving it inconsistent
+    with the `User-Agent` product token. The header now reads
+    `output.mode.github.publishInfo.maven.coordinate`, which is populated for both
+    remote and `--local` generation. Also emits `X-Fern-SDK-Version` in cases where a
+    coordinate resolves without a version previously being set.
+  type: fix

--- a/generators/java/sdk/src/main/java/com/fern/java/client/generators/ClientOptionsGenerator.java
+++ b/generators/java/sdk/src/main/java/com/fern/java/client/generators/ClientOptionsGenerator.java
@@ -194,15 +194,10 @@ public final class ClientOptionsGenerator extends AbstractFileGenerator {
      * GitHub output mode, which would otherwise take precedence and leak into {@code X-Fern-SDK-Name}.
      */
     private static Optional<SdkCoordinate> resolveFromGithubOutputMode(GeneratorConfig generatorConfig) {
-        return generatorConfig
-                .getOutput()
-                .getMode()
-                .getGithub()
-                .flatMap(githubOutputMode -> githubOutputMode
-                        .getPublishInfo()
-                        .flatMap(GithubPublishInfo::getMaven)
-                        .map(maven -> new SdkCoordinate(
-                                maven.getCoordinate(), Optional.of(githubOutputMode.getVersion()))));
+        return generatorConfig.getOutput().getMode().getGithub().flatMap(githubOutputMode -> githubOutputMode
+                .getPublishInfo()
+                .flatMap(GithubPublishInfo::getMaven)
+                .map(maven -> new SdkCoordinate(maven.getCoordinate(), Optional.of(githubOutputMode.getVersion()))));
     }
 
     /**
@@ -223,8 +218,9 @@ public final class ClientOptionsGenerator extends AbstractFileGenerator {
     private static Optional<SdkCoordinate> resolveFromIrPublishConfig(IntermediateRepresentation ir) {
         return ir.getPublishConfig()
                 .flatMap(ClientOptionsGenerator::extractMavenTarget)
-                .flatMap(mavenTarget ->
-                        mavenTarget.getCoordinate().map(coordinate -> new SdkCoordinate(coordinate, mavenTarget.getVersion())));
+                .flatMap(mavenTarget -> mavenTarget
+                        .getCoordinate()
+                        .map(coordinate -> new SdkCoordinate(coordinate, mavenTarget.getVersion())));
     }
 
     /** A resolved {@code X-Fern-SDK-Name} coordinate together with an optional {@code X-Fern-SDK-Version}. */

--- a/generators/java/sdk/src/main/java/com/fern/java/client/generators/ClientOptionsGenerator.java
+++ b/generators/java/sdk/src/main/java/com/fern/java/client/generators/ClientOptionsGenerator.java
@@ -17,6 +17,7 @@
 package com.fern.java.client.generators;
 
 import com.fern.generator.exec.model.config.GeneratorConfig;
+import com.fern.generator.exec.model.config.GithubPublishInfo;
 import com.fern.ir.model.ir.ApiVersionScheme;
 import com.fern.ir.model.ir.HeaderApiVersionScheme;
 import com.fern.ir.model.ir.IntermediateRepresentation;
@@ -160,39 +161,21 @@ public final class ClientOptionsGenerator extends AbstractFileGenerator {
             PlatformHeaders platformHeaders, GeneratorConfig generatorConfig, IntermediateRepresentation ir) {
         Map<String, String> entries = new HashMap<>();
 
-        // Try generatorConfig.publish first (remote generation)
-        if (generatorConfig.getPublish().isPresent()) {
-            entries.put(
-                    platformHeaders.getSdkName(),
-                    generatorConfig
-                            .getPublish()
-                            .get()
-                            .getRegistriesV2()
-                            .getMaven()
-                            .getCoordinate());
-            entries.put(
-                    platformHeaders.getSdkVersion(),
-                    generatorConfig.getPublish().get().getVersion());
-        }
-        // Fallback to IR publishConfig (local generation with explicit maven config)
-        else if (ir.getPublishConfig().isPresent()) {
-            Optional<MavenPublishTarget> mavenTarget =
-                    extractMavenTarget(ir.getPublishConfig().get());
-            if (mavenTarget.isPresent()) {
-                mavenTarget.get().getCoordinate().ifPresent(coord -> entries.put(platformHeaders.getSdkName(), coord));
-                mavenTarget
-                        .get()
-                        .getVersion()
-                        .ifPresent(version -> entries.put(platformHeaders.getSdkVersion(), version));
-            }
-        }
-        // Final fallback: generate default coordinate matching Fiddle's RegistryConfigFactory behavior
-        // This ensures local generation matches remote generation for GitHub output mode without explicit maven config
-        else {
-            String fallbackCoordinate = String.format(
-                    "com.%s.fern:%s-sdk", generatorConfig.getOrganization(), generatorConfig.getWorkspaceName());
-            entries.put(platformHeaders.getSdkName(), fallbackCoordinate);
-        }
+        // Resolve the SDK coordinate from the highest-priority source that carries it, then emit the name (with a
+        // synthesized fallback) and the version (when known). Sources are flattened so that a source which supplies a
+        // coordinate but no version still yields an X-Fern-SDK-Name header.
+        Optional<SdkCoordinate> resolvedCoordinate = resolveFromGithubOutputMode(generatorConfig)
+                .or(() -> resolveFromGeneratorPublish(generatorConfig))
+                .or(() -> resolveFromIrPublishConfig(ir));
+
+        String sdkName = resolvedCoordinate
+                .map(coordinate -> coordinate.name)
+                .orElseGet(() -> String.format(
+                        "com.%s.fern:%s-sdk", generatorConfig.getOrganization(), generatorConfig.getWorkspaceName()));
+        entries.put(platformHeaders.getSdkName(), sdkName);
+        resolvedCoordinate
+                .flatMap(coordinate -> coordinate.version)
+                .ifPresent(version -> entries.put(platformHeaders.getSdkVersion(), version));
 
         if (platformHeaders.getUserAgent().isPresent()) {
             entries.put(
@@ -201,6 +184,58 @@ public final class ClientOptionsGenerator extends AbstractFileGenerator {
         }
         entries.put(platformHeaders.getLanguage(), "JAVA");
         return entries;
+    }
+
+    /**
+     * Resolves the SDK coordinate from the GitHub output mode's publish info
+     * ({@code output.mode.github.publishInfo.maven}). This is the user-configured Maven coordinate and is populated for
+     * both remote (Fiddle) and {@code --local} GitHub-mode generation. It must be checked before
+     * {@link GeneratorConfig#getPublish()} because Fiddle also sets a synthesized (and incorrect) publish coordinate in
+     * GitHub output mode, which would otherwise take precedence and leak into {@code X-Fern-SDK-Name}.
+     */
+    private static Optional<SdkCoordinate> resolveFromGithubOutputMode(GeneratorConfig generatorConfig) {
+        return generatorConfig
+                .getOutput()
+                .getMode()
+                .getGithub()
+                .flatMap(githubOutputMode -> githubOutputMode
+                        .getPublishInfo()
+                        .flatMap(GithubPublishInfo::getMaven)
+                        .map(maven -> new SdkCoordinate(
+                                maven.getCoordinate(), Optional.of(githubOutputMode.getVersion()))));
+    }
+
+    /**
+     * Resolves the SDK coordinate from {@code generatorConfig.publish.registriesV2.maven} (remote publish/registry
+     * mode).
+     */
+    private static Optional<SdkCoordinate> resolveFromGeneratorPublish(GeneratorConfig generatorConfig) {
+        return generatorConfig
+                .getPublish()
+                .map(publish -> new SdkCoordinate(
+                        publish.getRegistriesV2().getMaven().getCoordinate(), Optional.of(publish.getVersion())));
+    }
+
+    /**
+     * Resolves the SDK coordinate from the IR's {@code publishConfig} Maven target (local generation with an explicit
+     * maven target).
+     */
+    private static Optional<SdkCoordinate> resolveFromIrPublishConfig(IntermediateRepresentation ir) {
+        return ir.getPublishConfig()
+                .flatMap(ClientOptionsGenerator::extractMavenTarget)
+                .flatMap(mavenTarget ->
+                        mavenTarget.getCoordinate().map(coordinate -> new SdkCoordinate(coordinate, mavenTarget.getVersion())));
+    }
+
+    /** A resolved {@code X-Fern-SDK-Name} coordinate together with an optional {@code X-Fern-SDK-Version}. */
+    private static final class SdkCoordinate {
+        private final String name;
+        private final Optional<String> version;
+
+        private SdkCoordinate(String name, Optional<String> version) {
+            this.name = name;
+            this.version = version;
+        }
     }
 
     private static final String USER_AGENT_METHOD_NAME = "getUserAgent";

--- a/seed/java-sdk/accept-header/accept-header/src/main/java/com/seed/accept/core/ClientOptions.java
+++ b/seed/java-sdk/accept-header/accept-header/src/main/java/com/seed/accept/core/ClientOptions.java
@@ -49,7 +49,8 @@ public final class ClientOptions {
             {
                 put("User-Agent", "com.fern.accept-header/0.0.1");
                 put("X-Fern-Language", "JAVA");
-                put("X-Fern-SDK-Name", "com.seed.fern:accept-sdk");
+                put("X-Fern-SDK-Name", "com.fern:accept-header");
+                put("X-Fern-SDK-Version", "0.0.1");
             }
         });
         this.headerSuppliers = headerSuppliers;

--- a/seed/java-sdk/alias-extends/src/main/java/com/seed/aliasExtends/core/ClientOptions.java
+++ b/seed/java-sdk/alias-extends/src/main/java/com/seed/aliasExtends/core/ClientOptions.java
@@ -49,7 +49,8 @@ public final class ClientOptions {
             {
                 put("User-Agent", "com.fern.alias-extends/0.0.1");
                 put("X-Fern-Language", "JAVA");
-                put("X-Fern-SDK-Name", "com.seed.fern:alias-extends-sdk");
+                put("X-Fern-SDK-Name", "com.fern:alias-extends");
+                put("X-Fern-SDK-Version", "0.0.1");
             }
         });
         this.headerSuppliers = headerSuppliers;

--- a/seed/java-sdk/alias/src/main/java/com/seed/alias/core/ClientOptions.java
+++ b/seed/java-sdk/alias/src/main/java/com/seed/alias/core/ClientOptions.java
@@ -49,7 +49,8 @@ public final class ClientOptions {
             {
                 put("User-Agent", "com.fern.alias/0.0.1");
                 put("X-Fern-Language", "JAVA");
-                put("X-Fern-SDK-Name", "com.seed.fern:alias-sdk");
+                put("X-Fern-SDK-Name", "com.fern:alias");
+                put("X-Fern-SDK-Version", "0.0.1");
             }
         });
         this.headerSuppliers = headerSuppliers;

--- a/seed/java-sdk/allof-inline/src/main/java/com/seed/api/core/ClientOptions.java
+++ b/seed/java-sdk/allof-inline/src/main/java/com/seed/api/core/ClientOptions.java
@@ -49,7 +49,8 @@ public final class ClientOptions {
             {
                 put("User-Agent", "com.fern.allof-inline/0.0.1");
                 put("X-Fern-Language", "JAVA");
-                put("X-Fern-SDK-Name", "com.seed.fern:api-sdk");
+                put("X-Fern-SDK-Name", "com.fern:allof-inline");
+                put("X-Fern-SDK-Version", "0.0.1");
             }
         });
         this.headerSuppliers = headerSuppliers;

--- a/seed/java-sdk/allof/src/main/java/com/seed/api/core/ClientOptions.java
+++ b/seed/java-sdk/allof/src/main/java/com/seed/api/core/ClientOptions.java
@@ -49,7 +49,8 @@ public final class ClientOptions {
             {
                 put("User-Agent", "com.fern.allof/0.0.1");
                 put("X-Fern-Language", "JAVA");
-                put("X-Fern-SDK-Name", "com.seed.fern:api-sdk");
+                put("X-Fern-SDK-Name", "com.fern:allof");
+                put("X-Fern-SDK-Version", "0.0.1");
             }
         });
         this.headerSuppliers = headerSuppliers;

--- a/seed/java-sdk/any-auth/src/main/java/com/seed/anyAuth/core/ClientOptions.java
+++ b/seed/java-sdk/any-auth/src/main/java/com/seed/anyAuth/core/ClientOptions.java
@@ -49,7 +49,8 @@ public final class ClientOptions {
             {
                 put("User-Agent", "com.fern.any-auth/0.0.1");
                 put("X-Fern-Language", "JAVA");
-                put("X-Fern-SDK-Name", "com.seed.fern:any-auth-sdk");
+                put("X-Fern-SDK-Name", "com.fern:any-auth");
+                put("X-Fern-SDK-Version", "0.0.1");
             }
         });
         this.headerSuppliers = headerSuppliers;

--- a/seed/java-sdk/api-wide-base-path-with-default/src/main/java/com/seed/api/core/ClientOptions.java
+++ b/seed/java-sdk/api-wide-base-path-with-default/src/main/java/com/seed/api/core/ClientOptions.java
@@ -52,7 +52,8 @@ public final class ClientOptions {
             {
                 put("User-Agent", "com.fern.api-wide-base-path-with-default/0.0.1");
                 put("X-Fern-Language", "JAVA");
-                put("X-Fern-SDK-Name", "com.seed.fern:api-sdk");
+                put("X-Fern-SDK-Name", "com.fern:api-wide-base-path-with-default");
+                put("X-Fern-SDK-Version", "0.0.1");
             }
         });
         this.headerSuppliers = headerSuppliers;

--- a/seed/java-sdk/api-wide-base-path/src/main/java/com/seed/apiWideBasePath/core/ClientOptions.java
+++ b/seed/java-sdk/api-wide-base-path/src/main/java/com/seed/apiWideBasePath/core/ClientOptions.java
@@ -52,7 +52,8 @@ public final class ClientOptions {
             {
                 put("User-Agent", "com.fern.api-wide-base-path/0.0.1");
                 put("X-Fern-Language", "JAVA");
-                put("X-Fern-SDK-Name", "com.seed.fern:api-wide-base-path-sdk");
+                put("X-Fern-SDK-Name", "com.fern:api-wide-base-path");
+                put("X-Fern-SDK-Version", "0.0.1");
             }
         });
         this.headerSuppliers = headerSuppliers;

--- a/seed/java-sdk/audiences/src/main/java/com/seed/audiences/core/ClientOptions.java
+++ b/seed/java-sdk/audiences/src/main/java/com/seed/audiences/core/ClientOptions.java
@@ -49,7 +49,8 @@ public final class ClientOptions {
             {
                 put("User-Agent", "com.fern.audiences/0.0.1");
                 put("X-Fern-Language", "JAVA");
-                put("X-Fern-SDK-Name", "com.seed.fern:audiences-sdk");
+                put("X-Fern-SDK-Name", "com.fern:audiences");
+                put("X-Fern-SDK-Version", "0.0.1");
             }
         });
         this.headerSuppliers = headerSuppliers;

--- a/seed/java-sdk/basic-auth-environment-variables/src/main/java/com/seed/basicAuthEnvironmentVariables/core/ClientOptions.java
+++ b/seed/java-sdk/basic-auth-environment-variables/src/main/java/com/seed/basicAuthEnvironmentVariables/core/ClientOptions.java
@@ -49,7 +49,8 @@ public final class ClientOptions {
             {
                 put("User-Agent", "com.fern.basic-auth-environment-variables/0.0.1");
                 put("X-Fern-Language", "JAVA");
-                put("X-Fern-SDK-Name", "com.seed.fern:basic-auth-environment-variables-sdk");
+                put("X-Fern-SDK-Name", "com.fern:basic-auth-environment-variables");
+                put("X-Fern-SDK-Version", "0.0.1");
             }
         });
         this.headerSuppliers = headerSuppliers;

--- a/seed/java-sdk/basic-auth-pw-omitted/basic-auth-pw-omitted/src/main/java/com/seed/basicAuthPwOmitted/core/ClientOptions.java
+++ b/seed/java-sdk/basic-auth-pw-omitted/basic-auth-pw-omitted/src/main/java/com/seed/basicAuthPwOmitted/core/ClientOptions.java
@@ -49,7 +49,8 @@ public final class ClientOptions {
             {
                 put("User-Agent", "com.fern.basic-auth-pw-omitted/0.0.1");
                 put("X-Fern-Language", "JAVA");
-                put("X-Fern-SDK-Name", "com.seed.fern:basic-auth-pw-omitted-sdk");
+                put("X-Fern-SDK-Name", "com.fern:basic-auth-pw-omitted");
+                put("X-Fern-SDK-Version", "0.0.1");
             }
         });
         this.headerSuppliers = headerSuppliers;

--- a/seed/java-sdk/basic-auth/basic-auth/src/main/java/com/seed/basicAuth/core/ClientOptions.java
+++ b/seed/java-sdk/basic-auth/basic-auth/src/main/java/com/seed/basicAuth/core/ClientOptions.java
@@ -49,7 +49,8 @@ public final class ClientOptions {
             {
                 put("User-Agent", "com.fern.basic-auth/0.0.1");
                 put("X-Fern-Language", "JAVA");
-                put("X-Fern-SDK-Name", "com.seed.fern:basic-auth-sdk");
+                put("X-Fern-SDK-Name", "com.fern:basic-auth");
+                put("X-Fern-SDK-Version", "0.0.1");
             }
         });
         this.headerSuppliers = headerSuppliers;

--- a/seed/java-sdk/bearer-token-environment-variable/src/main/java/com/seed/bearerTokenEnvironmentVariable/core/ClientOptions.java
+++ b/seed/java-sdk/bearer-token-environment-variable/src/main/java/com/seed/bearerTokenEnvironmentVariable/core/ClientOptions.java
@@ -49,7 +49,8 @@ public final class ClientOptions {
             {
                 put("User-Agent", "com.fern.bearer-token-environment-variable/0.0.1");
                 put("X-Fern-Language", "JAVA");
-                put("X-Fern-SDK-Name", "com.seed.fern:bearer-token-environment-variable-sdk");
+                put("X-Fern-SDK-Name", "com.fern:bearer-token-environment-variable");
+                put("X-Fern-SDK-Version", "0.0.1");
             }
         });
         this.headerSuppliers = headerSuppliers;

--- a/seed/java-sdk/bytes-download/src/main/java/com/seed/bytesDownload/core/ClientOptions.java
+++ b/seed/java-sdk/bytes-download/src/main/java/com/seed/bytesDownload/core/ClientOptions.java
@@ -49,7 +49,8 @@ public final class ClientOptions {
             {
                 put("User-Agent", "com.fern.bytes-download/0.0.1");
                 put("X-Fern-Language", "JAVA");
-                put("X-Fern-SDK-Name", "com.seed.fern:bytes-download-sdk");
+                put("X-Fern-SDK-Name", "com.fern:bytes-download");
+                put("X-Fern-SDK-Version", "0.0.1");
             }
         });
         this.headerSuppliers = headerSuppliers;

--- a/seed/java-sdk/bytes-upload/src/main/java/com/seed/bytesUpload/core/ClientOptions.java
+++ b/seed/java-sdk/bytes-upload/src/main/java/com/seed/bytesUpload/core/ClientOptions.java
@@ -49,7 +49,8 @@ public final class ClientOptions {
             {
                 put("User-Agent", "com.fern.bytes-upload/0.0.1");
                 put("X-Fern-Language", "JAVA");
-                put("X-Fern-SDK-Name", "com.seed.fern:bytes-upload-sdk");
+                put("X-Fern-SDK-Name", "com.fern:bytes-upload");
+                put("X-Fern-SDK-Version", "0.0.1");
             }
         });
         this.headerSuppliers = headerSuppliers;

--- a/seed/java-sdk/circular-references-advanced/src/main/java/com/seed/api/core/ClientOptions.java
+++ b/seed/java-sdk/circular-references-advanced/src/main/java/com/seed/api/core/ClientOptions.java
@@ -49,7 +49,8 @@ public final class ClientOptions {
             {
                 put("User-Agent", "com.fern.circular-references-advanced/0.0.1");
                 put("X-Fern-Language", "JAVA");
-                put("X-Fern-SDK-Name", "com.seed.fern:api-sdk");
+                put("X-Fern-SDK-Name", "com.fern:circular-references-advanced");
+                put("X-Fern-SDK-Version", "0.0.1");
             }
         });
         this.headerSuppliers = headerSuppliers;

--- a/seed/java-sdk/circular-references-extends/src/main/java/com/seed/api/core/ClientOptions.java
+++ b/seed/java-sdk/circular-references-extends/src/main/java/com/seed/api/core/ClientOptions.java
@@ -49,7 +49,8 @@ public final class ClientOptions {
             {
                 put("User-Agent", "com.fern.circular-references-extends/0.0.1");
                 put("X-Fern-Language", "JAVA");
-                put("X-Fern-SDK-Name", "com.seed.fern:api-sdk");
+                put("X-Fern-SDK-Name", "com.fern:circular-references-extends");
+                put("X-Fern-SDK-Version", "0.0.1");
             }
         });
         this.headerSuppliers = headerSuppliers;

--- a/seed/java-sdk/circular-references/src/main/java/com/seed/api/core/ClientOptions.java
+++ b/seed/java-sdk/circular-references/src/main/java/com/seed/api/core/ClientOptions.java
@@ -49,7 +49,8 @@ public final class ClientOptions {
             {
                 put("User-Agent", "com.fern.circular-references/0.0.1");
                 put("X-Fern-Language", "JAVA");
-                put("X-Fern-SDK-Name", "com.seed.fern:api-sdk");
+                put("X-Fern-SDK-Name", "com.fern:circular-references");
+                put("X-Fern-SDK-Version", "0.0.1");
             }
         });
         this.headerSuppliers = headerSuppliers;

--- a/seed/java-sdk/client-side-params/default/src/main/java/com/seed/clientSideParams/core/ClientOptions.java
+++ b/seed/java-sdk/client-side-params/default/src/main/java/com/seed/clientSideParams/core/ClientOptions.java
@@ -49,7 +49,8 @@ public final class ClientOptions {
             {
                 put("User-Agent", "com.fern.client-side-params/0.0.1");
                 put("X-Fern-Language", "JAVA");
-                put("X-Fern-SDK-Name", "com.seed.fern:client-side-params-sdk");
+                put("X-Fern-SDK-Name", "com.fern:client-side-params");
+                put("X-Fern-SDK-Version", "0.0.1");
             }
         });
         this.headerSuppliers = headerSuppliers;

--- a/seed/java-sdk/content-type/src/main/java/com/seed/contentTypes/core/ClientOptions.java
+++ b/seed/java-sdk/content-type/src/main/java/com/seed/contentTypes/core/ClientOptions.java
@@ -49,7 +49,8 @@ public final class ClientOptions {
             {
                 put("User-Agent", "com.fern.content-type/0.0.1");
                 put("X-Fern-Language", "JAVA");
-                put("X-Fern-SDK-Name", "com.seed.fern:content-types-sdk");
+                put("X-Fern-SDK-Name", "com.fern:content-type");
+                put("X-Fern-SDK-Version", "0.0.1");
             }
         });
         this.headerSuppliers = headerSuppliers;

--- a/seed/java-sdk/cross-package-type-names/src/main/java/com/seed/crossPackageTypeNames/core/ClientOptions.java
+++ b/seed/java-sdk/cross-package-type-names/src/main/java/com/seed/crossPackageTypeNames/core/ClientOptions.java
@@ -49,7 +49,8 @@ public final class ClientOptions {
             {
                 put("User-Agent", "com.fern.cross-package-type-names/0.0.1");
                 put("X-Fern-Language", "JAVA");
-                put("X-Fern-SDK-Name", "com.seed.fern:cross-package-type-names-sdk");
+                put("X-Fern-SDK-Name", "com.fern:cross-package-type-names");
+                put("X-Fern-SDK-Version", "0.0.1");
             }
         });
         this.headerSuppliers = headerSuppliers;

--- a/seed/java-sdk/discriminated-union-with-nested-oneof/src/main/java/com/seed/api/core/ClientOptions.java
+++ b/seed/java-sdk/discriminated-union-with-nested-oneof/src/main/java/com/seed/api/core/ClientOptions.java
@@ -49,7 +49,8 @@ public final class ClientOptions {
             {
                 put("User-Agent", "com.fern.discriminated-union-with-nested-oneof/0.0.1");
                 put("X-Fern-Language", "JAVA");
-                put("X-Fern-SDK-Name", "com.seed.fern:api-sdk");
+                put("X-Fern-SDK-Name", "com.fern:discriminated-union-with-nested-oneof");
+                put("X-Fern-SDK-Version", "0.0.1");
             }
         });
         this.headerSuppliers = headerSuppliers;

--- a/seed/java-sdk/dollar-string-examples/src/main/java/com/seed/dollarStringExamples/core/ClientOptions.java
+++ b/seed/java-sdk/dollar-string-examples/src/main/java/com/seed/dollarStringExamples/core/ClientOptions.java
@@ -49,7 +49,8 @@ public final class ClientOptions {
             {
                 put("User-Agent", "com.fern.dollar-string-examples/0.0.1");
                 put("X-Fern-Language", "JAVA");
-                put("X-Fern-SDK-Name", "com.seed.fern:dollar-string-examples-sdk");
+                put("X-Fern-SDK-Name", "com.fern:dollar-string-examples");
+                put("X-Fern-SDK-Version", "0.0.1");
             }
         });
         this.headerSuppliers = headerSuppliers;

--- a/seed/java-sdk/empty-clients/src/main/java/com/seed/emptyClients/core/ClientOptions.java
+++ b/seed/java-sdk/empty-clients/src/main/java/com/seed/emptyClients/core/ClientOptions.java
@@ -49,7 +49,8 @@ public final class ClientOptions {
             {
                 put("User-Agent", "com.fern.empty-clients/0.0.1");
                 put("X-Fern-Language", "JAVA");
-                put("X-Fern-SDK-Name", "com.seed.fern:empty-clients-sdk");
+                put("X-Fern-SDK-Name", "com.fern:empty-clients");
+                put("X-Fern-SDK-Version", "0.0.1");
             }
         });
         this.headerSuppliers = headerSuppliers;

--- a/seed/java-sdk/endpoint-security-auth/src/main/java/com/seed/endpointSecurityAuth/core/ClientOptions.java
+++ b/seed/java-sdk/endpoint-security-auth/src/main/java/com/seed/endpointSecurityAuth/core/ClientOptions.java
@@ -52,7 +52,8 @@ public final class ClientOptions {
             {
                 put("User-Agent", "com.fern.endpoint-security-auth/0.0.1");
                 put("X-Fern-Language", "JAVA");
-                put("X-Fern-SDK-Name", "com.seed.fern:endpoint-security-auth-sdk");
+                put("X-Fern-SDK-Name", "com.fern:endpoint-security-auth");
+                put("X-Fern-SDK-Version", "0.0.1");
             }
         });
         this.headerSuppliers = headerSuppliers;

--- a/seed/java-sdk/enum/forward-compatible-enums/src/main/java/com/seed/_enum/core/ClientOptions.java
+++ b/seed/java-sdk/enum/forward-compatible-enums/src/main/java/com/seed/_enum/core/ClientOptions.java
@@ -49,7 +49,8 @@ public final class ClientOptions {
             {
                 put("User-Agent", "com.fern.enum/0.0.1");
                 put("X-Fern-Language", "JAVA");
-                put("X-Fern-SDK-Name", "com.seed.fern:enum-sdk");
+                put("X-Fern-SDK-Name", "com.fern:enum");
+                put("X-Fern-SDK-Version", "0.0.1");
             }
         });
         this.headerSuppliers = headerSuppliers;

--- a/seed/java-sdk/enum/no-custom-config/src/main/java/com/seed/_enum/core/ClientOptions.java
+++ b/seed/java-sdk/enum/no-custom-config/src/main/java/com/seed/_enum/core/ClientOptions.java
@@ -49,7 +49,8 @@ public final class ClientOptions {
             {
                 put("User-Agent", "com.fern.enum/0.0.1");
                 put("X-Fern-Language", "JAVA");
-                put("X-Fern-SDK-Name", "com.seed.fern:enum-sdk");
+                put("X-Fern-SDK-Name", "com.fern:enum");
+                put("X-Fern-SDK-Version", "0.0.1");
             }
         });
         this.headerSuppliers = headerSuppliers;

--- a/seed/java-sdk/error-property/src/main/java/com/seed/errorProperty/core/ClientOptions.java
+++ b/seed/java-sdk/error-property/src/main/java/com/seed/errorProperty/core/ClientOptions.java
@@ -49,7 +49,8 @@ public final class ClientOptions {
             {
                 put("User-Agent", "com.fern.error-property/0.0.1");
                 put("X-Fern-Language", "JAVA");
-                put("X-Fern-SDK-Name", "com.seed.fern:error-property-sdk");
+                put("X-Fern-SDK-Name", "com.fern:error-property");
+                put("X-Fern-SDK-Version", "0.0.1");
             }
         });
         this.headerSuppliers = headerSuppliers;

--- a/seed/java-sdk/errors/src/main/java/com/seed/errors/core/ClientOptions.java
+++ b/seed/java-sdk/errors/src/main/java/com/seed/errors/core/ClientOptions.java
@@ -49,7 +49,8 @@ public final class ClientOptions {
             {
                 put("User-Agent", "com.fern.errors/0.0.1");
                 put("X-Fern-Language", "JAVA");
-                put("X-Fern-SDK-Name", "com.seed.fern:errors-sdk");
+                put("X-Fern-SDK-Name", "com.fern:errors");
+                put("X-Fern-SDK-Version", "0.0.1");
             }
         });
         this.headerSuppliers = headerSuppliers;

--- a/seed/java-sdk/examples/default/src/main/java/com/seed/examples/core/ClientOptions.java
+++ b/seed/java-sdk/examples/default/src/main/java/com/seed/examples/core/ClientOptions.java
@@ -49,7 +49,8 @@ public final class ClientOptions {
             {
                 put("User-Agent", "com.fern.examples/0.0.1");
                 put("X-Fern-Language", "JAVA");
-                put("X-Fern-SDK-Name", "com.seed.fern:examples-sdk");
+                put("X-Fern-SDK-Name", "com.fern:examples");
+                put("X-Fern-SDK-Version", "0.0.1");
             }
         });
         this.headerSuppliers = headerSuppliers;

--- a/seed/java-sdk/examples/inline-file-properties/src/main/java/com/seed/examples/core/ClientOptions.java
+++ b/seed/java-sdk/examples/inline-file-properties/src/main/java/com/seed/examples/core/ClientOptions.java
@@ -49,7 +49,8 @@ public final class ClientOptions {
             {
                 put("User-Agent", "com.fern.examples/0.0.1");
                 put("X-Fern-Language", "JAVA");
-                put("X-Fern-SDK-Name", "com.seed.fern:examples-sdk");
+                put("X-Fern-SDK-Name", "com.fern:examples");
+                put("X-Fern-SDK-Version", "0.0.1");
             }
         });
         this.headerSuppliers = headerSuppliers;

--- a/seed/java-sdk/examples/no-custom-config/src/main/java/com/seed/examples/core/ClientOptions.java
+++ b/seed/java-sdk/examples/no-custom-config/src/main/java/com/seed/examples/core/ClientOptions.java
@@ -49,7 +49,8 @@ public final class ClientOptions {
             {
                 put("User-Agent", "com.fern.examples/0.0.1");
                 put("X-Fern-Language", "JAVA");
-                put("X-Fern-SDK-Name", "com.seed.fern:examples-sdk");
+                put("X-Fern-SDK-Name", "com.fern:examples");
+                put("X-Fern-SDK-Version", "0.0.1");
             }
         });
         this.headerSuppliers = headerSuppliers;

--- a/seed/java-sdk/examples/readme-config/src/main/java/com/seed/examples/core/ClientOptions.java
+++ b/seed/java-sdk/examples/readme-config/src/main/java/com/seed/examples/core/ClientOptions.java
@@ -49,7 +49,8 @@ public final class ClientOptions {
             {
                 put("User-Agent", "com.fern.examples/0.0.1");
                 put("X-Fern-Language", "JAVA");
-                put("X-Fern-SDK-Name", "com.seed.fern:examples-sdk");
+                put("X-Fern-SDK-Name", "com.fern:examples");
+                put("X-Fern-SDK-Version", "0.0.1");
             }
         });
         this.headerSuppliers = headerSuppliers;

--- a/seed/java-sdk/exhaustive/custom-client-class-name/src/main/java/com/seed/exhaustive/core/ClientOptions.java
+++ b/seed/java-sdk/exhaustive/custom-client-class-name/src/main/java/com/seed/exhaustive/core/ClientOptions.java
@@ -49,7 +49,8 @@ public final class ClientOptions {
             {
                 put("User-Agent", "com.fern.exhaustive/0.0.1");
                 put("X-Fern-Language", "JAVA");
-                put("X-Fern-SDK-Name", "com.seed.fern:exhaustive-sdk");
+                put("X-Fern-SDK-Name", "com.fern:exhaustive");
+                put("X-Fern-SDK-Version", "0.0.1");
             }
         });
         this.headerSuppliers = headerSuppliers;

--- a/seed/java-sdk/exhaustive/custom-dependency/src/main/java/com/seed/exhaustive/core/ClientOptions.java
+++ b/seed/java-sdk/exhaustive/custom-dependency/src/main/java/com/seed/exhaustive/core/ClientOptions.java
@@ -49,7 +49,8 @@ public final class ClientOptions {
             {
                 put("User-Agent", "com.fern.exhaustive/0.0.1");
                 put("X-Fern-Language", "JAVA");
-                put("X-Fern-SDK-Name", "com.seed.fern:exhaustive-sdk");
+                put("X-Fern-SDK-Name", "com.fern:exhaustive");
+                put("X-Fern-SDK-Version", "0.0.1");
             }
         });
         this.headerSuppliers = headerSuppliers;

--- a/seed/java-sdk/exhaustive/custom-error-names/src/main/java/com/seed/exhaustive/core/ClientOptions.java
+++ b/seed/java-sdk/exhaustive/custom-error-names/src/main/java/com/seed/exhaustive/core/ClientOptions.java
@@ -49,7 +49,8 @@ public final class ClientOptions {
             {
                 put("User-Agent", "com.fern.exhaustive/0.0.1");
                 put("X-Fern-Language", "JAVA");
-                put("X-Fern-SDK-Name", "com.seed.fern:exhaustive-sdk");
+                put("X-Fern-SDK-Name", "com.fern:exhaustive");
+                put("X-Fern-SDK-Version", "0.0.1");
             }
         });
         this.headerSuppliers = headerSuppliers;

--- a/seed/java-sdk/exhaustive/custom-interceptors/src/main/java/com/seed/exhaustive/core/ClientOptions.java
+++ b/seed/java-sdk/exhaustive/custom-interceptors/src/main/java/com/seed/exhaustive/core/ClientOptions.java
@@ -52,7 +52,8 @@ public final class ClientOptions {
             {
                 put("User-Agent", "com.fern.exhaustive/0.0.1");
                 put("X-Fern-Language", "JAVA");
-                put("X-Fern-SDK-Name", "com.seed.fern:exhaustive-sdk");
+                put("X-Fern-SDK-Name", "com.fern:exhaustive");
+                put("X-Fern-SDK-Version", "0.0.1");
             }
         });
         this.headerSuppliers = headerSuppliers;

--- a/seed/java-sdk/exhaustive/custom-license/src/main/java/com/seed/exhaustive/core/ClientOptions.java
+++ b/seed/java-sdk/exhaustive/custom-license/src/main/java/com/seed/exhaustive/core/ClientOptions.java
@@ -49,7 +49,8 @@ public final class ClientOptions {
             {
                 put("User-Agent", "com.fern.exhaustive/0.0.1");
                 put("X-Fern-Language", "JAVA");
-                put("X-Fern-SDK-Name", "com.seed.fern:exhaustive-sdk");
+                put("X-Fern-SDK-Name", "com.fern:exhaustive");
+                put("X-Fern-SDK-Version", "0.0.1");
             }
         });
         this.headerSuppliers = headerSuppliers;

--- a/seed/java-sdk/exhaustive/custom-plugins/src/main/java/com/seed/exhaustive/core/ClientOptions.java
+++ b/seed/java-sdk/exhaustive/custom-plugins/src/main/java/com/seed/exhaustive/core/ClientOptions.java
@@ -49,7 +49,8 @@ public final class ClientOptions {
             {
                 put("User-Agent", "com.fern.exhaustive/0.0.1");
                 put("X-Fern-Language", "JAVA");
-                put("X-Fern-SDK-Name", "com.seed.fern:exhaustive-sdk");
+                put("X-Fern-SDK-Name", "com.fern:exhaustive");
+                put("X-Fern-SDK-Version", "0.0.1");
             }
         });
         this.headerSuppliers = headerSuppliers;

--- a/seed/java-sdk/exhaustive/enable-public-constructors/src/main/java/com/seed/exhaustive/core/ClientOptions.java
+++ b/seed/java-sdk/exhaustive/enable-public-constructors/src/main/java/com/seed/exhaustive/core/ClientOptions.java
@@ -49,7 +49,8 @@ public final class ClientOptions {
             {
                 put("User-Agent", "com.fern.exhaustive/0.0.1");
                 put("X-Fern-Language", "JAVA");
-                put("X-Fern-SDK-Name", "com.seed.fern:exhaustive-sdk");
+                put("X-Fern-SDK-Name", "com.fern:exhaustive");
+                put("X-Fern-SDK-Version", "0.0.1");
             }
         });
         this.headerSuppliers = headerSuppliers;

--- a/seed/java-sdk/exhaustive/flat-package-layout/src/main/java/com/seed/exhaustive/core/ClientOptions.java
+++ b/seed/java-sdk/exhaustive/flat-package-layout/src/main/java/com/seed/exhaustive/core/ClientOptions.java
@@ -49,7 +49,8 @@ public final class ClientOptions {
             {
                 put("User-Agent", "com.fern.exhaustive/0.0.1");
                 put("X-Fern-Language", "JAVA");
-                put("X-Fern-SDK-Name", "com.seed.fern:exhaustive-sdk");
+                put("X-Fern-SDK-Name", "com.fern:exhaustive");
+                put("X-Fern-SDK-Version", "0.0.1");
             }
         });
         this.headerSuppliers = headerSuppliers;

--- a/seed/java-sdk/exhaustive/forward-compatible-enums/src/main/java/com/seed/exhaustive/core/ClientOptions.java
+++ b/seed/java-sdk/exhaustive/forward-compatible-enums/src/main/java/com/seed/exhaustive/core/ClientOptions.java
@@ -49,7 +49,8 @@ public final class ClientOptions {
             {
                 put("User-Agent", "com.fern.exhaustive/0.0.1");
                 put("X-Fern-Language", "JAVA");
-                put("X-Fern-SDK-Name", "com.seed.fern:exhaustive-sdk");
+                put("X-Fern-SDK-Name", "com.fern:exhaustive");
+                put("X-Fern-SDK-Version", "0.0.1");
             }
         });
         this.headerSuppliers = headerSuppliers;

--- a/seed/java-sdk/exhaustive/json-include-non-empty/src/main/java/com/seed/exhaustive/core/ClientOptions.java
+++ b/seed/java-sdk/exhaustive/json-include-non-empty/src/main/java/com/seed/exhaustive/core/ClientOptions.java
@@ -49,7 +49,8 @@ public final class ClientOptions {
             {
                 put("User-Agent", "com.fern.exhaustive/0.0.1");
                 put("X-Fern-Language", "JAVA");
-                put("X-Fern-SDK-Name", "com.seed.fern:exhaustive-sdk");
+                put("X-Fern-SDK-Name", "com.fern:exhaustive");
+                put("X-Fern-SDK-Version", "0.0.1");
             }
         });
         this.headerSuppliers = headerSuppliers;

--- a/seed/java-sdk/exhaustive/no-custom-config/src/main/java/com/seed/exhaustive/core/ClientOptions.java
+++ b/seed/java-sdk/exhaustive/no-custom-config/src/main/java/com/seed/exhaustive/core/ClientOptions.java
@@ -49,7 +49,8 @@ public final class ClientOptions {
             {
                 put("User-Agent", "com.fern.exhaustive/0.0.1");
                 put("X-Fern-Language", "JAVA");
-                put("X-Fern-SDK-Name", "com.seed.fern:exhaustive-sdk");
+                put("X-Fern-SDK-Name", "com.fern:exhaustive");
+                put("X-Fern-SDK-Version", "0.0.1");
             }
         });
         this.headerSuppliers = headerSuppliers;

--- a/seed/java-sdk/exhaustive/publish-to/src/main/java/com/seed/exhaustive/core/ClientOptions.java
+++ b/seed/java-sdk/exhaustive/publish-to/src/main/java/com/seed/exhaustive/core/ClientOptions.java
@@ -49,7 +49,8 @@ public final class ClientOptions {
             {
                 put("User-Agent", "com.fern.exhaustive/0.0.1");
                 put("X-Fern-Language", "JAVA");
-                put("X-Fern-SDK-Name", "com.seed.fern:exhaustive-sdk");
+                put("X-Fern-SDK-Name", "com.fern:exhaustive");
+                put("X-Fern-SDK-Version", "0.0.1");
             }
         });
         this.headerSuppliers = headerSuppliers;

--- a/seed/java-sdk/exhaustive/signed_publish/src/main/java/com/seed/exhaustive/core/ClientOptions.java
+++ b/seed/java-sdk/exhaustive/signed_publish/src/main/java/com/seed/exhaustive/core/ClientOptions.java
@@ -49,7 +49,8 @@ public final class ClientOptions {
             {
                 put("User-Agent", "com.fern.exhaustive/0.0.1");
                 put("X-Fern-Language", "JAVA");
-                put("X-Fern-SDK-Name", "com.seed.fern:exhaustive-sdk");
+                put("X-Fern-SDK-Name", "com.fern:exhaustive");
+                put("X-Fern-SDK-Version", "0.0.1");
             }
         });
         this.headerSuppliers = headerSuppliers;

--- a/seed/java-sdk/extends/src/main/java/com/seed/_extends/core/ClientOptions.java
+++ b/seed/java-sdk/extends/src/main/java/com/seed/_extends/core/ClientOptions.java
@@ -49,7 +49,8 @@ public final class ClientOptions {
             {
                 put("User-Agent", "com.fern.extends/0.0.1");
                 put("X-Fern-Language", "JAVA");
-                put("X-Fern-SDK-Name", "com.seed.fern:extends-sdk");
+                put("X-Fern-SDK-Name", "com.fern:extends");
+                put("X-Fern-SDK-Version", "0.0.1");
             }
         });
         this.headerSuppliers = headerSuppliers;

--- a/seed/java-sdk/extra-properties/src/main/java/com/seed/extraProperties/core/ClientOptions.java
+++ b/seed/java-sdk/extra-properties/src/main/java/com/seed/extraProperties/core/ClientOptions.java
@@ -49,7 +49,8 @@ public final class ClientOptions {
             {
                 put("User-Agent", "com.fern.extra-properties/0.0.1");
                 put("X-Fern-Language", "JAVA");
-                put("X-Fern-SDK-Name", "com.seed.fern:extra-properties-sdk");
+                put("X-Fern-SDK-Name", "com.fern:extra-properties");
+                put("X-Fern-SDK-Version", "0.0.1");
             }
         });
         this.headerSuppliers = headerSuppliers;

--- a/seed/java-sdk/file-download/src/main/java/com/seed/fileDownload/core/ClientOptions.java
+++ b/seed/java-sdk/file-download/src/main/java/com/seed/fileDownload/core/ClientOptions.java
@@ -49,7 +49,8 @@ public final class ClientOptions {
             {
                 put("User-Agent", "com.fern.file-download/0.0.1");
                 put("X-Fern-Language", "JAVA");
-                put("X-Fern-SDK-Name", "com.seed.fern:file-download-sdk");
+                put("X-Fern-SDK-Name", "com.fern:file-download");
+                put("X-Fern-SDK-Version", "0.0.1");
             }
         });
         this.headerSuppliers = headerSuppliers;

--- a/seed/java-sdk/file-upload-openapi/src/main/java/com/seed/api/core/ClientOptions.java
+++ b/seed/java-sdk/file-upload-openapi/src/main/java/com/seed/api/core/ClientOptions.java
@@ -49,7 +49,8 @@ public final class ClientOptions {
             {
                 put("User-Agent", "com.fern.file-upload-openapi/0.0.1");
                 put("X-Fern-Language", "JAVA");
-                put("X-Fern-SDK-Name", "com.seed.fern:api-sdk");
+                put("X-Fern-SDK-Name", "com.fern:file-upload-openapi");
+                put("X-Fern-SDK-Version", "0.0.1");
             }
         });
         this.headerSuppliers = headerSuppliers;

--- a/seed/java-sdk/file-upload/inline-file-properties/src/main/java/com/seed/fileUpload/core/ClientOptions.java
+++ b/seed/java-sdk/file-upload/inline-file-properties/src/main/java/com/seed/fileUpload/core/ClientOptions.java
@@ -49,7 +49,8 @@ public final class ClientOptions {
             {
                 put("User-Agent", "com.fern.file-upload/0.0.1");
                 put("X-Fern-Language", "JAVA");
-                put("X-Fern-SDK-Name", "com.seed.fern:file-upload-sdk");
+                put("X-Fern-SDK-Name", "com.fern:file-upload");
+                put("X-Fern-SDK-Version", "0.0.1");
             }
         });
         this.headerSuppliers = headerSuppliers;

--- a/seed/java-sdk/file-upload/no-custom-config/src/main/java/com/seed/fileUpload/core/ClientOptions.java
+++ b/seed/java-sdk/file-upload/no-custom-config/src/main/java/com/seed/fileUpload/core/ClientOptions.java
@@ -49,7 +49,8 @@ public final class ClientOptions {
             {
                 put("User-Agent", "com.fern.file-upload/0.0.1");
                 put("X-Fern-Language", "JAVA");
-                put("X-Fern-SDK-Name", "com.seed.fern:file-upload-sdk");
+                put("X-Fern-SDK-Name", "com.fern:file-upload");
+                put("X-Fern-SDK-Version", "0.0.1");
             }
         });
         this.headerSuppliers = headerSuppliers;

--- a/seed/java-sdk/file-upload/wrapped-aliases/src/main/java/com/seed/fileUpload/core/ClientOptions.java
+++ b/seed/java-sdk/file-upload/wrapped-aliases/src/main/java/com/seed/fileUpload/core/ClientOptions.java
@@ -49,7 +49,8 @@ public final class ClientOptions {
             {
                 put("User-Agent", "com.fern.file-upload/0.0.1");
                 put("X-Fern-Language", "JAVA");
-                put("X-Fern-SDK-Name", "com.seed.fern:file-upload-sdk");
+                put("X-Fern-SDK-Name", "com.fern:file-upload");
+                put("X-Fern-SDK-Version", "0.0.1");
             }
         });
         this.headerSuppliers = headerSuppliers;

--- a/seed/java-sdk/folders/src/main/java/com/seed/api/core/ClientOptions.java
+++ b/seed/java-sdk/folders/src/main/java/com/seed/api/core/ClientOptions.java
@@ -49,7 +49,8 @@ public final class ClientOptions {
             {
                 put("User-Agent", "com.fern.folders/0.0.1");
                 put("X-Fern-Language", "JAVA");
-                put("X-Fern-SDK-Name", "com.seed.fern:api-sdk");
+                put("X-Fern-SDK-Name", "com.fern:folders");
+                put("X-Fern-SDK-Version", "0.0.1");
             }
         });
         this.headerSuppliers = headerSuppliers;

--- a/seed/java-sdk/header-auth-environment-variable/src/main/java/com/seed/headerTokenEnvironmentVariable/core/ClientOptions.java
+++ b/seed/java-sdk/header-auth-environment-variable/src/main/java/com/seed/headerTokenEnvironmentVariable/core/ClientOptions.java
@@ -49,7 +49,8 @@ public final class ClientOptions {
             {
                 put("User-Agent", "com.fern.header-auth-environment-variable/0.0.1");
                 put("X-Fern-Language", "JAVA");
-                put("X-Fern-SDK-Name", "com.seed.fern:header-token-environment-variable-sdk");
+                put("X-Fern-SDK-Name", "com.fern:header-auth-environment-variable");
+                put("X-Fern-SDK-Version", "0.0.1");
             }
         });
         this.headerSuppliers = headerSuppliers;

--- a/seed/java-sdk/header-auth/header-auth/src/main/java/com/seed/headerToken/core/ClientOptions.java
+++ b/seed/java-sdk/header-auth/header-auth/src/main/java/com/seed/headerToken/core/ClientOptions.java
@@ -49,7 +49,8 @@ public final class ClientOptions {
             {
                 put("User-Agent", "com.fern.header-auth/0.0.1");
                 put("X-Fern-Language", "JAVA");
-                put("X-Fern-SDK-Name", "com.seed.fern:header-token-sdk");
+                put("X-Fern-SDK-Name", "com.fern:header-auth");
+                put("X-Fern-SDK-Version", "0.0.1");
             }
         });
         this.headerSuppliers = headerSuppliers;

--- a/seed/java-sdk/http-head/src/main/java/com/seed/httpHead/core/ClientOptions.java
+++ b/seed/java-sdk/http-head/src/main/java/com/seed/httpHead/core/ClientOptions.java
@@ -49,7 +49,8 @@ public final class ClientOptions {
             {
                 put("User-Agent", "com.fern.http-head/0.0.1");
                 put("X-Fern-Language", "JAVA");
-                put("X-Fern-SDK-Name", "com.seed.fern:http-head-sdk");
+                put("X-Fern-SDK-Name", "com.fern:http-head");
+                put("X-Fern-SDK-Version", "0.0.1");
             }
         });
         this.headerSuppliers = headerSuppliers;

--- a/seed/java-sdk/idempotency-headers/auto-generate-idempotency-key/src/main/java/com/seed/idempotencyHeaders/core/ClientOptions.java
+++ b/seed/java-sdk/idempotency-headers/auto-generate-idempotency-key/src/main/java/com/seed/idempotencyHeaders/core/ClientOptions.java
@@ -49,7 +49,8 @@ public final class ClientOptions {
             {
                 put("User-Agent", "com.fern.idempotency-headers/0.0.1");
                 put("X-Fern-Language", "JAVA");
-                put("X-Fern-SDK-Name", "com.seed.fern:idempotency-headers-sdk");
+                put("X-Fern-SDK-Name", "com.fern:idempotency-headers");
+                put("X-Fern-SDK-Version", "0.0.1");
             }
         });
         this.headerSuppliers = headerSuppliers;

--- a/seed/java-sdk/idempotency-headers/no-custom-config/src/main/java/com/seed/idempotencyHeaders/core/ClientOptions.java
+++ b/seed/java-sdk/idempotency-headers/no-custom-config/src/main/java/com/seed/idempotencyHeaders/core/ClientOptions.java
@@ -49,7 +49,8 @@ public final class ClientOptions {
             {
                 put("User-Agent", "com.fern.idempotency-headers/0.0.1");
                 put("X-Fern-Language", "JAVA");
-                put("X-Fern-SDK-Name", "com.seed.fern:idempotency-headers-sdk");
+                put("X-Fern-SDK-Name", "com.fern:idempotency-headers");
+                put("X-Fern-SDK-Version", "0.0.1");
             }
         });
         this.headerSuppliers = headerSuppliers;

--- a/seed/java-sdk/imdb/disable-required-property-builder-checks/src/main/java/com/seed/api/core/ClientOptions.java
+++ b/seed/java-sdk/imdb/disable-required-property-builder-checks/src/main/java/com/seed/api/core/ClientOptions.java
@@ -49,7 +49,8 @@ public final class ClientOptions {
             {
                 put("User-Agent", "com.fern.imdb/0.0.1");
                 put("X-Fern-Language", "JAVA");
-                put("X-Fern-SDK-Name", "com.seed.fern:api-sdk");
+                put("X-Fern-SDK-Name", "com.fern:imdb");
+                put("X-Fern-SDK-Version", "0.0.1");
             }
         });
         this.headerSuppliers = headerSuppliers;

--- a/seed/java-sdk/imdb/flat-package-layout/src/main/java/com/seed/api/core/ClientOptions.java
+++ b/seed/java-sdk/imdb/flat-package-layout/src/main/java/com/seed/api/core/ClientOptions.java
@@ -49,7 +49,8 @@ public final class ClientOptions {
             {
                 put("User-Agent", "com.fern.imdb/0.0.1");
                 put("X-Fern-Language", "JAVA");
-                put("X-Fern-SDK-Name", "com.seed.fern:api-sdk");
+                put("X-Fern-SDK-Name", "com.fern:imdb");
+                put("X-Fern-SDK-Version", "0.0.1");
             }
         });
         this.headerSuppliers = headerSuppliers;

--- a/seed/java-sdk/imdb/include-platform-headers/src/main/java/com/seed/api/core/ClientOptions.java
+++ b/seed/java-sdk/imdb/include-platform-headers/src/main/java/com/seed/api/core/ClientOptions.java
@@ -52,7 +52,8 @@ public final class ClientOptions {
             {
                 put("User-Agent", getUserAgent());
                 put("X-Fern-Language", "JAVA");
-                put("X-Fern-SDK-Name", "com.seed.fern:api-sdk");
+                put("X-Fern-SDK-Name", "com.fern:imdb");
+                put("X-Fern-SDK-Version", "0.0.1");
             }
         });
         this.headerSuppliers = headerSuppliers;

--- a/seed/java-sdk/inferred-auth-explicit/src/main/java/com/seed/inferredAuthExplicit/core/ClientOptions.java
+++ b/seed/java-sdk/inferred-auth-explicit/src/main/java/com/seed/inferredAuthExplicit/core/ClientOptions.java
@@ -49,7 +49,8 @@ public final class ClientOptions {
             {
                 put("User-Agent", "com.fern.inferred-auth-explicit/0.0.1");
                 put("X-Fern-Language", "JAVA");
-                put("X-Fern-SDK-Name", "com.seed.fern:inferred-auth-explicit-sdk");
+                put("X-Fern-SDK-Name", "com.fern:inferred-auth-explicit");
+                put("X-Fern-SDK-Version", "0.0.1");
             }
         });
         this.headerSuppliers = headerSuppliers;

--- a/seed/java-sdk/inferred-auth-implicit-api-key/src/main/java/com/seed/inferredAuthImplicitApiKey/core/ClientOptions.java
+++ b/seed/java-sdk/inferred-auth-implicit-api-key/src/main/java/com/seed/inferredAuthImplicitApiKey/core/ClientOptions.java
@@ -49,7 +49,8 @@ public final class ClientOptions {
             {
                 put("User-Agent", "com.fern.inferred-auth-implicit-api-key/0.0.1");
                 put("X-Fern-Language", "JAVA");
-                put("X-Fern-SDK-Name", "com.seed.fern:inferred-auth-implicit-api-key-sdk");
+                put("X-Fern-SDK-Name", "com.fern:inferred-auth-implicit-api-key");
+                put("X-Fern-SDK-Version", "0.0.1");
             }
         });
         this.headerSuppliers = headerSuppliers;

--- a/seed/java-sdk/inferred-auth-implicit-no-expiry/src/main/java/com/seed/inferredAuthImplicitNoExpiry/core/ClientOptions.java
+++ b/seed/java-sdk/inferred-auth-implicit-no-expiry/src/main/java/com/seed/inferredAuthImplicitNoExpiry/core/ClientOptions.java
@@ -49,7 +49,8 @@ public final class ClientOptions {
             {
                 put("User-Agent", "com.fern.inferred-auth-implicit-no-expiry/0.0.1");
                 put("X-Fern-Language", "JAVA");
-                put("X-Fern-SDK-Name", "com.seed.fern:inferred-auth-implicit-no-expiry-sdk");
+                put("X-Fern-SDK-Name", "com.fern:inferred-auth-implicit-no-expiry");
+                put("X-Fern-SDK-Version", "0.0.1");
             }
         });
         this.headerSuppliers = headerSuppliers;

--- a/seed/java-sdk/inferred-auth-implicit-reference/src/main/java/com/seed/inferredAuthImplicit/core/ClientOptions.java
+++ b/seed/java-sdk/inferred-auth-implicit-reference/src/main/java/com/seed/inferredAuthImplicit/core/ClientOptions.java
@@ -49,7 +49,8 @@ public final class ClientOptions {
             {
                 put("User-Agent", "com.fern.inferred-auth-implicit-reference/0.0.1");
                 put("X-Fern-Language", "JAVA");
-                put("X-Fern-SDK-Name", "com.seed.fern:inferred-auth-implicit-sdk");
+                put("X-Fern-SDK-Name", "com.fern:inferred-auth-implicit-reference");
+                put("X-Fern-SDK-Version", "0.0.1");
             }
         });
         this.headerSuppliers = headerSuppliers;

--- a/seed/java-sdk/inferred-auth-implicit/src/main/java/com/seed/inferredAuthImplicit/core/ClientOptions.java
+++ b/seed/java-sdk/inferred-auth-implicit/src/main/java/com/seed/inferredAuthImplicit/core/ClientOptions.java
@@ -49,7 +49,8 @@ public final class ClientOptions {
             {
                 put("User-Agent", "com.fern.inferred-auth-implicit/0.0.1");
                 put("X-Fern-Language", "JAVA");
-                put("X-Fern-SDK-Name", "com.seed.fern:inferred-auth-implicit-sdk");
+                put("X-Fern-SDK-Name", "com.fern:inferred-auth-implicit");
+                put("X-Fern-SDK-Version", "0.0.1");
             }
         });
         this.headerSuppliers = headerSuppliers;

--- a/seed/java-sdk/inline-enum-type-name-override/src/main/java/com/seed/api/core/ClientOptions.java
+++ b/seed/java-sdk/inline-enum-type-name-override/src/main/java/com/seed/api/core/ClientOptions.java
@@ -49,7 +49,8 @@ public final class ClientOptions {
             {
                 put("User-Agent", "com.fern.inline-enum-type-name-override/0.0.1");
                 put("X-Fern-Language", "JAVA");
-                put("X-Fern-SDK-Name", "com.seed.fern:api-sdk");
+                put("X-Fern-SDK-Name", "com.fern:inline-enum-type-name-override");
+                put("X-Fern-SDK-Version", "0.0.1");
             }
         });
         this.headerSuppliers = headerSuppliers;

--- a/seed/java-sdk/java-builder-extension/base-client/src/main/java/com/seed/builderExtension/core/ClientOptions.java
+++ b/seed/java-sdk/java-builder-extension/base-client/src/main/java/com/seed/builderExtension/core/ClientOptions.java
@@ -49,7 +49,8 @@ public final class ClientOptions {
             {
                 put("User-Agent", "com.fern.java-builder-extension/0.0.1");
                 put("X-Fern-Language", "JAVA");
-                put("X-Fern-SDK-Name", "com.seed.fern:builder-extension-sdk");
+                put("X-Fern-SDK-Name", "com.fern:java-builder-extension");
+                put("X-Fern-SDK-Version", "0.0.1");
             }
         });
         this.headerSuppliers = headerSuppliers;

--- a/seed/java-sdk/java-builder-extension/extensible-builders/src/main/java/com/seed/builderExtension/core/ClientOptions.java
+++ b/seed/java-sdk/java-builder-extension/extensible-builders/src/main/java/com/seed/builderExtension/core/ClientOptions.java
@@ -49,7 +49,8 @@ public final class ClientOptions {
             {
                 put("User-Agent", "com.fern.java-builder-extension/0.0.1");
                 put("X-Fern-Language", "JAVA");
-                put("X-Fern-SDK-Name", "com.seed.fern:builder-extension-sdk");
+                put("X-Fern-SDK-Name", "com.fern:java-builder-extension");
+                put("X-Fern-SDK-Version", "0.0.1");
             }
         });
         this.headerSuppliers = headerSuppliers;

--- a/seed/java-sdk/java-custom-package-prefix/java-custom-package-prefix/src/main/java/com/customprefix/core/ClientOptions.java
+++ b/seed/java-sdk/java-custom-package-prefix/java-custom-package-prefix/src/main/java/com/customprefix/core/ClientOptions.java
@@ -49,7 +49,8 @@ public final class ClientOptions {
             {
                 put("User-Agent", "com.fern.java-custom-package-prefix/0.0.1");
                 put("X-Fern-Language", "JAVA");
-                put("X-Fern-SDK-Name", "com.seed.fern:api-sdk");
+                put("X-Fern-SDK-Name", "com.fern:java-custom-package-prefix");
+                put("X-Fern-SDK-Version", "0.0.1");
             }
         });
         this.headerSuppliers = headerSuppliers;

--- a/seed/java-sdk/java-default-timeout/default/src/main/java/com/seed/javaDefaultTimeout/core/ClientOptions.java
+++ b/seed/java-sdk/java-default-timeout/default/src/main/java/com/seed/javaDefaultTimeout/core/ClientOptions.java
@@ -49,7 +49,8 @@ public final class ClientOptions {
             {
                 put("User-Agent", "com.fern.java-default-timeout/0.0.1");
                 put("X-Fern-Language", "JAVA");
-                put("X-Fern-SDK-Name", "com.seed.fern:java-default-timeout-sdk");
+                put("X-Fern-SDK-Name", "com.fern:java-default-timeout");
+                put("X-Fern-SDK-Version", "0.0.1");
             }
         });
         this.headerSuppliers = headerSuppliers;

--- a/seed/java-sdk/java-endpoint-security-token-subpackage/src/main/java/com/seed/javaEndpointSecurityTokenSubpackage/core/ClientOptions.java
+++ b/seed/java-sdk/java-endpoint-security-token-subpackage/src/main/java/com/seed/javaEndpointSecurityTokenSubpackage/core/ClientOptions.java
@@ -52,7 +52,8 @@ public final class ClientOptions {
             {
                 put("User-Agent", "com.fern.java-endpoint-security-token-subpackage/0.0.1");
                 put("X-Fern-Language", "JAVA");
-                put("X-Fern-SDK-Name", "com.seed.fern:java-endpoint-security-token-subpackage-sdk");
+                put("X-Fern-SDK-Name", "com.fern:java-endpoint-security-token-subpackage");
+                put("X-Fern-SDK-Version", "0.0.1");
             }
         });
         this.headerSuppliers = headerSuppliers;

--- a/seed/java-sdk/java-global-header-env/src/main/java/com/seed/javaGlobalHeaderEnv/core/ClientOptions.java
+++ b/seed/java-sdk/java-global-header-env/src/main/java/com/seed/javaGlobalHeaderEnv/core/ClientOptions.java
@@ -49,7 +49,8 @@ public final class ClientOptions {
             {
                 put("User-Agent", "com.fern.java-global-header-env/0.0.1");
                 put("X-Fern-Language", "JAVA");
-                put("X-Fern-SDK-Name", "com.seed.fern:java-global-header-env-sdk");
+                put("X-Fern-SDK-Name", "com.fern:java-global-header-env");
+                put("X-Fern-SDK-Version", "0.0.1");
             }
         });
         this.headerSuppliers = headerSuppliers;

--- a/seed/java-sdk/java-idempotency-headers-file-upload/auto-generate-idempotency-key/src/main/java/com/seed/javaIdempotencyHeadersFileUpload/core/ClientOptions.java
+++ b/seed/java-sdk/java-idempotency-headers-file-upload/auto-generate-idempotency-key/src/main/java/com/seed/javaIdempotencyHeadersFileUpload/core/ClientOptions.java
@@ -49,7 +49,8 @@ public final class ClientOptions {
             {
                 put("User-Agent", "com.fern.java-idempotency-headers-file-upload/0.0.1");
                 put("X-Fern-Language", "JAVA");
-                put("X-Fern-SDK-Name", "com.seed.fern:java-idempotency-headers-file-upload-sdk");
+                put("X-Fern-SDK-Name", "com.fern:java-idempotency-headers-file-upload");
+                put("X-Fern-SDK-Version", "0.0.1");
             }
         });
         this.headerSuppliers = headerSuppliers;

--- a/seed/java-sdk/java-idempotency-headers-file-upload/default/src/main/java/com/seed/javaIdempotencyHeadersFileUpload/core/ClientOptions.java
+++ b/seed/java-sdk/java-idempotency-headers-file-upload/default/src/main/java/com/seed/javaIdempotencyHeadersFileUpload/core/ClientOptions.java
@@ -49,7 +49,8 @@ public final class ClientOptions {
             {
                 put("User-Agent", "com.fern.java-idempotency-headers-file-upload/0.0.1");
                 put("X-Fern-Language", "JAVA");
-                put("X-Fern-SDK-Name", "com.seed.fern:java-idempotency-headers-file-upload-sdk");
+                put("X-Fern-SDK-Name", "com.fern:java-idempotency-headers-file-upload");
+                put("X-Fern-SDK-Version", "0.0.1");
             }
         });
         this.headerSuppliers = headerSuppliers;

--- a/seed/java-sdk/java-inline-types/enable-forward-compatible-enums/src/main/java/com/seed/object/core/ClientOptions.java
+++ b/seed/java-sdk/java-inline-types/enable-forward-compatible-enums/src/main/java/com/seed/object/core/ClientOptions.java
@@ -49,7 +49,8 @@ public final class ClientOptions {
             {
                 put("User-Agent", "com.fern.java-inline-types/0.0.1");
                 put("X-Fern-Language", "JAVA");
-                put("X-Fern-SDK-Name", "com.seed.fern:object-sdk");
+                put("X-Fern-SDK-Name", "com.fern:java-inline-types");
+                put("X-Fern-SDK-Version", "0.0.1");
             }
         });
         this.headerSuppliers = headerSuppliers;

--- a/seed/java-sdk/java-inline-types/inline/src/main/java/com/seed/object/core/ClientOptions.java
+++ b/seed/java-sdk/java-inline-types/inline/src/main/java/com/seed/object/core/ClientOptions.java
@@ -49,7 +49,8 @@ public final class ClientOptions {
             {
                 put("User-Agent", "com.fern.java-inline-types/0.0.1");
                 put("X-Fern-Language", "JAVA");
-                put("X-Fern-SDK-Name", "com.seed.fern:object-sdk");
+                put("X-Fern-SDK-Name", "com.fern:java-inline-types");
+                put("X-Fern-SDK-Version", "0.0.1");
             }
         });
         this.headerSuppliers = headerSuppliers;

--- a/seed/java-sdk/java-inline-types/no-inline/src/main/java/com/seed/object/core/ClientOptions.java
+++ b/seed/java-sdk/java-inline-types/no-inline/src/main/java/com/seed/object/core/ClientOptions.java
@@ -49,7 +49,8 @@ public final class ClientOptions {
             {
                 put("User-Agent", "com.fern.java-inline-types/0.0.1");
                 put("X-Fern-Language", "JAVA");
-                put("X-Fern-SDK-Name", "com.seed.fern:object-sdk");
+                put("X-Fern-SDK-Name", "com.fern:java-inline-types");
+                put("X-Fern-SDK-Version", "0.0.1");
             }
         });
         this.headerSuppliers = headerSuppliers;

--- a/seed/java-sdk/java-inline-types/no-wrapped-aliases/src/main/java/com/seed/object/core/ClientOptions.java
+++ b/seed/java-sdk/java-inline-types/no-wrapped-aliases/src/main/java/com/seed/object/core/ClientOptions.java
@@ -49,7 +49,8 @@ public final class ClientOptions {
             {
                 put("User-Agent", "com.fern.java-inline-types/0.0.1");
                 put("X-Fern-Language", "JAVA");
-                put("X-Fern-SDK-Name", "com.seed.fern:object-sdk");
+                put("X-Fern-SDK-Name", "com.fern:java-inline-types");
+                put("X-Fern-SDK-Version", "0.0.1");
             }
         });
         this.headerSuppliers = headerSuppliers;

--- a/seed/java-sdk/java-many-properties/default/src/main/java/com/seed/manyProperties/core/ClientOptions.java
+++ b/seed/java-sdk/java-many-properties/default/src/main/java/com/seed/manyProperties/core/ClientOptions.java
@@ -49,7 +49,8 @@ public final class ClientOptions {
             {
                 put("User-Agent", "com.fern.java-many-properties/0.0.1");
                 put("X-Fern-Language", "JAVA");
-                put("X-Fern-SDK-Name", "com.seed.fern:many-properties-sdk");
+                put("X-Fern-SDK-Name", "com.fern:java-many-properties");
+                put("X-Fern-SDK-Version", "0.0.1");
             }
         });
         this.headerSuppliers = headerSuppliers;

--- a/seed/java-sdk/java-multi-env-url-templating/no-custom-config/src/main/java/com/seed/api/core/ClientOptions.java
+++ b/seed/java-sdk/java-multi-env-url-templating/no-custom-config/src/main/java/com/seed/api/core/ClientOptions.java
@@ -49,7 +49,8 @@ public final class ClientOptions {
             {
                 put("User-Agent", "com.fern.java-multi-env-url-templating/0.0.1");
                 put("X-Fern-Language", "JAVA");
-                put("X-Fern-SDK-Name", "com.seed.fern:api-sdk");
+                put("X-Fern-SDK-Name", "com.fern:java-multi-env-url-templating");
+                put("X-Fern-SDK-Version", "0.0.1");
             }
         });
         this.headerSuppliers = headerSuppliers;

--- a/seed/java-sdk/java-nullable-named-request-types/custom-config/src/main/java/com/seed/api/core/ClientOptions.java
+++ b/seed/java-sdk/java-nullable-named-request-types/custom-config/src/main/java/com/seed/api/core/ClientOptions.java
@@ -49,7 +49,8 @@ public final class ClientOptions {
             {
                 put("User-Agent", "com.fern.java-nullable-named-request-types/0.0.1");
                 put("X-Fern-Language", "JAVA");
-                put("X-Fern-SDK-Name", "com.seed.fern:api-sdk");
+                put("X-Fern-SDK-Name", "com.fern:java-nullable-named-request-types");
+                put("X-Fern-SDK-Version", "0.0.1");
             }
         });
         this.headerSuppliers = headerSuppliers;

--- a/seed/java-sdk/java-oauth-token-optional/no-custom-config/src/main/java/com/seed/javaOauthTokenOptional/core/ClientOptions.java
+++ b/seed/java-sdk/java-oauth-token-optional/no-custom-config/src/main/java/com/seed/javaOauthTokenOptional/core/ClientOptions.java
@@ -49,7 +49,8 @@ public final class ClientOptions {
             {
                 put("User-Agent", "com.fern.java-oauth-token-optional/0.0.1");
                 put("X-Fern-Language", "JAVA");
-                put("X-Fern-SDK-Name", "com.seed.fern:java-oauth-token-optional-sdk");
+                put("X-Fern-SDK-Name", "com.fern:java-oauth-token-optional");
+                put("X-Fern-SDK-Version", "0.0.1");
             }
         });
         this.headerSuppliers = headerSuppliers;

--- a/seed/java-sdk/java-optional-nullable-query-params/default/src/main/java/com/seed/javaOptionalNullableQueryParams/core/ClientOptions.java
+++ b/seed/java-sdk/java-optional-nullable-query-params/default/src/main/java/com/seed/javaOptionalNullableQueryParams/core/ClientOptions.java
@@ -49,7 +49,8 @@ public final class ClientOptions {
             {
                 put("User-Agent", "com.fern.java-optional-nullable-query-params/0.0.1");
                 put("X-Fern-Language", "JAVA");
-                put("X-Fern-SDK-Name", "com.seed.fern:java-optional-nullable-query-params-sdk");
+                put("X-Fern-SDK-Name", "com.fern:java-optional-nullable-query-params");
+                put("X-Fern-SDK-Version", "0.0.1");
             }
         });
         this.headerSuppliers = headerSuppliers;

--- a/seed/java-sdk/java-optional-query-params-overloads/src/main/java/com/seed/javaOptionalQueryParamsOverloads/core/ClientOptions.java
+++ b/seed/java-sdk/java-optional-query-params-overloads/src/main/java/com/seed/javaOptionalQueryParamsOverloads/core/ClientOptions.java
@@ -49,7 +49,8 @@ public final class ClientOptions {
             {
                 put("User-Agent", "com.fern.java-optional-query-params-overloads/0.0.1");
                 put("X-Fern-Language", "JAVA");
-                put("X-Fern-SDK-Name", "com.seed.fern:java-optional-query-params-overloads-sdk");
+                put("X-Fern-SDK-Name", "com.fern:java-optional-query-params-overloads");
+                put("X-Fern-SDK-Version", "0.0.1");
             }
         });
         this.headerSuppliers = headerSuppliers;

--- a/seed/java-sdk/java-pagination-deep-cursor-path/java-pagination-deep-cursor-path/src/main/java/com/seed/deepCursorPath/core/ClientOptions.java
+++ b/seed/java-sdk/java-pagination-deep-cursor-path/java-pagination-deep-cursor-path/src/main/java/com/seed/deepCursorPath/core/ClientOptions.java
@@ -49,7 +49,8 @@ public final class ClientOptions {
             {
                 put("User-Agent", "com.fern.java-pagination-deep-cursor-path/0.0.1");
                 put("X-Fern-Language", "JAVA");
-                put("X-Fern-SDK-Name", "com.seed.fern:deep-cursor-path-sdk");
+                put("X-Fern-SDK-Name", "com.fern:java-pagination-deep-cursor-path");
+                put("X-Fern-SDK-Version", "0.0.1");
             }
         });
         this.headerSuppliers = headerSuppliers;

--- a/seed/java-sdk/java-pagination-deep-cursor-path/wire-tests/src/main/java/com/seed/deepCursorPath/core/ClientOptions.java
+++ b/seed/java-sdk/java-pagination-deep-cursor-path/wire-tests/src/main/java/com/seed/deepCursorPath/core/ClientOptions.java
@@ -49,7 +49,8 @@ public final class ClientOptions {
             {
                 put("User-Agent", "com.fern.java-pagination-deep-cursor-path/0.0.1");
                 put("X-Fern-Language", "JAVA");
-                put("X-Fern-SDK-Name", "com.seed.fern:deep-cursor-path-sdk");
+                put("X-Fern-SDK-Name", "com.fern:java-pagination-deep-cursor-path");
+                put("X-Fern-SDK-Version", "0.0.1");
             }
         });
         this.headerSuppliers = headerSuppliers;

--- a/seed/java-sdk/java-path-param-key-conflict/default/src/main/java/com/seed/api/core/ClientOptions.java
+++ b/seed/java-sdk/java-path-param-key-conflict/default/src/main/java/com/seed/api/core/ClientOptions.java
@@ -49,7 +49,8 @@ public final class ClientOptions {
             {
                 put("User-Agent", "com.fern.java-path-param-key-conflict/0.0.1");
                 put("X-Fern-Language", "JAVA");
-                put("X-Fern-SDK-Name", "com.seed.fern:api-sdk");
+                put("X-Fern-SDK-Name", "com.fern:java-path-param-key-conflict");
+                put("X-Fern-SDK-Version", "0.0.1");
             }
         });
         this.headerSuppliers = headerSuppliers;

--- a/seed/java-sdk/java-path-parameter-suffix/default/src/main/java/com/seed/api/core/ClientOptions.java
+++ b/seed/java-sdk/java-path-parameter-suffix/default/src/main/java/com/seed/api/core/ClientOptions.java
@@ -49,7 +49,8 @@ public final class ClientOptions {
             {
                 put("User-Agent", "com.fern.java-path-parameter-suffix/0.0.1");
                 put("X-Fern-Language", "JAVA");
-                put("X-Fern-SDK-Name", "com.seed.fern:api-sdk");
+                put("X-Fern-SDK-Name", "com.fern:java-path-parameter-suffix");
+                put("X-Fern-SDK-Version", "0.0.1");
             }
         });
         this.headerSuppliers = headerSuppliers;

--- a/seed/java-sdk/java-required-body-optional-headers/src/main/java/com/seed/javaRequiredBodyOptionalHeaders/core/ClientOptions.java
+++ b/seed/java-sdk/java-required-body-optional-headers/src/main/java/com/seed/javaRequiredBodyOptionalHeaders/core/ClientOptions.java
@@ -49,7 +49,8 @@ public final class ClientOptions {
             {
                 put("User-Agent", "com.fern.java-required-body-optional-headers/0.0.1");
                 put("X-Fern-Language", "JAVA");
-                put("X-Fern-SDK-Name", "com.seed.fern:java-required-body-optional-headers-sdk");
+                put("X-Fern-SDK-Name", "com.fern:java-required-body-optional-headers");
+                put("X-Fern-SDK-Version", "0.0.1");
             }
         });
         this.headerSuppliers = headerSuppliers;

--- a/seed/java-sdk/java-single-property-endpoint/java-single-property-endpoint/src/main/java/com/seed/singleProperty/core/ClientOptions.java
+++ b/seed/java-sdk/java-single-property-endpoint/java-single-property-endpoint/src/main/java/com/seed/singleProperty/core/ClientOptions.java
@@ -49,7 +49,8 @@ public final class ClientOptions {
             {
                 put("User-Agent", "com.fern.java-single-property-endpoint/0.0.1");
                 put("X-Fern-Language", "JAVA");
-                put("X-Fern-SDK-Name", "com.seed.fern:single-property-sdk");
+                put("X-Fern-SDK-Name", "com.fern:java-single-property-endpoint");
+                put("X-Fern-SDK-Version", "0.0.1");
             }
         });
         this.headerSuppliers = headerSuppliers;

--- a/seed/java-sdk/java-staged-builder-ordering/src/main/java/com/seed/stagedBuilderOrdering/core/ClientOptions.java
+++ b/seed/java-sdk/java-staged-builder-ordering/src/main/java/com/seed/stagedBuilderOrdering/core/ClientOptions.java
@@ -49,7 +49,8 @@ public final class ClientOptions {
             {
                 put("User-Agent", "com.fern.java-staged-builder-ordering/0.0.1");
                 put("X-Fern-Language", "JAVA");
-                put("X-Fern-SDK-Name", "com.seed.fern:staged-builder-ordering-sdk");
+                put("X-Fern-SDK-Name", "com.fern:java-staged-builder-ordering");
+                put("X-Fern-SDK-Version", "0.0.1");
             }
         });
         this.headerSuppliers = headerSuppliers;

--- a/seed/java-sdk/java-streaming-accept-header/src/main/java/com/seed/javaStreamingAcceptHeader/core/ClientOptions.java
+++ b/seed/java-sdk/java-streaming-accept-header/src/main/java/com/seed/javaStreamingAcceptHeader/core/ClientOptions.java
@@ -49,7 +49,8 @@ public final class ClientOptions {
             {
                 put("User-Agent", "com.fern.java-streaming-accept-header/0.0.1");
                 put("X-Fern-Language", "JAVA");
-                put("X-Fern-SDK-Name", "com.seed.fern:java-streaming-accept-header-sdk");
+                put("X-Fern-SDK-Name", "com.fern:java-streaming-accept-header");
+                put("X-Fern-SDK-Version", "0.0.1");
             }
         });
         this.headerSuppliers = headerSuppliers;

--- a/seed/java-sdk/java-websocket-shared-discriminator/src/main/java/com/seed/javaWebsocketSharedDiscriminator/core/ClientOptions.java
+++ b/seed/java-sdk/java-websocket-shared-discriminator/src/main/java/com/seed/javaWebsocketSharedDiscriminator/core/ClientOptions.java
@@ -52,7 +52,8 @@ public final class ClientOptions {
             {
                 put("User-Agent", "com.fern.java-websocket-shared-discriminator/0.0.1");
                 put("X-Fern-Language", "JAVA");
-                put("X-Fern-SDK-Name", "com.seed.fern:java-websocket-shared-discriminator-sdk");
+                put("X-Fern-SDK-Name", "com.fern:java-websocket-shared-discriminator");
+                put("X-Fern-SDK-Version", "0.0.1");
             }
         });
         this.headerSuppliers = headerSuppliers;

--- a/seed/java-sdk/java-with-property-conflict/default/src/main/java/com/seed/javaWithPropertyConflict/core/ClientOptions.java
+++ b/seed/java-sdk/java-with-property-conflict/default/src/main/java/com/seed/javaWithPropertyConflict/core/ClientOptions.java
@@ -49,7 +49,8 @@ public final class ClientOptions {
             {
                 put("User-Agent", "com.fern.java-with-property-conflict/0.0.1");
                 put("X-Fern-Language", "JAVA");
-                put("X-Fern-SDK-Name", "com.seed.fern:java-with-property-conflict-sdk");
+                put("X-Fern-SDK-Name", "com.fern:java-with-property-conflict");
+                put("X-Fern-SDK-Version", "0.0.1");
             }
         });
         this.headerSuppliers = headerSuppliers;

--- a/seed/java-sdk/license/src/main/java/com/seed/license/core/ClientOptions.java
+++ b/seed/java-sdk/license/src/main/java/com/seed/license/core/ClientOptions.java
@@ -49,7 +49,8 @@ public final class ClientOptions {
             {
                 put("User-Agent", "com.fern.license/0.0.1");
                 put("X-Fern-Language", "JAVA");
-                put("X-Fern-SDK-Name", "com.seed.fern:license-sdk");
+                put("X-Fern-SDK-Name", "com.fern:license");
+                put("X-Fern-SDK-Version", "0.0.1");
             }
         });
         this.headerSuppliers = headerSuppliers;

--- a/seed/java-sdk/literal-user-agent/src/main/java/com/seed/literalUserAgent/core/ClientOptions.java
+++ b/seed/java-sdk/literal-user-agent/src/main/java/com/seed/literalUserAgent/core/ClientOptions.java
@@ -48,7 +48,8 @@ public final class ClientOptions {
         this.headers.putAll(new HashMap<String, String>() {
             {
                 put("X-Fern-Language", "JAVA");
-                put("X-Fern-SDK-Name", "com.seed.fern:literal-user-agent-sdk");
+                put("X-Fern-SDK-Name", "com.fern:literal-user-agent");
+                put("X-Fern-SDK-Version", "0.0.1");
             }
         });
         this.headerSuppliers = headerSuppliers;

--- a/seed/java-sdk/literal/src/main/java/com/seed/literal/core/ClientOptions.java
+++ b/seed/java-sdk/literal/src/main/java/com/seed/literal/core/ClientOptions.java
@@ -49,7 +49,8 @@ public final class ClientOptions {
             {
                 put("User-Agent", "com.fern.literal/0.0.1");
                 put("X-Fern-Language", "JAVA");
-                put("X-Fern-SDK-Name", "com.seed.fern:literal-sdk");
+                put("X-Fern-SDK-Name", "com.fern:literal");
+                put("X-Fern-SDK-Version", "0.0.1");
             }
         });
         this.headerSuppliers = headerSuppliers;

--- a/seed/java-sdk/literals-unions/src/main/java/com/seed/literalsUnions/core/ClientOptions.java
+++ b/seed/java-sdk/literals-unions/src/main/java/com/seed/literalsUnions/core/ClientOptions.java
@@ -49,7 +49,8 @@ public final class ClientOptions {
             {
                 put("User-Agent", "com.fern.literals-unions/0.0.1");
                 put("X-Fern-Language", "JAVA");
-                put("X-Fern-SDK-Name", "com.seed.fern:literals-unions-sdk");
+                put("X-Fern-SDK-Name", "com.fern:literals-unions");
+                put("X-Fern-SDK-Version", "0.0.1");
             }
         });
         this.headerSuppliers = headerSuppliers;

--- a/seed/java-sdk/mixed-case/src/main/java/com/seed/mixedCase/core/ClientOptions.java
+++ b/seed/java-sdk/mixed-case/src/main/java/com/seed/mixedCase/core/ClientOptions.java
@@ -49,7 +49,8 @@ public final class ClientOptions {
             {
                 put("User-Agent", "com.fern.mixed-case/0.0.1");
                 put("X-Fern-Language", "JAVA");
-                put("X-Fern-SDK-Name", "com.seed.fern:mixed-case-sdk");
+                put("X-Fern-SDK-Name", "com.fern:mixed-case");
+                put("X-Fern-SDK-Version", "0.0.1");
             }
         });
         this.headerSuppliers = headerSuppliers;

--- a/seed/java-sdk/mixed-file-directory/src/main/java/com/seed/mixedFileDirectory/core/ClientOptions.java
+++ b/seed/java-sdk/mixed-file-directory/src/main/java/com/seed/mixedFileDirectory/core/ClientOptions.java
@@ -49,7 +49,8 @@ public final class ClientOptions {
             {
                 put("User-Agent", "com.fern.mixed-file-directory/0.0.1");
                 put("X-Fern-Language", "JAVA");
-                put("X-Fern-SDK-Name", "com.seed.fern:mixed-file-directory-sdk");
+                put("X-Fern-SDK-Name", "com.fern:mixed-file-directory");
+                put("X-Fern-SDK-Version", "0.0.1");
             }
         });
         this.headerSuppliers = headerSuppliers;

--- a/seed/java-sdk/multi-content-type-examples/src/main/java/com/seed/api/core/ClientOptions.java
+++ b/seed/java-sdk/multi-content-type-examples/src/main/java/com/seed/api/core/ClientOptions.java
@@ -49,7 +49,8 @@ public final class ClientOptions {
             {
                 put("User-Agent", "com.fern.multi-content-type-examples/0.0.1");
                 put("X-Fern-Language", "JAVA");
-                put("X-Fern-SDK-Name", "com.seed.fern:api-sdk");
+                put("X-Fern-SDK-Name", "com.fern:multi-content-type-examples");
+                put("X-Fern-SDK-Version", "0.0.1");
             }
         });
         this.headerSuppliers = headerSuppliers;

--- a/seed/java-sdk/multi-line-docs/src/main/java/com/seed/multiLineDocs/core/ClientOptions.java
+++ b/seed/java-sdk/multi-line-docs/src/main/java/com/seed/multiLineDocs/core/ClientOptions.java
@@ -49,7 +49,8 @@ public final class ClientOptions {
             {
                 put("User-Agent", "com.fern.multi-line-docs/0.0.1");
                 put("X-Fern-Language", "JAVA");
-                put("X-Fern-SDK-Name", "com.seed.fern:multi-line-docs-sdk");
+                put("X-Fern-SDK-Name", "com.fern:multi-line-docs");
+                put("X-Fern-SDK-Version", "0.0.1");
             }
         });
         this.headerSuppliers = headerSuppliers;

--- a/seed/java-sdk/multi-url-environment-no-default/src/main/java/com/seed/multiUrlEnvironmentNoDefault/core/ClientOptions.java
+++ b/seed/java-sdk/multi-url-environment-no-default/src/main/java/com/seed/multiUrlEnvironmentNoDefault/core/ClientOptions.java
@@ -49,7 +49,8 @@ public final class ClientOptions {
             {
                 put("User-Agent", "com.fern.multi-url-environment-no-default/0.0.1");
                 put("X-Fern-Language", "JAVA");
-                put("X-Fern-SDK-Name", "com.seed.fern:multi-url-environment-no-default-sdk");
+                put("X-Fern-SDK-Name", "com.fern:multi-url-environment-no-default");
+                put("X-Fern-SDK-Version", "0.0.1");
             }
         });
         this.headerSuppliers = headerSuppliers;

--- a/seed/java-sdk/multi-url-environment-reference/src/main/java/com/seed/api/core/ClientOptions.java
+++ b/seed/java-sdk/multi-url-environment-reference/src/main/java/com/seed/api/core/ClientOptions.java
@@ -49,7 +49,8 @@ public final class ClientOptions {
             {
                 put("User-Agent", "com.fern.multi-url-environment-reference/0.0.1");
                 put("X-Fern-Language", "JAVA");
-                put("X-Fern-SDK-Name", "com.seed.fern:api-sdk");
+                put("X-Fern-SDK-Name", "com.fern:multi-url-environment-reference");
+                put("X-Fern-SDK-Version", "0.0.1");
             }
         });
         this.headerSuppliers = headerSuppliers;

--- a/seed/java-sdk/multi-url-environment/src/main/java/com/seed/multiUrlEnvironment/core/ClientOptions.java
+++ b/seed/java-sdk/multi-url-environment/src/main/java/com/seed/multiUrlEnvironment/core/ClientOptions.java
@@ -49,7 +49,8 @@ public final class ClientOptions {
             {
                 put("User-Agent", "com.fern.multi-url-environment/0.0.1");
                 put("X-Fern-Language", "JAVA");
-                put("X-Fern-SDK-Name", "com.seed.fern:multi-url-environment-sdk");
+                put("X-Fern-SDK-Name", "com.fern:multi-url-environment");
+                put("X-Fern-SDK-Version", "0.0.1");
             }
         });
         this.headerSuppliers = headerSuppliers;

--- a/seed/java-sdk/multiple-request-bodies/src/main/java/com/seed/api/core/ClientOptions.java
+++ b/seed/java-sdk/multiple-request-bodies/src/main/java/com/seed/api/core/ClientOptions.java
@@ -49,7 +49,8 @@ public final class ClientOptions {
             {
                 put("User-Agent", "com.fern.multiple-request-bodies/0.0.1");
                 put("X-Fern-Language", "JAVA");
-                put("X-Fern-SDK-Name", "com.seed.fern:api-sdk");
+                put("X-Fern-SDK-Name", "com.fern:multiple-request-bodies");
+                put("X-Fern-SDK-Version", "0.0.1");
             }
         });
         this.headerSuppliers = headerSuppliers;

--- a/seed/java-sdk/no-content-response/src/main/java/com/seed/api/core/ClientOptions.java
+++ b/seed/java-sdk/no-content-response/src/main/java/com/seed/api/core/ClientOptions.java
@@ -49,7 +49,8 @@ public final class ClientOptions {
             {
                 put("User-Agent", "com.fern.no-content-response/0.0.1");
                 put("X-Fern-Language", "JAVA");
-                put("X-Fern-SDK-Name", "com.seed.fern:api-sdk");
+                put("X-Fern-SDK-Name", "com.fern:no-content-response");
+                put("X-Fern-SDK-Version", "0.0.1");
             }
         });
         this.headerSuppliers = headerSuppliers;

--- a/seed/java-sdk/no-environment/src/main/java/com/seed/noEnvironment/core/ClientOptions.java
+++ b/seed/java-sdk/no-environment/src/main/java/com/seed/noEnvironment/core/ClientOptions.java
@@ -49,7 +49,8 @@ public final class ClientOptions {
             {
                 put("User-Agent", "com.fern.no-environment/0.0.1");
                 put("X-Fern-Language", "JAVA");
-                put("X-Fern-SDK-Name", "com.seed.fern:no-environment-sdk");
+                put("X-Fern-SDK-Name", "com.fern:no-environment");
+                put("X-Fern-SDK-Version", "0.0.1");
             }
         });
         this.headerSuppliers = headerSuppliers;

--- a/seed/java-sdk/no-retries/src/main/java/com/seed/noRetries/core/ClientOptions.java
+++ b/seed/java-sdk/no-retries/src/main/java/com/seed/noRetries/core/ClientOptions.java
@@ -49,7 +49,8 @@ public final class ClientOptions {
             {
                 put("User-Agent", "com.fern.no-retries/0.0.1");
                 put("X-Fern-Language", "JAVA");
-                put("X-Fern-SDK-Name", "com.seed.fern:no-retries-sdk");
+                put("X-Fern-SDK-Name", "com.fern:no-retries");
+                put("X-Fern-SDK-Version", "0.0.1");
             }
         });
         this.headerSuppliers = headerSuppliers;

--- a/seed/java-sdk/null-type/src/main/java/com/seed/api/core/ClientOptions.java
+++ b/seed/java-sdk/null-type/src/main/java/com/seed/api/core/ClientOptions.java
@@ -49,7 +49,8 @@ public final class ClientOptions {
             {
                 put("User-Agent", "com.fern.null-type/0.0.1");
                 put("X-Fern-Language", "JAVA");
-                put("X-Fern-SDK-Name", "com.seed.fern:api-sdk");
+                put("X-Fern-SDK-Name", "com.fern:null-type");
+                put("X-Fern-SDK-Version", "0.0.1");
             }
         });
         this.headerSuppliers = headerSuppliers;

--- a/seed/java-sdk/nullable-allof-extends/src/main/java/com/seed/api/core/ClientOptions.java
+++ b/seed/java-sdk/nullable-allof-extends/src/main/java/com/seed/api/core/ClientOptions.java
@@ -49,7 +49,8 @@ public final class ClientOptions {
             {
                 put("User-Agent", "com.fern.nullable-allof-extends/0.0.1");
                 put("X-Fern-Language", "JAVA");
-                put("X-Fern-SDK-Name", "com.seed.fern:api-sdk");
+                put("X-Fern-SDK-Name", "com.fern:nullable-allof-extends");
+                put("X-Fern-SDK-Version", "0.0.1");
             }
         });
         this.headerSuppliers = headerSuppliers;

--- a/seed/java-sdk/nullable-optional/collapse-optional-nullable/src/main/java/com/seed/nullableOptional/core/ClientOptions.java
+++ b/seed/java-sdk/nullable-optional/collapse-optional-nullable/src/main/java/com/seed/nullableOptional/core/ClientOptions.java
@@ -49,7 +49,8 @@ public final class ClientOptions {
             {
                 put("User-Agent", "com.fern.nullable-optional/0.0.1");
                 put("X-Fern-Language", "JAVA");
-                put("X-Fern-SDK-Name", "com.seed.fern:nullable-optional-sdk");
+                put("X-Fern-SDK-Name", "com.fern:nullable-optional");
+                put("X-Fern-SDK-Version", "0.0.1");
             }
         });
         this.headerSuppliers = headerSuppliers;

--- a/seed/java-sdk/nullable-optional/legacy/src/main/java/com/seed/nullableOptional/core/ClientOptions.java
+++ b/seed/java-sdk/nullable-optional/legacy/src/main/java/com/seed/nullableOptional/core/ClientOptions.java
@@ -49,7 +49,8 @@ public final class ClientOptions {
             {
                 put("User-Agent", "com.fern.nullable-optional/0.0.1");
                 put("X-Fern-Language", "JAVA");
-                put("X-Fern-SDK-Name", "com.seed.fern:nullable-optional-sdk");
+                put("X-Fern-SDK-Name", "com.fern:nullable-optional");
+                put("X-Fern-SDK-Version", "0.0.1");
             }
         });
         this.headerSuppliers = headerSuppliers;

--- a/seed/java-sdk/nullable-optional/with-nullable-annotation/src/main/java/com/seed/nullableOptional/core/ClientOptions.java
+++ b/seed/java-sdk/nullable-optional/with-nullable-annotation/src/main/java/com/seed/nullableOptional/core/ClientOptions.java
@@ -49,7 +49,8 @@ public final class ClientOptions {
             {
                 put("User-Agent", "com.fern.nullable-optional/0.0.1");
                 put("X-Fern-Language", "JAVA");
-                put("X-Fern-SDK-Name", "com.seed.fern:nullable-optional-sdk");
+                put("X-Fern-SDK-Name", "com.fern:nullable-optional");
+                put("X-Fern-SDK-Version", "0.0.1");
             }
         });
         this.headerSuppliers = headerSuppliers;

--- a/seed/java-sdk/nullable-request-body/src/main/java/com/seed/api/core/ClientOptions.java
+++ b/seed/java-sdk/nullable-request-body/src/main/java/com/seed/api/core/ClientOptions.java
@@ -49,7 +49,8 @@ public final class ClientOptions {
             {
                 put("User-Agent", "com.fern.nullable-request-body/0.0.1");
                 put("X-Fern-Language", "JAVA");
-                put("X-Fern-SDK-Name", "com.seed.fern:api-sdk");
+                put("X-Fern-SDK-Name", "com.fern:nullable-request-body");
+                put("X-Fern-SDK-Version", "0.0.1");
             }
         });
         this.headerSuppliers = headerSuppliers;

--- a/seed/java-sdk/nullable/no-custom-config/src/main/java/com/seed/nullable/core/ClientOptions.java
+++ b/seed/java-sdk/nullable/no-custom-config/src/main/java/com/seed/nullable/core/ClientOptions.java
@@ -49,7 +49,8 @@ public final class ClientOptions {
             {
                 put("User-Agent", "com.fern.nullable/0.0.1");
                 put("X-Fern-Language", "JAVA");
-                put("X-Fern-SDK-Name", "com.seed.fern:nullable-sdk");
+                put("X-Fern-SDK-Name", "com.fern:nullable");
+                put("X-Fern-SDK-Version", "0.0.1");
             }
         });
         this.headerSuppliers = headerSuppliers;

--- a/seed/java-sdk/nullable/wrapped-aliases/src/main/java/com/seed/nullable/core/ClientOptions.java
+++ b/seed/java-sdk/nullable/wrapped-aliases/src/main/java/com/seed/nullable/core/ClientOptions.java
@@ -49,7 +49,8 @@ public final class ClientOptions {
             {
                 put("User-Agent", "com.fern.nullable/0.0.1");
                 put("X-Fern-Language", "JAVA");
-                put("X-Fern-SDK-Name", "com.seed.fern:nullable-sdk");
+                put("X-Fern-SDK-Name", "com.fern:nullable");
+                put("X-Fern-SDK-Version", "0.0.1");
             }
         });
         this.headerSuppliers = headerSuppliers;

--- a/seed/java-sdk/oauth-client-credentials-custom/src/main/java/com/seed/oauthClientCredentials/core/ClientOptions.java
+++ b/seed/java-sdk/oauth-client-credentials-custom/src/main/java/com/seed/oauthClientCredentials/core/ClientOptions.java
@@ -49,7 +49,8 @@ public final class ClientOptions {
             {
                 put("User-Agent", "com.fern.oauth-client-credentials-custom/0.0.1");
                 put("X-Fern-Language", "JAVA");
-                put("X-Fern-SDK-Name", "com.seed.fern:oauth-client-credentials-sdk");
+                put("X-Fern-SDK-Name", "com.fern:oauth-client-credentials-custom");
+                put("X-Fern-SDK-Version", "0.0.1");
             }
         });
         this.headerSuppliers = headerSuppliers;

--- a/seed/java-sdk/oauth-client-credentials-default/src/main/java/com/seed/oauthClientCredentialsDefault/core/ClientOptions.java
+++ b/seed/java-sdk/oauth-client-credentials-default/src/main/java/com/seed/oauthClientCredentialsDefault/core/ClientOptions.java
@@ -49,7 +49,8 @@ public final class ClientOptions {
             {
                 put("User-Agent", "com.fern.oauth-client-credentials-default/0.0.1");
                 put("X-Fern-Language", "JAVA");
-                put("X-Fern-SDK-Name", "com.seed.fern:oauth-client-credentials-default-sdk");
+                put("X-Fern-SDK-Name", "com.fern:oauth-client-credentials-default");
+                put("X-Fern-SDK-Version", "0.0.1");
             }
         });
         this.headerSuppliers = headerSuppliers;

--- a/seed/java-sdk/oauth-client-credentials-environment-variables/src/main/java/com/seed/oauthClientCredentialsEnvironmentVariables/core/ClientOptions.java
+++ b/seed/java-sdk/oauth-client-credentials-environment-variables/src/main/java/com/seed/oauthClientCredentialsEnvironmentVariables/core/ClientOptions.java
@@ -49,7 +49,8 @@ public final class ClientOptions {
             {
                 put("User-Agent", "com.fern.oauth-client-credentials-environment-variables/0.0.1");
                 put("X-Fern-Language", "JAVA");
-                put("X-Fern-SDK-Name", "com.seed.fern:oauth-client-credentials-environment-variables-sdk");
+                put("X-Fern-SDK-Name", "com.fern:oauth-client-credentials-environment-variables");
+                put("X-Fern-SDK-Version", "0.0.1");
             }
         });
         this.headerSuppliers = headerSuppliers;

--- a/seed/java-sdk/oauth-client-credentials-mandatory-auth/no-custom-config/src/main/java/com/seed/oauthClientCredentialsMandatoryAuth/core/ClientOptions.java
+++ b/seed/java-sdk/oauth-client-credentials-mandatory-auth/no-custom-config/src/main/java/com/seed/oauthClientCredentialsMandatoryAuth/core/ClientOptions.java
@@ -49,7 +49,8 @@ public final class ClientOptions {
             {
                 put("User-Agent", "com.fern.oauth-client-credentials-mandatory-auth/0.0.1");
                 put("X-Fern-Language", "JAVA");
-                put("X-Fern-SDK-Name", "com.seed.fern:oauth-client-credentials-mandatory-auth-sdk");
+                put("X-Fern-SDK-Name", "com.fern:oauth-client-credentials-mandatory-auth");
+                put("X-Fern-SDK-Version", "0.0.1");
             }
         });
         this.headerSuppliers = headerSuppliers;

--- a/seed/java-sdk/oauth-client-credentials-nested-root/src/main/java/com/seed/oauthClientCredentials/core/ClientOptions.java
+++ b/seed/java-sdk/oauth-client-credentials-nested-root/src/main/java/com/seed/oauthClientCredentials/core/ClientOptions.java
@@ -49,7 +49,8 @@ public final class ClientOptions {
             {
                 put("User-Agent", "com.fern.oauth-client-credentials-nested-root/0.0.1");
                 put("X-Fern-Language", "JAVA");
-                put("X-Fern-SDK-Name", "com.seed.fern:oauth-client-credentials-sdk");
+                put("X-Fern-SDK-Name", "com.fern:oauth-client-credentials-nested-root");
+                put("X-Fern-SDK-Version", "0.0.1");
             }
         });
         this.headerSuppliers = headerSuppliers;

--- a/seed/java-sdk/oauth-client-credentials-openapi/src/main/java/com/seed/api/core/ClientOptions.java
+++ b/seed/java-sdk/oauth-client-credentials-openapi/src/main/java/com/seed/api/core/ClientOptions.java
@@ -49,7 +49,8 @@ public final class ClientOptions {
             {
                 put("User-Agent", "com.fern.oauth-client-credentials-openapi/0.0.1");
                 put("X-Fern-Language", "JAVA");
-                put("X-Fern-SDK-Name", "com.seed.fern:api-sdk");
+                put("X-Fern-SDK-Name", "com.fern:oauth-client-credentials-openapi");
+                put("X-Fern-SDK-Version", "0.0.1");
             }
         });
         this.headerSuppliers = headerSuppliers;

--- a/seed/java-sdk/oauth-client-credentials-reference/src/main/java/com/seed/oauthClientCredentialsReference/core/ClientOptions.java
+++ b/seed/java-sdk/oauth-client-credentials-reference/src/main/java/com/seed/oauthClientCredentialsReference/core/ClientOptions.java
@@ -49,7 +49,8 @@ public final class ClientOptions {
             {
                 put("User-Agent", "com.fern.oauth-client-credentials-reference/0.0.1");
                 put("X-Fern-Language", "JAVA");
-                put("X-Fern-SDK-Name", "com.seed.fern:oauth-client-credentials-reference-sdk");
+                put("X-Fern-SDK-Name", "com.fern:oauth-client-credentials-reference");
+                put("X-Fern-SDK-Version", "0.0.1");
             }
         });
         this.headerSuppliers = headerSuppliers;

--- a/seed/java-sdk/oauth-client-credentials-with-variables/src/main/java/com/seed/oauthClientCredentialsWithVariables/core/ClientOptions.java
+++ b/seed/java-sdk/oauth-client-credentials-with-variables/src/main/java/com/seed/oauthClientCredentialsWithVariables/core/ClientOptions.java
@@ -52,7 +52,8 @@ public final class ClientOptions {
             {
                 put("User-Agent", "com.fern.oauth-client-credentials-with-variables/0.0.1");
                 put("X-Fern-Language", "JAVA");
-                put("X-Fern-SDK-Name", "com.seed.fern:oauth-client-credentials-with-variables-sdk");
+                put("X-Fern-SDK-Name", "com.fern:oauth-client-credentials-with-variables");
+                put("X-Fern-SDK-Version", "0.0.1");
             }
         });
         this.headerSuppliers = headerSuppliers;

--- a/seed/java-sdk/oauth-client-credentials/custom-interceptors/src/main/java/com/seed/oauthClientCredentials/core/ClientOptions.java
+++ b/seed/java-sdk/oauth-client-credentials/custom-interceptors/src/main/java/com/seed/oauthClientCredentials/core/ClientOptions.java
@@ -52,7 +52,8 @@ public final class ClientOptions {
             {
                 put("User-Agent", "com.fern.oauth-client-credentials/0.0.1");
                 put("X-Fern-Language", "JAVA");
-                put("X-Fern-SDK-Name", "com.seed.fern:oauth-client-credentials-sdk");
+                put("X-Fern-SDK-Name", "com.fern:oauth-client-credentials");
+                put("X-Fern-SDK-Version", "0.0.1");
             }
         });
         this.headerSuppliers = headerSuppliers;

--- a/seed/java-sdk/oauth-client-credentials/oauth-client-credentials/src/main/java/com/seed/oauthClientCredentials/core/ClientOptions.java
+++ b/seed/java-sdk/oauth-client-credentials/oauth-client-credentials/src/main/java/com/seed/oauthClientCredentials/core/ClientOptions.java
@@ -49,7 +49,8 @@ public final class ClientOptions {
             {
                 put("User-Agent", "com.fern.oauth-client-credentials/0.0.1");
                 put("X-Fern-Language", "JAVA");
-                put("X-Fern-SDK-Name", "com.seed.fern:oauth-client-credentials-sdk");
+                put("X-Fern-SDK-Name", "com.fern:oauth-client-credentials");
+                put("X-Fern-SDK-Version", "0.0.1");
             }
         });
         this.headerSuppliers = headerSuppliers;

--- a/seed/java-sdk/oauth-pkce/src/main/java/com/seed/oauthPkce/core/ClientOptions.java
+++ b/seed/java-sdk/oauth-pkce/src/main/java/com/seed/oauthPkce/core/ClientOptions.java
@@ -49,7 +49,8 @@ public final class ClientOptions {
             {
                 put("User-Agent", "com.fern.oauth-pkce/0.0.1");
                 put("X-Fern-Language", "JAVA");
-                put("X-Fern-SDK-Name", "com.seed.fern:oauth-pkce-sdk");
+                put("X-Fern-SDK-Name", "com.fern:oauth-pkce");
+                put("X-Fern-SDK-Version", "0.0.1");
             }
         });
         this.headerSuppliers = headerSuppliers;

--- a/seed/java-sdk/object/src/main/java/com/seed/object/core/ClientOptions.java
+++ b/seed/java-sdk/object/src/main/java/com/seed/object/core/ClientOptions.java
@@ -49,7 +49,8 @@ public final class ClientOptions {
             {
                 put("User-Agent", "com.fern.object/0.0.1");
                 put("X-Fern-Language", "JAVA");
-                put("X-Fern-SDK-Name", "com.seed.fern:object-sdk");
+                put("X-Fern-SDK-Name", "com.fern:object");
+                put("X-Fern-SDK-Version", "0.0.1");
             }
         });
         this.headerSuppliers = headerSuppliers;

--- a/seed/java-sdk/objects-with-imports/src/main/java/com/seed/objectsWithImports/core/ClientOptions.java
+++ b/seed/java-sdk/objects-with-imports/src/main/java/com/seed/objectsWithImports/core/ClientOptions.java
@@ -49,7 +49,8 @@ public final class ClientOptions {
             {
                 put("User-Agent", "com.fern.objects-with-imports/0.0.1");
                 put("X-Fern-Language", "JAVA");
-                put("X-Fern-SDK-Name", "com.seed.fern:objects-with-imports-sdk");
+                put("X-Fern-SDK-Name", "com.fern:objects-with-imports");
+                put("X-Fern-SDK-Version", "0.0.1");
             }
         });
         this.headerSuppliers = headerSuppliers;

--- a/seed/java-sdk/openapi-path-param-body-collision/src/main/java/com/seed/api/core/ClientOptions.java
+++ b/seed/java-sdk/openapi-path-param-body-collision/src/main/java/com/seed/api/core/ClientOptions.java
@@ -49,7 +49,8 @@ public final class ClientOptions {
             {
                 put("User-Agent", "com.fern.openapi-path-param-body-collision/0.0.1");
                 put("X-Fern-Language", "JAVA");
-                put("X-Fern-SDK-Name", "com.seed.fern:api-sdk");
+                put("X-Fern-SDK-Name", "com.fern:openapi-path-param-body-collision");
+                put("X-Fern-SDK-Version", "0.0.1");
             }
         });
         this.headerSuppliers = headerSuppliers;

--- a/seed/java-sdk/openapi-request-body-ref/no-custom-config/src/main/java/com/seed/api/core/ClientOptions.java
+++ b/seed/java-sdk/openapi-request-body-ref/no-custom-config/src/main/java/com/seed/api/core/ClientOptions.java
@@ -49,7 +49,8 @@ public final class ClientOptions {
             {
                 put("User-Agent", "com.fern.openapi-request-body-ref/0.0.1");
                 put("X-Fern-Language", "JAVA");
-                put("X-Fern-SDK-Name", "com.seed.fern:api-sdk");
+                put("X-Fern-SDK-Name", "com.fern:openapi-request-body-ref");
+                put("X-Fern-SDK-Version", "0.0.1");
             }
         });
         this.headerSuppliers = headerSuppliers;

--- a/seed/java-sdk/openapi-subtitle/src/main/java/com/seed/api/core/ClientOptions.java
+++ b/seed/java-sdk/openapi-subtitle/src/main/java/com/seed/api/core/ClientOptions.java
@@ -49,7 +49,8 @@ public final class ClientOptions {
             {
                 put("User-Agent", "com.fern.openapi-subtitle/0.0.1");
                 put("X-Fern-Language", "JAVA");
-                put("X-Fern-SDK-Name", "com.seed.fern:api-sdk");
+                put("X-Fern-SDK-Name", "com.fern:openapi-subtitle");
+                put("X-Fern-SDK-Version", "0.0.1");
             }
         });
         this.headerSuppliers = headerSuppliers;

--- a/seed/java-sdk/optional/wire-tests/src/main/java/com/seed/objectsWithImports/core/ClientOptions.java
+++ b/seed/java-sdk/optional/wire-tests/src/main/java/com/seed/objectsWithImports/core/ClientOptions.java
@@ -49,7 +49,8 @@ public final class ClientOptions {
             {
                 put("User-Agent", "com.fern.optional/0.0.1");
                 put("X-Fern-Language", "JAVA");
-                put("X-Fern-SDK-Name", "com.seed.fern:objects-with-imports-sdk");
+                put("X-Fern-SDK-Name", "com.fern:optional");
+                put("X-Fern-SDK-Version", "0.0.1");
             }
         });
         this.headerSuppliers = headerSuppliers;

--- a/seed/java-sdk/package-yml/src/main/java/com/seed/packageYml/core/ClientOptions.java
+++ b/seed/java-sdk/package-yml/src/main/java/com/seed/packageYml/core/ClientOptions.java
@@ -52,7 +52,8 @@ public final class ClientOptions {
             {
                 put("User-Agent", "com.fern.package-yml/0.0.1");
                 put("X-Fern-Language", "JAVA");
-                put("X-Fern-SDK-Name", "com.seed.fern:package-yml-sdk");
+                put("X-Fern-SDK-Name", "com.fern:package-yml");
+                put("X-Fern-SDK-Version", "0.0.1");
             }
         });
         this.headerSuppliers = headerSuppliers;

--- a/seed/java-sdk/pagination-custom/default/src/main/java/com/seed/pagination/core/ClientOptions.java
+++ b/seed/java-sdk/pagination-custom/default/src/main/java/com/seed/pagination/core/ClientOptions.java
@@ -49,7 +49,8 @@ public final class ClientOptions {
             {
                 put("User-Agent", "com.fern.pagination-custom/0.0.1");
                 put("X-Fern-Language", "JAVA");
-                put("X-Fern-SDK-Name", "com.seed.fern:pagination-sdk");
+                put("X-Fern-SDK-Name", "com.fern:pagination-custom");
+                put("X-Fern-SDK-Version", "0.0.1");
             }
         });
         this.headerSuppliers = headerSuppliers;

--- a/seed/java-sdk/pagination-uri-path/wire-tests/src/main/java/com/seed/paginationUriPath/core/ClientOptions.java
+++ b/seed/java-sdk/pagination-uri-path/wire-tests/src/main/java/com/seed/paginationUriPath/core/ClientOptions.java
@@ -49,7 +49,8 @@ public final class ClientOptions {
             {
                 put("User-Agent", "com.fern.pagination-uri-path/0.0.1");
                 put("X-Fern-Language", "JAVA");
-                put("X-Fern-SDK-Name", "com.seed.fern:pagination-uri-path-sdk");
+                put("X-Fern-SDK-Name", "com.fern:pagination-uri-path");
+                put("X-Fern-SDK-Version", "0.0.1");
             }
         });
         this.headerSuppliers = headerSuppliers;

--- a/seed/java-sdk/pagination/default/src/main/java/com/seed/pagination/core/ClientOptions.java
+++ b/seed/java-sdk/pagination/default/src/main/java/com/seed/pagination/core/ClientOptions.java
@@ -49,7 +49,8 @@ public final class ClientOptions {
             {
                 put("User-Agent", "com.fern.pagination/0.0.1");
                 put("X-Fern-Language", "JAVA");
-                put("X-Fern-SDK-Name", "com.seed.fern:pagination-sdk");
+                put("X-Fern-SDK-Name", "com.fern:pagination");
+                put("X-Fern-SDK-Version", "0.0.1");
             }
         });
         this.headerSuppliers = headerSuppliers;

--- a/seed/java-sdk/pagination/item-index-semantics/src/main/java/com/seed/pagination/core/ClientOptions.java
+++ b/seed/java-sdk/pagination/item-index-semantics/src/main/java/com/seed/pagination/core/ClientOptions.java
@@ -49,7 +49,8 @@ public final class ClientOptions {
             {
                 put("User-Agent", "com.fern.pagination/0.0.1");
                 put("X-Fern-Language", "JAVA");
-                put("X-Fern-SDK-Name", "com.seed.fern:pagination-sdk");
+                put("X-Fern-SDK-Name", "com.fern:pagination");
+                put("X-Fern-SDK-Version", "0.0.1");
             }
         });
         this.headerSuppliers = headerSuppliers;

--- a/seed/java-sdk/path-parameters/src/main/java/com/seed/pathParameters/core/ClientOptions.java
+++ b/seed/java-sdk/path-parameters/src/main/java/com/seed/pathParameters/core/ClientOptions.java
@@ -52,7 +52,8 @@ public final class ClientOptions {
             {
                 put("User-Agent", "com.fern.path-parameters/0.0.1");
                 put("X-Fern-Language", "JAVA");
-                put("X-Fern-SDK-Name", "com.seed.fern:path-parameters-sdk");
+                put("X-Fern-SDK-Name", "com.fern:path-parameters");
+                put("X-Fern-SDK-Version", "0.0.1");
             }
         });
         this.headerSuppliers = headerSuppliers;

--- a/seed/java-sdk/plain-text/src/main/java/com/seed/plainText/core/ClientOptions.java
+++ b/seed/java-sdk/plain-text/src/main/java/com/seed/plainText/core/ClientOptions.java
@@ -49,7 +49,8 @@ public final class ClientOptions {
             {
                 put("User-Agent", "com.fern.plain-text/0.0.1");
                 put("X-Fern-Language", "JAVA");
-                put("X-Fern-SDK-Name", "com.seed.fern:plain-text-sdk");
+                put("X-Fern-SDK-Name", "com.fern:plain-text");
+                put("X-Fern-SDK-Version", "0.0.1");
             }
         });
         this.headerSuppliers = headerSuppliers;

--- a/seed/java-sdk/property-access/src/main/java/com/seed/propertyAccess/core/ClientOptions.java
+++ b/seed/java-sdk/property-access/src/main/java/com/seed/propertyAccess/core/ClientOptions.java
@@ -49,7 +49,8 @@ public final class ClientOptions {
             {
                 put("User-Agent", "com.fern.property-access/0.0.1");
                 put("X-Fern-Language", "JAVA");
-                put("X-Fern-SDK-Name", "com.seed.fern:property-access-sdk");
+                put("X-Fern-SDK-Name", "com.fern:property-access");
+                put("X-Fern-SDK-Version", "0.0.1");
             }
         });
         this.headerSuppliers = headerSuppliers;

--- a/seed/java-sdk/public-object/src/main/java/com/seed/publicObject/core/ClientOptions.java
+++ b/seed/java-sdk/public-object/src/main/java/com/seed/publicObject/core/ClientOptions.java
@@ -49,7 +49,8 @@ public final class ClientOptions {
             {
                 put("User-Agent", "com.fern.public-object/0.0.1");
                 put("X-Fern-Language", "JAVA");
-                put("X-Fern-SDK-Name", "com.seed.fern:public-object-sdk");
+                put("X-Fern-SDK-Name", "com.fern:public-object");
+                put("X-Fern-SDK-Version", "0.0.1");
             }
         });
         this.headerSuppliers = headerSuppliers;

--- a/seed/java-sdk/query-param-name-conflict/src/main/java/com/seed/api/core/ClientOptions.java
+++ b/seed/java-sdk/query-param-name-conflict/src/main/java/com/seed/api/core/ClientOptions.java
@@ -49,7 +49,8 @@ public final class ClientOptions {
             {
                 put("User-Agent", "com.fern.query-param-name-conflict/0.0.1");
                 put("X-Fern-Language", "JAVA");
-                put("X-Fern-SDK-Name", "com.seed.fern:api-sdk");
+                put("X-Fern-SDK-Name", "com.fern:query-param-name-conflict");
+                put("X-Fern-SDK-Version", "0.0.1");
             }
         });
         this.headerSuppliers = headerSuppliers;

--- a/seed/java-sdk/query-parameters-openapi-as-objects/src/main/java/com/seed/api/core/ClientOptions.java
+++ b/seed/java-sdk/query-parameters-openapi-as-objects/src/main/java/com/seed/api/core/ClientOptions.java
@@ -49,7 +49,8 @@ public final class ClientOptions {
             {
                 put("User-Agent", "com.fern.query-parameters-openapi-as-objects/0.0.1");
                 put("X-Fern-Language", "JAVA");
-                put("X-Fern-SDK-Name", "com.seed.fern:api-sdk");
+                put("X-Fern-SDK-Name", "com.fern:query-parameters-openapi-as-objects");
+                put("X-Fern-SDK-Version", "0.0.1");
             }
         });
         this.headerSuppliers = headerSuppliers;

--- a/seed/java-sdk/query-parameters-openapi/src/main/java/com/seed/api/core/ClientOptions.java
+++ b/seed/java-sdk/query-parameters-openapi/src/main/java/com/seed/api/core/ClientOptions.java
@@ -49,7 +49,8 @@ public final class ClientOptions {
             {
                 put("User-Agent", "com.fern.query-parameters-openapi/0.0.1");
                 put("X-Fern-Language", "JAVA");
-                put("X-Fern-SDK-Name", "com.seed.fern:api-sdk");
+                put("X-Fern-SDK-Name", "com.fern:query-parameters-openapi");
+                put("X-Fern-SDK-Version", "0.0.1");
             }
         });
         this.headerSuppliers = headerSuppliers;

--- a/seed/java-sdk/query-parameters/src/main/java/com/seed/queryParameters/core/ClientOptions.java
+++ b/seed/java-sdk/query-parameters/src/main/java/com/seed/queryParameters/core/ClientOptions.java
@@ -49,7 +49,8 @@ public final class ClientOptions {
             {
                 put("User-Agent", "com.fern.query-parameters/0.0.1");
                 put("X-Fern-Language", "JAVA");
-                put("X-Fern-SDK-Name", "com.seed.fern:query-parameters-sdk");
+                put("X-Fern-SDK-Name", "com.fern:query-parameters");
+                put("X-Fern-SDK-Version", "0.0.1");
             }
         });
         this.headerSuppliers = headerSuppliers;

--- a/seed/java-sdk/request-parameters/src/main/java/com/seed/requestParameters/core/ClientOptions.java
+++ b/seed/java-sdk/request-parameters/src/main/java/com/seed/requestParameters/core/ClientOptions.java
@@ -49,7 +49,8 @@ public final class ClientOptions {
             {
                 put("User-Agent", "com.fern.request-parameters/0.0.1");
                 put("X-Fern-Language", "JAVA");
-                put("X-Fern-SDK-Name", "com.seed.fern:request-parameters-sdk");
+                put("X-Fern-SDK-Name", "com.fern:request-parameters");
+                put("X-Fern-SDK-Version", "0.0.1");
             }
         });
         this.headerSuppliers = headerSuppliers;

--- a/seed/java-sdk/required-nullable/src/main/java/com/seed/api/core/ClientOptions.java
+++ b/seed/java-sdk/required-nullable/src/main/java/com/seed/api/core/ClientOptions.java
@@ -49,7 +49,8 @@ public final class ClientOptions {
             {
                 put("User-Agent", "com.fern.required-nullable/0.0.1");
                 put("X-Fern-Language", "JAVA");
-                put("X-Fern-SDK-Name", "com.seed.fern:api-sdk");
+                put("X-Fern-SDK-Name", "com.fern:required-nullable");
+                put("X-Fern-SDK-Version", "0.0.1");
             }
         });
         this.headerSuppliers = headerSuppliers;

--- a/seed/java-sdk/reserved-keywords/src/main/java/com/seed/nurseryApi/core/ClientOptions.java
+++ b/seed/java-sdk/reserved-keywords/src/main/java/com/seed/nurseryApi/core/ClientOptions.java
@@ -49,7 +49,8 @@ public final class ClientOptions {
             {
                 put("User-Agent", "com.fern.reserved-keywords/0.0.1");
                 put("X-Fern-Language", "JAVA");
-                put("X-Fern-SDK-Name", "com.seed.fern:nursery-api-sdk");
+                put("X-Fern-SDK-Name", "com.fern:reserved-keywords");
+                put("X-Fern-SDK-Version", "0.0.1");
             }
         });
         this.headerSuppliers = headerSuppliers;

--- a/seed/java-sdk/response-property/src/main/java/com/seed/responseProperty/core/ClientOptions.java
+++ b/seed/java-sdk/response-property/src/main/java/com/seed/responseProperty/core/ClientOptions.java
@@ -49,7 +49,8 @@ public final class ClientOptions {
             {
                 put("User-Agent", "com.fern.response-property/0.0.1");
                 put("X-Fern-Language", "JAVA");
-                put("X-Fern-SDK-Name", "com.seed.fern:response-property-sdk");
+                put("X-Fern-SDK-Name", "com.fern:response-property");
+                put("X-Fern-SDK-Version", "0.0.1");
             }
         });
         this.headerSuppliers = headerSuppliers;

--- a/seed/java-sdk/schemaless-request-body-examples/src/main/java/com/seed/api/core/ClientOptions.java
+++ b/seed/java-sdk/schemaless-request-body-examples/src/main/java/com/seed/api/core/ClientOptions.java
@@ -49,7 +49,8 @@ public final class ClientOptions {
             {
                 put("User-Agent", "com.fern.schemaless-request-body-examples/0.0.1");
                 put("X-Fern-Language", "JAVA");
-                put("X-Fern-SDK-Name", "com.seed.fern:api-sdk");
+                put("X-Fern-SDK-Name", "com.fern:schemaless-request-body-examples");
+                put("X-Fern-SDK-Version", "0.0.1");
             }
         });
         this.headerSuppliers = headerSuppliers;

--- a/seed/java-sdk/server-sent-event-examples/no-custom-config/src/main/java/com/seed/serverSentEvents/core/ClientOptions.java
+++ b/seed/java-sdk/server-sent-event-examples/no-custom-config/src/main/java/com/seed/serverSentEvents/core/ClientOptions.java
@@ -49,7 +49,8 @@ public final class ClientOptions {
             {
                 put("User-Agent", "com.fern.server-sent-event-examples/0.0.1");
                 put("X-Fern-Language", "JAVA");
-                put("X-Fern-SDK-Name", "com.seed.fern:server-sent-events-sdk");
+                put("X-Fern-SDK-Name", "com.fern:server-sent-event-examples");
+                put("X-Fern-SDK-Version", "0.0.1");
             }
         });
         this.headerSuppliers = headerSuppliers;

--- a/seed/java-sdk/server-sent-event-examples/with-wire-tests/src/main/java/com/seed/serverSentEvents/core/ClientOptions.java
+++ b/seed/java-sdk/server-sent-event-examples/with-wire-tests/src/main/java/com/seed/serverSentEvents/core/ClientOptions.java
@@ -49,7 +49,8 @@ public final class ClientOptions {
             {
                 put("User-Agent", "com.fern.server-sent-event-examples/0.0.1");
                 put("X-Fern-Language", "JAVA");
-                put("X-Fern-SDK-Name", "com.seed.fern:server-sent-events-sdk");
+                put("X-Fern-SDK-Name", "com.fern:server-sent-event-examples");
+                put("X-Fern-SDK-Version", "0.0.1");
             }
         });
         this.headerSuppliers = headerSuppliers;

--- a/seed/java-sdk/server-sent-events-openapi/with-wire-tests/src/main/java/com/seed/api/core/ClientOptions.java
+++ b/seed/java-sdk/server-sent-events-openapi/with-wire-tests/src/main/java/com/seed/api/core/ClientOptions.java
@@ -49,7 +49,8 @@ public final class ClientOptions {
             {
                 put("User-Agent", "com.fern.server-sent-events-openapi/0.0.1");
                 put("X-Fern-Language", "JAVA");
-                put("X-Fern-SDK-Name", "com.seed.fern:api-sdk");
+                put("X-Fern-SDK-Name", "com.fern:server-sent-events-openapi");
+                put("X-Fern-SDK-Version", "0.0.1");
             }
         });
         this.headerSuppliers = headerSuppliers;

--- a/seed/java-sdk/server-sent-events-resumable/src/main/java/com/seed/serverSentEventsResumable/core/ClientOptions.java
+++ b/seed/java-sdk/server-sent-events-resumable/src/main/java/com/seed/serverSentEventsResumable/core/ClientOptions.java
@@ -49,7 +49,8 @@ public final class ClientOptions {
             {
                 put("User-Agent", "com.fern.server-sent-events-resumable/0.0.1");
                 put("X-Fern-Language", "JAVA");
-                put("X-Fern-SDK-Name", "com.seed.fern:server-sent-events-resumable-sdk");
+                put("X-Fern-SDK-Name", "com.fern:server-sent-events-resumable");
+                put("X-Fern-SDK-Version", "0.0.1");
             }
         });
         this.headerSuppliers = headerSuppliers;

--- a/seed/java-sdk/server-sent-events/src/main/java/com/seed/serverSentEvents/core/ClientOptions.java
+++ b/seed/java-sdk/server-sent-events/src/main/java/com/seed/serverSentEvents/core/ClientOptions.java
@@ -49,7 +49,8 @@ public final class ClientOptions {
             {
                 put("User-Agent", "com.fern.server-sent-events/0.0.1");
                 put("X-Fern-Language", "JAVA");
-                put("X-Fern-SDK-Name", "com.seed.fern:server-sent-events-sdk");
+                put("X-Fern-SDK-Name", "com.fern:server-sent-events");
+                put("X-Fern-SDK-Version", "0.0.1");
             }
         });
         this.headerSuppliers = headerSuppliers;

--- a/seed/java-sdk/server-url-templating-single-url/src/main/java/com/seed/api/core/ClientOptions.java
+++ b/seed/java-sdk/server-url-templating-single-url/src/main/java/com/seed/api/core/ClientOptions.java
@@ -49,7 +49,8 @@ public final class ClientOptions {
             {
                 put("User-Agent", "com.fern.server-url-templating-single-url/0.0.1");
                 put("X-Fern-Language", "JAVA");
-                put("X-Fern-SDK-Name", "com.seed.fern:api-sdk");
+                put("X-Fern-SDK-Name", "com.fern:server-url-templating-single-url");
+                put("X-Fern-SDK-Version", "0.0.1");
             }
         });
         this.headerSuppliers = headerSuppliers;

--- a/seed/java-sdk/server-url-templating/src/main/java/com/seed/api/core/ClientOptions.java
+++ b/seed/java-sdk/server-url-templating/src/main/java/com/seed/api/core/ClientOptions.java
@@ -49,7 +49,8 @@ public final class ClientOptions {
             {
                 put("User-Agent", "com.fern.server-url-templating/0.0.1");
                 put("X-Fern-Language", "JAVA");
-                put("X-Fern-SDK-Name", "com.seed.fern:api-sdk");
+                put("X-Fern-SDK-Name", "com.fern:server-url-templating");
+                put("X-Fern-SDK-Version", "0.0.1");
             }
         });
         this.headerSuppliers = headerSuppliers;

--- a/seed/java-sdk/simple-api/src/main/java/com/seed/simpleApi/core/ClientOptions.java
+++ b/seed/java-sdk/simple-api/src/main/java/com/seed/simpleApi/core/ClientOptions.java
@@ -49,7 +49,8 @@ public final class ClientOptions {
             {
                 put("User-Agent", "com.fern.simple-api/0.0.1");
                 put("X-Fern-Language", "JAVA");
-                put("X-Fern-SDK-Name", "com.seed.fern:simple-api-sdk");
+                put("X-Fern-SDK-Name", "com.fern:simple-api");
+                put("X-Fern-SDK-Version", "0.0.1");
             }
         });
         this.headerSuppliers = headerSuppliers;

--- a/seed/java-sdk/simple-fhir/src/main/java/com/seed/api/core/ClientOptions.java
+++ b/seed/java-sdk/simple-fhir/src/main/java/com/seed/api/core/ClientOptions.java
@@ -49,7 +49,8 @@ public final class ClientOptions {
             {
                 put("User-Agent", "com.fern.simple-fhir/0.0.1");
                 put("X-Fern-Language", "JAVA");
-                put("X-Fern-SDK-Name", "com.seed.fern:api-sdk");
+                put("X-Fern-SDK-Name", "com.fern:simple-fhir");
+                put("X-Fern-SDK-Version", "0.0.1");
             }
         });
         this.headerSuppliers = headerSuppliers;

--- a/seed/java-sdk/single-url-environment-default/src/main/java/com/seed/singleUrlEnvironmentDefault/core/ClientOptions.java
+++ b/seed/java-sdk/single-url-environment-default/src/main/java/com/seed/singleUrlEnvironmentDefault/core/ClientOptions.java
@@ -49,7 +49,8 @@ public final class ClientOptions {
             {
                 put("User-Agent", "com.fern.single-url-environment-default/0.0.1");
                 put("X-Fern-Language", "JAVA");
-                put("X-Fern-SDK-Name", "com.seed.fern:single-url-environment-default-sdk");
+                put("X-Fern-SDK-Name", "com.fern:single-url-environment-default");
+                put("X-Fern-SDK-Version", "0.0.1");
             }
         });
         this.headerSuppliers = headerSuppliers;

--- a/seed/java-sdk/single-url-environment-no-default/src/main/java/com/seed/singleUrlEnvironmentNoDefault/core/ClientOptions.java
+++ b/seed/java-sdk/single-url-environment-no-default/src/main/java/com/seed/singleUrlEnvironmentNoDefault/core/ClientOptions.java
@@ -49,7 +49,8 @@ public final class ClientOptions {
             {
                 put("User-Agent", "com.fern.single-url-environment-no-default/0.0.1");
                 put("X-Fern-Language", "JAVA");
-                put("X-Fern-SDK-Name", "com.seed.fern:single-url-environment-no-default-sdk");
+                put("X-Fern-SDK-Name", "com.fern:single-url-environment-no-default");
+                put("X-Fern-SDK-Version", "0.0.1");
             }
         });
         this.headerSuppliers = headerSuppliers;

--- a/seed/java-sdk/streaming-parameter/src/main/java/com/seed/streaming/core/ClientOptions.java
+++ b/seed/java-sdk/streaming-parameter/src/main/java/com/seed/streaming/core/ClientOptions.java
@@ -49,7 +49,8 @@ public final class ClientOptions {
             {
                 put("User-Agent", "com.fern.streaming-parameter/0.0.1");
                 put("X-Fern-Language", "JAVA");
-                put("X-Fern-SDK-Name", "com.seed.fern:streaming-sdk");
+                put("X-Fern-SDK-Name", "com.fern:streaming-parameter");
+                put("X-Fern-SDK-Version", "0.0.1");
             }
         });
         this.headerSuppliers = headerSuppliers;

--- a/seed/java-sdk/streaming/streaming/src/main/java/com/seed/streaming/core/ClientOptions.java
+++ b/seed/java-sdk/streaming/streaming/src/main/java/com/seed/streaming/core/ClientOptions.java
@@ -49,7 +49,8 @@ public final class ClientOptions {
             {
                 put("User-Agent", "com.fern.streaming/0.0.1");
                 put("X-Fern-Language", "JAVA");
-                put("X-Fern-SDK-Name", "com.seed.fern:streaming-sdk");
+                put("X-Fern-SDK-Name", "com.fern:streaming");
+                put("X-Fern-SDK-Version", "0.0.1");
             }
         });
         this.headerSuppliers = headerSuppliers;

--- a/seed/java-sdk/trace/src/main/java/com/seed/trace/core/ClientOptions.java
+++ b/seed/java-sdk/trace/src/main/java/com/seed/trace/core/ClientOptions.java
@@ -49,7 +49,8 @@ public final class ClientOptions {
             {
                 put("User-Agent", "com.fern.trace/0.0.1");
                 put("X-Fern-Language", "JAVA");
-                put("X-Fern-SDK-Name", "com.seed.fern:trace-sdk");
+                put("X-Fern-SDK-Name", "com.fern:trace");
+                put("X-Fern-SDK-Version", "0.0.1");
             }
         });
         this.headerSuppliers = headerSuppliers;

--- a/seed/java-sdk/undiscriminated-union-with-response-property/src/main/java/com/seed/undiscriminatedUnionWithResponseProperty/core/ClientOptions.java
+++ b/seed/java-sdk/undiscriminated-union-with-response-property/src/main/java/com/seed/undiscriminatedUnionWithResponseProperty/core/ClientOptions.java
@@ -49,7 +49,8 @@ public final class ClientOptions {
             {
                 put("User-Agent", "com.fern.undiscriminated-union-with-response-property/0.0.1");
                 put("X-Fern-Language", "JAVA");
-                put("X-Fern-SDK-Name", "com.seed.fern:undiscriminated-union-with-response-property-sdk");
+                put("X-Fern-SDK-Name", "com.fern:undiscriminated-union-with-response-property");
+                put("X-Fern-SDK-Version", "0.0.1");
             }
         });
         this.headerSuppliers = headerSuppliers;

--- a/seed/java-sdk/undiscriminated-unions/src/main/java/com/seed/undiscriminatedUnions/core/ClientOptions.java
+++ b/seed/java-sdk/undiscriminated-unions/src/main/java/com/seed/undiscriminatedUnions/core/ClientOptions.java
@@ -49,7 +49,8 @@ public final class ClientOptions {
             {
                 put("User-Agent", "com.fern.undiscriminated-unions/0.0.1");
                 put("X-Fern-Language", "JAVA");
-                put("X-Fern-SDK-Name", "com.seed.fern:undiscriminated-unions-sdk");
+                put("X-Fern-SDK-Name", "com.fern:undiscriminated-unions");
+                put("X-Fern-SDK-Version", "0.0.1");
             }
         });
         this.headerSuppliers = headerSuppliers;

--- a/seed/java-sdk/union-query-parameters/src/main/java/com/seed/unionQueryParameters/core/ClientOptions.java
+++ b/seed/java-sdk/union-query-parameters/src/main/java/com/seed/unionQueryParameters/core/ClientOptions.java
@@ -49,7 +49,8 @@ public final class ClientOptions {
             {
                 put("User-Agent", "com.fern.union-query-parameters/0.0.1");
                 put("X-Fern-Language", "JAVA");
-                put("X-Fern-SDK-Name", "com.seed.fern:union-query-parameters-sdk");
+                put("X-Fern-SDK-Name", "com.fern:union-query-parameters");
+                put("X-Fern-SDK-Version", "0.0.1");
             }
         });
         this.headerSuppliers = headerSuppliers;

--- a/seed/java-sdk/unions-with-local-date/default/src/main/java/com/seed/unions/core/ClientOptions.java
+++ b/seed/java-sdk/unions-with-local-date/default/src/main/java/com/seed/unions/core/ClientOptions.java
@@ -49,7 +49,8 @@ public final class ClientOptions {
             {
                 put("User-Agent", "com.fern.unions-with-local-date/0.0.1");
                 put("X-Fern-Language", "JAVA");
-                put("X-Fern-SDK-Name", "com.seed.fern:unions-sdk");
+                put("X-Fern-SDK-Name", "com.fern:unions-with-local-date");
+                put("X-Fern-SDK-Version", "0.0.1");
             }
         });
         this.headerSuppliers = headerSuppliers;

--- a/seed/java-sdk/unions/default/src/main/java/com/seed/unions/core/ClientOptions.java
+++ b/seed/java-sdk/unions/default/src/main/java/com/seed/unions/core/ClientOptions.java
@@ -49,7 +49,8 @@ public final class ClientOptions {
             {
                 put("User-Agent", "com.fern.unions/0.0.1");
                 put("X-Fern-Language", "JAVA");
-                put("X-Fern-SDK-Name", "com.seed.fern:unions-sdk");
+                put("X-Fern-SDK-Name", "com.fern:unions");
+                put("X-Fern-SDK-Version", "0.0.1");
             }
         });
         this.headerSuppliers = headerSuppliers;

--- a/seed/java-sdk/unknown/src/main/java/com/seed/unknownAsAny/core/ClientOptions.java
+++ b/seed/java-sdk/unknown/src/main/java/com/seed/unknownAsAny/core/ClientOptions.java
@@ -49,7 +49,8 @@ public final class ClientOptions {
             {
                 put("User-Agent", "com.fern.unknown/0.0.1");
                 put("X-Fern-Language", "JAVA");
-                put("X-Fern-SDK-Name", "com.seed.fern:unknown-as-any-sdk");
+                put("X-Fern-SDK-Name", "com.fern:unknown");
+                put("X-Fern-SDK-Version", "0.0.1");
             }
         });
         this.headerSuppliers = headerSuppliers;

--- a/seed/java-sdk/url-form-encoded/src/main/java/com/seed/api/core/ClientOptions.java
+++ b/seed/java-sdk/url-form-encoded/src/main/java/com/seed/api/core/ClientOptions.java
@@ -49,7 +49,8 @@ public final class ClientOptions {
             {
                 put("User-Agent", "com.fern.url-form-encoded/0.0.1");
                 put("X-Fern-Language", "JAVA");
-                put("X-Fern-SDK-Name", "com.seed.fern:api-sdk");
+                put("X-Fern-SDK-Name", "com.fern:url-form-encoded");
+                put("X-Fern-SDK-Version", "0.0.1");
             }
         });
         this.headerSuppliers = headerSuppliers;

--- a/seed/java-sdk/validation/src/main/java/com/seed/validation/core/ClientOptions.java
+++ b/seed/java-sdk/validation/src/main/java/com/seed/validation/core/ClientOptions.java
@@ -49,7 +49,8 @@ public final class ClientOptions {
             {
                 put("User-Agent", "com.fern.validation/0.0.1");
                 put("X-Fern-Language", "JAVA");
-                put("X-Fern-SDK-Name", "com.seed.fern:validation-sdk");
+                put("X-Fern-SDK-Name", "com.fern:validation");
+                put("X-Fern-SDK-Version", "0.0.1");
             }
         });
         this.headerSuppliers = headerSuppliers;

--- a/seed/java-sdk/variables/src/main/java/com/seed/variables/core/ClientOptions.java
+++ b/seed/java-sdk/variables/src/main/java/com/seed/variables/core/ClientOptions.java
@@ -52,7 +52,8 @@ public final class ClientOptions {
             {
                 put("User-Agent", "com.fern.variables/0.0.1");
                 put("X-Fern-Language", "JAVA");
-                put("X-Fern-SDK-Name", "com.seed.fern:variables-sdk");
+                put("X-Fern-SDK-Name", "com.fern:variables");
+                put("X-Fern-SDK-Version", "0.0.1");
             }
         });
         this.headerSuppliers = headerSuppliers;

--- a/seed/java-sdk/version-no-default/src/main/java/com/seed/version/core/ClientOptions.java
+++ b/seed/java-sdk/version-no-default/src/main/java/com/seed/version/core/ClientOptions.java
@@ -55,7 +55,8 @@ public final class ClientOptions {
             {
                 put("User-Agent", "com.fern.version-no-default/0.0.1");
                 put("X-Fern-Language", "JAVA");
-                put("X-Fern-SDK-Name", "com.seed.fern:version-sdk");
+                put("X-Fern-SDK-Name", "com.fern:version-no-default");
+                put("X-Fern-SDK-Version", "0.0.1");
             }
         });
         this.headerSuppliers = headerSuppliers;

--- a/seed/java-sdk/version/forward-compatible-enums/src/main/java/com/seed/version/core/ClientOptions.java
+++ b/seed/java-sdk/version/forward-compatible-enums/src/main/java/com/seed/version/core/ClientOptions.java
@@ -58,7 +58,8 @@ public final class ClientOptions {
             {
                 put("User-Agent", "com.fern.version/0.0.1");
                 put("X-Fern-Language", "JAVA");
-                put("X-Fern-SDK-Name", "com.seed.fern:version-sdk");
+                put("X-Fern-SDK-Name", "com.fern:version");
+                put("X-Fern-SDK-Version", "0.0.1");
             }
         });
         this.headerSuppliers = headerSuppliers;

--- a/seed/java-sdk/version/no-custom-config/src/main/java/com/seed/version/core/ClientOptions.java
+++ b/seed/java-sdk/version/no-custom-config/src/main/java/com/seed/version/core/ClientOptions.java
@@ -58,7 +58,8 @@ public final class ClientOptions {
             {
                 put("User-Agent", "com.fern.version/0.0.1");
                 put("X-Fern-Language", "JAVA");
-                put("X-Fern-SDK-Name", "com.seed.fern:version-sdk");
+                put("X-Fern-SDK-Name", "com.fern:version");
+                put("X-Fern-SDK-Version", "0.0.1");
             }
         });
         this.headerSuppliers = headerSuppliers;

--- a/seed/java-sdk/webhook-audience/src/main/java/com/seed/api/core/ClientOptions.java
+++ b/seed/java-sdk/webhook-audience/src/main/java/com/seed/api/core/ClientOptions.java
@@ -49,7 +49,8 @@ public final class ClientOptions {
             {
                 put("User-Agent", "com.fern.webhook-audience/0.0.1");
                 put("X-Fern-Language", "JAVA");
-                put("X-Fern-SDK-Name", "com.seed.fern:api-sdk");
+                put("X-Fern-SDK-Name", "com.fern:webhook-audience");
+                put("X-Fern-SDK-Version", "0.0.1");
             }
         });
         this.headerSuppliers = headerSuppliers;

--- a/seed/java-sdk/webhooks/src/main/java/com/seed/webhooks/core/ClientOptions.java
+++ b/seed/java-sdk/webhooks/src/main/java/com/seed/webhooks/core/ClientOptions.java
@@ -49,7 +49,8 @@ public final class ClientOptions {
             {
                 put("User-Agent", "com.fern.webhooks/0.0.1");
                 put("X-Fern-Language", "JAVA");
-                put("X-Fern-SDK-Name", "com.seed.fern:webhooks-sdk");
+                put("X-Fern-SDK-Name", "com.fern:webhooks");
+                put("X-Fern-SDK-Version", "0.0.1");
             }
         });
         this.headerSuppliers = headerSuppliers;

--- a/seed/java-sdk/websocket-bearer-auth/src/main/java/com/seed/websocketBearerAuth/core/ClientOptions.java
+++ b/seed/java-sdk/websocket-bearer-auth/src/main/java/com/seed/websocketBearerAuth/core/ClientOptions.java
@@ -52,7 +52,8 @@ public final class ClientOptions {
             {
                 put("User-Agent", "com.fern.websocket-bearer-auth/0.0.1");
                 put("X-Fern-Language", "JAVA");
-                put("X-Fern-SDK-Name", "com.seed.fern:websocket-bearer-auth-sdk");
+                put("X-Fern-SDK-Name", "com.fern:websocket-bearer-auth");
+                put("X-Fern-SDK-Version", "0.0.1");
             }
         });
         this.headerSuppliers = headerSuppliers;

--- a/seed/java-sdk/websocket-inferred-auth/src/main/java/com/seed/websocketAuth/core/ClientOptions.java
+++ b/seed/java-sdk/websocket-inferred-auth/src/main/java/com/seed/websocketAuth/core/ClientOptions.java
@@ -52,7 +52,8 @@ public final class ClientOptions {
             {
                 put("User-Agent", "com.fern.websocket-inferred-auth/0.0.1");
                 put("X-Fern-Language", "JAVA");
-                put("X-Fern-SDK-Name", "com.seed.fern:websocket-auth-sdk");
+                put("X-Fern-SDK-Name", "com.fern:websocket-inferred-auth");
+                put("X-Fern-SDK-Version", "0.0.1");
             }
         });
         this.headerSuppliers = headerSuppliers;

--- a/seed/java-sdk/websocket-multi-url/src/main/java/com/seed/websocketMultiUrl/core/ClientOptions.java
+++ b/seed/java-sdk/websocket-multi-url/src/main/java/com/seed/websocketMultiUrl/core/ClientOptions.java
@@ -52,7 +52,8 @@ public final class ClientOptions {
             {
                 put("User-Agent", "com.fern.websocket-multi-url/0.0.1");
                 put("X-Fern-Language", "JAVA");
-                put("X-Fern-SDK-Name", "com.seed.fern:websocket-multi-url-sdk");
+                put("X-Fern-SDK-Name", "com.fern:websocket-multi-url");
+                put("X-Fern-SDK-Version", "0.0.1");
             }
         });
         this.headerSuppliers = headerSuppliers;

--- a/seed/java-sdk/websocket/src/main/java/com/seed/websocket/core/ClientOptions.java
+++ b/seed/java-sdk/websocket/src/main/java/com/seed/websocket/core/ClientOptions.java
@@ -52,7 +52,8 @@ public final class ClientOptions {
             {
                 put("User-Agent", "com.fern.websocket/0.0.1");
                 put("X-Fern-Language", "JAVA");
-                put("X-Fern-SDK-Name", "com.seed.fern:websocket-sdk");
+                put("X-Fern-SDK-Name", "com.fern:websocket");
+                put("X-Fern-SDK-Version", "0.0.1");
             }
         });
         this.headerSuppliers = headerSuppliers;

--- a/seed/java-sdk/x-fern-default/src/main/java/com/seed/api/core/ClientOptions.java
+++ b/seed/java-sdk/x-fern-default/src/main/java/com/seed/api/core/ClientOptions.java
@@ -49,7 +49,8 @@ public final class ClientOptions {
             {
                 put("User-Agent", "com.fern.x-fern-default/0.0.1");
                 put("X-Fern-Language", "JAVA");
-                put("X-Fern-SDK-Name", "com.seed.fern:api-sdk");
+                put("X-Fern-SDK-Name", "com.fern:x-fern-default");
+                put("X-Fern-SDK-Version", "0.0.1");
             }
         });
         this.headerSuppliers = headerSuppliers;

--- a/seed/java-sdk/x-fern-global-parameters/src/main/java/com/seed/api/core/ClientOptions.java
+++ b/seed/java-sdk/x-fern-global-parameters/src/main/java/com/seed/api/core/ClientOptions.java
@@ -49,7 +49,8 @@ public final class ClientOptions {
             {
                 put("User-Agent", "com.fern.x-fern-global-parameters/0.0.1");
                 put("X-Fern-Language", "JAVA");
-                put("X-Fern-SDK-Name", "com.seed.fern:api-sdk");
+                put("X-Fern-SDK-Name", "com.fern:x-fern-global-parameters");
+                put("X-Fern-SDK-Version", "0.0.1");
             }
         });
         this.headerSuppliers = headerSuppliers;


### PR DESCRIPTION
## Description
Refs FSE-68 · Pylon #22458 (Deepgram)

In GitHub output mode the Java SDK generator resolved `X-Fern-SDK-Name` from `generatorConfig.publish` — which Fiddle synthesizes to `com.<org>.fern:<workspace>-sdk` — instead of the user-configured Maven coordinate. The result: a customer configuring `output.coordinate: com.deepgram:deepgram-java-sdk` got `X-Fern-SDK-Name: com.deepgram.fern:api-sdk`, inconsistent with the correct `User-Agent` product token (which is computed CLI-side). `fern generate --local` hit the same synthesized fallback.

The correct coordinate is already present in the request as `output.mode.github.publishInfo.maven.coordinate` (the Java generator reads it for `build.gradle` group/artifact) — only the header path missed it.

## How other languages handle this
The header only ever carries the header *name* (`X-Fern-SDK-Name`) in the IR — each generator computes the *value* itself, and there are two schools of thought:

- **Published package coordinate** (same source as the `User-Agent`): **TypeScript** uses the npm package name (`@deepgram/sdk`), **Python** uses the PyPI package name (`deepgram-sdk`). Both resolve it from the IR `publishConfig` / GitHub `publishInfo` — i.e. the user-configured name.
- **Internal code identifier**: **Go** uses the module path (`github.com/acme/acme-go`), **C#** the root namespace, **PHP** the root namespace, **Ruby** the gem namespace, **Rust** the crate name. **Swift** doesn't emit the header at all.

Java belongs to the first group (it uses the Maven coordinate, like TS/Python use their package names) — but it was reading that coordinate from the wrong source.

## Why Java was wrong / how this aligns it
The languages in the *published-coordinate* group derive the value from where the user's configured name actually lives (IR `publishConfig` / GitHub `publishInfo`), which is why TS and Python already emit the right thing. Java used the same *intent* but read from `generatorConfig.publish` first — the slot Fiddle fills with a synthesized `com.<org>.fern:<workspace>-sdk` placeholder in GitHub output mode — so it leaked the placeholder instead of the configured coordinate.

This PR points Java at the same source TS/Python use: it now reads the coordinate from `output.mode.github.publishInfo.maven.coordinate` first, so `X-Fern-SDK-Name` matches the configured coordinate and the `User-Agent` product token — bringing Java in line with the other package-coordinate languages.

## Changes Made
- `ClientOptionsGenerator.getPlatformHeadersEntries`: resolve the SDK coordinate from a priority chain — GitHub output mode `publishInfo.maven.coordinate` (populated for both remote and `--local`), then `generatorConfig.publish`, then the IR `publishConfig`, then the synthesized fallback.
- Flattened the resolution so a source with a coordinate but no version still emits `X-Fern-SDK-Name` (fixes a latent bug where an IR publish config without a maven target emitted no name at all), and `X-Fern-SDK-Version` is now populated in the GitHub-mode path.
- Regenerated 188 `java-sdk` seed fixtures — diff is exclusively the corrected `X-Fern-SDK-Name` (now the configured coordinate) plus a newly-populated `X-Fern-SDK-Version`. `local_files`-mode fixtures correctly keep the fallback (no coordinate configured).
- Added changelog entry (`type: fix`).

## Testing
- [x] Java generator compiles (JDK 17).
- [x] Regenerated the whole `java-sdk` fixture suite and inspected the resulting `core/ClientOptions.java`.

Seed drives the `--local` GitHub-output path (`defaultOutputMode: github`), setting the GitHub publish coordinate to `com.fern:<fixture>` — so the fixture diff is an exact before/after for this fix. In every affected fixture the header flips from the synthesized fallback to the configured coordinate, e.g.:

```diff
  put("User-Agent", "com.fern.exhaustive/0.0.1");
  put("X-Fern-Language", "JAVA");
- put("X-Fern-SDK-Name", "com.seed.fern:exhaustive-sdk");
+ put("X-Fern-SDK-Name", "com.fern:exhaustive");
+ put("X-Fern-SDK-Version", "0.0.1");
```

`X-Fern-SDK-Name` now equals the configured coordinate and matches the `User-Agent` product token (`:` rendered as `.` in the RFC-compliant User-Agent). Command used:

```bash
pnpm seed test --generator java-sdk --local --skip-scripts
```

## Follow-up (separate, in `fern-api/fiddle`)
`RegistryConfigFactory.getMavenOutput` should read `publishInfo` for `visitGithub`/`visitGithubV2` rather than synthesizing a coordinate, and the pypi/npm equivalents should be audited for the same gap. Tracked separately per FSE-68.

Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/17268" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->