### PR TITLE
feat(cli): --pack builds a source zip artifact for Go SDKs

### DIFF
--- a/packages/cli/cli/changes/unreleased/pack-go-source-zip.yml
+++ b/packages/cli/cli/changes/unreleased/pack-go-source-zip.yml
@@ -1,0 +1,7 @@
+- summary: |
+    `fern generate --pack` now produces a source zip artifact for Go SDKs in `fern-dist/`
+    (`<output-dir>-source.zip`). Go modules have no binary package format, so the zip contains the
+    module source (excluding `fern-dist/` and `.git/`) and can be shared internally and referenced
+    with a `replace` directive in `go.mod`. The zip is built in-process, so it works identically in
+    host and docker pack modes without any toolchain.
+  type: feat

--- a/packages/cli/cli/package.json
+++ b/packages/cli/cli/package.json
@@ -116,6 +116,7 @@
     "@types/pngjs": "catalog:",
     "@types/semver": "catalog:",
     "@types/tar": "catalog:",
+    "@types/yazl": "catalog:",
     "@types/url-join": "4.0.1",
     "@types/ws": "catalog:",
     "@types/yargs": "^17.0.28",
@@ -144,6 +145,7 @@
     "vitest": "catalog:",
     "ws": "catalog:",
     "yaml": "catalog:",
-    "yargs": "^17.4.1"
+    "yargs": "^17.4.1",
+    "yazl": "catalog:"
   }
 }

--- a/packages/cli/cli/src/commands/generate/__test__/packLocalOutput.test.ts
+++ b/packages/cli/cli/src/commands/generate/__test__/packLocalOutput.test.ts
@@ -1,7 +1,7 @@
 import { generatorsYml } from "@fern-api/configuration-loader";
 import { AbsoluteFilePath } from "@fern-api/fs-utils";
 import { createMockTaskContext } from "@fern-api/task-context";
-import { mkdir, mkdtemp, writeFile } from "fs/promises";
+import { mkdir, mkdtemp, readdir, stat, writeFile } from "fs/promises";
 import { tmpdir } from "os";
 import path from "path";
 import { beforeEach, describe, expect, it, vi } from "vitest";
@@ -94,7 +94,10 @@ describe("packLocalOutputForGroup", () => {
         expect(commands[2]).toContain("npm pack");
     });
 
