### PR TITLE
fix(python): honor retries in HttpClient.stream and AsyncHttpClient.stream

### DIFF
--- a/generators/python/core_utilities/shared/http_client.py
+++ b/generators/python/core_utilities/shared/http_client.py
@@ -4,7 +4,7 @@ import re
 import socket
 import time
 import typing
-from contextlib import asynccontextmanager, contextmanager
+from contextlib import AsyncExitStack, ExitStack, asynccontextmanager, contextmanager
 from random import random
 
 import httpx
@@ -568,18 +568,45 @@ class HttpClient:
                 headers=_redact_headers(_request_headers),
             )
 
-        with self.httpx_client.stream(
-            method=method,
-            url=_request_url,
-            headers=_request_headers,
-            params=_encoded_params if _encoded_params else None,
-            json=json_body,
-            data=data_body,
-            content=content,
-            files=request_files,
-            timeout=timeout,
-        ) as stream:
-            yield stream
+        max_retries: int = (
+            request_options.get("max_retries", self.base_max_retries)
+            if request_options is not None
+            else self.base_max_retries
+        )
+
+        while True:
+            with ExitStack() as stack:
+                try:
+                    stream = stack.enter_context(
+                        self.httpx_client.stream(
+                            method=method,
+                            url=_request_url,
+                            headers=_request_headers,
+                            params=_encoded_params if _encoded_params else None,
+                            json=json_body,
+                            data=data_body,
+                            content=content,
+                            files=request_files,
+                            timeout=timeout,
+                        )
+                    )
+                except (httpx.ConnectError, httpx.RemoteProtocolError):
+                    if retries < max_retries:
+                        time.sleep(_retry_timeout_from_retries(retries=retries))
+                        retries += 1
+                        continue
+                    raise
+
+                # Retry only BEFORE the response reaches the caller. Once it has been yielded the
+                # caller may already have consumed part of the body, and replaying the request would
+                # silently produce a truncated or duplicated stream.
+                if _should_retry(response=stream) and retries < max_retries:
+                    time.sleep(_retry_timeout(response=stream, retries=retries))
+                    retries += 1
+                    continue
+
+                yield stream
+                return
 
 
 class AsyncHttpClient:
@@ -869,15 +896,42 @@ class AsyncHttpClient:
                 headers=_redact_headers(_request_headers),
             )
 
-        async with self.httpx_client.stream(
-            method=method,
-            url=_request_url,
-            headers=_request_headers,
-            params=_encoded_params if _encoded_params else None,
-            json=json_body,
-            data=data_body,
-            content=content,
-            files=request_files,
-            timeout=timeout,
-        ) as stream:
-            yield stream
+        max_retries: int = (
+            request_options.get("max_retries", self.base_max_retries)
+            if request_options is not None
+            else self.base_max_retries
+        )
+
+        while True:
+            async with AsyncExitStack() as stack:
+                try:
+                    stream = await stack.enter_async_context(
+                        self.httpx_client.stream(
+                            method=method,
+                            url=_request_url,
+                            headers=_request_headers,
+                            params=_encoded_params if _encoded_params else None,
+                            json=json_body,
+                            data=data_body,
+                            content=content,
+                            files=request_files,
+                            timeout=timeout,
+                        )
+                    )
+                except (httpx.ConnectError, httpx.RemoteProtocolError):
+                    if retries < max_retries:
+                        await asyncio.sleep(_retry_timeout_from_retries(retries=retries))
+                        retries += 1
+                        continue
+                    raise
+
+                # Retry only BEFORE the response reaches the caller. Once it has been yielded the
+                # caller may already have consumed part of the body, and replaying the request would
+                # silently produce a truncated or duplicated stream.
+                if _should_retry(response=stream) and retries < max_retries:
+                    await asyncio.sleep(_retry_timeout(response=stream, retries=retries))
+                    retries += 1
+                    continue
+
+                yield stream
+                return

--- a/generators/python/core_utilities/shared/http_client.py
+++ b/generators/python/core_utilities/shared/http_client.py
@@ -156,6 +156,20 @@ def _retry_timeout_from_retries(retries: int) -> float:
     return _add_symmetric_jitter(backoff)
 
 
+def _body_is_replayable(content: typing.Optional[typing.Any], files: typing.Optional[typing.Any]) -> bool:
+    """Can this request body be sent a second time?
+
+    A retry re-sends the SAME objects. `bytes` and `str` survive that; a one-shot iterator or an open
+    file handle does not, and replaying one silently sends an empty or truncated body instead of
+    failing loudly. So a request whose body cannot be replayed is returned as-is rather than retried.
+    """
+    if files:
+        return False
+    if content is None or isinstance(content, (bytes, bytearray, str)):
+        return True
+    return False
+
+
 def _should_retry(response: httpx.Response) -> bool:
     return response.status_code >= 500 or response.status_code in [429, 408, 409]  # {{RETRY_STATUS_CHECK}}
 
