### PR TITLE
feat(typescript): redeclare typed body property on generated error classes

### DIFF
--- a/generators/typescript/sdk/changes/unreleased/feat-typed-error-body-property.yml
+++ b/generators/typescript/sdk/changes/unreleased/feat-typed-error-body-property.yml
@@ -1,0 +1,7 @@
+- summary: |
+    Generated error classes now redeclare the `body` property with the error's
+    typed body (e.g. `public declare readonly body: MyErrorBody;`) instead of
+    inheriting `body?: unknown` from the base API error class. This makes
+    `err.body.<field>` type-check in catch blocks without casting when the
+    error has a declared body schema.
+  type: feat

--- a/generators/typescript/sdk/sdk-error-generator/src/GeneratedSdkErrorClassImpl.ts
+++ b/generators/typescript/sdk/sdk-error-generator/src/GeneratedSdkErrorClassImpl.ts
@@ -2,7 +2,7 @@ import { FernIr } from "@fern-fern/ir-sdk";
 import { AbstractErrorClassGenerator } from "@fern-typescript/abstract-error-class-generator";
 import { getOriginalName, getTextOfTsNode } from "@fern-typescript/commons";
 import { FileContext, GeneratedSdkErrorClass } from "@fern-typescript/contexts";
-import { OptionalKind, ParameterDeclarationStructure, PropertyDeclarationStructure, ts } from "ts-morph";
+import { OptionalKind, ParameterDeclarationStructure, PropertyDeclarationStructure, Scope, ts } from "ts-morph";
 
 export declare namespace GeneratedSdkErrorClassImpl {
     export interface Init {
@@ -59,8 +59,21 @@ export class GeneratedSdkErrorClassImpl
         // no-op
     }
 
-    protected getClassProperties(): OptionalKind<PropertyDeclarationStructure>[] {
-        return [];
+    protected getClassProperties(context: FileContext): OptionalKind<PropertyDeclarationStructure>[] {
+        if (this.errorDeclaration.type == null || this.errorDeclaration.type.type === "unknown") {
+            return [];
+        }
+        const referenceToType = context.type.getReferenceToType(this.errorDeclaration.type);
+        return [
+            {
+                name: GeneratedSdkErrorClassImpl.BODY_CONSTRUCTOR_PARAMETER_NAME,
+                isReadonly: true,
+                hasDeclareKeyword: true,
+                hasQuestionToken: referenceToType.isOptional,
+                type: getTextOfTsNode(referenceToType.typeNodeWithoutUndefined),
+                scope: Scope.Public
+            }
+        ];
     }
 
     protected getConstructorParameters(context: FileContext): OptionalKind<ParameterDeclarationStructure>[] {

--- a/generators/typescript/sdk/sdk-error-generator/src/__test__/SdkErrorGenerator.test.ts
+++ b/generators/typescript/sdk/sdk-error-generator/src/__test__/SdkErrorGenerator.test.ts
@@ -210,6 +210,15 @@ describe("GeneratedSdkErrorClassImpl", () => {
             expect(optionalContext.sourceFile.getFullText()).toMatchSnapshot();
         });
 
+        it("writes error class with unknown body type", () => {
+            const errorClass = createErrorClass({
+                type: FernIr.TypeReference.unknown()
+            });
+            const context = createMockFileContext();
+            errorClass.writeToFile(context);
+            expect(context.sourceFile.getFullText()).toMatchSnapshot();
+        });
+
         it("writes error class with custom status code", () => {
             const errorClass = createErrorClass({
                 statusCode: 404,

--- a/generators/typescript/sdk/sdk-error-generator/src/__test__/__snapshots__/SdkErrorGenerator.test.ts.snap
+++ b/generators/typescript/sdk/sdk-error-generator/src/__test__/__snapshots__/SdkErrorGenerator.test.ts.snap
@@ -10,6 +10,8 @@ exports[`GeneratedSdkErrorClassImpl > build > builds new expression without body
 
 exports[`GeneratedSdkErrorClassImpl > writeToFile > writes error class with body type 1`] = `
 "export class BadRequestError extends ApiError {
+    declare public readonly body: string;
+
     constructor(body: string, rawResponse?: RawResponse) {
         super({
             message: "BadRequest",
@@ -49,6 +51,8 @@ exports[`GeneratedSdkErrorClassImpl > writeToFile > writes error class with cust
 
 exports[`GeneratedSdkErrorClassImpl > writeToFile > writes error class with named body type 1`] = `
 "export class BadRequestError extends ApiError {
+    declare public readonly body: string;
+
     constructor(body: string, rawResponse?: RawResponse) {
         super({
             message: "BadRequest",
@@ -69,7 +73,29 @@ exports[`GeneratedSdkErrorClassImpl > writeToFile > writes error class with name
 
 exports[`GeneratedSdkErrorClassImpl > writeToFile > writes error class with optional body type 1`] = `
 "export class BadRequestError extends ApiError {
+    declare public readonly body?: string;
+
     constructor(body?: string, rawResponse?: RawResponse) {
+        super({
+            message: "BadRequest",
+            statusCode: 400,
+            body: body,
+            rawResponse: rawResponse
+        });
+        Object.setPrototypeOf(this, new.target.prototype);
+        if (Error.captureStackTrace) {
+            Error.captureStackTrace(this, this.constructor);
+        }
+
+        this.name = "BadRequestError";
+    }
+}
+"
+`;
+
+exports[`GeneratedSdkErrorClassImpl > writeToFile > writes error class with unknown body type 1`] = `
+"export class BadRequestError extends ApiError {
+    constructor(body: string, rawResponse?: RawResponse) {
         super({
             message: "BadRequest",
             statusCode: 400,

--- a/seed/ts-sdk/basic-auth-environment-variables/src/api/resources/errors/errors/UnauthorizedRequest.ts
+++ b/seed/ts-sdk/basic-auth-environment-variables/src/api/resources/errors/errors/UnauthorizedRequest.ts
@@ -5,6 +5,8 @@ import * as errors from "../../../../errors/index.js";
 import type * as SeedBasicAuthEnvironmentVariables from "../../../index.js";
 
 export class UnauthorizedRequest extends errors.SeedBasicAuthEnvironmentVariablesError {
+    public declare readonly body: SeedBasicAuthEnvironmentVariables.UnauthorizedRequestErrorBody;
+
     constructor(body: SeedBasicAuthEnvironmentVariables.UnauthorizedRequestErrorBody, rawResponse?: core.RawResponse) {
         super({
             message: "UnauthorizedRequest",

--- a/seed/ts-sdk/basic-auth-pw-omitted/src/api/resources/errors/errors/UnauthorizedRequest.ts
+++ b/seed/ts-sdk/basic-auth-pw-omitted/src/api/resources/errors/errors/UnauthorizedRequest.ts
@@ -5,6 +5,8 @@ import * as errors from "../../../../errors/index.js";
 import type * as SeedBasicAuthPwOmitted from "../../../index.js";
 
 export class UnauthorizedRequest extends errors.SeedBasicAuthPwOmittedError {
+    public declare readonly body: SeedBasicAuthPwOmitted.UnauthorizedRequestErrorBody;
+
     constructor(body: SeedBasicAuthPwOmitted.UnauthorizedRequestErrorBody, rawResponse?: core.RawResponse) {
         super({
             message: "UnauthorizedRequest",

--- a/seed/ts-sdk/basic-auth/src/api/resources/errors/errors/UnauthorizedRequest.ts
+++ b/seed/ts-sdk/basic-auth/src/api/resources/errors/errors/UnauthorizedRequest.ts
@@ -5,6 +5,8 @@ import * as errors from "../../../../errors/index.js";
 import type * as SeedBasicAuth from "../../../index.js";
 
 export class UnauthorizedRequest extends errors.SeedBasicAuthError {
+    public declare readonly body: SeedBasicAuth.UnauthorizedRequestErrorBody;
+
     constructor(body: SeedBasicAuth.UnauthorizedRequestErrorBody, rawResponse?: core.RawResponse) {
         super({
             message: "UnauthorizedRequest",

--- a/seed/ts-sdk/error-property/no-custom-config/src/api/resources/errors/errors/PropertyBasedErrorTest.ts
+++ b/seed/ts-sdk/error-property/no-custom-config/src/api/resources/errors/errors/PropertyBasedErrorTest.ts
@@ -5,6 +5,8 @@ import * as errors from "../../../../errors/index.js";
 import type * as SeedErrorProperty from "../../../index.js";
 
 export class PropertyBasedErrorTest extends errors.SeedErrorPropertyError {
+    public declare readonly body: SeedErrorProperty.PropertyBasedErrorTestBody;
+
     constructor(body: SeedErrorProperty.PropertyBasedErrorTestBody, rawResponse?: core.RawResponse) {
         super({
             message: "PropertyBasedErrorTest",

--- a/seed/ts-sdk/error-property/union-utils/src/api/resources/errors/errors/PropertyBasedErrorTest.ts
+++ b/seed/ts-sdk/error-property/union-utils/src/api/resources/errors/errors/PropertyBasedErrorTest.ts
@@ -5,6 +5,8 @@ import * as errors from "../../../../errors/index.js";
 import type * as SeedErrorProperty from "../../../index.js";
 
 export class PropertyBasedErrorTest extends errors.SeedErrorPropertyError {
+    public declare readonly body: SeedErrorProperty.PropertyBasedErrorTestBody;
+
     constructor(body: SeedErrorProperty.PropertyBasedErrorTestBody, rawResponse?: core.RawResponse) {
         super({
             message: "PropertyBasedErrorTest",

--- a/seed/ts-sdk/errors/src/api/resources/commons/errors/BadRequestError.ts
+++ b/seed/ts-sdk/errors/src/api/resources/commons/errors/BadRequestError.ts
@@ -5,6 +5,8 @@ import * as errors from "../../../../errors/index.js";
 import type * as SeedErrors from "../../../index.js";
 
 export class BadRequestError extends errors.SeedErrorsError {
+    public declare readonly body: SeedErrors.ErrorBody;
+
     constructor(body: SeedErrors.ErrorBody, rawResponse?: core.RawResponse) {
         super({
             message: "BadRequestError",

--- a/seed/ts-sdk/errors/src/api/resources/commons/errors/InternalServerError.ts
+++ b/seed/ts-sdk/errors/src/api/resources/commons/errors/InternalServerError.ts
@@ -5,6 +5,8 @@ import * as errors from "../../../../errors/index.js";
 import type * as SeedErrors from "../../../index.js";
 
 export class InternalServerError extends errors.SeedErrorsError {
+    public declare readonly body: SeedErrors.ErrorBody;
+
     constructor(body: SeedErrors.ErrorBody, rawResponse?: core.RawResponse) {
         super({
             message: "InternalServerError",

--- a/seed/ts-sdk/errors/src/api/resources/commons/errors/NotFoundError.ts
+++ b/seed/ts-sdk/errors/src/api/resources/commons/errors/NotFoundError.ts
@@ -5,6 +5,8 @@ import * as errors from "../../../../errors/index.js";
 import type * as SeedErrors from "../../../index.js";
 
 export class NotFoundError extends errors.SeedErrorsError {
+    public declare readonly body: SeedErrors.ErrorBody;
+
     constructor(body: SeedErrors.ErrorBody, rawResponse?: core.RawResponse) {
         super({
             message: "NotFoundError",

--- a/seed/ts-sdk/errors/src/api/resources/simple/errors/FooTooLittle.ts
+++ b/seed/ts-sdk/errors/src/api/resources/simple/errors/FooTooLittle.ts
@@ -5,6 +5,8 @@ import * as errors from "../../../../errors/index.js";
 import type * as SeedErrors from "../../../index.js";
 
 export class FooTooLittle extends errors.SeedErrorsError {
+    public declare readonly body: SeedErrors.ErrorBody;
+
     constructor(body: SeedErrors.ErrorBody, rawResponse?: core.RawResponse) {
         super({
             message: "FooTooLittle",

--- a/seed/ts-sdk/errors/src/api/resources/simple/errors/FooTooMuch.ts
+++ b/seed/ts-sdk/errors/src/api/resources/simple/errors/FooTooMuch.ts
@@ -5,6 +5,8 @@ import * as errors from "../../../../errors/index.js";
 import type * as SeedErrors from "../../../index.js";
 
 export class FooTooMuch extends errors.SeedErrorsError {
+    public declare readonly body: SeedErrors.ErrorBody;
+
     constructor(body: SeedErrors.ErrorBody, rawResponse?: core.RawResponse) {
         super({
             message: "FooTooMuch",

--- a/seed/ts-sdk/examples/examples-with-api-reference/src/api/resources/types/errors/NotFoundError.ts
+++ b/seed/ts-sdk/examples/examples-with-api-reference/src/api/resources/types/errors/NotFoundError.ts
@@ -4,6 +4,8 @@ import type * as core from "../../../../core/index.js";
 import * as errors from "../../../../errors/index.js";
 
 export class NotFoundError extends errors.SeedExamplesError {
+    public declare readonly body: string;
+
     constructor(body: string, rawResponse?: core.RawResponse) {
         super({
             message: "NotFoundError",

--- a/seed/ts-sdk/examples/retain-original-casing/src/api/resources/types/errors/NotFoundError.ts
+++ b/seed/ts-sdk/examples/retain-original-casing/src/api/resources/types/errors/NotFoundError.ts
@@ -4,6 +4,8 @@ import type * as core from "../../../../core/index.js";
 import * as errors from "../../../../errors/index.js";
 
 export class NotFoundError extends errors.SeedExamplesError {
+    public declare readonly body: string;
+
     constructor(body: string, rawResponse?: core.RawResponse) {
         super({
             message: "NotFoundError",

--- a/seed/ts-sdk/exhaustive/allow-extra-fields/src/api/resources/generalErrors/errors/BadRequestBody.ts
+++ b/seed/ts-sdk/exhaustive/allow-extra-fields/src/api/resources/generalErrors/errors/BadRequestBody.ts
@@ -5,6 +5,8 @@ import * as errors from "../../../../errors/index.js";
 import type * as SeedExhaustive from "../../../index.js";
 
 export class BadRequestBody extends errors.SeedExhaustiveError {
+    public declare readonly body: SeedExhaustive.BadObjectRequestInfo;
+
     constructor(body: SeedExhaustive.BadObjectRequestInfo, rawResponse?: core.RawResponse) {
         super({
             message: "BadRequestBody",

--- a/seed/ts-sdk/exhaustive/allow-extra-fields/src/api/resources/types/resources/enum/errors/ErrorWithEnumBody.ts
+++ b/seed/ts-sdk/exhaustive/allow-extra-fields/src/api/resources/types/resources/enum/errors/ErrorWithEnumBody.ts
@@ -5,6 +5,8 @@ import * as errors from "../../../../../../errors/index.js";
 import type * as SeedExhaustive from "../../../../../index.js";
 
 export class ErrorWithEnumBody extends errors.SeedExhaustiveError {
+    public declare readonly body: SeedExhaustive.types.WeatherReport;
+
     constructor(body: SeedExhaustive.types.WeatherReport, rawResponse?: core.RawResponse) {
         super({
             message: "ErrorWithEnumBody",

--- a/seed/ts-sdk/exhaustive/allow-extra-fields/src/api/resources/types/resources/object/errors/NestedObjectWithOptionalFieldError.ts
+++ b/seed/ts-sdk/exhaustive/allow-extra-fields/src/api/resources/types/resources/object/errors/NestedObjectWithOptionalFieldError.ts
@@ -5,6 +5,8 @@ import * as errors from "../../../../../../errors/index.js";
 import type * as SeedExhaustive from "../../../../../index.js";
 
 export class NestedObjectWithOptionalFieldError extends errors.SeedExhaustiveError {
+    public declare readonly body: SeedExhaustive.types.NestedObjectWithOptionalField;
+
     constructor(body: SeedExhaustive.types.NestedObjectWithOptionalField, rawResponse?: core.RawResponse) {
         super({
             message: "NestedObjectWithOptionalFieldError",

--- a/seed/ts-sdk/exhaustive/allow-extra-fields/src/api/resources/types/resources/object/errors/NestedObjectWithRequiredFieldError.ts
+++ b/seed/ts-sdk/exhaustive/allow-extra-fields/src/api/resources/types/resources/object/errors/NestedObjectWithRequiredFieldError.ts
@@ -5,6 +5,8 @@ import * as errors from "../../../../../../errors/index.js";
 import type * as SeedExhaustive from "../../../../../index.js";
 
 export class NestedObjectWithRequiredFieldError extends errors.SeedExhaustiveError {
+    public declare readonly body: SeedExhaustive.types.NestedObjectWithRequiredField;
+
     constructor(body: SeedExhaustive.types.NestedObjectWithRequiredField, rawResponse?: core.RawResponse) {
         super({
             message: "NestedObjectWithRequiredFieldError",

--- a/seed/ts-sdk/exhaustive/allow-extra-fields/src/api/resources/types/resources/object/errors/ObjectWithOptionalFieldError.ts
+++ b/seed/ts-sdk/exhaustive/allow-extra-fields/src/api/resources/types/resources/object/errors/ObjectWithOptionalFieldError.ts
@@ -5,6 +5,8 @@ import * as errors from "../../../../../../errors/index.js";
 import type * as SeedExhaustive from "../../../../../index.js";
 
 export class ObjectWithOptionalFieldError extends errors.SeedExhaustiveError {
+    public declare readonly body: SeedExhaustive.types.ObjectWithOptionalField;
+
     constructor(body: SeedExhaustive.types.ObjectWithOptionalField, rawResponse?: core.RawResponse) {
         super({
             message: "ObjectWithOptionalFieldError",

--- a/seed/ts-sdk/exhaustive/allow-extra-fields/src/api/resources/types/resources/object/errors/ObjectWithRequiredFieldError.ts
+++ b/seed/ts-sdk/exhaustive/allow-extra-fields/src/api/resources/types/resources/object/errors/ObjectWithRequiredFieldError.ts
@@ -5,6 +5,8 @@ import * as errors from "../../../../../../errors/index.js";
 import type * as SeedExhaustive from "../../../../../index.js";
 
 export class ObjectWithRequiredFieldError extends errors.SeedExhaustiveError {
+    public declare readonly body: SeedExhaustive.types.ObjectWithRequiredField;
+
     constructor(body: SeedExhaustive.types.ObjectWithRequiredField, rawResponse?: core.RawResponse) {
         super({
             message: "ObjectWithRequiredFieldError",

--- a/seed/ts-sdk/exhaustive/allow-extra-fields/src/api/resources/types/resources/union/errors/ErrorWithUnionBody.ts
+++ b/seed/ts-sdk/exhaustive/allow-extra-fields/src/api/resources/types/resources/union/errors/ErrorWithUnionBody.ts
@@ -5,6 +5,8 @@ import * as errors from "../../../../../../errors/index.js";
 import type * as SeedExhaustive from "../../../../../index.js";
 
 export class ErrorWithUnionBody extends errors.SeedExhaustiveError {
+    public declare readonly body: SeedExhaustive.types.Animal;
+
     constructor(body: SeedExhaustive.types.Animal, rawResponse?: core.RawResponse) {
         super({
             message: "ErrorWithUnionBody",

--- a/seed/ts-sdk/exhaustive/bigint-serde-layer/src/api/resources/generalErrors/errors/BadRequestBody.ts
+++ b/seed/ts-sdk/exhaustive/bigint-serde-layer/src/api/resources/generalErrors/errors/BadRequestBody.ts
@@ -5,6 +5,8 @@ import * as errors from "../../../../errors/index.js";
 import type * as SeedExhaustive from "../../../index.js";
 
 export class BadRequestBody extends errors.SeedExhaustiveError {
+    public declare readonly body: SeedExhaustive.BadObjectRequestInfo;
+
     constructor(body: SeedExhaustive.BadObjectRequestInfo, rawResponse?: core.RawResponse) {
         super({
             message: "BadRequestBody",

--- a/seed/ts-sdk/exhaustive/bigint-serde-layer/src/api/resources/types/resources/enum/errors/ErrorWithEnumBody.ts
+++ b/seed/ts-sdk/exhaustive/bigint-serde-layer/src/api/resources/types/resources/enum/errors/ErrorWithEnumBody.ts
@@ -5,6 +5,8 @@ import * as errors from "../../../../../../errors/index.js";
 import type * as SeedExhaustive from "../../../../../index.js";
 
 export class ErrorWithEnumBody extends errors.SeedExhaustiveError {
+    public declare readonly body: SeedExhaustive.types.WeatherReport;
+
     constructor(body: SeedExhaustive.types.WeatherReport, rawResponse?: core.RawResponse) {
         super({
             message: "ErrorWithEnumBody",

--- a/seed/ts-sdk/exhaustive/bigint-serde-layer/src/api/resources/types/resources/object/errors/NestedObjectWithOptionalFieldError.ts
+++ b/seed/ts-sdk/exhaustive/bigint-serde-layer/src/api/resources/types/resources/object/errors/NestedObjectWithOptionalFieldError.ts
@@ -5,6 +5,8 @@ import * as errors from "../../../../../../errors/index.js";
 import type * as SeedExhaustive from "../../../../../index.js";
 
 export class NestedObjectWithOptionalFieldError extends errors.SeedExhaustiveError {
+    public declare readonly body: SeedExhaustive.types.NestedObjectWithOptionalField;
+
     constructor(body: SeedExhaustive.types.NestedObjectWithOptionalField, rawResponse?: core.RawResponse) {
         super({
             message: "NestedObjectWithOptionalFieldError",

--- a/seed/ts-sdk/exhaustive/bigint-serde-layer/src/api/resources/types/resources/object/errors/NestedObjectWithRequiredFieldError.ts
+++ b/seed/ts-sdk/exhaustive/bigint-serde-layer/src/api/resources/types/resources/object/errors/NestedObjectWithRequiredFieldError.ts
@@ -5,6 +5,8 @@ import * as errors from "../../../../../../errors/index.js";
 import type * as SeedExhaustive from "../../../../../index.js";
 
 export class NestedObjectWithRequiredFieldError extends errors.SeedExhaustiveError {
+    public declare readonly body: SeedExhaustive.types.NestedObjectWithRequiredField;
+
     constructor(body: SeedExhaustive.types.NestedObjectWithRequiredField, rawResponse?: core.RawResponse) {
         super({
             message: "NestedObjectWithRequiredFieldError",

--- a/seed/ts-sdk/exhaustive/bigint-serde-layer/src/api/resources/types/resources/object/errors/ObjectWithOptionalFieldError.ts
+++ b/seed/ts-sdk/exhaustive/bigint-serde-layer/src/api/resources/types/resources/object/errors/ObjectWithOptionalFieldError.ts
@@ -5,6 +5,8 @@ import * as errors from "../../../../../../errors/index.js";
 import type * as SeedExhaustive from "../../../../../index.js";
 
 export class ObjectWithOptionalFieldError extends errors.SeedExhaustiveError {
+    public declare readonly body: SeedExhaustive.types.ObjectWithOptionalField;
+
     constructor(body: SeedExhaustive.types.ObjectWithOptionalField, rawResponse?: core.RawResponse) {
         super({
             message: "ObjectWithOptionalFieldError",

--- a/seed/ts-sdk/exhaustive/bigint-serde-layer/src/api/resources/types/resources/object/errors/ObjectWithRequiredFieldError.ts
+++ b/seed/ts-sdk/exhaustive/bigint-serde-layer/src/api/resources/types/resources/object/errors/ObjectWithRequiredFieldError.ts
@@ -5,6 +5,8 @@ import * as errors from "../../../../../../errors/index.js";
 import type * as SeedExhaustive from "../../../../../index.js";
 
 export class ObjectWithRequiredFieldError extends errors.SeedExhaustiveError {
+    public declare readonly body: SeedExhaustive.types.ObjectWithRequiredField;
+
     constructor(body: SeedExhaustive.types.ObjectWithRequiredField, rawResponse?: core.RawResponse) {
         super({
             message: "ObjectWithRequiredFieldError",

--- a/seed/ts-sdk/exhaustive/bigint-serde-layer/src/api/resources/types/resources/union/errors/ErrorWithUnionBody.ts
+++ b/seed/ts-sdk/exhaustive/bigint-serde-layer/src/api/resources/types/resources/union/errors/ErrorWithUnionBody.ts
@@ -5,6 +5,8 @@ import * as errors from "../../../../../../errors/index.js";
 import type * as SeedExhaustive from "../../../../../index.js";
 
 export class ErrorWithUnionBody extends errors.SeedExhaustiveError {
+    public declare readonly body: SeedExhaustive.types.Animal;
+
     constructor(body: SeedExhaustive.types.Animal, rawResponse?: core.RawResponse) {
         super({
             message: "ErrorWithUnionBody",

--- a/seed/ts-sdk/exhaustive/bigint/src/api/resources/generalErrors/errors/BadRequestBody.ts
+++ b/seed/ts-sdk/exhaustive/bigint/src/api/resources/generalErrors/errors/BadRequestBody.ts
@@ -5,6 +5,8 @@ import * as errors from "../../../../errors/index.js";
 import type * as SeedExhaustive from "../../../index.js";
 
 export class BadRequestBody extends errors.SeedExhaustiveError {
+    public declare readonly body: SeedExhaustive.BadObjectRequestInfo;
+
     constructor(body: SeedExhaustive.BadObjectRequestInfo, rawResponse?: core.RawResponse) {
         super({
             message: "BadRequestBody",

--- a/seed/ts-sdk/exhaustive/bigint/src/api/resources/types/resources/enum/errors/ErrorWithEnumBody.ts
+++ b/seed/ts-sdk/exhaustive/bigint/src/api/resources/types/resources/enum/errors/ErrorWithEnumBody.ts
@@ -5,6 +5,8 @@ import * as errors from "../../../../../../errors/index.js";
 import type * as SeedExhaustive from "../../../../../index.js";
 
 export class ErrorWithEnumBody extends errors.SeedExhaustiveError {
+    public declare readonly body: SeedExhaustive.types.WeatherReport;
+
     constructor(body: SeedExhaustive.types.WeatherReport, rawResponse?: core.RawResponse) {
         super({
             message: "ErrorWithEnumBody",

--- a/seed/ts-sdk/exhaustive/bigint/src/api/resources/types/resources/object/errors/NestedObjectWithOptionalFieldError.ts
+++ b/seed/ts-sdk/exhaustive/bigint/src/api/resources/types/resources/object/errors/NestedObjectWithOptionalFieldError.ts
@@ -5,6 +5,8 @@ import * as errors from "../../../../../../errors/index.js";
 import type * as SeedExhaustive from "../../../../../index.js";
 
 export class NestedObjectWithOptionalFieldError extends errors.SeedExhaustiveError {
+    public declare readonly body: SeedExhaustive.types.NestedObjectWithOptionalField;
+
     constructor(body: SeedExhaustive.types.NestedObjectWithOptionalField, rawResponse?: core.RawResponse) {
         super({
             message: "NestedObjectWithOptionalFieldError",

--- a/seed/ts-sdk/exhaustive/bigint/src/api/resources/types/resources/object/errors/NestedObjectWithRequiredFieldError.ts
+++ b/seed/ts-sdk/exhaustive/bigint/src/api/resources/types/resources/object/errors/NestedObjectWithRequiredFieldError.ts
@@ -5,6 +5,8 @@ import * as errors from "../../../../../../errors/index.js";
 import type * as SeedExhaustive from "../../../../../index.js";
 
 export class NestedObjectWithRequiredFieldError extends errors.SeedExhaustiveError {
+    public declare readonly body: SeedExhaustive.types.NestedObjectWithRequiredField;
+
     constructor(body: SeedExhaustive.types.NestedObjectWithRequiredField, rawResponse?: core.RawResponse) {
         super({
             message: "NestedObjectWithRequiredFieldError",

--- a/seed/ts-sdk/exhaustive/bigint/src/api/resources/types/resources/object/errors/ObjectWithOptionalFieldError.ts
+++ b/seed/ts-sdk/exhaustive/bigint/src/api/resources/types/resources/object/errors/ObjectWithOptionalFieldError.ts
@@ -5,6 +5,8 @@ import * as errors from "../../../../../../errors/index.js";
 import type * as SeedExhaustive from "../../../../../index.js";
 
 export class ObjectWithOptionalFieldError extends errors.SeedExhaustiveError {
+    public declare readonly body: SeedExhaustive.types.ObjectWithOptionalField;
+
     constructor(body: SeedExhaustive.types.ObjectWithOptionalField, rawResponse?: core.RawResponse) {
         super({
             message: "ObjectWithOptionalFieldError",

--- a/seed/ts-sdk/exhaustive/bigint/src/api/resources/types/resources/object/errors/ObjectWithRequiredFieldError.ts
+++ b/seed/ts-sdk/exhaustive/bigint/src/api/resources/types/resources/object/errors/ObjectWithRequiredFieldError.ts
@@ -5,6 +5,8 @@ import * as errors from "../../../../../../errors/index.js";
 import type * as SeedExhaustive from "../../../../../index.js";
 
 export class ObjectWithRequiredFieldError extends errors.SeedExhaustiveError {
+    public declare readonly body: SeedExhaustive.types.ObjectWithRequiredField;
+
     constructor(body: SeedExhaustive.types.ObjectWithRequiredField, rawResponse?: core.RawResponse) {
         super({
             message: "ObjectWithRequiredFieldError",

--- a/seed/ts-sdk/exhaustive/bigint/src/api/resources/types/resources/union/errors/ErrorWithUnionBody.ts
+++ b/seed/ts-sdk/exhaustive/bigint/src/api/resources/types/resources/union/errors/ErrorWithUnionBody.ts
@@ -5,6 +5,8 @@ import * as errors from "../../../../../../errors/index.js";
 import type * as SeedExhaustive from "../../../../../index.js";
 
 export class ErrorWithUnionBody extends errors.SeedExhaustiveError {
+    public declare readonly body: SeedExhaustive.types.Animal;
+
     constructor(body: SeedExhaustive.types.Animal, rawResponse?: core.RawResponse) {
         super({
             message: "ErrorWithUnionBody",

--- a/seed/ts-sdk/exhaustive/consolidate-type-files/src/api/resources/generalErrors/errors/BadRequestBody.ts
+++ b/seed/ts-sdk/exhaustive/consolidate-type-files/src/api/resources/generalErrors/errors/BadRequestBody.ts
@@ -5,6 +5,8 @@ import * as errors from "../../../../errors/index.js";
 import type * as SeedExhaustive from "../../../index.js";
 
 export class BadRequestBody extends errors.SeedExhaustiveError {
+    public declare readonly body: SeedExhaustive.BadObjectRequestInfo;
+
     constructor(body: SeedExhaustive.BadObjectRequestInfo, rawResponse?: core.RawResponse) {
         super({
             message: "BadRequestBody",

--- a/seed/ts-sdk/exhaustive/consolidate-type-files/src/api/resources/types/resources/enum/errors/ErrorWithEnumBody.ts
+++ b/seed/ts-sdk/exhaustive/consolidate-type-files/src/api/resources/types/resources/enum/errors/ErrorWithEnumBody.ts
@@ -5,6 +5,8 @@ import * as errors from "../../../../../../errors/index.js";
 import type * as SeedExhaustive from "../../../../../index.js";
 
 export class ErrorWithEnumBody extends errors.SeedExhaustiveError {
+    public declare readonly body: SeedExhaustive.types.WeatherReport;
+
     constructor(body: SeedExhaustive.types.WeatherReport, rawResponse?: core.RawResponse) {
         super({
             message: "ErrorWithEnumBody",

--- a/seed/ts-sdk/exhaustive/consolidate-type-files/src/api/resources/types/resources/object/errors/NestedObjectWithOptionalFieldError.ts
+++ b/seed/ts-sdk/exhaustive/consolidate-type-files/src/api/resources/types/resources/object/errors/NestedObjectWithOptionalFieldError.ts
@@ -5,6 +5,8 @@ import * as errors from "../../../../../../errors/index.js";
 import type * as SeedExhaustive from "../../../../../index.js";
 
 export class NestedObjectWithOptionalFieldError extends errors.SeedExhaustiveError {
+    public declare readonly body: SeedExhaustive.types.NestedObjectWithOptionalField;
+
     constructor(body: SeedExhaustive.types.NestedObjectWithOptionalField, rawResponse?: core.RawResponse) {
         super({
             message: "NestedObjectWithOptionalFieldError",

--- a/seed/ts-sdk/exhaustive/consolidate-type-files/src/api/resources/types/resources/object/errors/NestedObjectWithRequiredFieldError.ts
+++ b/seed/ts-sdk/exhaustive/consolidate-type-files/src/api/resources/types/resources/object/errors/NestedObjectWithRequiredFieldError.ts
@@ -5,6 +5,8 @@ import * as errors from "../../../../../../errors/index.js";
 import type * as SeedExhaustive from "../../../../../index.js";
 
 export class NestedObjectWithRequiredFieldError extends errors.SeedExhaustiveError {
+    public declare readonly body: SeedExhaustive.types.NestedObjectWithRequiredField;
+
     constructor(body: SeedExhaustive.types.NestedObjectWithRequiredField, rawResponse?: core.RawResponse) {
         super({
             message: "NestedObjectWithRequiredFieldError",

--- a/seed/ts-sdk/exhaustive/consolidate-type-files/src/api/resources/types/resources/object/errors/ObjectWithOptionalFieldError.ts
+++ b/seed/ts-sdk/exhaustive/consolidate-type-files/src/api/resources/types/resources/object/errors/ObjectWithOptionalFieldError.ts
@@ -5,6 +5,8 @@ import * as errors from "../../../../../../errors/index.js";
 import type * as SeedExhaustive from "../../../../../index.js";
 
 export class ObjectWithOptionalFieldError extends errors.SeedExhaustiveError {
+    public declare readonly body: SeedExhaustive.types.ObjectWithOptionalField;
+
     constructor(body: SeedExhaustive.types.ObjectWithOptionalField, rawResponse?: core.RawResponse) {
         super({
             message: "ObjectWithOptionalFieldError",

--- a/seed/ts-sdk/exhaustive/consolidate-type-files/src/api/resources/types/resources/object/errors/ObjectWithRequiredFieldError.ts
+++ b/seed/ts-sdk/exhaustive/consolidate-type-files/src/api/resources/types/resources/object/errors/ObjectWithRequiredFieldError.ts
@@ -5,6 +5,8 @@ import * as errors from "../../../../../../errors/index.js";
 import type * as SeedExhaustive from "../../../../../index.js";
 
 export class ObjectWithRequiredFieldError extends errors.SeedExhaustiveError {
+    public declare readonly body: SeedExhaustive.types.ObjectWithRequiredField;
+
     constructor(body: SeedExhaustive.types.ObjectWithRequiredField, rawResponse?: core.RawResponse) {
         super({
             message: "ObjectWithRequiredFieldError",

--- a/seed/ts-sdk/exhaustive/consolidate-type-files/src/api/resources/types/resources/union/errors/ErrorWithUnionBody.ts
+++ b/seed/ts-sdk/exhaustive/consolidate-type-files/src/api/resources/types/resources/union/errors/ErrorWithUnionBody.ts
@@ -5,6 +5,8 @@ import * as errors from "../../../../../../errors/index.js";
 import type * as SeedExhaustive from "../../../../../index.js";
 
 export class ErrorWithUnionBody extends errors.SeedExhaustiveError {
+    public declare readonly body: SeedExhaustive.types.Animal;
+
     constructor(body: SeedExhaustive.types.Animal, rawResponse?: core.RawResponse) {
         super({
             message: "ErrorWithUnionBody",

--- a/seed/ts-sdk/exhaustive/export-all-requests-at-root/src/api/resources/generalErrors/errors/BadRequestBody.ts
+++ b/seed/ts-sdk/exhaustive/export-all-requests-at-root/src/api/resources/generalErrors/errors/BadRequestBody.ts
@@ -5,6 +5,8 @@ import * as errors from "../../../../errors/index.js";
 import type * as SeedExhaustive from "../../../index.js";
 
 export class BadRequestBody extends errors.SeedExhaustiveError {
+    public declare readonly body: SeedExhaustive.BadObjectRequestInfo;
+
     constructor(body: SeedExhaustive.BadObjectRequestInfo, rawResponse?: core.RawResponse) {
         super({
             message: "BadRequestBody",

--- a/seed/ts-sdk/exhaustive/export-all-requests-at-root/src/api/resources/types/resources/enum/errors/ErrorWithEnumBody.ts
+++ b/seed/ts-sdk/exhaustive/export-all-requests-at-root/src/api/resources/types/resources/enum/errors/ErrorWithEnumBody.ts
@@ -5,6 +5,8 @@ import * as errors from "../../../../../../errors/index.js";
 import type * as SeedExhaustive from "../../../../../index.js";
 
 export class ErrorWithEnumBody extends errors.SeedExhaustiveError {
+    public declare readonly body: SeedExhaustive.types.WeatherReport;
+
     constructor(body: SeedExhaustive.types.WeatherReport, rawResponse?: core.RawResponse) {
         super({
             message: "ErrorWithEnumBody",

--- a/seed/ts-sdk/exhaustive/export-all-requests-at-root/src/api/resources/types/resources/object/errors/NestedObjectWithOptionalFieldError.ts
+++ b/seed/ts-sdk/exhaustive/export-all-requests-at-root/src/api/resources/types/resources/object/errors/NestedObjectWithOptionalFieldError.ts
@@ -5,6 +5,8 @@ import * as errors from "../../../../../../errors/index.js";
 import type * as SeedExhaustive from "../../../../../index.js";
 
 export class NestedObjectWithOptionalFieldError extends errors.SeedExhaustiveError {
+    public declare readonly body: SeedExhaustive.types.NestedObjectWithOptionalField;
+
     constructor(body: SeedExhaustive.types.NestedObjectWithOptionalField, rawResponse?: core.RawResponse) {
         super({
             message: "NestedObjectWithOptionalFieldError",

--- a/seed/ts-sdk/exhaustive/export-all-requests-at-root/src/api/resources/types/resources/object/errors/NestedObjectWithRequiredFieldError.ts
+++ b/seed/ts-sdk/exhaustive/export-all-requests-at-root/src/api/resources/types/resources/object/errors/NestedObjectWithRequiredFieldError.ts
@@ -5,6 +5,8 @@ import * as errors from "../../../../../../errors/index.js";
 import type * as SeedExhaustive from "../../../../../index.js";
 
 export class NestedObjectWithRequiredFieldError extends errors.SeedExhaustiveError {
+    public declare readonly body: SeedExhaustive.types.NestedObjectWithRequiredField;
+
     constructor(body: SeedExhaustive.types.NestedObjectWithRequiredField, rawResponse?: core.RawResponse) {
         super({
             message: "NestedObjectWithRequiredFieldError",

--- a/seed/ts-sdk/exhaustive/export-all-requests-at-root/src/api/resources/types/resources/object/errors/ObjectWithOptionalFieldError.ts
+++ b/seed/ts-sdk/exhaustive/export-all-requests-at-root/src/api/resources/types/resources/object/errors/ObjectWithOptionalFieldError.ts
@@ -5,6 +5,8 @@ import * as errors from "../../../../../../errors/index.js";
 import type * as SeedExhaustive from "../../../../../index.js";
 
 export class ObjectWithOptionalFieldError extends errors.SeedExhaustiveError {
+    public declare readonly body: SeedExhaustive.types.ObjectWithOptionalField;
+
     constructor(body: SeedExhaustive.types.ObjectWithOptionalField, rawResponse?: core.RawResponse) {
         super({
             message: "ObjectWithOptionalFieldError",

--- a/seed/ts-sdk/exhaustive/export-all-requests-at-root/src/api/resources/types/resources/object/errors/ObjectWithRequiredFieldError.ts
+++ b/seed/ts-sdk/exhaustive/export-all-requests-at-root/src/api/resources/types/resources/object/errors/ObjectWithRequiredFieldError.ts
@@ -5,6 +5,8 @@ import * as errors from "../../../../../../errors/index.js";
 import type * as SeedExhaustive from "../../../../../index.js";
 
 export class ObjectWithRequiredFieldError extends errors.SeedExhaustiveError {
+    public declare readonly body: SeedExhaustive.types.ObjectWithRequiredField;
+
     constructor(body: SeedExhaustive.types.ObjectWithRequiredField, rawResponse?: core.RawResponse) {
         super({
             message: "ObjectWithRequiredFieldError",

--- a/seed/ts-sdk/exhaustive/export-all-requests-at-root/src/api/resources/types/resources/union/errors/ErrorWithUnionBody.ts
+++ b/seed/ts-sdk/exhaustive/export-all-requests-at-root/src/api/resources/types/resources/union/errors/ErrorWithUnionBody.ts
@@ -5,6 +5,8 @@ import * as errors from "../../../../../../errors/index.js";
 import type * as SeedExhaustive from "../../../../../index.js";
 
 export class ErrorWithUnionBody extends errors.SeedExhaustiveError {
+    public declare readonly body: SeedExhaustive.types.Animal;
+
     constructor(body: SeedExhaustive.types.Animal, rawResponse?: core.RawResponse) {
         super({
             message: "ErrorWithUnionBody",

--- a/seed/ts-sdk/exhaustive/flatten-request-parameters/src/api/resources/generalErrors/errors/BadRequestBody.ts
+++ b/seed/ts-sdk/exhaustive/flatten-request-parameters/src/api/resources/generalErrors/errors/BadRequestBody.ts
@@ -5,6 +5,8 @@ import * as errors from "../../../../errors/index.js";
 import type * as SeedExhaustive from "../../../index.js";
 
 export class BadRequestBody extends errors.SeedExhaustiveError {
+    public declare readonly body: SeedExhaustive.BadObjectRequestInfo;
+
     constructor(body: SeedExhaustive.BadObjectRequestInfo, rawResponse?: core.RawResponse) {
         super({
             message: "BadRequestBody",

--- a/seed/ts-sdk/exhaustive/flatten-request-parameters/src/api/resources/types/resources/enum/errors/ErrorWithEnumBody.ts
+++ b/seed/ts-sdk/exhaustive/flatten-request-parameters/src/api/resources/types/resources/enum/errors/ErrorWithEnumBody.ts
@@ -5,6 +5,8 @@ import * as errors from "../../../../../../errors/index.js";
 import type * as SeedExhaustive from "../../../../../index.js";
 
 export class ErrorWithEnumBody extends errors.SeedExhaustiveError {
+    public declare readonly body: SeedExhaustive.types.WeatherReport;
+
     constructor(body: SeedExhaustive.types.WeatherReport, rawResponse?: core.RawResponse) {
         super({
             message: "ErrorWithEnumBody",

--- a/seed/ts-sdk/exhaustive/flatten-request-parameters/src/api/resources/types/resources/object/errors/NestedObjectWithOptionalFieldError.ts
+++ b/seed/ts-sdk/exhaustive/flatten-request-parameters/src/api/resources/types/resources/object/errors/NestedObjectWithOptionalFieldError.ts
@@ -5,6 +5,8 @@ import * as errors from "../../../../../../errors/index.js";
 import type * as SeedExhaustive from "../../../../../index.js";
 
 export class NestedObjectWithOptionalFieldError extends errors.SeedExhaustiveError {
+    public declare readonly body: SeedExhaustive.types.NestedObjectWithOptionalField;
+
     constructor(body: SeedExhaustive.types.NestedObjectWithOptionalField, rawResponse?: core.RawResponse) {
         super({
             message: "NestedObjectWithOptionalFieldError",

--- a/seed/ts-sdk/exhaustive/flatten-request-parameters/src/api/resources/types/resources/object/errors/NestedObjectWithRequiredFieldError.ts
+++ b/seed/ts-sdk/exhaustive/flatten-request-parameters/src/api/resources/types/resources/object/errors/NestedObjectWithRequiredFieldError.ts
@@ -5,6 +5,8 @@ import * as errors from "../../../../../../errors/index.js";
 import type * as SeedExhaustive from "../../../../../index.js";
 
 export class NestedObjectWithRequiredFieldError extends errors.SeedExhaustiveError {
+    public declare readonly body: SeedExhaustive.types.NestedObjectWithRequiredField;
+
     constructor(body: SeedExhaustive.types.NestedObjectWithRequiredField, rawResponse?: core.RawResponse) {
         super({
             message: "NestedObjectWithRequiredFieldError",

--- a/seed/ts-sdk/exhaustive/flatten-request-parameters/src/api/resources/types/resources/object/errors/ObjectWithOptionalFieldError.ts
+++ b/seed/ts-sdk/exhaustive/flatten-request-parameters/src/api/resources/types/resources/object/errors/ObjectWithOptionalFieldError.ts
@@ -5,6 +5,8 @@ import * as errors from "../../../../../../errors/index.js";
 import type * as SeedExhaustive from "../../../../../index.js";
 
 export class ObjectWithOptionalFieldError extends errors.SeedExhaustiveError {
+    public declare readonly body: SeedExhaustive.types.ObjectWithOptionalField;
+
     constructor(body: SeedExhaustive.types.ObjectWithOptionalField, rawResponse?: core.RawResponse) {
         super({
             message: "ObjectWithOptionalFieldError",

--- a/seed/ts-sdk/exhaustive/flatten-request-parameters/src/api/resources/types/resources/object/errors/ObjectWithRequiredFieldError.ts
+++ b/seed/ts-sdk/exhaustive/flatten-request-parameters/src/api/resources/types/resources/object/errors/ObjectWithRequiredFieldError.ts
@@ -5,6 +5,8 @@ import * as errors from "../../../../../../errors/index.js";
 import type * as SeedExhaustive from "../../../../../index.js";
 
 export class ObjectWithRequiredFieldError extends errors.SeedExhaustiveError {
+    public declare readonly body: SeedExhaustive.types.ObjectWithRequiredField;
+
     constructor(body: SeedExhaustive.types.ObjectWithRequiredField, rawResponse?: core.RawResponse) {
         super({
             message: "ObjectWithRequiredFieldError",

--- a/seed/ts-sdk/exhaustive/flatten-request-parameters/src/api/resources/types/resources/union/errors/ErrorWithUnionBody.ts
+++ b/seed/ts-sdk/exhaustive/flatten-request-parameters/src/api/resources/types/resources/union/errors/ErrorWithUnionBody.ts
@@ -5,6 +5,8 @@ import * as errors from "../../../../../../errors/index.js";
 import type * as SeedExhaustive from "../../../../../index.js";
 
 export class ErrorWithUnionBody extends errors.SeedExhaustiveError {
+    public declare readonly body: SeedExhaustive.types.Animal;
+
     constructor(body: SeedExhaustive.types.Animal, rawResponse?: core.RawResponse) {
         super({
             message: "ErrorWithUnionBody",

--- a/seed/ts-sdk/exhaustive/include-idempotency-key/src/api/resources/generalErrors/errors/BadRequestBody.ts
+++ b/seed/ts-sdk/exhaustive/include-idempotency-key/src/api/resources/generalErrors/errors/BadRequestBody.ts
@@ -5,6 +5,8 @@ import * as errors from "../../../../errors/index.js";
 import type * as SeedExhaustive from "../../../index.js";
 
 export class BadRequestBody extends errors.SeedExhaustiveError {
+    public declare readonly body: SeedExhaustive.BadObjectRequestInfo;
+
     constructor(body: SeedExhaustive.BadObjectRequestInfo, rawResponse?: core.RawResponse) {
         super({
             message: "BadRequestBody",

--- a/seed/ts-sdk/exhaustive/include-idempotency-key/src/api/resources/types/resources/enum/errors/ErrorWithEnumBody.ts
+++ b/seed/ts-sdk/exhaustive/include-idempotency-key/src/api/resources/types/resources/enum/errors/ErrorWithEnumBody.ts
@@ -5,6 +5,8 @@ import * as errors from "../../../../../../errors/index.js";
 import type * as SeedExhaustive from "../../../../../index.js";
 
 export class ErrorWithEnumBody extends errors.SeedExhaustiveError {
+    public declare readonly body: SeedExhaustive.types.WeatherReport;
+
     constructor(body: SeedExhaustive.types.WeatherReport, rawResponse?: core.RawResponse) {
         super({
             message: "ErrorWithEnumBody",

--- a/seed/ts-sdk/exhaustive/include-idempotency-key/src/api/resources/types/resources/object/errors/NestedObjectWithOptionalFieldError.ts
+++ b/seed/ts-sdk/exhaustive/include-idempotency-key/src/api/resources/types/resources/object/errors/NestedObjectWithOptionalFieldError.ts
@@ -5,6 +5,8 @@ import * as errors from "../../../../../../errors/index.js";
 import type * as SeedExhaustive from "../../../../../index.js";
 
 export class NestedObjectWithOptionalFieldError extends errors.SeedExhaustiveError {
+    public declare readonly body: SeedExhaustive.types.NestedObjectWithOptionalField;
+
     constructor(body: SeedExhaustive.types.NestedObjectWithOptionalField, rawResponse?: core.RawResponse) {
         super({
             message: "NestedObjectWithOptionalFieldError",

--- a/seed/ts-sdk/exhaustive/include-idempotency-key/src/api/resources/types/resources/object/errors/NestedObjectWithRequiredFieldError.ts
+++ b/seed/ts-sdk/exhaustive/include-idempotency-key/src/api/resources/types/resources/object/errors/NestedObjectWithRequiredFieldError.ts
@@ -5,6 +5,8 @@ import * as errors from "../../../../../../errors/index.js";
 import type * as SeedExhaustive from "../../../../../index.js";
 
 export class NestedObjectWithRequiredFieldError extends errors.SeedExhaustiveError {
+    public declare readonly body: SeedExhaustive.types.NestedObjectWithRequiredField;
+
     constructor(body: SeedExhaustive.types.NestedObjectWithRequiredField, rawResponse?: core.RawResponse) {
         super({
             message: "NestedObjectWithRequiredFieldError",

--- a/seed/ts-sdk/exhaustive/include-idempotency-key/src/api/resources/types/resources/object/errors/ObjectWithOptionalFieldError.ts
+++ b/seed/ts-sdk/exhaustive/include-idempotency-key/src/api/resources/types/resources/object/errors/ObjectWithOptionalFieldError.ts
@@ -5,6 +5,8 @@ import * as errors from "../../../../../../errors/index.js";
 import type * as SeedExhaustive from "../../../../../index.js";
 
 export class ObjectWithOptionalFieldError extends errors.SeedExhaustiveError {
+    public declare readonly body: SeedExhaustive.types.ObjectWithOptionalField;
+
     constructor(body: SeedExhaustive.types.ObjectWithOptionalField, rawResponse?: core.RawResponse) {
         super({
             message: "ObjectWithOptionalFieldError",

--- a/seed/ts-sdk/exhaustive/include-idempotency-key/src/api/resources/types/resources/object/errors/ObjectWithRequiredFieldError.ts
+++ b/seed/ts-sdk/exhaustive/include-idempotency-key/src/api/resources/types/resources/object/errors/ObjectWithRequiredFieldError.ts
@@ -5,6 +5,8 @@ import * as errors from "../../../../../../errors/index.js";
 import type * as SeedExhaustive from "../../../../../index.js";
 
 export class ObjectWithRequiredFieldError extends errors.SeedExhaustiveError {
+    public declare readonly body: SeedExhaustive.types.ObjectWithRequiredField;
+
     constructor(body: SeedExhaustive.types.ObjectWithRequiredField, rawResponse?: core.RawResponse) {
         super({
             message: "ObjectWithRequiredFieldError",

--- a/seed/ts-sdk/exhaustive/include-idempotency-key/src/api/resources/types/resources/union/errors/ErrorWithUnionBody.ts
+++ b/seed/ts-sdk/exhaustive/include-idempotency-key/src/api/resources/types/resources/union/errors/ErrorWithUnionBody.ts
@@ -5,6 +5,8 @@ import * as errors from "../../../../../../errors/index.js";
 import type * as SeedExhaustive from "../../../../../index.js";
 
 export class ErrorWithUnionBody extends errors.SeedExhaustiveError {
+    public declare readonly body: SeedExhaustive.types.Animal;
+
     constructor(body: SeedExhaustive.types.Animal, rawResponse?: core.RawResponse) {
         super({
             message: "ErrorWithUnionBody",

--- a/seed/ts-sdk/exhaustive/local-files-no-source/cjs/api/resources/generalErrors/errors/BadRequestBody.d.ts
+++ b/seed/ts-sdk/exhaustive/local-files-no-source/cjs/api/resources/generalErrors/errors/BadRequestBody.d.ts
@@ -2,5 +2,6 @@ import type * as core from "../../../../core/index.js";
 import * as errors from "../../../../errors/index.js";
 import type * as SeedExhaustive from "../../../index.js";
 export declare class BadRequestBody extends errors.SeedExhaustiveError {
+    readonly body: SeedExhaustive.BadObjectRequestInfo;
     constructor(body: SeedExhaustive.BadObjectRequestInfo, rawResponse?: core.RawResponse);
 }

--- a/seed/ts-sdk/exhaustive/local-files-no-source/cjs/api/resources/types/resources/enum/errors/ErrorWithEnumBody.d.ts
+++ b/seed/ts-sdk/exhaustive/local-files-no-source/cjs/api/resources/types/resources/enum/errors/ErrorWithEnumBody.d.ts
@@ -2,5 +2,6 @@ import type * as core from "../../../../../../core/index.js";
 import * as errors from "../../../../../../errors/index.js";
 import type * as SeedExhaustive from "../../../../../index.js";
 export declare class ErrorWithEnumBody extends errors.SeedExhaustiveError {
+    readonly body: SeedExhaustive.types.WeatherReport;
     constructor(body: SeedExhaustive.types.WeatherReport, rawResponse?: core.RawResponse);
 }

--- a/seed/ts-sdk/exhaustive/local-files-no-source/cjs/api/resources/types/resources/object/errors/NestedObjectWithOptionalFieldError.d.ts
+++ b/seed/ts-sdk/exhaustive/local-files-no-source/cjs/api/resources/types/resources/object/errors/NestedObjectWithOptionalFieldError.d.ts
@@ -2,5 +2,6 @@ import type * as core from "../../../../../../core/index.js";
 import * as errors from "../../../../../../errors/index.js";
 import type * as SeedExhaustive from "../../../../../index.js";
 export declare class NestedObjectWithOptionalFieldError extends errors.SeedExhaustiveError {
+    readonly body: SeedExhaustive.types.NestedObjectWithOptionalField;
     constructor(body: SeedExhaustive.types.NestedObjectWithOptionalField, rawResponse?: core.RawResponse);
 }

--- a/seed/ts-sdk/exhaustive/local-files-no-source/cjs/api/resources/types/resources/object/errors/NestedObjectWithRequiredFieldError.d.ts
+++ b/seed/ts-sdk/exhaustive/local-files-no-source/cjs/api/resources/types/resources/object/errors/NestedObjectWithRequiredFieldError.d.ts
@@ -2,5 +2,6 @@ import type * as core from "../../../../../../core/index.js";
 import * as errors from "../../../../../../errors/index.js";
 import type * as SeedExhaustive from "../../../../../index.js";
 export declare class NestedObjectWithRequiredFieldError extends errors.SeedExhaustiveError {
+    readonly body: SeedExhaustive.types.NestedObjectWithRequiredField;
     constructor(body: SeedExhaustive.types.NestedObjectWithRequiredField, rawResponse?: core.RawResponse);
 }

--- a/seed/ts-sdk/exhaustive/local-files-no-source/cjs/api/resources/types/resources/object/errors/ObjectWithOptionalFieldError.d.ts
+++ b/seed/ts-sdk/exhaustive/local-files-no-source/cjs/api/resources/types/resources/object/errors/ObjectWithOptionalFieldError.d.ts
@@ -2,5 +2,6 @@ import type * as core from "../../../../../../core/index.js";
 import * as errors from "../../../../../../errors/index.js";
 import type * as SeedExhaustive from "../../../../../index.js";
 export declare class ObjectWithOptionalFieldError extends errors.SeedExhaustiveError {
+    readonly body: SeedExhaustive.types.ObjectWithOptionalField;
     constructor(body: SeedExhaustive.types.ObjectWithOptionalField, rawResponse?: core.RawResponse);
 }

--- a/seed/ts-sdk/exhaustive/local-files-no-source/cjs/api/resources/types/resources/object/errors/ObjectWithRequiredFieldError.d.ts
+++ b/seed/ts-sdk/exhaustive/local-files-no-source/cjs/api/resources/types/resources/object/errors/ObjectWithRequiredFieldError.d.ts
@@ -2,5 +2,6 @@ import type * as core from "../../../../../../core/index.js";
 import * as errors from "../../../../../../errors/index.js";
 import type * as SeedExhaustive from "../../../../../index.js";
 export declare class ObjectWithRequiredFieldError extends errors.SeedExhaustiveError {
+    readonly body: SeedExhaustive.types.ObjectWithRequiredField;
     constructor(body: SeedExhaustive.types.ObjectWithRequiredField, rawResponse?: core.RawResponse);
 }

--- a/seed/ts-sdk/exhaustive/local-files-no-source/cjs/api/resources/types/resources/union/errors/ErrorWithUnionBody.d.ts
+++ b/seed/ts-sdk/exhaustive/local-files-no-source/cjs/api/resources/types/resources/union/errors/ErrorWithUnionBody.d.ts
@@ -2,5 +2,6 @@ import type * as core from "../../../../../../core/index.js";
 import * as errors from "../../../../../../errors/index.js";
 import type * as SeedExhaustive from "../../../../../index.js";
 export declare class ErrorWithUnionBody extends errors.SeedExhaustiveError {
+    readonly body: SeedExhaustive.types.Animal;
     constructor(body: SeedExhaustive.types.Animal, rawResponse?: core.RawResponse);
 }

--- a/seed/ts-sdk/exhaustive/local-files-no-source/esm/api/resources/generalErrors/errors/BadRequestBody.d.mts
+++ b/seed/ts-sdk/exhaustive/local-files-no-source/esm/api/resources/generalErrors/errors/BadRequestBody.d.mts
@@ -2,5 +2,6 @@ import type * as core from "../../../../core/index.mjs";
 import * as errors from "../../../../errors/index.mjs";
 import type * as SeedExhaustive from "../../../index.mjs";
 export declare class BadRequestBody extends errors.SeedExhaustiveError {
+    readonly body: SeedExhaustive.BadObjectRequestInfo;
     constructor(body: SeedExhaustive.BadObjectRequestInfo, rawResponse?: core.RawResponse);
 }

--- a/seed/ts-sdk/exhaustive/local-files-no-source/esm/api/resources/types/resources/enum/errors/ErrorWithEnumBody.d.mts
+++ b/seed/ts-sdk/exhaustive/local-files-no-source/esm/api/resources/types/resources/enum/errors/ErrorWithEnumBody.d.mts
@@ -2,5 +2,6 @@ import type * as core from "../../../../../../core/index.mjs";
 import * as errors from "../../../../../../errors/index.mjs";
 import type * as SeedExhaustive from "../../../../../index.mjs";
 export declare class ErrorWithEnumBody extends errors.SeedExhaustiveError {
+    readonly body: SeedExhaustive.types.WeatherReport;
     constructor(body: SeedExhaustive.types.WeatherReport, rawResponse?: core.RawResponse);
 }

--- a/seed/ts-sdk/exhaustive/local-files-no-source/esm/api/resources/types/resources/object/errors/NestedObjectWithOptionalFieldError.d.mts
+++ b/seed/ts-sdk/exhaustive/local-files-no-source/esm/api/resources/types/resources/object/errors/NestedObjectWithOptionalFieldError.d.mts
@@ -2,5 +2,6 @@ import type * as core from "../../../../../../core/index.mjs";
 import * as errors from "../../../../../../errors/index.mjs";
 import type * as SeedExhaustive from "../../../../../index.mjs";
 export declare class NestedObjectWithOptionalFieldError extends errors.SeedExhaustiveError {
+    readonly body: SeedExhaustive.types.NestedObjectWithOptionalField;
     constructor(body: SeedExhaustive.types.NestedObjectWithOptionalField, rawResponse?: core.RawResponse);
 }

--- a/seed/ts-sdk/exhaustive/local-files-no-source/esm/api/resources/types/resources/object/errors/NestedObjectWithRequiredFieldError.d.mts
+++ b/seed/ts-sdk/exhaustive/local-files-no-source/esm/api/resources/types/resources/object/errors/NestedObjectWithRequiredFieldError.d.mts
@@ -2,5 +2,6 @@ import type * as core from "../../../../../../core/index.mjs";
 import * as errors from "../../../../../../errors/index.mjs";
 import type * as SeedExhaustive from "../../../../../index.mjs";
 export declare class NestedObjectWithRequiredFieldError extends errors.SeedExhaustiveError {
+    readonly body: SeedExhaustive.types.NestedObjectWithRequiredField;
     constructor(body: SeedExhaustive.types.NestedObjectWithRequiredField, rawResponse?: core.RawResponse);
 }

--- a/seed/ts-sdk/exhaustive/local-files-no-source/esm/api/resources/types/resources/object/errors/ObjectWithOptionalFieldError.d.mts
+++ b/seed/ts-sdk/exhaustive/local-files-no-source/esm/api/resources/types/resources/object/errors/ObjectWithOptionalFieldError.d.mts
@@ -2,5 +2,6 @@ import type * as core from "../../../../../../core/index.mjs";
 import * as errors from "../../../../../../errors/index.mjs";
 import type * as SeedExhaustive from "../../../../../index.mjs";
 export declare class ObjectWithOptionalFieldError extends errors.SeedExhaustiveError {
+    readonly body: SeedExhaustive.types.ObjectWithOptionalField;
     constructor(body: SeedExhaustive.types.ObjectWithOptionalField, rawResponse?: core.RawResponse);
 }

--- a/seed/ts-sdk/exhaustive/local-files-no-source/esm/api/resources/types/resources/object/errors/ObjectWithRequiredFieldError.d.mts
+++ b/seed/ts-sdk/exhaustive/local-files-no-source/esm/api/resources/types/resources/object/errors/ObjectWithRequiredFieldError.d.mts
@@ -2,5 +2,6 @@ import type * as core from "../../../../../../core/index.mjs";
 import * as errors from "../../../../../../errors/index.mjs";
 import type * as SeedExhaustive from "../../../../../index.mjs";
 export declare class ObjectWithRequiredFieldError extends errors.SeedExhaustiveError {
+    readonly body: SeedExhaustive.types.ObjectWithRequiredField;
     constructor(body: SeedExhaustive.types.ObjectWithRequiredField, rawResponse?: core.RawResponse);
 }

--- a/seed/ts-sdk/exhaustive/local-files-no-source/esm/api/resources/types/resources/union/errors/ErrorWithUnionBody.d.mts
+++ b/seed/ts-sdk/exhaustive/local-files-no-source/esm/api/resources/types/resources/union/errors/ErrorWithUnionBody.d.mts
@@ -2,5 +2,6 @@ import type * as core from "../../../../../../core/index.mjs";
 import * as errors from "../../../../../../errors/index.mjs";
 import type * as SeedExhaustive from "../../../../../index.mjs";
 export declare class ErrorWithUnionBody extends errors.SeedExhaustiveError {
+    readonly body: SeedExhaustive.types.Animal;
     constructor(body: SeedExhaustive.types.Animal, rawResponse?: core.RawResponse);
 }

--- a/seed/ts-sdk/exhaustive/local-files/api/resources/generalErrors/errors/BadRequestBody.ts
+++ b/seed/ts-sdk/exhaustive/local-files/api/resources/generalErrors/errors/BadRequestBody.ts
@@ -5,6 +5,8 @@ import * as errors from "../../../../errors/index.js";
 import type * as SeedExhaustive from "../../../index.js";
 
 export class BadRequestBody extends errors.SeedExhaustiveError {
+    public declare readonly body: SeedExhaustive.BadObjectRequestInfo;
+
     constructor(body: SeedExhaustive.BadObjectRequestInfo, rawResponse?: core.RawResponse) {
         super({
             message: "BadRequestBody",

--- a/seed/ts-sdk/exhaustive/local-files/api/resources/types/resources/enum/errors/ErrorWithEnumBody.ts
+++ b/seed/ts-sdk/exhaustive/local-files/api/resources/types/resources/enum/errors/ErrorWithEnumBody.ts
@@ -5,6 +5,8 @@ import * as errors from "../../../../../../errors/index.js";
 import type * as SeedExhaustive from "../../../../../index.js";
 
 export class ErrorWithEnumBody extends errors.SeedExhaustiveError {
+    public declare readonly body: SeedExhaustive.types.WeatherReport;
+
     constructor(body: SeedExhaustive.types.WeatherReport, rawResponse?: core.RawResponse) {
         super({
             message: "ErrorWithEnumBody",

--- a/seed/ts-sdk/exhaustive/local-files/api/resources/types/resources/object/errors/NestedObjectWithOptionalFieldError.ts
+++ b/seed/ts-sdk/exhaustive/local-files/api/resources/types/resources/object/errors/NestedObjectWithOptionalFieldError.ts
@@ -5,6 +5,8 @@ import * as errors from "../../../../../../errors/index.js";
 import type * as SeedExhaustive from "../../../../../index.js";
 
 export class NestedObjectWithOptionalFieldError extends errors.SeedExhaustiveError {
+    public declare readonly body: SeedExhaustive.types.NestedObjectWithOptionalField;
+
     constructor(body: SeedExhaustive.types.NestedObjectWithOptionalField, rawResponse?: core.RawResponse) {
         super({
             message: "NestedObjectWithOptionalFieldError",

--- a/seed/ts-sdk/exhaustive/local-files/api/resources/types/resources/object/errors/NestedObjectWithRequiredFieldError.ts
+++ b/seed/ts-sdk/exhaustive/local-files/api/resources/types/resources/object/errors/NestedObjectWithRequiredFieldError.ts
@@ -5,6 +5,8 @@ import * as errors from "../../../../../../errors/index.js";
 import type * as SeedExhaustive from "../../../../../index.js";
 
 export class NestedObjectWithRequiredFieldError extends errors.SeedExhaustiveError {
+    public declare readonly body: SeedExhaustive.types.NestedObjectWithRequiredField;
+
     constructor(body: SeedExhaustive.types.NestedObjectWithRequiredField, rawResponse?: core.RawResponse) {
         super({
             message: "NestedObjectWithRequiredFieldError",

--- a/seed/ts-sdk/exhaustive/local-files/api/resources/types/resources/object/errors/ObjectWithOptionalFieldError.ts
+++ b/seed/ts-sdk/exhaustive/local-files/api/resources/types/resources/object/errors/ObjectWithOptionalFieldError.ts
@@ -5,6 +5,8 @@ import * as errors from "../../../../../../errors/index.js";
 import type * as SeedExhaustive from "../../../../../index.js";
 
 export class ObjectWithOptionalFieldError extends errors.SeedExhaustiveError {
+    public declare readonly body: SeedExhaustive.types.ObjectWithOptionalField;
+
     constructor(body: SeedExhaustive.types.ObjectWithOptionalField, rawResponse?: core.RawResponse) {
         super({
             message: "ObjectWithOptionalFieldError",

--- a/seed/ts-sdk/exhaustive/local-files/api/resources/types/resources/object/errors/ObjectWithRequiredFieldError.ts
+++ b/seed/ts-sdk/exhaustive/local-files/api/resources/types/resources/object/errors/ObjectWithRequiredFieldError.ts
@@ -5,6 +5,8 @@ import * as errors from "../../../../../../errors/index.js";
 import type * as SeedExhaustive from "../../../../../index.js";
 
 export class ObjectWithRequiredFieldError extends errors.SeedExhaustiveError {
+    public declare readonly body: SeedExhaustive.types.ObjectWithRequiredField;
+
     constructor(body: SeedExhaustive.types.ObjectWithRequiredField, rawResponse?: core.RawResponse) {
         super({
             message: "ObjectWithRequiredFieldError",

--- a/seed/ts-sdk/exhaustive/local-files/api/resources/types/resources/union/errors/ErrorWithUnionBody.ts
+++ b/seed/ts-sdk/exhaustive/local-files/api/resources/types/resources/union/errors/ErrorWithUnionBody.ts
@@ -5,6 +5,8 @@ import * as errors from "../../../../../../errors/index.js";
 import type * as SeedExhaustive from "../../../../../index.js";
 
 export class ErrorWithUnionBody extends errors.SeedExhaustiveError {
+    public declare readonly body: SeedExhaustive.types.Animal;
+
     constructor(body: SeedExhaustive.types.Animal, rawResponse?: core.RawResponse) {
         super({
             message: "ErrorWithUnionBody",

--- a/seed/ts-sdk/exhaustive/multiple-exports/src/api/resources/generalErrors/errors/BadRequestBody.ts
+++ b/seed/ts-sdk/exhaustive/multiple-exports/src/api/resources/generalErrors/errors/BadRequestBody.ts
@@ -5,6 +5,8 @@ import * as errors from "../../../../errors/index.js";
 import type * as SeedExhaustive from "../../../index.js";
 
 export class BadRequestBody extends errors.SeedExhaustiveError {
+    public declare readonly body: SeedExhaustive.BadObjectRequestInfo;
+
     constructor(body: SeedExhaustive.BadObjectRequestInfo, rawResponse?: core.RawResponse) {
         super({
             message: "BadRequestBody",

--- a/seed/ts-sdk/exhaustive/multiple-exports/src/api/resources/types/resources/enum/errors/ErrorWithEnumBody.ts
+++ b/seed/ts-sdk/exhaustive/multiple-exports/src/api/resources/types/resources/enum/errors/ErrorWithEnumBody.ts
@@ -5,6 +5,8 @@ import * as errors from "../../../../../../errors/index.js";
 import type * as SeedExhaustive from "../../../../../index.js";
 
 export class ErrorWithEnumBody extends errors.SeedExhaustiveError {
+    public declare readonly body: SeedExhaustive.types.WeatherReport;
+
     constructor(body: SeedExhaustive.types.WeatherReport, rawResponse?: core.RawResponse) {
         super({
             message: "ErrorWithEnumBody",

--- a/seed/ts-sdk/exhaustive/multiple-exports/src/api/resources/types/resources/object/errors/NestedObjectWithOptionalFieldError.ts
+++ b/seed/ts-sdk/exhaustive/multiple-exports/src/api/resources/types/resources/object/errors/NestedObjectWithOptionalFieldError.ts
@@ -5,6 +5,8 @@ import * as errors from "../../../../../../errors/index.js";
 import type * as SeedExhaustive from "../../../../../index.js";
 
 export class NestedObjectWithOptionalFieldError extends errors.SeedExhaustiveError {
+    public declare readonly body: SeedExhaustive.types.NestedObjectWithOptionalField;
+
     constructor(body: SeedExhaustive.types.NestedObjectWithOptionalField, rawResponse?: core.RawResponse) {
         super({
             message: "NestedObjectWithOptionalFieldError",

--- a/seed/ts-sdk/exhaustive/multiple-exports/src/api/resources/types/resources/object/errors/NestedObjectWithRequiredFieldError.ts
+++ b/seed/ts-sdk/exhaustive/multiple-exports/src/api/resources/types/resources/object/errors/NestedObjectWithRequiredFieldError.ts
@@ -5,6 +5,8 @@ import * as errors from "../../../../../../errors/index.js";
 import type * as SeedExhaustive from "../../../../../index.js";
 
 export class NestedObjectWithRequiredFieldError extends errors.SeedExhaustiveError {
+    public declare readonly body: SeedExhaustive.types.NestedObjectWithRequiredField;
+
     constructor(body: SeedExhaustive.types.NestedObjectWithRequiredField, rawResponse?: core.RawResponse) {
         super({
             message: "NestedObjectWithRequiredFieldError",

--- a/seed/ts-sdk/exhaustive/multiple-exports/src/api/resources/types/resources/object/errors/ObjectWithOptionalFieldError.ts
+++ b/seed/ts-sdk/exhaustive/multiple-exports/src/api/resources/types/resources/object/errors/ObjectWithOptionalFieldError.ts
@@ -5,6 +5,8 @@ import * as errors from "../../../../../../errors/index.js";
 import type * as SeedExhaustive from "../../../../../index.js";
 
 export class ObjectWithOptionalFieldError extends errors.SeedExhaustiveError {
+    public declare readonly body: SeedExhaustive.types.ObjectWithOptionalField;
+
     constructor(body: SeedExhaustive.types.ObjectWithOptionalField, rawResponse?: core.RawResponse) {
         super({
             message: "ObjectWithOptionalFieldError",

--- a/seed/ts-sdk/exhaustive/multiple-exports/src/api/resources/types/resources/object/errors/ObjectWithRequiredFieldError.ts
+++ b/seed/ts-sdk/exhaustive/multiple-exports/src/api/resources/types/resources/object/errors/ObjectWithRequiredFieldError.ts
@@ -5,6 +5,8 @@ import * as errors from "../../../../../../errors/index.js";
 import type * as SeedExhaustive from "../../../../../index.js";
 
 export class ObjectWithRequiredFieldError extends errors.SeedExhaustiveError {
+    public declare readonly body: SeedExhaustive.types.ObjectWithRequiredField;
+
     constructor(body: SeedExhaustive.types.ObjectWithRequiredField, rawResponse?: core.RawResponse) {
         super({
             message: "ObjectWithRequiredFieldError",

--- a/seed/ts-sdk/exhaustive/multiple-exports/src/api/resources/types/resources/union/errors/ErrorWithUnionBody.ts
+++ b/seed/ts-sdk/exhaustive/multiple-exports/src/api/resources/types/resources/union/errors/ErrorWithUnionBody.ts
@@ -5,6 +5,8 @@ import * as errors from "../../../../../../errors/index.js";
 import type * as SeedExhaustive from "../../../../../index.js";
 
 export class ErrorWithUnionBody extends errors.SeedExhaustiveError {
+    public declare readonly body: SeedExhaustive.types.Animal;
+
     constructor(body: SeedExhaustive.types.Animal, rawResponse?: core.RawResponse) {
         super({
             message: "ErrorWithUnionBody",

--- a/seed/ts-sdk/exhaustive/no-custom-config/src/api/resources/generalErrors/errors/BadRequestBody.ts
+++ b/seed/ts-sdk/exhaustive/no-custom-config/src/api/resources/generalErrors/errors/BadRequestBody.ts
@@ -5,6 +5,8 @@ import * as errors from "../../../../errors/index.js";
 import type * as SeedExhaustive from "../../../index.js";
 
 export class BadRequestBody extends errors.SeedExhaustiveError {
+    public declare readonly body: SeedExhaustive.BadObjectRequestInfo;
+
     constructor(body: SeedExhaustive.BadObjectRequestInfo, rawResponse?: core.RawResponse) {
         super({
             message: "BadRequestBody",

--- a/seed/ts-sdk/exhaustive/no-custom-config/src/api/resources/types/resources/enum/errors/ErrorWithEnumBody.ts
+++ b/seed/ts-sdk/exhaustive/no-custom-config/src/api/resources/types/resources/enum/errors/ErrorWithEnumBody.ts
@@ -5,6 +5,8 @@ import * as errors from "../../../../../../errors/index.js";
 import type * as SeedExhaustive from "../../../../../index.js";
 
 export class ErrorWithEnumBody extends errors.SeedExhaustiveError {
+    public declare readonly body: SeedExhaustive.types.WeatherReport;
+
     constructor(body: SeedExhaustive.types.WeatherReport, rawResponse?: core.RawResponse) {
         super({
             message: "ErrorWithEnumBody",

--- a/seed/ts-sdk/exhaustive/no-custom-config/src/api/resources/types/resources/object/errors/NestedObjectWithOptionalFieldError.ts
+++ b/seed/ts-sdk/exhaustive/no-custom-config/src/api/resources/types/resources/object/errors/NestedObjectWithOptionalFieldError.ts
@@ -5,6 +5,8 @@ import * as errors from "../../../../../../errors/index.js";
 import type * as SeedExhaustive from "../../../../../index.js";
 
 export class NestedObjectWithOptionalFieldError extends errors.SeedExhaustiveError {
+    public declare readonly body: SeedExhaustive.types.NestedObjectWithOptionalField;
+
     constructor(body: SeedExhaustive.types.NestedObjectWithOptionalField, rawResponse?: core.RawResponse) {
         super({
             message: "NestedObjectWithOptionalFieldError",

--- a/seed/ts-sdk/exhaustive/no-custom-config/src/api/resources/types/resources/object/errors/NestedObjectWithRequiredFieldError.ts
+++ b/seed/ts-sdk/exhaustive/no-custom-config/src/api/resources/types/resources/object/errors/NestedObjectWithRequiredFieldError.ts
@@ -5,6 +5,8 @@ import * as errors from "../../../../../../errors/index.js";
 import type * as SeedExhaustive from "../../../../../index.js";
 
 export class NestedObjectWithRequiredFieldError extends errors.SeedExhaustiveError {
+    public declare readonly body: SeedExhaustive.types.NestedObjectWithRequiredField;
+
     constructor(body: SeedExhaustive.types.NestedObjectWithRequiredField, rawResponse?: core.RawResponse) {
         super({
             message: "NestedObjectWithRequiredFieldError",

--- a/seed/ts-sdk/exhaustive/no-custom-config/src/api/resources/types/resources/object/errors/ObjectWithOptionalFieldError.ts
+++ b/seed/ts-sdk/exhaustive/no-custom-config/src/api/resources/types/resources/object/errors/ObjectWithOptionalFieldError.ts
@@ -5,6 +5,8 @@ import * as errors from "../../../../../../errors/index.js";
 import type * as SeedExhaustive from "../../../../../index.js";
 
 export class ObjectWithOptionalFieldError extends errors.SeedExhaustiveError {
+    public declare readonly body: SeedExhaustive.types.ObjectWithOptionalField;
+
     constructor(body: SeedExhaustive.types.ObjectWithOptionalField, rawResponse?: core.RawResponse) {
         super({
             message: "ObjectWithOptionalFieldError",

--- a/seed/ts-sdk/exhaustive/no-custom-config/src/api/resources/types/resources/object/errors/ObjectWithRequiredFieldError.ts
+++ b/seed/ts-sdk/exhaustive/no-custom-config/src/api/resources/types/resources/object/errors/ObjectWithRequiredFieldError.ts
@@ -5,6 +5,8 @@ import * as errors from "../../../../../../errors/index.js";
 import type * as SeedExhaustive from "../../../../../index.js";
 
 export class ObjectWithRequiredFieldError extends errors.SeedExhaustiveError {
+    public declare readonly body: SeedExhaustive.types.ObjectWithRequiredField;
+
     constructor(body: SeedExhaustive.types.ObjectWithRequiredField, rawResponse?: core.RawResponse) {
         super({
             message: "ObjectWithRequiredFieldError",

--- a/seed/ts-sdk/exhaustive/no-custom-config/src/api/resources/types/resources/union/errors/ErrorWithUnionBody.ts
+++ b/seed/ts-sdk/exhaustive/no-custom-config/src/api/resources/types/resources/union/errors/ErrorWithUnionBody.ts
@@ -5,6 +5,8 @@ import * as errors from "../../../../../../errors/index.js";
 import type * as SeedExhaustive from "../../../../../index.js";
 
 export class ErrorWithUnionBody extends errors.SeedExhaustiveError {
+    public declare readonly body: SeedExhaustive.types.Animal;
+
     constructor(body: SeedExhaustive.types.Animal, rawResponse?: core.RawResponse) {
         super({
             message: "ErrorWithUnionBody",

--- a/seed/ts-sdk/exhaustive/node-fetch/src/api/resources/generalErrors/errors/BadRequestBody.ts
+++ b/seed/ts-sdk/exhaustive/node-fetch/src/api/resources/generalErrors/errors/BadRequestBody.ts
@@ -5,6 +5,8 @@ import * as errors from "../../../../errors/index.js";
 import type * as SeedExhaustive from "../../../index.js";
 
 export class BadRequestBody extends errors.SeedExhaustiveError {
+    public declare readonly body: SeedExhaustive.BadObjectRequestInfo;
+
     constructor(body: SeedExhaustive.BadObjectRequestInfo, rawResponse?: core.RawResponse) {
         super({
             message: "BadRequestBody",

--- a/seed/ts-sdk/exhaustive/node-fetch/src/api/resources/types/resources/enum/errors/ErrorWithEnumBody.ts
+++ b/seed/ts-sdk/exhaustive/node-fetch/src/api/resources/types/resources/enum/errors/ErrorWithEnumBody.ts
@@ -5,6 +5,8 @@ import * as errors from "../../../../../../errors/index.js";
 import type * as SeedExhaustive from "../../../../../index.js";
 
 export class ErrorWithEnumBody extends errors.SeedExhaustiveError {
+    public declare readonly body: SeedExhaustive.types.WeatherReport;
+
     constructor(body: SeedExhaustive.types.WeatherReport, rawResponse?: core.RawResponse) {
         super({
             message: "ErrorWithEnumBody",

--- a/seed/ts-sdk/exhaustive/node-fetch/src/api/resources/types/resources/object/errors/NestedObjectWithOptionalFieldError.ts
+++ b/seed/ts-sdk/exhaustive/node-fetch/src/api/resources/types/resources/object/errors/NestedObjectWithOptionalFieldError.ts
@@ -5,6 +5,8 @@ import * as errors from "../../../../../../errors/index.js";
 import type * as SeedExhaustive from "../../../../../index.js";
 
 export class NestedObjectWithOptionalFieldError extends errors.SeedExhaustiveError {
+    public declare readonly body: SeedExhaustive.types.NestedObjectWithOptionalField;
+
     constructor(body: SeedExhaustive.types.NestedObjectWithOptionalField, rawResponse?: core.RawResponse) {
         super({
             message: "NestedObjectWithOptionalFieldError",

--- a/seed/ts-sdk/exhaustive/node-fetch/src/api/resources/types/resources/object/errors/NestedObjectWithRequiredFieldError.ts
+++ b/seed/ts-sdk/exhaustive/node-fetch/src/api/resources/types/resources/object/errors/NestedObjectWithRequiredFieldError.ts
@@ -5,6 +5,8 @@ import * as errors from "../../../../../../errors/index.js";
 import type * as SeedExhaustive from "../../../../../index.js";
 
 export class NestedObjectWithRequiredFieldError extends errors.SeedExhaustiveError {
+    public declare readonly body: SeedExhaustive.types.NestedObjectWithRequiredField;
+
     constructor(body: SeedExhaustive.types.NestedObjectWithRequiredField, rawResponse?: core.RawResponse) {
         super({
             message: "NestedObjectWithRequiredFieldError",

--- a/seed/ts-sdk/exhaustive/node-fetch/src/api/resources/types/resources/object/errors/ObjectWithOptionalFieldError.ts
+++ b/seed/ts-sdk/exhaustive/node-fetch/src/api/resources/types/resources/object/errors/ObjectWithOptionalFieldError.ts
@@ -5,6 +5,8 @@ import * as errors from "../../../../../../errors/index.js";
 import type * as SeedExhaustive from "../../../../../index.js";
 
 export class ObjectWithOptionalFieldError extends errors.SeedExhaustiveError {
+    public declare readonly body: SeedExhaustive.types.ObjectWithOptionalField;
+
     constructor(body: SeedExhaustive.types.ObjectWithOptionalField, rawResponse?: core.RawResponse) {
         super({
             message: "ObjectWithOptionalFieldError",

--- a/seed/ts-sdk/exhaustive/node-fetch/src/api/resources/types/resources/object/errors/ObjectWithRequiredFieldError.ts
+++ b/seed/ts-sdk/exhaustive/node-fetch/src/api/resources/types/resources/object/errors/ObjectWithRequiredFieldError.ts
@@ -5,6 +5,8 @@ import * as errors from "../../../../../../errors/index.js";
 import type * as SeedExhaustive from "../../../../../index.js";
 
 export class ObjectWithRequiredFieldError extends errors.SeedExhaustiveError {
+    public declare readonly body: SeedExhaustive.types.ObjectWithRequiredField;
+
     constructor(body: SeedExhaustive.types.ObjectWithRequiredField, rawResponse?: core.RawResponse) {
         super({
             message: "ObjectWithRequiredFieldError",

--- a/seed/ts-sdk/exhaustive/node-fetch/src/api/resources/types/resources/union/errors/ErrorWithUnionBody.ts
+++ b/seed/ts-sdk/exhaustive/node-fetch/src/api/resources/types/resources/union/errors/ErrorWithUnionBody.ts
@@ -5,6 +5,8 @@ import * as errors from "../../../../../../errors/index.js";
 import type * as SeedExhaustive from "../../../../../index.js";
 
 export class ErrorWithUnionBody extends errors.SeedExhaustiveError {
+    public declare readonly body: SeedExhaustive.types.Animal;
+
     constructor(body: SeedExhaustive.types.Animal, rawResponse?: core.RawResponse) {
         super({
             message: "ErrorWithUnionBody",

--- a/seed/ts-sdk/exhaustive/output-src-only/api/resources/generalErrors/errors/BadRequestBody.ts
+++ b/seed/ts-sdk/exhaustive/output-src-only/api/resources/generalErrors/errors/BadRequestBody.ts
@@ -5,6 +5,8 @@ import * as errors from "../../../../errors/index.js";
 import type * as SeedExhaustive from "../../../index.js";
 
 export class BadRequestBody extends errors.SeedExhaustiveError {
+    public declare readonly body: SeedExhaustive.BadObjectRequestInfo;
+
     constructor(body: SeedExhaustive.BadObjectRequestInfo, rawResponse?: core.RawResponse) {
         super({
             message: "BadRequestBody",

--- a/seed/ts-sdk/exhaustive/output-src-only/api/resources/types/resources/enum/errors/ErrorWithEnumBody.ts
+++ b/seed/ts-sdk/exhaustive/output-src-only/api/resources/types/resources/enum/errors/ErrorWithEnumBody.ts
@@ -5,6 +5,8 @@ import * as errors from "../../../../../../errors/index.js";
 import type * as SeedExhaustive from "../../../../../index.js";
 
 export class ErrorWithEnumBody extends errors.SeedExhaustiveError {
+    public declare readonly body: SeedExhaustive.types.WeatherReport;
+
     constructor(body: SeedExhaustive.types.WeatherReport, rawResponse?: core.RawResponse) {
         super({
             message: "ErrorWithEnumBody",

--- a/seed/ts-sdk/exhaustive/output-src-only/api/resources/types/resources/object/errors/NestedObjectWithOptionalFieldError.ts
+++ b/seed/ts-sdk/exhaustive/output-src-only/api/resources/types/resources/object/errors/NestedObjectWithOptionalFieldError.ts
@@ -5,6 +5,8 @@ import * as errors from "../../../../../../errors/index.js";
 import type * as SeedExhaustive from "../../../../../index.js";
 
 export class NestedObjectWithOptionalFieldError extends errors.SeedExhaustiveError {
+    public declare readonly body: SeedExhaustive.types.NestedObjectWithOptionalField;
+
     constructor(body: SeedExhaustive.types.NestedObjectWithOptionalField, rawResponse?: core.RawResponse) {
         super({
             message: "NestedObjectWithOptionalFieldError",

--- a/seed/ts-sdk/exhaustive/output-src-only/api/resources/types/resources/object/errors/NestedObjectWithRequiredFieldError.ts
+++ b/seed/ts-sdk/exhaustive/output-src-only/api/resources/types/resources/object/errors/NestedObjectWithRequiredFieldError.ts
@@ -5,6 +5,8 @@ import * as errors from "../../../../../../errors/index.js";
 import type * as SeedExhaustive from "../../../../../index.js";
 
 export class NestedObjectWithRequiredFieldError extends errors.SeedExhaustiveError {
+    public declare readonly body: SeedExhaustive.types.NestedObjectWithRequiredField;
+
     constructor(body: SeedExhaustive.types.NestedObjectWithRequiredField, rawResponse?: core.RawResponse) {
         super({
             message: "NestedObjectWithRequiredFieldError",

--- a/seed/ts-sdk/exhaustive/output-src-only/api/resources/types/resources/object/errors/ObjectWithOptionalFieldError.ts
+++ b/seed/ts-sdk/exhaustive/output-src-only/api/resources/types/resources/object/errors/ObjectWithOptionalFieldError.ts
@@ -5,6 +5,8 @@ import * as errors from "../../../../../../errors/index.js";
 import type * as SeedExhaustive from "../../../../../index.js";
 
 export class ObjectWithOptionalFieldError extends errors.SeedExhaustiveError {
+    public declare readonly body: SeedExhaustive.types.ObjectWithOptionalField;
+
     constructor(body: SeedExhaustive.types.ObjectWithOptionalField, rawResponse?: core.RawResponse) {
         super({
             message: "ObjectWithOptionalFieldError",

--- a/seed/ts-sdk/exhaustive/output-src-only/api/resources/types/resources/object/errors/ObjectWithRequiredFieldError.ts
+++ b/seed/ts-sdk/exhaustive/output-src-only/api/resources/types/resources/object/errors/ObjectWithRequiredFieldError.ts
@@ -5,6 +5,8 @@ import * as errors from "../../../../../../errors/index.js";
 import type * as SeedExhaustive from "../../../../../index.js";
 
 export class ObjectWithRequiredFieldError extends errors.SeedExhaustiveError {
+    public declare readonly body: SeedExhaustive.types.ObjectWithRequiredField;
+
     constructor(body: SeedExhaustive.types.ObjectWithRequiredField, rawResponse?: core.RawResponse) {
         super({
             message: "ObjectWithRequiredFieldError",

--- a/seed/ts-sdk/exhaustive/output-src-only/api/resources/types/resources/union/errors/ErrorWithUnionBody.ts
+++ b/seed/ts-sdk/exhaustive/output-src-only/api/resources/types/resources/union/errors/ErrorWithUnionBody.ts
@@ -5,6 +5,8 @@ import * as errors from "../../../../../../errors/index.js";
 import type * as SeedExhaustive from "../../../../../index.js";
 
 export class ErrorWithUnionBody extends errors.SeedExhaustiveError {
+    public declare readonly body: SeedExhaustive.types.Animal;
+
     constructor(body: SeedExhaustive.types.Animal, rawResponse?: core.RawResponse) {
         super({
             message: "ErrorWithUnionBody",

--- a/seed/ts-sdk/exhaustive/package-path/src/test-packagePath/api/resources/generalErrors/errors/BadRequestBody.ts
+++ b/seed/ts-sdk/exhaustive/package-path/src/test-packagePath/api/resources/generalErrors/errors/BadRequestBody.ts
@@ -5,6 +5,8 @@ import * as errors from "../../../../errors/index.js";
 import type * as SeedExhaustive from "../../../index.js";
 
 export class BadRequestBody extends errors.SeedExhaustiveError {
+    public declare readonly body: SeedExhaustive.BadObjectRequestInfo;
+
     constructor(body: SeedExhaustive.BadObjectRequestInfo, rawResponse?: core.RawResponse) {
         super({
             message: "BadRequestBody",

--- a/seed/ts-sdk/exhaustive/package-path/src/test-packagePath/api/resources/types/resources/enum/errors/ErrorWithEnumBody.ts
+++ b/seed/ts-sdk/exhaustive/package-path/src/test-packagePath/api/resources/types/resources/enum/errors/ErrorWithEnumBody.ts
@@ -5,6 +5,8 @@ import * as errors from "../../../../../../errors/index.js";
 import type * as SeedExhaustive from "../../../../../index.js";
 
 export class ErrorWithEnumBody extends errors.SeedExhaustiveError {
+    public declare readonly body: SeedExhaustive.types.WeatherReport;
+
     constructor(body: SeedExhaustive.types.WeatherReport, rawResponse?: core.RawResponse) {
         super({
             message: "ErrorWithEnumBody",

--- a/seed/ts-sdk/exhaustive/package-path/src/test-packagePath/api/resources/types/resources/object/errors/NestedObjectWithOptionalFieldError.ts
+++ b/seed/ts-sdk/exhaustive/package-path/src/test-packagePath/api/resources/types/resources/object/errors/NestedObjectWithOptionalFieldError.ts
@@ -5,6 +5,8 @@ import * as errors from "../../../../../../errors/index.js";
 import type * as SeedExhaustive from "../../../../../index.js";
 
 export class NestedObjectWithOptionalFieldError extends errors.SeedExhaustiveError {
+    public declare readonly body: SeedExhaustive.types.NestedObjectWithOptionalField;
+
     constructor(body: SeedExhaustive.types.NestedObjectWithOptionalField, rawResponse?: core.RawResponse) {
         super({
             message: "NestedObjectWithOptionalFieldError",

--- a/seed/ts-sdk/exhaustive/package-path/src/test-packagePath/api/resources/types/resources/object/errors/NestedObjectWithRequiredFieldError.ts
+++ b/seed/ts-sdk/exhaustive/package-path/src/test-packagePath/api/resources/types/resources/object/errors/NestedObjectWithRequiredFieldError.ts
@@ -5,6 +5,8 @@ import * as errors from "../../../../../../errors/index.js";
 import type * as SeedExhaustive from "../../../../../index.js";
 
 export class NestedObjectWithRequiredFieldError extends errors.SeedExhaustiveError {
+    public declare readonly body: SeedExhaustive.types.NestedObjectWithRequiredField;
+
     constructor(body: SeedExhaustive.types.NestedObjectWithRequiredField, rawResponse?: core.RawResponse) {
         super({
             message: "NestedObjectWithRequiredFieldError",

--- a/seed/ts-sdk/exhaustive/package-path/src/test-packagePath/api/resources/types/resources/object/errors/ObjectWithOptionalFieldError.ts
+++ b/seed/ts-sdk/exhaustive/package-path/src/test-packagePath/api/resources/types/resources/object/errors/ObjectWithOptionalFieldError.ts
@@ -5,6 +5,8 @@ import * as errors from "../../../../../../errors/index.js";
 import type * as SeedExhaustive from "../../../../../index.js";
 
 export class ObjectWithOptionalFieldError extends errors.SeedExhaustiveError {
+    public declare readonly body: SeedExhaustive.types.ObjectWithOptionalField;
+
     constructor(body: SeedExhaustive.types.ObjectWithOptionalField, rawResponse?: core.RawResponse) {
         super({
             message: "ObjectWithOptionalFieldError",

--- a/seed/ts-sdk/exhaustive/package-path/src/test-packagePath/api/resources/types/resources/object/errors/ObjectWithRequiredFieldError.ts
+++ b/seed/ts-sdk/exhaustive/package-path/src/test-packagePath/api/resources/types/resources/object/errors/ObjectWithRequiredFieldError.ts
@@ -5,6 +5,8 @@ import * as errors from "../../../../../../errors/index.js";
 import type * as SeedExhaustive from "../../../../../index.js";
 
 export class ObjectWithRequiredFieldError extends errors.SeedExhaustiveError {
+    public declare readonly body: SeedExhaustive.types.ObjectWithRequiredField;
+
     constructor(body: SeedExhaustive.types.ObjectWithRequiredField, rawResponse?: core.RawResponse) {
         super({
             message: "ObjectWithRequiredFieldError",

--- a/seed/ts-sdk/exhaustive/package-path/src/test-packagePath/api/resources/types/resources/union/errors/ErrorWithUnionBody.ts
+++ b/seed/ts-sdk/exhaustive/package-path/src/test-packagePath/api/resources/types/resources/union/errors/ErrorWithUnionBody.ts
@@ -5,6 +5,8 @@ import * as errors from "../../../../../../errors/index.js";
 import type * as SeedExhaustive from "../../../../../index.js";
 
 export class ErrorWithUnionBody extends errors.SeedExhaustiveError {
+    public declare readonly body: SeedExhaustive.types.Animal;
+
     constructor(body: SeedExhaustive.types.Animal, rawResponse?: core.RawResponse) {
         super({
             message: "ErrorWithUnionBody",

--- a/seed/ts-sdk/exhaustive/parameter-naming-camel-case/src/api/resources/generalErrors/errors/BadRequestBody.ts
+++ b/seed/ts-sdk/exhaustive/parameter-naming-camel-case/src/api/resources/generalErrors/errors/BadRequestBody.ts
@@ -5,6 +5,8 @@ import * as errors from "../../../../errors/index.js";
 import type * as SeedExhaustive from "../../../index.js";
 
 export class BadRequestBody extends errors.SeedExhaustiveError {
+    public declare readonly body: SeedExhaustive.BadObjectRequestInfo;
+
     constructor(body: SeedExhaustive.BadObjectRequestInfo, rawResponse?: core.RawResponse) {
         super({
             message: "BadRequestBody",

--- a/seed/ts-sdk/exhaustive/parameter-naming-camel-case/src/api/resources/types/resources/enum/errors/ErrorWithEnumBody.ts
+++ b/seed/ts-sdk/exhaustive/parameter-naming-camel-case/src/api/resources/types/resources/enum/errors/ErrorWithEnumBody.ts
@@ -5,6 +5,8 @@ import * as errors from "../../../../../../errors/index.js";
 import type * as SeedExhaustive from "../../../../../index.js";
 
 export class ErrorWithEnumBody extends errors.SeedExhaustiveError {
+    public declare readonly body: SeedExhaustive.types.WeatherReport;
+
     constructor(body: SeedExhaustive.types.WeatherReport, rawResponse?: core.RawResponse) {
         super({
             message: "ErrorWithEnumBody",

--- a/seed/ts-sdk/exhaustive/parameter-naming-camel-case/src/api/resources/types/resources/object/errors/NestedObjectWithOptionalFieldError.ts
+++ b/seed/ts-sdk/exhaustive/parameter-naming-camel-case/src/api/resources/types/resources/object/errors/NestedObjectWithOptionalFieldError.ts
@@ -5,6 +5,8 @@ import * as errors from "../../../../../../errors/index.js";
 import type * as SeedExhaustive from "../../../../../index.js";
 
 export class NestedObjectWithOptionalFieldError extends errors.SeedExhaustiveError {
+    public declare readonly body: SeedExhaustive.types.NestedObjectWithOptionalField;
+
     constructor(body: SeedExhaustive.types.NestedObjectWithOptionalField, rawResponse?: core.RawResponse) {
         super({
             message: "NestedObjectWithOptionalFieldError",

--- a/seed/ts-sdk/exhaustive/parameter-naming-camel-case/src/api/resources/types/resources/object/errors/NestedObjectWithRequiredFieldError.ts
+++ b/seed/ts-sdk/exhaustive/parameter-naming-camel-case/src/api/resources/types/resources/object/errors/NestedObjectWithRequiredFieldError.ts
@@ -5,6 +5,8 @@ import * as errors from "../../../../../../errors/index.js";
 import type * as SeedExhaustive from "../../../../../index.js";
 
 export class NestedObjectWithRequiredFieldError extends errors.SeedExhaustiveError {
+    public declare readonly body: SeedExhaustive.types.NestedObjectWithRequiredField;
+
     constructor(body: SeedExhaustive.types.NestedObjectWithRequiredField, rawResponse?: core.RawResponse) {
         super({
             message: "NestedObjectWithRequiredFieldError",

--- a/seed/ts-sdk/exhaustive/parameter-naming-camel-case/src/api/resources/types/resources/object/errors/ObjectWithOptionalFieldError.ts
+++ b/seed/ts-sdk/exhaustive/parameter-naming-camel-case/src/api/resources/types/resources/object/errors/ObjectWithOptionalFieldError.ts
@@ -5,6 +5,8 @@ import * as errors from "../../../../../../errors/index.js";
 import type * as SeedExhaustive from "../../../../../index.js";
 
 export class ObjectWithOptionalFieldError extends errors.SeedExhaustiveError {
+    public declare readonly body: SeedExhaustive.types.ObjectWithOptionalField;
+
     constructor(body: SeedExhaustive.types.ObjectWithOptionalField, rawResponse?: core.RawResponse) {
         super({
             message: "ObjectWithOptionalFieldError",

--- a/seed/ts-sdk/exhaustive/parameter-naming-camel-case/src/api/resources/types/resources/object/errors/ObjectWithRequiredFieldError.ts
+++ b/seed/ts-sdk/exhaustive/parameter-naming-camel-case/src/api/resources/types/resources/object/errors/ObjectWithRequiredFieldError.ts
@@ -5,6 +5,8 @@ import * as errors from "../../../../../../errors/index.js";
 import type * as SeedExhaustive from "../../../../../index.js";
 
 export class ObjectWithRequiredFieldError extends errors.SeedExhaustiveError {
+    public declare readonly body: SeedExhaustive.types.ObjectWithRequiredField;
+
     constructor(body: SeedExhaustive.types.ObjectWithRequiredField, rawResponse?: core.RawResponse) {
         super({
             message: "ObjectWithRequiredFieldError",

--- a/seed/ts-sdk/exhaustive/parameter-naming-camel-case/src/api/resources/types/resources/union/errors/ErrorWithUnionBody.ts
+++ b/seed/ts-sdk/exhaustive/parameter-naming-camel-case/src/api/resources/types/resources/union/errors/ErrorWithUnionBody.ts
@@ -5,6 +5,8 @@ import * as errors from "../../../../../../errors/index.js";
 import type * as SeedExhaustive from "../../../../../index.js";
 
 export class ErrorWithUnionBody extends errors.SeedExhaustiveError {
+    public declare readonly body: SeedExhaustive.types.Animal;
+
     constructor(body: SeedExhaustive.types.Animal, rawResponse?: core.RawResponse) {
         super({
             message: "ErrorWithUnionBody",

--- a/seed/ts-sdk/exhaustive/parameter-naming-original-name/src/api/resources/generalErrors/errors/BadRequestBody.ts
+++ b/seed/ts-sdk/exhaustive/parameter-naming-original-name/src/api/resources/generalErrors/errors/BadRequestBody.ts
@@ -5,6 +5,8 @@ import * as errors from "../../../../errors/index.js";
 import type * as SeedExhaustive from "../../../index.js";
 
 export class BadRequestBody extends errors.SeedExhaustiveError {
+    public declare readonly body: SeedExhaustive.BadObjectRequestInfo;
+
     constructor(body: SeedExhaustive.BadObjectRequestInfo, rawResponse?: core.RawResponse) {
         super({
             message: "BadRequestBody",

--- a/seed/ts-sdk/exhaustive/parameter-naming-original-name/src/api/resources/types/resources/enum/errors/ErrorWithEnumBody.ts
+++ b/seed/ts-sdk/exhaustive/parameter-naming-original-name/src/api/resources/types/resources/enum/errors/ErrorWithEnumBody.ts
@@ -5,6 +5,8 @@ import * as errors from "../../../../../../errors/index.js";
 import type * as SeedExhaustive from "../../../../../index.js";
 
 export class ErrorWithEnumBody extends errors.SeedExhaustiveError {
+    public declare readonly body: SeedExhaustive.types.WeatherReport;
+
     constructor(body: SeedExhaustive.types.WeatherReport, rawResponse?: core.RawResponse) {
         super({
             message: "ErrorWithEnumBody",

--- a/seed/ts-sdk/exhaustive/parameter-naming-original-name/src/api/resources/types/resources/object/errors/NestedObjectWithOptionalFieldError.ts
+++ b/seed/ts-sdk/exhaustive/parameter-naming-original-name/src/api/resources/types/resources/object/errors/NestedObjectWithOptionalFieldError.ts
@@ -5,6 +5,8 @@ import * as errors from "../../../../../../errors/index.js";
 import type * as SeedExhaustive from "../../../../../index.js";
 
 export class NestedObjectWithOptionalFieldError extends errors.SeedExhaustiveError {
+    public declare readonly body: SeedExhaustive.types.NestedObjectWithOptionalField;
+
     constructor(body: SeedExhaustive.types.NestedObjectWithOptionalField, rawResponse?: core.RawResponse) {
         super({
             message: "NestedObjectWithOptionalFieldError",

--- a/seed/ts-sdk/exhaustive/parameter-naming-original-name/src/api/resources/types/resources/object/errors/NestedObjectWithRequiredFieldError.ts
+++ b/seed/ts-sdk/exhaustive/parameter-naming-original-name/src/api/resources/types/resources/object/errors/NestedObjectWithRequiredFieldError.ts
@@ -5,6 +5,8 @@ import * as errors from "../../../../../../errors/index.js";
 import type * as SeedExhaustive from "../../../../../index.js";
 
 export class NestedObjectWithRequiredFieldError extends errors.SeedExhaustiveError {
+    public declare readonly body: SeedExhaustive.types.NestedObjectWithRequiredField;
+
     constructor(body: SeedExhaustive.types.NestedObjectWithRequiredField, rawResponse?: core.RawResponse) {
         super({
             message: "NestedObjectWithRequiredFieldError",

--- a/seed/ts-sdk/exhaustive/parameter-naming-original-name/src/api/resources/types/resources/object/errors/ObjectWithOptionalFieldError.ts
+++ b/seed/ts-sdk/exhaustive/parameter-naming-original-name/src/api/resources/types/resources/object/errors/ObjectWithOptionalFieldError.ts
@@ -5,6 +5,8 @@ import * as errors from "../../../../../../errors/index.js";
 import type * as SeedExhaustive from "../../../../../index.js";
 
 export class ObjectWithOptionalFieldError extends errors.SeedExhaustiveError {
+    public declare readonly body: SeedExhaustive.types.ObjectWithOptionalField;
+
     constructor(body: SeedExhaustive.types.ObjectWithOptionalField, rawResponse?: core.RawResponse) {
         super({
             message: "ObjectWithOptionalFieldError",

--- a/seed/ts-sdk/exhaustive/parameter-naming-original-name/src/api/resources/types/resources/object/errors/ObjectWithRequiredFieldError.ts
+++ b/seed/ts-sdk/exhaustive/parameter-naming-original-name/src/api/resources/types/resources/object/errors/ObjectWithRequiredFieldError.ts
@@ -5,6 +5,8 @@ import * as errors from "../../../../../../errors/index.js";
 import type * as SeedExhaustive from "../../../../../index.js";
 
 export class ObjectWithRequiredFieldError extends errors.SeedExhaustiveError {
+    public declare readonly body: SeedExhaustive.types.ObjectWithRequiredField;
+
     constructor(body: SeedExhaustive.types.ObjectWithRequiredField, rawResponse?: core.RawResponse) {
         super({
             message: "ObjectWithRequiredFieldError",

--- a/seed/ts-sdk/exhaustive/parameter-naming-original-name/src/api/resources/types/resources/union/errors/ErrorWithUnionBody.ts
+++ b/seed/ts-sdk/exhaustive/parameter-naming-original-name/src/api/resources/types/resources/union/errors/ErrorWithUnionBody.ts
@@ -5,6 +5,8 @@ import * as errors from "../../../../../../errors/index.js";
 import type * as SeedExhaustive from "../../../../../index.js";
 
 export class ErrorWithUnionBody extends errors.SeedExhaustiveError {
+    public declare readonly body: SeedExhaustive.types.Animal;
+
     constructor(body: SeedExhaustive.types.Animal, rawResponse?: core.RawResponse) {
         super({
             message: "ErrorWithUnionBody",

--- a/seed/ts-sdk/exhaustive/parameter-naming-snake-case/src/api/resources/generalErrors/errors/BadRequestBody.ts
+++ b/seed/ts-sdk/exhaustive/parameter-naming-snake-case/src/api/resources/generalErrors/errors/BadRequestBody.ts
@@ -5,6 +5,8 @@ import * as errors from "../../../../errors/index.js";
 import type * as SeedExhaustive from "../../../index.js";
 
 export class BadRequestBody extends errors.SeedExhaustiveError {
+    public declare readonly body: SeedExhaustive.BadObjectRequestInfo;
+
     constructor(body: SeedExhaustive.BadObjectRequestInfo, rawResponse?: core.RawResponse) {
         super({
             message: "BadRequestBody",

--- a/seed/ts-sdk/exhaustive/parameter-naming-snake-case/src/api/resources/types/resources/enum/errors/ErrorWithEnumBody.ts
+++ b/seed/ts-sdk/exhaustive/parameter-naming-snake-case/src/api/resources/types/resources/enum/errors/ErrorWithEnumBody.ts
@@ -5,6 +5,8 @@ import * as errors from "../../../../../../errors/index.js";
 import type * as SeedExhaustive from "../../../../../index.js";
 
 export class ErrorWithEnumBody extends errors.SeedExhaustiveError {
+    public declare readonly body: SeedExhaustive.types.WeatherReport;
+
     constructor(body: SeedExhaustive.types.WeatherReport, rawResponse?: core.RawResponse) {
         super({
             message: "ErrorWithEnumBody",

--- a/seed/ts-sdk/exhaustive/parameter-naming-snake-case/src/api/resources/types/resources/object/errors/NestedObjectWithOptionalFieldError.ts
+++ b/seed/ts-sdk/exhaustive/parameter-naming-snake-case/src/api/resources/types/resources/object/errors/NestedObjectWithOptionalFieldError.ts
@@ -5,6 +5,8 @@ import * as errors from "../../../../../../errors/index.js";
 import type * as SeedExhaustive from "../../../../../index.js";
 
 export class NestedObjectWithOptionalFieldError extends errors.SeedExhaustiveError {
+    public declare readonly body: SeedExhaustive.types.NestedObjectWithOptionalField;
+
     constructor(body: SeedExhaustive.types.NestedObjectWithOptionalField, rawResponse?: core.RawResponse) {
         super({
             message: "NestedObjectWithOptionalFieldError",

--- a/seed/ts-sdk/exhaustive/parameter-naming-snake-case/src/api/resources/types/resources/object/errors/NestedObjectWithRequiredFieldError.ts
+++ b/seed/ts-sdk/exhaustive/parameter-naming-snake-case/src/api/resources/types/resources/object/errors/NestedObjectWithRequiredFieldError.ts
@@ -5,6 +5,8 @@ import * as errors from "../../../../../../errors/index.js";
 import type * as SeedExhaustive from "../../../../../index.js";
 
 export class NestedObjectWithRequiredFieldError extends errors.SeedExhaustiveError {
+    public declare readonly body: SeedExhaustive.types.NestedObjectWithRequiredField;
+
     constructor(body: SeedExhaustive.types.NestedObjectWithRequiredField, rawResponse?: core.RawResponse) {
         super({
             message: "NestedObjectWithRequiredFieldError",

--- a/seed/ts-sdk/exhaustive/parameter-naming-snake-case/src/api/resources/types/resources/object/errors/ObjectWithOptionalFieldError.ts
+++ b/seed/ts-sdk/exhaustive/parameter-naming-snake-case/src/api/resources/types/resources/object/errors/ObjectWithOptionalFieldError.ts
@@ -5,6 +5,8 @@ import * as errors from "../../../../../../errors/index.js";
 import type * as SeedExhaustive from "../../../../../index.js";
 
 export class ObjectWithOptionalFieldError extends errors.SeedExhaustiveError {
+    public declare readonly body: SeedExhaustive.types.ObjectWithOptionalField;
+
     constructor(body: SeedExhaustive.types.ObjectWithOptionalField, rawResponse?: core.RawResponse) {
         super({
             message: "ObjectWithOptionalFieldError",

--- a/seed/ts-sdk/exhaustive/parameter-naming-snake-case/src/api/resources/types/resources/object/errors/ObjectWithRequiredFieldError.ts
+++ b/seed/ts-sdk/exhaustive/parameter-naming-snake-case/src/api/resources/types/resources/object/errors/ObjectWithRequiredFieldError.ts
@@ -5,6 +5,8 @@ import * as errors from "../../../../../../errors/index.js";
 import type * as SeedExhaustive from "../../../../../index.js";
 
 export class ObjectWithRequiredFieldError extends errors.SeedExhaustiveError {
+    public declare readonly body: SeedExhaustive.types.ObjectWithRequiredField;
+
     constructor(body: SeedExhaustive.types.ObjectWithRequiredField, rawResponse?: core.RawResponse) {
         super({
             message: "ObjectWithRequiredFieldError",

--- a/seed/ts-sdk/exhaustive/parameter-naming-snake-case/src/api/resources/types/resources/union/errors/ErrorWithUnionBody.ts
+++ b/seed/ts-sdk/exhaustive/parameter-naming-snake-case/src/api/resources/types/resources/union/errors/ErrorWithUnionBody.ts
@@ -5,6 +5,8 @@ import * as errors from "../../../../../../errors/index.js";
 import type * as SeedExhaustive from "../../../../../index.js";
 
 export class ErrorWithUnionBody extends errors.SeedExhaustiveError {
+    public declare readonly body: SeedExhaustive.types.Animal;
+
     constructor(body: SeedExhaustive.types.Animal, rawResponse?: core.RawResponse) {
         super({
             message: "ErrorWithUnionBody",

--- a/seed/ts-sdk/exhaustive/parameter-naming-wire-value/src/api/resources/generalErrors/errors/BadRequestBody.ts
+++ b/seed/ts-sdk/exhaustive/parameter-naming-wire-value/src/api/resources/generalErrors/errors/BadRequestBody.ts
@@ -5,6 +5,8 @@ import * as errors from "../../../../errors/index.js";
 import type * as SeedExhaustive from "../../../index.js";
 
 export class BadRequestBody extends errors.SeedExhaustiveError {
+    public declare readonly body: SeedExhaustive.BadObjectRequestInfo;
+
     constructor(body: SeedExhaustive.BadObjectRequestInfo, rawResponse?: core.RawResponse) {
         super({
             message: "BadRequestBody",

--- a/seed/ts-sdk/exhaustive/parameter-naming-wire-value/src/api/resources/types/resources/enum/errors/ErrorWithEnumBody.ts
+++ b/seed/ts-sdk/exhaustive/parameter-naming-wire-value/src/api/resources/types/resources/enum/errors/ErrorWithEnumBody.ts
@@ -5,6 +5,8 @@ import * as errors from "../../../../../../errors/index.js";
 import type * as SeedExhaustive from "../../../../../index.js";
 
 export class ErrorWithEnumBody extends errors.SeedExhaustiveError {
+    public declare readonly body: SeedExhaustive.types.WeatherReport;
+
     constructor(body: SeedExhaustive.types.WeatherReport, rawResponse?: core.RawResponse) {
         super({
             message: "ErrorWithEnumBody",

--- a/seed/ts-sdk/exhaustive/parameter-naming-wire-value/src/api/resources/types/resources/object/errors/NestedObjectWithOptionalFieldError.ts
+++ b/seed/ts-sdk/exhaustive/parameter-naming-wire-value/src/api/resources/types/resources/object/errors/NestedObjectWithOptionalFieldError.ts
@@ -5,6 +5,8 @@ import * as errors from "../../../../../../errors/index.js";
 import type * as SeedExhaustive from "../../../../../index.js";
 
 export class NestedObjectWithOptionalFieldError extends errors.SeedExhaustiveError {
+    public declare readonly body: SeedExhaustive.types.NestedObjectWithOptionalField;
+
     constructor(body: SeedExhaustive.types.NestedObjectWithOptionalField, rawResponse?: core.RawResponse) {
         super({
             message: "NestedObjectWithOptionalFieldError",

--- a/seed/ts-sdk/exhaustive/parameter-naming-wire-value/src/api/resources/types/resources/object/errors/NestedObjectWithRequiredFieldError.ts
+++ b/seed/ts-sdk/exhaustive/parameter-naming-wire-value/src/api/resources/types/resources/object/errors/NestedObjectWithRequiredFieldError.ts
@@ -5,6 +5,8 @@ import * as errors from "../../../../../../errors/index.js";
 import type * as SeedExhaustive from "../../../../../index.js";
 
 export class NestedObjectWithRequiredFieldError extends errors.SeedExhaustiveError {
+    public declare readonly body: SeedExhaustive.types.NestedObjectWithRequiredField;
+
     constructor(body: SeedExhaustive.types.NestedObjectWithRequiredField, rawResponse?: core.RawResponse) {
         super({
             message: "NestedObjectWithRequiredFieldError",

--- a/seed/ts-sdk/exhaustive/parameter-naming-wire-value/src/api/resources/types/resources/object/errors/ObjectWithOptionalFieldError.ts
+++ b/seed/ts-sdk/exhaustive/parameter-naming-wire-value/src/api/resources/types/resources/object/errors/ObjectWithOptionalFieldError.ts
@@ -5,6 +5,8 @@ import * as errors from "../../../../../../errors/index.js";
 import type * as SeedExhaustive from "../../../../../index.js";
 
 export class ObjectWithOptionalFieldError extends errors.SeedExhaustiveError {
+    public declare readonly body: SeedExhaustive.types.ObjectWithOptionalField;
+
     constructor(body: SeedExhaustive.types.ObjectWithOptionalField, rawResponse?: core.RawResponse) {
         super({
             message: "ObjectWithOptionalFieldError",

--- a/seed/ts-sdk/exhaustive/parameter-naming-wire-value/src/api/resources/types/resources/object/errors/ObjectWithRequiredFieldError.ts
+++ b/seed/ts-sdk/exhaustive/parameter-naming-wire-value/src/api/resources/types/resources/object/errors/ObjectWithRequiredFieldError.ts
@@ -5,6 +5,8 @@ import * as errors from "../../../../../../errors/index.js";
 import type * as SeedExhaustive from "../../../../../index.js";
 
 export class ObjectWithRequiredFieldError extends errors.SeedExhaustiveError {
+    public declare readonly body: SeedExhaustive.types.ObjectWithRequiredField;
+
     constructor(body: SeedExhaustive.types.ObjectWithRequiredField, rawResponse?: core.RawResponse) {
         super({
             message: "ObjectWithRequiredFieldError",

--- a/seed/ts-sdk/exhaustive/parameter-naming-wire-value/src/api/resources/types/resources/union/errors/ErrorWithUnionBody.ts
+++ b/seed/ts-sdk/exhaustive/parameter-naming-wire-value/src/api/resources/types/resources/union/errors/ErrorWithUnionBody.ts
@@ -5,6 +5,8 @@ import * as errors from "../../../../../../errors/index.js";
 import type * as SeedExhaustive from "../../../../../index.js";
 
 export class ErrorWithUnionBody extends errors.SeedExhaustiveError {
+    public declare readonly body: SeedExhaustive.types.Animal;
+
     constructor(body: SeedExhaustive.types.Animal, rawResponse?: core.RawResponse) {
         super({
             message: "ErrorWithUnionBody",

--- a/seed/ts-sdk/exhaustive/retain-original-casing/src/api/resources/generalErrors/errors/BadRequestBody.ts
+++ b/seed/ts-sdk/exhaustive/retain-original-casing/src/api/resources/generalErrors/errors/BadRequestBody.ts
@@ -5,6 +5,8 @@ import * as errors from "../../../../errors/index.js";
 import type * as SeedExhaustive from "../../../index.js";
 
 export class BadRequestBody extends errors.SeedExhaustiveError {
+    public declare readonly body: SeedExhaustive.BadObjectRequestInfo;
+
     constructor(body: SeedExhaustive.BadObjectRequestInfo, rawResponse?: core.RawResponse) {
         super({
             message: "BadRequestBody",

--- a/seed/ts-sdk/exhaustive/retain-original-casing/src/api/resources/types/resources/enum/errors/ErrorWithEnumBody.ts
+++ b/seed/ts-sdk/exhaustive/retain-original-casing/src/api/resources/types/resources/enum/errors/ErrorWithEnumBody.ts
@@ -5,6 +5,8 @@ import * as errors from "../../../../../../errors/index.js";
 import type * as SeedExhaustive from "../../../../../index.js";
 
 export class ErrorWithEnumBody extends errors.SeedExhaustiveError {
+    public declare readonly body: SeedExhaustive.types.WeatherReport;
+
     constructor(body: SeedExhaustive.types.WeatherReport, rawResponse?: core.RawResponse) {
         super({
             message: "ErrorWithEnumBody",

--- a/seed/ts-sdk/exhaustive/retain-original-casing/src/api/resources/types/resources/object/errors/NestedObjectWithOptionalFieldError.ts
+++ b/seed/ts-sdk/exhaustive/retain-original-casing/src/api/resources/types/resources/object/errors/NestedObjectWithOptionalFieldError.ts
@@ -5,6 +5,8 @@ import * as errors from "../../../../../../errors/index.js";
 import type * as SeedExhaustive from "../../../../../index.js";
 
 export class NestedObjectWithOptionalFieldError extends errors.SeedExhaustiveError {
+    public declare readonly body: SeedExhaustive.types.NestedObjectWithOptionalField;
+
     constructor(body: SeedExhaustive.types.NestedObjectWithOptionalField, rawResponse?: core.RawResponse) {
         super({
             message: "NestedObjectWithOptionalFieldError",

--- a/seed/ts-sdk/exhaustive/retain-original-casing/src/api/resources/types/resources/object/errors/NestedObjectWithRequiredFieldError.ts
+++ b/seed/ts-sdk/exhaustive/retain-original-casing/src/api/resources/types/resources/object/errors/NestedObjectWithRequiredFieldError.ts
@@ -5,6 +5,8 @@ import * as errors from "../../../../../../errors/index.js";
 import type * as SeedExhaustive from "../../../../../index.js";
 
 export class NestedObjectWithRequiredFieldError extends errors.SeedExhaustiveError {
+    public declare readonly body: SeedExhaustive.types.NestedObjectWithRequiredField;
+
     constructor(body: SeedExhaustive.types.NestedObjectWithRequiredField, rawResponse?: core.RawResponse) {
         super({
             message: "NestedObjectWithRequiredFieldError",

--- a/seed/ts-sdk/exhaustive/retain-original-casing/src/api/resources/types/resources/object/errors/ObjectWithOptionalFieldError.ts
+++ b/seed/ts-sdk/exhaustive/retain-original-casing/src/api/resources/types/resources/object/errors/ObjectWithOptionalFieldError.ts
@@ -5,6 +5,8 @@ import * as errors from "../../../../../../errors/index.js";
 import type * as SeedExhaustive from "../../../../../index.js";
 
 export class ObjectWithOptionalFieldError extends errors.SeedExhaustiveError {
+    public declare readonly body: SeedExhaustive.types.ObjectWithOptionalField;
+
     constructor(body: SeedExhaustive.types.ObjectWithOptionalField, rawResponse?: core.RawResponse) {
         super({
             message: "ObjectWithOptionalFieldError",

--- a/seed/ts-sdk/exhaustive/retain-original-casing/src/api/resources/types/resources/object/errors/ObjectWithRequiredFieldError.ts
+++ b/seed/ts-sdk/exhaustive/retain-original-casing/src/api/resources/types/resources/object/errors/ObjectWithRequiredFieldError.ts
@@ -5,6 +5,8 @@ import * as errors from "../../../../../../errors/index.js";
 import type * as SeedExhaustive from "../../../../../index.js";
 
 export class ObjectWithRequiredFieldError extends errors.SeedExhaustiveError {
+    public declare readonly body: SeedExhaustive.types.ObjectWithRequiredField;
+
     constructor(body: SeedExhaustive.types.ObjectWithRequiredField, rawResponse?: core.RawResponse) {
         super({
             message: "ObjectWithRequiredFieldError",

--- a/seed/ts-sdk/exhaustive/retain-original-casing/src/api/resources/types/resources/union/errors/ErrorWithUnionBody.ts
+++ b/seed/ts-sdk/exhaustive/retain-original-casing/src/api/resources/types/resources/union/errors/ErrorWithUnionBody.ts
@@ -5,6 +5,8 @@ import * as errors from "../../../../../../errors/index.js";
 import type * as SeedExhaustive from "../../../../../index.js";
 
 export class ErrorWithUnionBody extends errors.SeedExhaustiveError {
+    public declare readonly body: SeedExhaustive.types.Animal;
+
     constructor(body: SeedExhaustive.types.Animal, rawResponse?: core.RawResponse) {
         super({
             message: "ErrorWithUnionBody",

--- a/seed/ts-sdk/exhaustive/serde-layer/src/api/resources/generalErrors/errors/BadRequestBody.ts
+++ b/seed/ts-sdk/exhaustive/serde-layer/src/api/resources/generalErrors/errors/BadRequestBody.ts
@@ -5,6 +5,8 @@ import * as errors from "../../../../errors/index.js";
 import type * as SeedExhaustive from "../../../index.js";
 
 export class BadRequestBody extends errors.SeedExhaustiveError {
+    public declare readonly body: SeedExhaustive.BadObjectRequestInfo;
+
     constructor(body: SeedExhaustive.BadObjectRequestInfo, rawResponse?: core.RawResponse) {
         super({
             message: "BadRequestBody",

--- a/seed/ts-sdk/exhaustive/serde-layer/src/api/resources/types/resources/enum/errors/ErrorWithEnumBody.ts
+++ b/seed/ts-sdk/exhaustive/serde-layer/src/api/resources/types/resources/enum/errors/ErrorWithEnumBody.ts
@@ -5,6 +5,8 @@ import * as errors from "../../../../../../errors/index.js";
 import type * as SeedExhaustive from "../../../../../index.js";
 
 export class ErrorWithEnumBody extends errors.SeedExhaustiveError {
+    public declare readonly body: SeedExhaustive.types.WeatherReport;
+
     constructor(body: SeedExhaustive.types.WeatherReport, rawResponse?: core.RawResponse) {
         super({
             message: "ErrorWithEnumBody",

--- a/seed/ts-sdk/exhaustive/serde-layer/src/api/resources/types/resources/object/errors/NestedObjectWithOptionalFieldError.ts
+++ b/seed/ts-sdk/exhaustive/serde-layer/src/api/resources/types/resources/object/errors/NestedObjectWithOptionalFieldError.ts
@@ -5,6 +5,8 @@ import * as errors from "../../../../../../errors/index.js";
 import type * as SeedExhaustive from "../../../../../index.js";
 
 export class NestedObjectWithOptionalFieldError extends errors.SeedExhaustiveError {
+    public declare readonly body: SeedExhaustive.types.NestedObjectWithOptionalField;
+
     constructor(body: SeedExhaustive.types.NestedObjectWithOptionalField, rawResponse?: core.RawResponse) {
         super({
             message: "NestedObjectWithOptionalFieldError",

--- a/seed/ts-sdk/exhaustive/serde-layer/src/api/resources/types/resources/object/errors/NestedObjectWithRequiredFieldError.ts
+++ b/seed/ts-sdk/exhaustive/serde-layer/src/api/resources/types/resources/object/errors/NestedObjectWithRequiredFieldError.ts
@@ -5,6 +5,8 @@ import * as errors from "../../../../../../errors/index.js";
 import type * as SeedExhaustive from "../../../../../index.js";
 
 export class NestedObjectWithRequiredFieldError extends errors.SeedExhaustiveError {
+    public declare readonly body: SeedExhaustive.types.NestedObjectWithRequiredField;
+
     constructor(body: SeedExhaustive.types.NestedObjectWithRequiredField, rawResponse?: core.RawResponse) {
         super({
             message: "NestedObjectWithRequiredFieldError",

--- a/seed/ts-sdk/exhaustive/serde-layer/src/api/resources/types/resources/object/errors/ObjectWithOptionalFieldError.ts
+++ b/seed/ts-sdk/exhaustive/serde-layer/src/api/resources/types/resources/object/errors/ObjectWithOptionalFieldError.ts
@@ -5,6 +5,8 @@ import * as errors from "../../../../../../errors/index.js";
 import type * as SeedExhaustive from "../../../../../index.js";
 
 export class ObjectWithOptionalFieldError extends errors.SeedExhaustiveError {
+    public declare readonly body: SeedExhaustive.types.ObjectWithOptionalField;
+
     constructor(body: SeedExhaustive.types.ObjectWithOptionalField, rawResponse?: core.RawResponse) {
         super({
             message: "ObjectWithOptionalFieldError",

--- a/seed/ts-sdk/exhaustive/serde-layer/src/api/resources/types/resources/object/errors/ObjectWithRequiredFieldError.ts
+++ b/seed/ts-sdk/exhaustive/serde-layer/src/api/resources/types/resources/object/errors/ObjectWithRequiredFieldError.ts
@@ -5,6 +5,8 @@ import * as errors from "../../../../../../errors/index.js";
 import type * as SeedExhaustive from "../../../../../index.js";
 
 export class ObjectWithRequiredFieldError extends errors.SeedExhaustiveError {
+    public declare readonly body: SeedExhaustive.types.ObjectWithRequiredField;
+
     constructor(body: SeedExhaustive.types.ObjectWithRequiredField, rawResponse?: core.RawResponse) {
         super({
             message: "ObjectWithRequiredFieldError",

--- a/seed/ts-sdk/exhaustive/serde-layer/src/api/resources/types/resources/union/errors/ErrorWithUnionBody.ts
+++ b/seed/ts-sdk/exhaustive/serde-layer/src/api/resources/types/resources/union/errors/ErrorWithUnionBody.ts
@@ -5,6 +5,8 @@ import * as errors from "../../../../../../errors/index.js";
 import type * as SeedExhaustive from "../../../../../index.js";
 
 export class ErrorWithUnionBody extends errors.SeedExhaustiveError {
+    public declare readonly body: SeedExhaustive.types.Animal;
+
     constructor(body: SeedExhaustive.types.Animal, rawResponse?: core.RawResponse) {
         super({
             message: "ErrorWithUnionBody",

--- a/seed/ts-sdk/exhaustive/use-jest/src/api/resources/generalErrors/errors/BadRequestBody.ts
+++ b/seed/ts-sdk/exhaustive/use-jest/src/api/resources/generalErrors/errors/BadRequestBody.ts
@@ -5,6 +5,8 @@ import * as errors from "../../../../errors/index.js";
 import type * as SeedExhaustive from "../../../index.js";
 
 export class BadRequestBody extends errors.SeedExhaustiveError {
+    public declare readonly body: SeedExhaustive.BadObjectRequestInfo;
+
     constructor(body: SeedExhaustive.BadObjectRequestInfo, rawResponse?: core.RawResponse) {
         super({
             message: "BadRequestBody",

--- a/seed/ts-sdk/exhaustive/use-jest/src/api/resources/types/resources/enum/errors/ErrorWithEnumBody.ts
+++ b/seed/ts-sdk/exhaustive/use-jest/src/api/resources/types/resources/enum/errors/ErrorWithEnumBody.ts
@@ -5,6 +5,8 @@ import * as errors from "../../../../../../errors/index.js";
 import type * as SeedExhaustive from "../../../../../index.js";
 
 export class ErrorWithEnumBody extends errors.SeedExhaustiveError {
+    public declare readonly body: SeedExhaustive.types.WeatherReport;
+
     constructor(body: SeedExhaustive.types.WeatherReport, rawResponse?: core.RawResponse) {
         super({
             message: "ErrorWithEnumBody",

--- a/seed/ts-sdk/exhaustive/use-jest/src/api/resources/types/resources/object/errors/NestedObjectWithOptionalFieldError.ts
+++ b/seed/ts-sdk/exhaustive/use-jest/src/api/resources/types/resources/object/errors/NestedObjectWithOptionalFieldError.ts
@@ -5,6 +5,8 @@ import * as errors from "../../../../../../errors/index.js";
 import type * as SeedExhaustive from "../../../../../index.js";
 
 export class NestedObjectWithOptionalFieldError extends errors.SeedExhaustiveError {
+    public declare readonly body: SeedExhaustive.types.NestedObjectWithOptionalField;
+
     constructor(body: SeedExhaustive.types.NestedObjectWithOptionalField, rawResponse?: core.RawResponse) {
         super({
             message: "NestedObjectWithOptionalFieldError",

--- a/seed/ts-sdk/exhaustive/use-jest/src/api/resources/types/resources/object/errors/NestedObjectWithRequiredFieldError.ts
+++ b/seed/ts-sdk/exhaustive/use-jest/src/api/resources/types/resources/object/errors/NestedObjectWithRequiredFieldError.ts
@@ -5,6 +5,8 @@ import * as errors from "../../../../../../errors/index.js";
 import type * as SeedExhaustive from "../../../../../index.js";
 
 export class NestedObjectWithRequiredFieldError extends errors.SeedExhaustiveError {
+    public declare readonly body: SeedExhaustive.types.NestedObjectWithRequiredField;
+
     constructor(body: SeedExhaustive.types.NestedObjectWithRequiredField, rawResponse?: core.RawResponse) {
         super({
             message: "NestedObjectWithRequiredFieldError",

--- a/seed/ts-sdk/exhaustive/use-jest/src/api/resources/types/resources/object/errors/ObjectWithOptionalFieldError.ts
+++ b/seed/ts-sdk/exhaustive/use-jest/src/api/resources/types/resources/object/errors/ObjectWithOptionalFieldError.ts
@@ -5,6 +5,8 @@ import * as errors from "../../../../../../errors/index.js";
 import type * as SeedExhaustive from "../../../../../index.js";
 
 export class ObjectWithOptionalFieldError extends errors.SeedExhaustiveError {
+    public declare readonly body: SeedExhaustive.types.ObjectWithOptionalField;
+
     constructor(body: SeedExhaustive.types.ObjectWithOptionalField, rawResponse?: core.RawResponse) {
         super({
             message: "ObjectWithOptionalFieldError",

--- a/seed/ts-sdk/exhaustive/use-jest/src/api/resources/types/resources/object/errors/ObjectWithRequiredFieldError.ts
+++ b/seed/ts-sdk/exhaustive/use-jest/src/api/resources/types/resources/object/errors/ObjectWithRequiredFieldError.ts
@@ -5,6 +5,8 @@ import * as errors from "../../../../../../errors/index.js";
 import type * as SeedExhaustive from "../../../../../index.js";
 
 export class ObjectWithRequiredFieldError extends errors.SeedExhaustiveError {
+    public declare readonly body: SeedExhaustive.types.ObjectWithRequiredField;
+
     constructor(body: SeedExhaustive.types.ObjectWithRequiredField, rawResponse?: core.RawResponse) {
         super({
             message: "ObjectWithRequiredFieldError",

--- a/seed/ts-sdk/exhaustive/use-jest/src/api/resources/types/resources/union/errors/ErrorWithUnionBody.ts
+++ b/seed/ts-sdk/exhaustive/use-jest/src/api/resources/types/resources/union/errors/ErrorWithUnionBody.ts
@@ -5,6 +5,8 @@ import * as errors from "../../../../../../errors/index.js";
 import type * as SeedExhaustive from "../../../../../index.js";
 
 export class ErrorWithUnionBody extends errors.SeedExhaustiveError {
+    public declare readonly body: SeedExhaustive.types.Animal;
+
     constructor(body: SeedExhaustive.types.Animal, rawResponse?: core.RawResponse) {
         super({
             message: "ErrorWithUnionBody",

--- a/seed/ts-sdk/exhaustive/web-stream-wrapper/src/api/resources/generalErrors/errors/BadRequestBody.ts
+++ b/seed/ts-sdk/exhaustive/web-stream-wrapper/src/api/resources/generalErrors/errors/BadRequestBody.ts
@@ -5,6 +5,8 @@ import * as errors from "../../../../errors/index.js";
 import type * as SeedExhaustive from "../../../index.js";
 
 export class BadRequestBody extends errors.SeedExhaustiveError {
+    public declare readonly body: SeedExhaustive.BadObjectRequestInfo;
+
     constructor(body: SeedExhaustive.BadObjectRequestInfo, rawResponse?: core.RawResponse) {
         super({
             message: "BadRequestBody",

--- a/seed/ts-sdk/exhaustive/web-stream-wrapper/src/api/resources/types/resources/enum/errors/ErrorWithEnumBody.ts
+++ b/seed/ts-sdk/exhaustive/web-stream-wrapper/src/api/resources/types/resources/enum/errors/ErrorWithEnumBody.ts
@@ -5,6 +5,8 @@ import * as errors from "../../../../../../errors/index.js";
 import type * as SeedExhaustive from "../../../../../index.js";
 
 export class ErrorWithEnumBody extends errors.SeedExhaustiveError {
+    public declare readonly body: SeedExhaustive.types.WeatherReport;
+
     constructor(body: SeedExhaustive.types.WeatherReport, rawResponse?: core.RawResponse) {
         super({
             message: "ErrorWithEnumBody",

--- a/seed/ts-sdk/exhaustive/web-stream-wrapper/src/api/resources/types/resources/object/errors/NestedObjectWithOptionalFieldError.ts
+++ b/seed/ts-sdk/exhaustive/web-stream-wrapper/src/api/resources/types/resources/object/errors/NestedObjectWithOptionalFieldError.ts
@@ -5,6 +5,8 @@ import * as errors from "../../../../../../errors/index.js";
 import type * as SeedExhaustive from "../../../../../index.js";
 
 export class NestedObjectWithOptionalFieldError extends errors.SeedExhaustiveError {
+    public declare readonly body: SeedExhaustive.types.NestedObjectWithOptionalField;
+
     constructor(body: SeedExhaustive.types.NestedObjectWithOptionalField, rawResponse?: core.RawResponse) {
         super({
             message: "NestedObjectWithOptionalFieldError",

--- a/seed/ts-sdk/exhaustive/web-stream-wrapper/src/api/resources/types/resources/object/errors/NestedObjectWithRequiredFieldError.ts
+++ b/seed/ts-sdk/exhaustive/web-stream-wrapper/src/api/resources/types/resources/object/errors/NestedObjectWithRequiredFieldError.ts
@@ -5,6 +5,8 @@ import * as errors from "../../../../../../errors/index.js";
 import type * as SeedExhaustive from "../../../../../index.js";
 
 export class NestedObjectWithRequiredFieldError extends errors.SeedExhaustiveError {
+    public declare readonly body: SeedExhaustive.types.NestedObjectWithRequiredField;
+
     constructor(body: SeedExhaustive.types.NestedObjectWithRequiredField, rawResponse?: core.RawResponse) {
         super({
             message: "NestedObjectWithRequiredFieldError",

--- a/seed/ts-sdk/exhaustive/web-stream-wrapper/src/api/resources/types/resources/object/errors/ObjectWithOptionalFieldError.ts
+++ b/seed/ts-sdk/exhaustive/web-stream-wrapper/src/api/resources/types/resources/object/errors/ObjectWithOptionalFieldError.ts
@@ -5,6 +5,8 @@ import * as errors from "../../../../../../errors/index.js";
 import type * as SeedExhaustive from "../../../../../index.js";
 
 export class ObjectWithOptionalFieldError extends errors.SeedExhaustiveError {
+    public declare readonly body: SeedExhaustive.types.ObjectWithOptionalField;
+
     constructor(body: SeedExhaustive.types.ObjectWithOptionalField, rawResponse?: core.RawResponse) {
         super({
             message: "ObjectWithOptionalFieldError",

--- a/seed/ts-sdk/exhaustive/web-stream-wrapper/src/api/resources/types/resources/object/errors/ObjectWithRequiredFieldError.ts
+++ b/seed/ts-sdk/exhaustive/web-stream-wrapper/src/api/resources/types/resources/object/errors/ObjectWithRequiredFieldError.ts
@@ -5,6 +5,8 @@ import * as errors from "../../../../../../errors/index.js";
 import type * as SeedExhaustive from "../../../../../index.js";
 
 export class ObjectWithRequiredFieldError extends errors.SeedExhaustiveError {
+    public declare readonly body: SeedExhaustive.types.ObjectWithRequiredField;
+
     constructor(body: SeedExhaustive.types.ObjectWithRequiredField, rawResponse?: core.RawResponse) {
         super({
             message: "ObjectWithRequiredFieldError",

--- a/seed/ts-sdk/exhaustive/web-stream-wrapper/src/api/resources/types/resources/union/errors/ErrorWithUnionBody.ts
+++ b/seed/ts-sdk/exhaustive/web-stream-wrapper/src/api/resources/types/resources/union/errors/ErrorWithUnionBody.ts
@@ -5,6 +5,8 @@ import * as errors from "../../../../../../errors/index.js";
 import type * as SeedExhaustive from "../../../../../index.js";
 
 export class ErrorWithUnionBody extends errors.SeedExhaustiveError {
+    public declare readonly body: SeedExhaustive.types.Animal;
+
     constructor(body: SeedExhaustive.types.Animal, rawResponse?: core.RawResponse) {
         super({
             message: "ErrorWithUnionBody",

--- a/seed/ts-sdk/folders/src/api/resources/folder/resources/service/errors/NotFoundError.ts
+++ b/seed/ts-sdk/folders/src/api/resources/folder/resources/service/errors/NotFoundError.ts
@@ -4,6 +4,8 @@ import type * as core from "../../../../../../core/index.js";
 import * as errors from "../../../../../../errors/index.js";
 
 export class NotFoundError extends errors.SeedApiError {
+    public declare readonly body: string;
+
     constructor(body: string, rawResponse?: core.RawResponse) {
         super({
             message: "NotFoundError",

--- a/seed/ts-sdk/imdb/branded-string-aliases/src/api/errors/NotFoundError.ts
+++ b/seed/ts-sdk/imdb/branded-string-aliases/src/api/errors/NotFoundError.ts
@@ -5,6 +5,8 @@ import * as errors from "../../errors/index.js";
 import type * as SeedApi from "../index.js";
 
 export class NotFoundError extends errors.SeedApiError {
+    public declare readonly body: SeedApi.MovieId;
+
     constructor(body: SeedApi.MovieId, rawResponse?: core.RawResponse) {
         super({
             message: "NotFoundError",

--- a/seed/ts-sdk/imdb/no-custom-config/src/api/errors/NotFoundError.ts
+++ b/seed/ts-sdk/imdb/no-custom-config/src/api/errors/NotFoundError.ts
@@ -5,6 +5,8 @@ import * as errors from "../../errors/index.js";
 import type * as SeedApi from "../index.js";
 
 export class NotFoundError extends errors.SeedApiError {
+    public declare readonly body: SeedApi.MovieId;
+
     constructor(body: SeedApi.MovieId, rawResponse?: core.RawResponse) {
         super({
             message: "NotFoundError",

--- a/seed/ts-sdk/imdb/omit-undefined/src/api/errors/NotFoundError.ts
+++ b/seed/ts-sdk/imdb/omit-undefined/src/api/errors/NotFoundError.ts
@@ -5,6 +5,8 @@ import * as errors from "../../errors/index.js";
 import type * as SeedApi from "../index.js";
 
 export class NotFoundError extends errors.SeedApiError {
+    public declare readonly body: SeedApi.MovieId;
+
     constructor(body: SeedApi.MovieId, rawResponse?: core.RawResponse) {
         super({
             message: "NotFoundError",

--- a/seed/ts-sdk/nullable-request-body/src/api/errors/UnprocessableEntityError.ts
+++ b/seed/ts-sdk/nullable-request-body/src/api/errors/UnprocessableEntityError.ts
@@ -5,6 +5,8 @@ import * as errors from "../../errors/index.js";
 import type * as SeedApi from "../index.js";
 
 export class UnprocessableEntityError extends errors.SeedApiError {
+    public declare readonly body: SeedApi.PlainObject;
+
     constructor(body: SeedApi.PlainObject, rawResponse?: core.RawResponse) {
         super({
             message: "UnprocessableEntityError",

--- a/seed/ts-sdk/server-sent-event-examples/src/api/resources/completions/errors/BadRequestError.ts
+++ b/seed/ts-sdk/server-sent-event-examples/src/api/resources/completions/errors/BadRequestError.ts
@@ -4,6 +4,8 @@ import type * as core from "../../../../core/index.js";
 import * as errors from "../../../../errors/index.js";
 
 export class BadRequestError extends errors.SeedServerSentEventsError {
+    public declare readonly body: string;
+
     constructor(body: string, rawResponse?: core.RawResponse) {
         super({
             message: "BadRequestError",

--- a/seed/ts-sdk/trace/no-custom-config/src/api/resources/playlist/errors/PlaylistIdNotFoundError.ts
+++ b/seed/ts-sdk/trace/no-custom-config/src/api/resources/playlist/errors/PlaylistIdNotFoundError.ts
@@ -5,6 +5,8 @@ import * as errors from "../../../../errors/index.js";
 import type * as SeedTrace from "../../../index.js";
 
 export class PlaylistIdNotFoundError extends errors.SeedTraceError {
+    public declare readonly body: SeedTrace.PlaylistIdNotFoundErrorBody;
+
     constructor(body: SeedTrace.PlaylistIdNotFoundErrorBody, rawResponse?: core.RawResponse) {
         super({
             message: "PlaylistIdNotFoundError",

--- a/seed/ts-sdk/trace/serde/src/api/resources/playlist/errors/PlaylistIdNotFoundError.ts
+++ b/seed/ts-sdk/trace/serde/src/api/resources/playlist/errors/PlaylistIdNotFoundError.ts
@@ -5,6 +5,8 @@ import * as errors from "../../../../errors/index.js";
 import type * as SeedTrace from "../../../index.js";
 
 export class PlaylistIdNotFoundError extends errors.SeedTraceError {
+    public declare readonly body: SeedTrace.PlaylistIdNotFoundErrorBody;
+
     constructor(body: SeedTrace.PlaylistIdNotFoundErrorBody, rawResponse?: core.RawResponse) {
         super({
             message: "PlaylistIdNotFoundError",

--- a/seed/ts-sdk/ts-error-name-collision/src/api/resources/commons/errors/BadRequestError.ts
+++ b/seed/ts-sdk/ts-error-name-collision/src/api/resources/commons/errors/BadRequestError.ts
@@ -5,6 +5,8 @@ import * as errors from "../../../../errors/index.js";
 import type * as SeedErrors from "../../../index.js";
 
 export class BadRequestError extends errors.SeedErrorsError {
+    public declare readonly body: SeedErrors.ErrorBody;
+
     constructor(body: SeedErrors.ErrorBody, rawResponse?: core.RawResponse) {
         super({
             message: "BadRequestError",

--- a/seed/ts-sdk/ts-error-name-collision/src/api/resources/commons/errors/InternalServerError.ts
+++ b/seed/ts-sdk/ts-error-name-collision/src/api/resources/commons/errors/InternalServerError.ts
@@ -5,6 +5,8 @@ import * as errors from "../../../../errors/index.js";
 import type * as SeedErrors from "../../../index.js";
 
 export class InternalServerError extends errors.SeedErrorsError {
+    public declare readonly body: SeedErrors.ErrorBody;
+
     constructor(body: SeedErrors.ErrorBody, rawResponse?: core.RawResponse) {
         super({
             message: "InternalServerError",

--- a/seed/ts-sdk/ts-error-name-collision/src/api/resources/commons/errors/NotFoundError.ts
+++ b/seed/ts-sdk/ts-error-name-collision/src/api/resources/commons/errors/NotFoundError.ts
@@ -5,6 +5,8 @@ import * as errors from "../../../../errors/index.js";
 import type * as SeedErrors from "../../../index.js";
 
 export class NotFoundError extends errors.SeedErrorsError {
+    public declare readonly body: SeedErrors.ErrorBody;
+
     constructor(body: SeedErrors.ErrorBody, rawResponse?: core.RawResponse) {
         super({
             message: "NotFoundError",

--- a/seed/ts-sdk/ts-error-name-collision/src/api/resources/simple/errors/FooTooLittle.ts
+++ b/seed/ts-sdk/ts-error-name-collision/src/api/resources/simple/errors/FooTooLittle.ts
@@ -5,6 +5,8 @@ import * as errors from "../../../../errors/index.js";
 import type * as SeedErrors from "../../../index.js";
 
 export class FooTooLittle extends errors.SeedErrorsError {
+    public declare readonly body: SeedErrors.ErrorBody;
+
     constructor(body: SeedErrors.ErrorBody, rawResponse?: core.RawResponse) {
         super({
             message: "FooTooLittle",

--- a/seed/ts-sdk/ts-error-name-collision/src/api/resources/simple/errors/FooTooMuch.ts
+++ b/seed/ts-sdk/ts-error-name-collision/src/api/resources/simple/errors/FooTooMuch.ts
@@ -5,6 +5,8 @@ import * as errors from "../../../../errors/index.js";
 import type * as SeedErrors from "../../../index.js";
 
 export class FooTooMuch extends errors.SeedErrorsError {
+    public declare readonly body: SeedErrors.ErrorBody;
+
     constructor(body: SeedErrors.ErrorBody, rawResponse?: core.RawResponse) {
         super({
             message: "FooTooMuch",

--- a/seed/ts-sdk/ts-express-casing/src/api/resources/imdb/errors/MovieDoesNotExistError.ts
+++ b/seed/ts-sdk/ts-express-casing/src/api/resources/imdb/errors/MovieDoesNotExistError.ts
@@ -5,6 +5,8 @@ import * as errors from "../../../../errors/index.js";
 import type * as SeedApi from "../../../index.js";
 
 export class MovieDoesNotExistError extends errors.SeedApiError {
+    public declare readonly body: SeedApi.MovieId;
+
     constructor(body: SeedApi.MovieId, rawResponse?: core.RawResponse) {
         super({
             message: "MovieDoesNotExistError",


### PR DESCRIPTION
## Description
Linear ticket: Refs —

Generated TS SDK error subclasses type their constructor `body` parameter, but instances still expose `body?: unknown` inherited from the base API error class, so `err.body?.code` fails to type-check in catch blocks and consumers must cast.

This makes error subclasses with a declared body schema redeclare the property:

```ts
export class UnauthorizedRequest extends errors.SeedBasicAuthError {
    public declare readonly body: SeedBasicAuth.UnauthorizedRequestErrorBody;

    constructor(body: SeedBasicAuth.UnauthorizedRequestErrorBody, rawResponse?: core.RawResponse) { ... }
}
```

`declare` is type-only (no runtime field emit, so no `useDefineForClassFields` clobbering of the value assigned in the base constructor). Errors whose body type is `unknown` (or absent) are unchanged.

## Changes Made
- `GeneratedSdkErrorClassImpl.getClassProperties`: emit `public declare readonly body[?]: <BodyType>` when `errorDeclaration.type` is present and not `unknown` (optionality mirrors the constructor parameter)
- Updated/added unit tests + snapshots (`SdkErrorGenerator.test.ts`), including a new unknown-body case verifying no redeclaration
- Regenerated affected ts-sdk seed fixtures (14 fixtures, 44/44 seed test cases passed)
- Changelog entry under `generators/typescript/sdk/changes/unreleased/`
- [ ] Updated README.md generator (if applicable)

## Testing
- [x] Unit tests added/updated (15 passed, snapshots reviewed)
- [x] Manual testing completed (seed test `--generator ts-sdk` across all affected fixtures: 44/44 passed)

Link to Devin session: https://app.devin.ai/sessions/0599f25ee1c94a199bfebc8fec336f15
Requested by: @iamnamananand996
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/17272" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->