-    it("does not run any command for go generators", async () => {
+    it("zips the module source for go generators without running any toolchain command", async () => {
+        await writeFile(path.join(outputDir, "go.mod"), "module example.com/test\n");
+        await mkdir(path.join(outputDir, "client"), { recursive: true });
+        await writeFile(path.join(outputDir, "client", "client.go"), "package client\n");
         const group = {
             groupName: "test",
             audiences: { type: "all" },
@@ -103,6 +106,10 @@ describe("packLocalOutputForGroup", () => {
 
         await packLocalOutputForGroup({ group, context: createMockTaskContext() });
         expect(loggingExecaMock).not.toHaveBeenCalled();
+        const distFiles = await readdir(path.join(outputDir, "fern-dist"));
+        expect(distFiles).toEqual([`${path.basename(outputDir)}-source.zip`]);
+        const zipStat = await stat(path.join(outputDir, "fern-dist", `${path.basename(outputDir)}-source.zip`));
+        expect(zipStat.size).toBeGreaterThan(0);
     });
 
     it("packs the non-test csproj for csharp generators", async () => {

--- a/packages/cli/cli/src/commands/generate/packLocalOutput.ts
+++ b/packages/cli/cli/src/commands/generate/packLocalOutput.ts
@@ -257,6 +257,7 @@ async function zipDirectory({
     await addEntries(sourceDir, "");
     zip.end();
     await new Promise<void>((resolve, reject) => {
+        zip.outputStream.on("error", reject);
         zip.outputStream.pipe(createWriteStream(zipPath)).on("close", resolve).on("error", reject);
     });
 }

--- a/packages/cli/cli/src/commands/generate/packLocalOutput.ts
+++ b/packages/cli/cli/src/commands/generate/packLocalOutput.ts
@@ -3,7 +3,10 @@ import { assertNever, ContainerRunner } from "@fern-api/core-utils";
 import { AbsoluteFilePath, doesPathExist, join, RelativeFilePath } from "@fern-api/fs-utils";
 import { loggingExeca } from "@fern-api/logging-execa";
 import { TaskContext } from "@fern-api/task-context";
+import { createWriteStream } from "fs";
 import { copyFile, mkdir, readdir, readFile, rename, rmdir } from "fs/promises";
+import { basename } from "path";
+import { ZipFile } from "yazl";
 
 /** Directory (inside each generator's local output) where packaged artifacts are written. */
 export const PACK_OUTPUT_DIRECTORY = "fern-dist";
@@ -149,12 +152,19 @@ async function packOutputForLanguage({
             logArtifacts({ distDir, context });
             return;
         }
-        case "go":
-            context.logger.warn(
-                "Go SDKs are distributed as source modules, so there is no package artifact to build. " +
-                    "Share the output directory itself (e.g. as a zip), or reference it with a 'replace' directive in go.mod."
-            );
+        case "go": {
+            // Go modules have no binary package format ('go get' always fetches source), so the
+            // shareable artifact is a zip of the module source. Consumers unzip it and reference
+            // it with a 'replace' directive in go.mod.
+            await mkdir(distDir, { recursive: true });
+            const zipName = `${basename(outputPath)}-source.zip`;
+            await zipDirectory({
+                sourceDir: outputPath,
+                zipPath: join(distDir, RelativeFilePath.of(zipName))
+            });
+            logArtifacts({ distDir, context });
             return;
+        }
         case "swift":
             context.logger.warn(
                 "Swift SDKs are distributed as source packages (Swift Package Manager), so there is no package artifact to build. " +
@@ -215,6 +225,40 @@ async function runPackCommands({
             cwd: outputPath
         });
     }
+}
+
+/**
+ * Zips the contents of a directory (excluding fern-dist itself and any .git directory) into
+ * `zipPath`. Runs in-process, so it behaves identically in host and docker pack modes and
+ * requires no language toolchain.
+ */
+async function zipDirectory({
+    sourceDir,
+    zipPath
+}: {
+    sourceDir: AbsoluteFilePath;
+    zipPath: AbsoluteFilePath;
+}): Promise<void> {
+    const zip = new ZipFile();
+    const addEntries = async (dir: AbsoluteFilePath, prefix: string): Promise<void> => {
+        for (const entry of await readdir(dir, { withFileTypes: true })) {
+            if (prefix === "" && (entry.name === PACK_OUTPUT_DIRECTORY || entry.name === ".git")) {
+                continue;
+            }
+            const entryPath = join(dir, RelativeFilePath.of(entry.name));
+            const entryName = prefix === "" ? entry.name : `${prefix}/${entry.name}`;
+            if (entry.isDirectory()) {
+                await addEntries(entryPath, entryName);
+            } else if (entry.isFile()) {
+                zip.addFile(entryPath, entryName);
+            }
+        }
+    };
+    await addEntries(sourceDir, "");
+    zip.end();
+    await new Promise<void>((resolve, reject) => {
+        zip.outputStream.pipe(createWriteStream(zipPath)).on("close", resolve).on("error", reject);
+    });
 }
 
 async function removeDistDirIfEmpty(outputPath: AbsoluteFilePath): Promise<void> {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4555,6 +4555,9 @@ importers:
       '@types/yargs':
         specifier: ^17.0.28
         version: 17.0.35
+      '@types/yazl':
+        specifier: 'catalog:'
+        version: 3.3.1
       axios:
         specifier: 'catalog:'
         version: 1.16.0
@@ -4633,6 +4636,9 @@ importers:
       yargs:
         specifier: ^17.4.1
         version: 17.7.2
+      yazl:
+        specifier: 'catalog:'
+        version: 3.3.1
     optionalDependencies:
       '@boundaryml/baml':
         specifier: 'catalog:'


### PR DESCRIPTION
## Description
Follow-up to #17284. Go modules have no binary package format (`go get` always fetches source), so `--pack` previously just logged a warning for Go generators and produced nothing in `fern-dist/`. Users sharing SDKs internally via `--pack` had no shareable file for Go.

Now `--pack` zips the Go module source into `fern-dist/<output-dir>-source.zip` (excluding `fern-dist/` itself and `.git/`). Consumers unzip it and reference it with a `replace` directive in `go.mod`. The zip is built in-process with `yazl` (already in the workspace catalog), so it behaves identically in `host` and `docker` pack modes and needs no toolchain or Docker image.

## Changes Made
- `packLocalOutput.ts`: `case "go"` now writes a source zip via a new `zipDirectory` helper instead of only warning
- Added `yazl` / `@types/yazl` (catalog versions) to `@fern-api/cli`
- CLI changelog entry under `changes/unreleased/`

## Testing
- [x] Unit tests added/updated — go pack test now asserts a non-empty `<dir>-source.zip` is created in `fern-dist/` with no toolchain command executed (8/8 pack tests pass)
- [x] Manual testing completed — compile passes; verified against twilio-core-fern-config


Link to Devin session: https://app.devin.ai/sessions/0076a65e5b6743f78ba15496f2573f41
Requested by: @iamnamananand996
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/17293" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->