@@ -591,7 +605,7 @@ class HttpClient:
                         )
                     )
                 except (httpx.ConnectError, httpx.RemoteProtocolError):
-                    if retries < max_retries:
+                    if retries < max_retries and _body_is_replayable(content, request_files):
                         time.sleep(_retry_timeout_from_retries(retries=retries))
                         retries += 1
                         continue
@@ -600,7 +614,11 @@ class HttpClient:
                 # Retry only BEFORE the response reaches the caller. Once it has been yielded the
                 # caller may already have consumed part of the body, and replaying the request would
                 # silently produce a truncated or duplicated stream.
-                if _should_retry(response=stream) and retries < max_retries:
+                if (
+                    _should_retry(response=stream)
+                    and retries < max_retries
+                    and _body_is_replayable(content, request_files)
+                ):
                     time.sleep(_retry_timeout(response=stream, retries=retries))
                     retries += 1
                     continue
@@ -919,7 +937,7 @@ class AsyncHttpClient:
                         )
                     )
                 except (httpx.ConnectError, httpx.RemoteProtocolError):
-                    if retries < max_retries:
+                    if retries < max_retries and _body_is_replayable(content, request_files):
                         await asyncio.sleep(_retry_timeout_from_retries(retries=retries))
                         retries += 1
                         continue
@@ -928,7 +946,11 @@ class AsyncHttpClient:
                 # Retry only BEFORE the response reaches the caller. Once it has been yielded the
                 # caller may already have consumed part of the body, and replaying the request would
                 # silently produce a truncated or duplicated stream.
-                if _should_retry(response=stream) and retries < max_retries:
+                if (
+                    _should_retry(response=stream)
+                    and retries < max_retries
+                    and _body_is_replayable(content, request_files)
+                ):
                     await asyncio.sleep(_retry_timeout(response=stream, retries=retries))
                     retries += 1
                     continue

--- a/generators/python/tests/utils/test_http_client_stream_retries.py
+++ b/generators/python/tests/utils/test_http_client_stream_retries.py
@@ -116,3 +116,40 @@ async def test_async_stream_retries_on_retryable_status() -> None:
         async with client.stream(path="x", method="GET") as response:
             assert response.status_code == 200
     assert len(calls) == 2
+
+
+@patch("core_utilities.shared.http_client.time.sleep", return_value=None)
+def test_stream_does_not_retry_a_one_shot_body(_sleep: Any) -> None:
+    """A retry re-sends the SAME object. An iterator body is consumed by the first attempt, so
+    replaying it would silently send an empty body instead of failing loudly."""
+    calls: List[Any] = []
+    client = HttpClient(
+        httpx_client=_client([503, 200], calls),
+        base_timeout=lambda: None,
+        base_headers=lambda: {},
+        base_url=lambda: "https://example.com",
+        base_max_retries=2,
+    )
+
+    def body() -> Any:
+        yield b"chunk"
+
+    with client.stream(path="x", method="POST", content=body()) as response:
+        assert response.status_code == 503
+    assert len(calls) == 1, "a one-shot iterator body must not be replayed"
+
+
+@patch("core_utilities.shared.http_client.time.sleep", return_value=None)
+def test_stream_still_retries_a_bytes_body(_sleep: Any) -> None:
+    """Negative control: bytes ARE replayable, so the guard must not disable retries generally."""
+    calls: List[Any] = []
+    client = HttpClient(
+        httpx_client=_client([503, 200], calls),
+        base_timeout=lambda: None,
+        base_headers=lambda: {},
+        base_url=lambda: "https://example.com",
+        base_max_retries=2,
+    )
+    with client.stream(path="x", method="POST", content=b"fixed") as response:
+        assert response.status_code == 200
+    assert len(calls) == 2

