### PR TITLE
feat(cli): rename --pack to --package and add --package-only

### DIFF
--- a/packages/cli/cli/changes/unreleased/rename-pack-to-package-add-package-only.yml
+++ b/packages/cli/cli/changes/unreleased/rename-pack-to-package-add-package-only.yml
@@ -1,0 +1,6 @@
+- summary: |
+    Rename the `--pack` and `--pack-mode` flags on `fern generate` to `--package` and
+    `--package-mode`, and add `--package-only`, which builds the distributable artifact into
+    `fern-dist/` and removes the generated SDK source, leaving only the package in the output
+    directory.
+  type: feat

--- a/packages/cli/cli/src/cli.ts
+++ b/packages/cli/cli/src/cli.ts
@@ -875,17 +875,23 @@ function addGenerateCommand(cli: Argv<GlobalCliOptions>, cliContext: CliContext)
                     description:
                         "Generate test files even when generating to a local file system (tests are normally only generated for GitHub output modes)"
                 })
-                .option("pack", {
+                .option("package", {
                     boolean: true,
                     default: false,
                     description:
                         "After generating to the local file system, build distributable package artifacts (npm tarball, wheel, JAR, NuGet package, gem, etc.) into a fern-dist/ folder inside the output directory."
                 })
-                .option("pack-mode", {
+                .option("package-mode", {
                     choices: ["host", "docker"] as const,
                     default: "host" as const,
                     description:
-                        "Where --pack runs the packaging toolchain: 'host' uses toolchains installed on this machine; 'docker' runs each toolchain inside an official Docker image (node, python, gradle, dotnet/sdk, ruby, composer, rust) with the output directory mounted, so no local toolchains are needed."
+                        "Where --package runs the packaging toolchain: 'host' uses toolchains installed on this machine; 'docker' runs each toolchain inside an official Docker image (node, python, gradle, dotnet/sdk, ruby, composer, rust) with the output directory mounted, so no local toolchains are needed."
+                })
+                .option("package-only", {
+                    boolean: true,
+                    default: false,
+                    description:
+                        "Like --package, but only the fern-dist/ artifact is kept in the output directory — the generated SDK source is removed after the package is built."
                 }),
         async (argv) => {
             if (argv.api != null && argv.api.length > 0 && argv.docs != null) {
@@ -961,22 +967,25 @@ function addGenerateCommand(cli: Argv<GlobalCliOptions>, cliContext: CliContext)
                     { code: CliError.Code.ConfigError }
                 );
             }
-            if (argv.pack && argv.preview) {
-                return cliContext.failWithoutThrowing("The --pack flag cannot be used with --preview.", undefined, {
+            const shouldPackage = argv.package || argv.packageOnly;
+            if (shouldPackage && argv.preview) {
+                return cliContext.failWithoutThrowing("The --package flag cannot be used with --preview.", undefined, {
                     code: CliError.Code.ConfigError
                 });
             }
-            if (argv.pack && argv.docs != null) {
+            if (shouldPackage && argv.docs != null) {
                 return cliContext.failWithoutThrowing(
-                    "The --pack flag can only be used for API generation, not docs generation.",
+                    "The --package flag can only be used for API generation, not docs generation.",
                     undefined,
                     { code: CliError.Code.ConfigError }
                 );
             }
-            if (argv.packMode !== "host" && !argv.pack) {
-                return cliContext.failWithoutThrowing("The --pack-mode flag can only be used with --pack.", undefined, {
-                    code: CliError.Code.ConfigError
-                });
+            if (argv.packageMode !== "host" && !shouldPackage) {
+                return cliContext.failWithoutThrowing(
+                    "The --package-mode flag can only be used with --package.",
+                    undefined,
+                    { code: CliError.Code.ConfigError }
+                );
             }
             if (argv.output != null && argv.docs != null) {
                 return cliContext.failWithoutThrowing(
@@ -1018,8 +1027,9 @@ function addGenerateCommand(cli: Argv<GlobalCliOptions>, cliContext: CliContext)
                     requireEnvVars: argv["require-env-vars"],
                     skipIfNoDiff: argv["skip-if-no-diff"],
                     generateTests: argv["generate-tests"],
-                    pack: argv.pack,
-                    packMode: argv.packMode
+                    pack: shouldPackage,
+                    packMode: argv.packageMode,
+                    packOnly: argv.packageOnly
                 });
             }
             if (argv.docs != null) {
@@ -1083,8 +1093,9 @@ function addGenerateCommand(cli: Argv<GlobalCliOptions>, cliContext: CliContext)
                 requireEnvVars: argv["require-env-vars"],
                 skipIfNoDiff: argv["skip-if-no-diff"],
                 generateTests: argv["generate-tests"],
-                pack: argv.pack,
-                packMode: argv.packMode
+                pack: shouldPackage,
+                packMode: argv.packageMode,
+                packOnly: argv.packageOnly
             });
         }
     );

--- a/packages/cli/cli/src/commands/generate/__test__/packLocalOutput.test.ts
+++ b/packages/cli/cli/src/commands/generate/__test__/packLocalOutput.test.ts
@@ -173,6 +173,36 @@ describe("packLocalOutputForGroup", () => {
         expect(command).toBe("podman");
     });
 
+    it("removes everything except fern-dist when packOnly is set", async () => {
+        await writeFile(path.join(outputDir, "go.mod"), "module example.com/test\n");
+        await mkdir(path.join(outputDir, "client"), { recursive: true });
+        await writeFile(path.join(outputDir, "client", "client.go"), "package client\n");
+        const group = {
+            groupName: "test",
+            audiences: { type: "all" },
+            generators: [createGenerator({ name: "fernapi/fern-go-sdk", language: "go", outputPath: outputDir })]
+        } as unknown as generatorsYml.GeneratorGroup;
+
+        await packLocalOutputForGroup({ group, context: createMockTaskContext(), packOnly: true });
+
+        expect(await readdir(outputDir)).toEqual(["fern-dist"]);
+        const distFiles = await readdir(path.join(outputDir, "fern-dist"));
+        expect(distFiles).toEqual([`${path.basename(outputDir)}-source.zip`]);
+    });
+
+    it("keeps generated source alongside fern-dist when packOnly is not set", async () => {
+        await writeFile(path.join(outputDir, "go.mod"), "module example.com/test\n");
+        const group = {
+            groupName: "test",
+            audiences: { type: "all" },
+            generators: [createGenerator({ name: "fernapi/fern-go-sdk", language: "go", outputPath: outputDir })]
+        } as unknown as generatorsYml.GeneratorGroup;
+
+        await packLocalOutputForGroup({ group, context: createMockTaskContext() });
+
+        expect((await readdir(outputDir)).sort()).toEqual(["fern-dist", "go.mod"]);
+    });
+
     it("fails when packaging a generator errors", async () => {
         loggingExecaMock.mockRejectedValueOnce(new Error("python3 not found"));
         const group = {

--- a/packages/cli/cli/src/commands/generate/__test__/packLocalOutput.test.ts
+++ b/packages/cli/cli/src/commands/generate/__test__/packLocalOutput.test.ts
@@ -190,6 +190,37 @@ describe("packLocalOutputForGroup", () => {
         expect(distFiles).toEqual([`${path.basename(outputDir)}-source.zip`]);
     });
 
+    it("preserves .git, .fernignore, and fernignore-listed paths when packOnly is set", async () => {
+        await writeFile(path.join(outputDir, "go.mod"), "module example.com/test\n");
+        await mkdir(path.join(outputDir, ".git"), { recursive: true });
+        await writeFile(path.join(outputDir, ".git", "HEAD"), "ref: refs/heads/main\n");
+        await mkdir(path.join(outputDir, "custom"), { recursive: true });
+        await writeFile(path.join(outputDir, "custom", "handwritten.go"), "package custom\n");
+        await writeFile(path.join(outputDir, ".fernignore"), "custom/**\n");
+        const group = {
+            groupName: "test",
+            audiences: { type: "all" },
+            generators: [createGenerator({ name: "fernapi/fern-go-sdk", language: "go", outputPath: outputDir })]
+        } as unknown as generatorsYml.GeneratorGroup;
+
+        await packLocalOutputForGroup({ group, context: createMockTaskContext(), packOnly: true });
+
+        expect((await readdir(outputDir)).sort()).toEqual([".fernignore", ".git", "custom", "fern-dist"]);
+    });
+
+    it("does not wipe the output directory when no artifact is produced (swift) and packOnly is set", async () => {
+        await writeFile(path.join(outputDir, "Package.swift"), "// swift-tools-version:5.9\n");
+        const group = {
+            groupName: "test",
+            audiences: { type: "all" },
+            generators: [createGenerator({ name: "fernapi/fern-swift-sdk", language: "swift", outputPath: outputDir })]
+        } as unknown as generatorsYml.GeneratorGroup;
+
+        await packLocalOutputForGroup({ group, context: createMockTaskContext(), packOnly: true });
+
+        expect(await readdir(outputDir)).toEqual(["Package.swift"]);
+    });
+
     it("keeps generated source alongside fern-dist when packOnly is not set", async () => {
         await writeFile(path.join(outputDir, "go.mod"), "module example.com/test\n");
         const group = {

--- a/packages/cli/cli/src/commands/generate/generateAPIWorkspace.ts
+++ b/packages/cli/cli/src/commands/generate/generateAPIWorkspace.ts
@@ -57,7 +57,8 @@ export async function generateWorkspace({
     generateTests,
     automation,
     pack,
-    packMode
+    packMode,
+    packOnly
 }: {
     organization: string;
     workspace: AbstractAPIWorkspace<unknown>;
@@ -99,8 +100,10 @@ export async function generateWorkspace({
     automation?: AutomationRunOptions;
     /** Build distributable package artifacts for local-file-system outputs after generation. */
     pack?: boolean;
-    /** Where --pack runs the packaging toolchain: on the host or inside Docker toolchain images. */
+    /** Where packaging runs the toolchain: on the host or inside Docker toolchain images. */
     packMode?: PackMode;
+    /** Keep only the fern-dist/ artifact in the output directory, removing the generated SDK source. */
+    packOnly?: boolean;
 }): Promise<void> {
     if (workspace.generatorsConfiguration == null) {
         context.logger.warn("This workspaces has no generators.yml");
@@ -239,7 +242,7 @@ export async function generateWorkspace({
                     });
                 }
                 if (pack) {
-                    await packLocalOutputForGroup({ group, context: groupContext, mode: packMode, runner });
+                    await packLocalOutputForGroup({ group, context: groupContext, mode: packMode, runner, packOnly });
                 }
             })
         )

--- a/packages/cli/cli/src/commands/generate/generateAPIWorkspaces.ts
+++ b/packages/cli/cli/src/commands/generate/generateAPIWorkspaces.ts
@@ -53,7 +53,8 @@ export async function generateAPIWorkspaces({
     generateTests,
     automation,
     pack,
-    packMode
+    packMode,
+    packOnly
 }: {
     project: Project;
     cliContext: CliContext;
@@ -90,8 +91,10 @@ export async function generateAPIWorkspaces({
     automation?: AutomationRunOptions;
     /** Build distributable package artifacts for local-file-system outputs after generation. */
     pack?: boolean;
-    /** Where --pack runs the packaging toolchain: on the host or inside Docker toolchain images. */
+    /** Where packaging runs the toolchain: on the host or inside Docker toolchain images. */
     packMode?: PackMode;
+    /** Keep only the fern-dist/ artifact in the output directory, removing the generated SDK source. */
+    packOnly?: boolean;
 }): Promise<void> {
     let token: FernToken | undefined = undefined;
 
@@ -195,7 +198,8 @@ export async function generateAPIWorkspaces({
                     generateTests,
                     automation,
                     pack,
-                    packMode
+                    packMode,
+                    packOnly
                 });
             });
         })

--- a/packages/cli/cli/src/commands/generate/packLocalOutput.ts
+++ b/packages/cli/cli/src/commands/generate/packLocalOutput.ts
@@ -4,7 +4,7 @@ import { AbsoluteFilePath, doesPathExist, join, RelativeFilePath } from "@fern-a
 import { loggingExeca } from "@fern-api/logging-execa";
 import { TaskContext } from "@fern-api/task-context";
 import { createWriteStream } from "fs";
-import { copyFile, mkdir, readdir, readFile, rename, rmdir } from "fs/promises";
+import { copyFile, mkdir, readdir, readFile, rename, rm, rmdir } from "fs/promises";
 import { basename } from "path";
 import { ZipFile } from "yazl";
 
@@ -14,7 +14,7 @@ export const PACK_OUTPUT_DIRECTORY = "fern-dist";
 /** Where the packaging toolchain runs: on the host machine, or inside a Docker toolchain image. */
 export type PackMode = "host" | "docker";
 
-/** Official toolchain images used when packing with `--pack-mode docker`. */
+/** Official toolchain images used when packing with `--package-mode docker`. */
 const PACK_DOCKER_IMAGES: Record<string, string> = {
     typescript: "node:22",
     python: "python:3.12",
@@ -39,12 +39,15 @@ export async function packLocalOutputForGroup({
     group,
     context,
     mode = "host",
-    runner
+    runner,
+    packOnly = false
 }: {
     group: generatorsYml.GeneratorGroup;
     context: TaskContext;
     mode?: PackMode;
     runner?: ContainerRunner;
+    /** Keep only the fern-dist/ artifact in each output directory, removing the generated SDK source. */
+    packOnly?: boolean;
 }): Promise<void> {
     const failures: string[] = [];
     for (const generator of group.generators) {
@@ -62,6 +65,9 @@ export async function packLocalOutputForGroup({
         }
         try {
             await packOutputForLanguage({ language, outputPath, context, mode, runner: runner ?? "docker" });
+            if (packOnly) {
+                await removeEverythingExceptDist({ outputPath, context });
+            }
         } catch (error) {
             const message = error instanceof Error ? error.message : String(error);
             context.logger.error(`Failed to package ${generator.name} output at ${outputPath}: ${message}`);
@@ -260,6 +266,26 @@ async function zipDirectory({
         zip.outputStream.on("error", reject);
         zip.outputStream.pipe(createWriteStream(zipPath)).on("close", resolve).on("error", reject);
     });
+}
+
+/**
+ * Removes every entry in the output directory except the fern-dist/ artifact folder, so only the
+ * distributable package remains (used by --package-only).
+ */
+async function removeEverythingExceptDist({
+    outputPath,
+    context
+}: {
+    outputPath: AbsoluteFilePath;
+    context: TaskContext;
+}): Promise<void> {
+    for (const entry of await readdir(outputPath)) {
+        if (entry === PACK_OUTPUT_DIRECTORY) {
+            continue;
+        }
+        await rm(join(outputPath, RelativeFilePath.of(entry)), { recursive: true, force: true });
+    }
+    context.logger.info(`Removed generated SDK source from ${outputPath}; only ${PACK_OUTPUT_DIRECTORY}/ remains.`);
 }
 
 async function removeDistDirIfEmpty(outputPath: AbsoluteFilePath): Promise<void> {

--- a/packages/cli/cli/src/commands/generate/packLocalOutput.ts
+++ b/packages/cli/cli/src/commands/generate/packLocalOutput.ts
@@ -1,4 +1,4 @@
-import { generatorsYml } from "@fern-api/configuration-loader";
+import { FERNIGNORE_FILENAME, generatorsYml, getFernIgnorePaths } from "@fern-api/configuration-loader";
 import { assertNever, ContainerRunner } from "@fern-api/core-utils";
 import { AbsoluteFilePath, doesPathExist, join, RelativeFilePath } from "@fern-api/fs-utils";
 import { loggingExeca } from "@fern-api/logging-execa";
@@ -64,9 +64,21 @@ export async function packLocalOutputForGroup({
             continue;
         }
         try {
-            await packOutputForLanguage({ language, outputPath, context, mode, runner: runner ?? "docker" });
+            const artifactProduced = await packOutputForLanguage({
+                language,
+                outputPath,
+                context,
+                mode,
+                runner: runner ?? "docker"
+            });
             if (packOnly) {
-                await removeEverythingExceptDist({ outputPath, context });
+                if (artifactProduced) {
+                    await removeEverythingExceptDist({ outputPath, context });
+                } else {
+                    context.logger.warn(
+                        `Keeping generated source for ${generator.name}: no package artifact was produced, so there is nothing to keep in ${PACK_OUTPUT_DIRECTORY}/.`
+                    );
+                }
             }
         } catch (error) {
             const message = error instanceof Error ? error.message : String(error);
@@ -80,6 +92,7 @@ export async function packLocalOutputForGroup({
     }
 }
 
+/** Packs one generator's output. Returns whether a package artifact was produced in fern-dist/. */
 async function packOutputForLanguage({
     language,
     outputPath,
@@ -92,7 +105,7 @@ async function packOutputForLanguage({
     context: TaskContext;
     mode: PackMode;
     runner: ContainerRunner;
-}): Promise<void> {
+}): Promise<boolean> {
     const distDir = join(outputPath, RelativeFilePath.of(PACK_OUTPUT_DIRECTORY));
     const run = async (commands: string[][]) => {
         await runPackCommands({ commands, language, outputPath, context, mode, runner });
@@ -107,13 +120,13 @@ async function packOutputForLanguage({
             commands.push(["npm", "pack", "--pack-destination", PACK_OUTPUT_DIRECTORY]);
             await run(commands);
             logArtifacts({ distDir, context });
-            return;
+            return true;
         }
         case "python": {
             await mkdir(distDir, { recursive: true });
             await run([["python3", "-m", "pip", "wheel", ".", "--no-deps", "--wheel-dir", PACK_OUTPUT_DIRECTORY]]);
             logArtifacts({ distDir, context });
-            return;
+            return true;
         }
         case "java": {
             await mkdir(distDir, { recursive: true });
@@ -121,7 +134,7 @@ async function packOutputForLanguage({
             const libsDir = join(outputPath, RelativeFilePath.of("build/libs"));
             await copyMatchingFiles({ fromDir: libsDir, toDir: distDir, extension: ".jar" });
             logArtifacts({ distDir, context });
-            return;
+            return true;
         }
         case "csharp": {
             await mkdir(distDir, { recursive: true });
@@ -131,7 +144,7 @@ async function packOutputForLanguage({
             }
             await run([["dotnet", "pack", csproj, "-c", "Release", "-o", PACK_OUTPUT_DIRECTORY]]);
             logArtifacts({ distDir, context });
-            return;
+            return true;
         }
         case "ruby": {
             await mkdir(distDir, { recursive: true });
@@ -142,13 +155,13 @@ async function packOutputForLanguage({
             await run([["gem", "build", gemspec]]);
             await moveMatchingFiles({ fromDir: outputPath, toDir: distDir, extension: ".gem" });
             logArtifacts({ distDir, context });
-            return;
+            return true;
         }
         case "php": {
             await mkdir(distDir, { recursive: true });
             await run([["composer", "archive", "--format=zip", `--dir=${PACK_OUTPUT_DIRECTORY}`]]);
             logArtifacts({ distDir, context });
-            return;
+            return true;
         }
         case "rust": {
             await mkdir(distDir, { recursive: true });
@@ -156,7 +169,7 @@ async function packOutputForLanguage({
             const packageDir = join(outputPath, RelativeFilePath.of("target/package"));
             await copyMatchingFiles({ fromDir: packageDir, toDir: distDir, extension: ".crate" });
             logArtifacts({ distDir, context });
-            return;
+            return true;
         }
         case "go": {
             // Go modules have no binary package format ('go get' always fetches source), so the
@@ -169,14 +182,14 @@ async function packOutputForLanguage({
                 zipPath: join(distDir, RelativeFilePath.of(zipName))
             });
             logArtifacts({ distDir, context });
-            return;
+            return true;
         }
         case "swift":
             context.logger.warn(
                 "Swift SDKs are distributed as source packages (Swift Package Manager), so there is no package artifact to build. " +
                     "Share the output directory itself, or reference it as a local package dependency."
             );
-            return;
+            return false;
         default:
             assertNever(language);
     }
@@ -269,8 +282,13 @@ async function zipDirectory({
 }
 
 /**
- * Removes every entry in the output directory except the fern-dist/ artifact folder, so only the
- * distributable package remains (used by --package-only).
+ * Removes the generated SDK source from the output directory so only the fern-dist/ artifact
+ * remains (used by --package-only). Never removes:
+ * - fern-dist/ (the artifact itself),
+ * - .git (output directories are often checked-in repos),
+ * - .fernignore and any top-level path covered by a .fernignore entry (hand-written files that
+ *   local generation intentionally preserves). Nested/glob entries are handled conservatively by
+ *   preserving their entire top-level directory.
  */
 async function removeEverythingExceptDist({
     outputPath,
@@ -279,13 +297,23 @@ async function removeEverythingExceptDist({
     outputPath: AbsoluteFilePath;
     context: TaskContext;
 }): Promise<void> {
+    const preserved = new Set<string>([PACK_OUTPUT_DIRECTORY, ".git"]);
+    const fernignorePath = join(outputPath, RelativeFilePath.of(FERNIGNORE_FILENAME));
+    if (await doesPathExist(fernignorePath)) {
+        for (const ignorePath of await getFernIgnorePaths({ absolutePathToFernignore: fernignorePath })) {
+            const topLevelSegment = ignorePath.split("/")[0];
+            if (topLevelSegment != null && topLevelSegment.length > 0) {
+                preserved.add(topLevelSegment);
+            }
+        }
+    }
     for (const entry of await readdir(outputPath)) {
-        if (entry === PACK_OUTPUT_DIRECTORY) {
+        if (preserved.has(entry)) {
             continue;
         }
         await rm(join(outputPath, RelativeFilePath.of(entry)), { recursive: true, force: true });
     }
-    context.logger.info(`Removed generated SDK source from ${outputPath}; only ${PACK_OUTPUT_DIRECTORY}/ remains.`);
+    context.logger.info(`Removed generated SDK source from ${outputPath}; kept ${[...preserved].join(", ")}.`);
 }
 
 async function removeDistDirIfEmpty(outputPath: AbsoluteFilePath): Promise<void> {


### PR DESCRIPTION
## Description
Renames the packaging flags on `fern generate` and adds an artifact-only mode:

- `--pack` → `--package`, `--pack-mode` → `--package-mode` (no aliases kept; `--pack` shipped very recently and known users are migrating their scripts).
- New `--package-only`: after generating and packaging, everything in the local output directory except `fern-dist/` is deleted, so only the shareable artifact remains — no SDK source is left behind.

```bash
fern generate --group node-sdk-local --version 0.0.1 --package-only --package-mode docker
# → SDKs/twilio-core-ts-sdk/ contains only fern-dist/twilio-core-0.0.1.tgz
```

## Changes Made
- `cli.ts`: `package`, `package-mode`, `package-only` options; `--package-only` implies `--package` (`shouldPackage = argv.package || argv.packageOnly`); validation messages updated.
- `packLocalOutputForGroup` takes `packOnly`; after a generator's packaging succeeds, `removeEverythingExceptDist` removes every entry in that output dir except `fern-dist/` (per-generator, so a failed sibling keeps its source for debugging).
- Plumbed `packOnly` through `generateAPIWorkspaces` / `generateWorkspace`.
- Changelog entry under `packages/cli/cli/changes/unreleased/`.

## Testing
- [x] Unit tests added/updated — 2 new tests (`packOnly` leaves only `fern-dist/`; default keeps source); 10/10 pass.
- [x] Manual testing completed — built the prod CLI and ran `generate --group go-sdk-local --package-only` against fern-demo/twilio-core-fern-config: output dir ends up containing only `fern-dist/twilio-core-go-sdk-source.zip`, with log "Removed generated SDK source from …; only fern-dist/ remains."
- [ ] Updated README.md generator (not applicable)

Link to Devin session: https://app.devin.ai/sessions/0076a65e5b6743f78ba15496f2573f41
Requested by: @iamnamananand996
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/17307" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->