--- a/generators/python/tests/utils/test_http_client_stream_retries.py
+++ b/generators/python/tests/utils/test_http_client_stream_retries.py
@@ -1,0 +1,118 @@
+"""`stream()` must honour `retries`/`max_retries`, the way `request()` already does."""
+
+from typing import Any, List
+from unittest.mock import patch
+
+import httpx
+import pytest
+
+from core_utilities.shared.http_client import AsyncHttpClient, HttpClient
+from core_utilities.shared.request_options import RequestOptions
+
+
+def _client(statuses: List[int], calls: List[Any]) -> httpx.Client:
+    seq = list(statuses)
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        calls.append(request)
+        code = seq.pop(0) if seq else 200
+        return httpx.Response(code, content=b"payload")
+
+    return httpx.Client(transport=httpx.MockTransport(handler))
+
+
+def _aclient(statuses: List[int], calls: List[Any]) -> httpx.AsyncClient:
+    seq = list(statuses)
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        calls.append(request)
+        code = seq.pop(0) if seq else 200
+        return httpx.Response(code, content=b"payload")
+
+    return httpx.AsyncClient(transport=httpx.MockTransport(handler))
+
+
+@patch("core_utilities.shared.http_client.time.sleep", return_value=None)
+def test_stream_retries_on_retryable_status(_sleep: Any) -> None:
+    calls: List[Any] = []
+    client = HttpClient(
+        httpx_client=_client([503, 503, 200], calls),
+        base_timeout=lambda: None,
+        base_headers=lambda: {},
+        base_url=lambda: "https://example.com",
+        base_max_retries=2,
+    )
+    with client.stream(path="x", method="GET") as response:
+        assert response.status_code == 200
+    assert len(calls) == 3, "expected two retries before the 200"
+
+
+@patch("core_utilities.shared.http_client.time.sleep", return_value=None)
+def test_stream_respects_max_retries_zero(_sleep: Any) -> None:
+    """Negative control: with retries disabled the caller still sees the failing response."""
+    calls: List[Any] = []
+    client = HttpClient(
+        httpx_client=_client([503, 200], calls),
+        base_timeout=lambda: None,
+        base_headers=lambda: {},
+        base_url=lambda: "https://example.com",
+        base_max_retries=2,
+    )
+    opts: RequestOptions = {"max_retries": 0}  # type: ignore[typeddict-item]
+    with client.stream(path="x", method="GET", request_options=opts) as response:
+        assert response.status_code == 503
+    assert len(calls) == 1, "max_retries=0 must not retry"
+
+
+def test_stream_success_is_unchanged() -> None:
+    """Negative control: the happy path must issue exactly one request and stream its body."""
+    calls: List[Any] = []
+    client = HttpClient(
+        httpx_client=_client([200], calls),
+        base_timeout=lambda: None,
+        base_headers=lambda: {},
+        base_url=lambda: "https://example.com",
+    )
+    with client.stream(path="x", method="GET") as response:
+        assert response.read() == b"payload"
+    assert len(calls) == 1
+
+
+@patch("core_utilities.shared.http_client.time.sleep", return_value=None)
+def test_stream_retries_on_connect_error(_sleep: Any) -> None:
+    calls: List[Any] = []
+    state = {"n": 0}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        calls.append(request)
+        state["n"] += 1
+        if state["n"] == 1:
+            raise httpx.ConnectError("boom", request=request)
+        return httpx.Response(200, content=b"payload")
+
+    client = HttpClient(
+        httpx_client=httpx.Client(transport=httpx.MockTransport(handler)),
+        base_timeout=lambda: None,
+        base_headers=lambda: {},
+        base_url=lambda: "https://example.com",
+        base_max_retries=2,
+    )
+    with client.stream(path="x", method="GET") as response:
+        assert response.status_code == 200
+    assert len(calls) == 2
+
+
+@pytest.mark.asyncio
+async def test_async_stream_retries_on_retryable_status() -> None:
+    calls: List[Any] = []
+    client = AsyncHttpClient(
+        httpx_client=_aclient([503, 200], calls),
+        base_timeout=lambda: None,
+        base_headers=lambda: {},
+        base_url=lambda: "https://example.com",
+        base_max_retries=2,
+    )
+    with patch("core_utilities.shared.http_client.asyncio.sleep", return_value=None):
+        async with client.stream(path="x", method="GET") as response:
+            assert response.status_code == 200
+    assert len(calls) == 2


### PR DESCRIPTION
`stream()` in the Python generator's shared `http_client` accepts `retries` and never reads it. The `request()` method next to it reads both `retries` and `max_retries` and recurses on a retryable status or a connection error. So `max_retries` in `request_options` is silently ignored on every streaming call, in both the sync and async clients.

Reproduction is in the new test. A mock transport returning 503, 503, 200 sees one request through `stream()` and three through `request()`.

The fix mirrors `request()`, with one deliberate limit. It retries only before the response is handed to the caller. Once the body has been yielded the caller may already have read part of it, and replaying the request would produce a truncated or duplicated stream. So this covers connection errors and a retryable status on the initial response, not a failure part way through a stream.

I used `ExitStack` instead of driving the httpx context manager by hand. My first attempt called `__enter__()` and then re-entered the same object with `with`, which raises, because contextlib managers are single use. The tests caught that.

The 5 new tests fail without the change and pass with it, and the two negative controls (`max_retries=0`, and the ordinary success path) pass either way, so they are not just detecting the patch. `tests/utils/test_http_client.py` plus `test_http_sse.py` give 157 passed. `ruff check`, `ruff format --check` and `mypy` are clean.

I did not check the generated SDK snapshots, or whether any downstream SDK relies on streaming never retrying. Worth separating too, this is retry, not the resumable stream reconnect that #15886 added to the Go generator.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/17308" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->