### PR TITLE
fix(cli): prefer x-fern-server-name over description in multi-api environment grouping

### DIFF
--- a/packages/cli/api-importers/openapi/openapi-ir-parser/src/parse.ts
+++ b/packages/cli/api-importers/openapi/openapi-ir-parser/src/parse.ts
@@ -212,7 +212,7 @@ interface MultiApiEndpoint extends Endpoint {
 type TypedEndpoint = StandardEndpoint | MultiApiEndpoint;
 
 function getRawEnvironmentName(server: SingleServerInput): string {
-    return String(server.description || server.name || server["x-fern-server-name"] || "default").trim();
+    return String(server.name || server["x-fern-server-name"] || server.description || "default").trim();
 }
 
 function getEnvironmentName(server: SingleServerInput): string {

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir/multi-api-environment-grouping-server-description.json
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir/multi-api-environment-grouping-server-description.json
@@ -1,0 +1,376 @@
+{
+  "specVersion": "1.0.0",
+  "title": "Core API",
+  "servers": [
+    {
+      "type": "grouped",
+      "name": "Production",
+      "description": "Production environment",
+      "urls": {
+        "api": {
+          "url": "https://api.example.com"
+        },
+        "auth": {
+          "url": "https://auth.example.com"
+        }
+      }
+    },
+    {
+      "type": "grouped",
+      "name": "Staging",
+      "description": "Staging environment",
+      "urls": {
+        "api": {
+          "url": "https://api.stage.example.com"
+        },
+        "auth": {
+          "url": "https://auth.stage.example.com"
+        }
+      }
+    },
+    {
+      "type": "grouped",
+      "name": "Development",
+      "description": "Development environment",
+      "urls": {
+        "api": {
+          "url": "https://api.dev.example.com"
+        },
+        "auth": {
+          "url": "https://auth.dev.example.com"
+        }
+      }
+    }
+  ],
+  "websocketServers": [],
+  "tags": {
+    "tagsById": {}
+  },
+  "hasEndpointsMarkedInternal": false,
+  "endpoints": [
+    {
+      "summary": "List widgets",
+      "audiences": [],
+      "operationId": "listWidgets",
+      "tags": [],
+      "pathParameters": [],
+      "queryParameters": [],
+      "headers": [],
+      "generatedRequestName": "ListWidgetsRequest",
+      "response": {
+        "description": "Successful response",
+        "schema": {
+          "value": {
+            "generatedName": "ListWidgetsResponseItem",
+            "schema": "Widget",
+            "source": {
+              "file": "../core-api.yml",
+              "type": "openapi"
+            },
+            "type": "reference"
+          },
+          "generatedName": "ListWidgetsResponse",
+          "groupName": [],
+          "type": "array"
+        },
+        "fullExamples": [],
+        "source": {
+          "file": "../core-api.yml",
+          "type": "openapi"
+        },
+        "statusCode": 200,
+        "type": "json"
+      },
+      "errors": {},
+      "authed": false,
+      "method": "GET",
+      "path": "/widgets",
+      "examples": [
+        {
+          "pathParameters": [],
+          "queryParameters": [],
+          "headers": [],
+          "response": {
+            "value": {
+              "value": [
+                {
+                  "properties": {
+                    "id": {
+                      "value": {
+                        "value": "id",
+                        "type": "string"
+                      },
+                      "type": "primitive"
+                    },
+                    "name": {
+                      "value": {
+                        "value": "name",
+                        "type": "string"
+                      },
+                      "type": "primitive"
+                    }
+                  },
+                  "type": "object"
+                }
+              ],
+              "type": "array"
+            },
+            "type": "withoutStreaming"
+          },
+          "codeSamples": [],
+          "type": "full"
+        }
+      ],
+      "source": {
+        "file": "../core-api.yml",
+        "type": "openapi"
+      },
+      "__apiName": "api",
+      "servers": [
+        {
+          "name": "api"
+        }
+      ]
+    },
+    {
+      "summary": "Issue a token",
+      "audiences": [],
+      "operationId": "issueToken",
+      "tags": [],
+      "pathParameters": [],
+      "queryParameters": [],
+      "headers": [],
+      "generatedRequestName": "IssueTokenRequest",
+      "request": {
+        "schema": {
+          "generatedName": "IssueTokenRequest",
+          "schema": "TokenRequest",
+          "source": {
+            "file": "../auth-api.yml",
+            "type": "openapi"
+          },
+          "type": "reference"
+        },
+        "contentType": "application/json",
+        "fullExamples": [],
+        "additionalProperties": false,
+        "source": {
+          "file": "../auth-api.yml",
+          "type": "openapi"
+        },
+        "type": "json"
+      },
+      "response": {
+        "description": "Successful response",
+        "schema": {
+          "generatedName": "IssueTokenResponse",
+          "schema": "TokenResponse",
+          "source": {
+            "file": "../auth-api.yml",
+            "type": "openapi"
+          },
+          "type": "reference"
+        },
+        "fullExamples": [],
+        "source": {
+          "file": "../auth-api.yml",
+          "type": "openapi"
+        },
+        "statusCode": 200,
+        "type": "json"
+      },
+      "errors": {},
+      "authed": false,
+      "method": "POST",
+      "path": "/token",
+      "examples": [
+        {
+          "pathParameters": [],
+          "queryParameters": [],
+          "headers": [],
+          "request": {
+            "properties": {},
+            "type": "object"
+          },
+          "response": {
+            "value": {
+              "properties": {
+                "accessToken": {
+                  "value": {
+                    "value": "accessToken",
+                    "type": "string"
+                  },
+                  "type": "primitive"
+                }
+              },
+              "type": "object"
+            },
+            "type": "withoutStreaming"
+          },
+          "codeSamples": [],
+          "type": "full"
+        }
+      ],
+      "source": {
+        "file": "../auth-api.yml",
+        "type": "openapi"
+      },
+      "__apiName": "auth",
+      "servers": [
+        {
+          "name": "auth"
+        }
+      ]
+    }
+  ],
+  "webhooks": [],
+  "channels": {},
+  "groupedSchemas": {
+    "rootSchemas": {
+      "Widget": {
+        "allOf": [],
+        "properties": [
+          {
+            "conflict": {},
+            "generatedName": "widgetId",
+            "key": "id",
+            "schema": {
+              "generatedName": "WidgetId",
+              "value": {
+                "schema": {
+                  "type": "string"
+                },
+                "generatedName": "WidgetId",
+                "groupName": [],
+                "type": "primitive"
+              },
+              "groupName": [],
+              "type": "optional"
+            },
+            "audiences": []
+          },
+          {
+            "conflict": {},
+            "generatedName": "widgetName",
+            "key": "name",
+            "schema": {
+              "generatedName": "WidgetName",
+              "value": {
+                "schema": {
+                  "type": "string"
+                },
+                "generatedName": "WidgetName",
+                "groupName": [],
+                "type": "primitive"
+              },
+              "groupName": [],
+              "type": "optional"
+            },
+            "audiences": []
+          }
+        ],
+        "allOfPropertyConflicts": [],
+        "generatedName": "Widget",
+        "groupName": [],
+        "additionalProperties": false,
+        "source": {
+          "file": "../core-api.yml",
+          "type": "openapi"
+        },
+        "type": "object"
+      },
+      "TokenRequest": {
+        "allOf": [],
+        "properties": [
+          {
+            "conflict": {},
+            "generatedName": "tokenRequestClientId",
+            "key": "clientId",
+            "schema": {
+              "generatedName": "TokenRequestClientId",
+              "value": {
+                "schema": {
+                  "type": "string"
+                },
+                "generatedName": "TokenRequestClientId",
+                "groupName": [],
+                "type": "primitive"
+              },
+              "groupName": [],
+              "type": "optional"
+            },
+            "audiences": []
+          },
+          {
+            "conflict": {},
+            "generatedName": "tokenRequestClientSecret",
+            "key": "clientSecret",
+            "schema": {
+              "generatedName": "TokenRequestClientSecret",
+              "value": {
+                "schema": {
+                  "type": "string"
+                },
+                "generatedName": "TokenRequestClientSecret",
+                "groupName": [],
+                "type": "primitive"
+              },
+              "groupName": [],
+              "type": "optional"
+            },
+            "audiences": []
+          }
+        ],
+        "allOfPropertyConflicts": [],
+        "generatedName": "TokenRequest",
+        "groupName": [],
+        "additionalProperties": false,
+        "source": {
+          "file": "../auth-api.yml",
+          "type": "openapi"
+        },
+        "type": "object"
+      },
+      "TokenResponse": {
+        "allOf": [],
+        "properties": [
+          {
+            "conflict": {},
+            "generatedName": "tokenResponseAccessToken",
+            "key": "accessToken",
+            "schema": {
+              "generatedName": "TokenResponseAccessToken",
+              "value": {
+                "schema": {
+                  "type": "string"
+                },
+                "generatedName": "TokenResponseAccessToken",
+                "groupName": [],
+                "type": "primitive"
+              },
+              "groupName": [],
+              "type": "optional"
+            },
+            "audiences": []
+          }
+        ],
+        "allOfPropertyConflicts": [],
+        "generatedName": "TokenResponse",
+        "groupName": [],
+        "additionalProperties": false,
+        "source": {
+          "file": "../auth-api.yml",
+          "type": "openapi"
+        },
+        "type": "object"
+      }
+    },
+    "namespacedSchemas": {}
+  },
+  "variables": {},
+  "nonRequestReferencedSchemas": {},
+  "securitySchemes": {},
+  "globalHeaders": [],
+  "idempotencyHeaders": [],
+  "groups": {}
+}

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi/multi-api-environment-grouping-server-description.json
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi/multi-api-environment-grouping-server-description.json
@@ -1,0 +1,224 @@
+{
+  "absoluteFilePath": "/DUMMY_PATH",
+  "importedDefinitions": {},
+  "namedDefinitionFiles": {
+    "__package__.yml": {
+      "absoluteFilepath": "/DUMMY_PATH",
+      "contents": {
+        "service": {
+          "auth": false,
+          "base-path": "",
+          "endpoints": {
+            "issueToken": {
+              "auth": undefined,
+              "display-name": "Issue a token",
+              "docs": undefined,
+              "examples": [
+                {
+                  "request": {},
+                  "response": {
+                    "body": {
+                      "accessToken": "accessToken",
+                    },
+                  },
+                },
+              ],
+              "method": "POST",
+              "pagination": undefined,
+              "path": "/token",
+              "request": {
+                "body": {
+                  "properties": {
+                    "clientId": "optional<string>",
+                    "clientSecret": "optional<string>",
+                  },
+                },
+                "content-type": "application/json",
+                "headers": undefined,
+                "name": "TokenRequest",
+                "path-parameters": undefined,
+                "query-parameters": undefined,
+              },
+              "response": {
+                "docs": "Successful response",
+                "status-code": 200,
+                "type": "TokenResponse",
+              },
+              "source": {
+                "openapi": "../auth-api.yml",
+              },
+              "url": "auth",
+            },
+            "listWidgets": {
+              "auth": undefined,
+              "display-name": "List widgets",
+              "docs": undefined,
+              "examples": [
+                {
+                  "response": {
+                    "body": [
+                      {
+                        "id": "id",
+                        "name": "name",
+                      },
+                    ],
+                  },
+                },
+              ],
+              "method": "GET",
+              "pagination": undefined,
+              "path": "/widgets",
+              "response": {
+                "docs": "Successful response",
+                "status-code": 200,
+                "type": "list<Widget>",
+              },
+              "source": {
+                "openapi": "../core-api.yml",
+              },
+              "url": "api",
+            },
+          },
+          "source": {
+            "openapi": "../auth-api.yml",
+          },
+        },
+        "types": {
+          "TokenResponse": {
+            "docs": undefined,
+            "inline": undefined,
+            "properties": {
+              "accessToken": "optional<string>",
+            },
+            "source": {
+              "openapi": "../auth-api.yml",
+            },
+          },
+          "Widget": {
+            "docs": undefined,
+            "inline": undefined,
+            "properties": {
+              "id": "optional<string>",
+              "name": "optional<string>",
+            },
+            "source": {
+              "openapi": "../core-api.yml",
+            },
+          },
+        },
+      },
+      "rawContents": "service:
+  auth: false
+  base-path: ''
+  endpoints:
+    listWidgets:
+      path: /widgets
+      method: GET
+      source:
+        openapi: ../core-api.yml
+      display-name: List widgets
+      response:
+        docs: Successful response
+        type: list<Widget>
+        status-code: 200
+      url: api
+      examples:
+        - response:
+            body:
+              - id: id
+                name: name
+    issueToken:
+      path: /token
+      method: POST
+      source:
+        openapi: ../auth-api.yml
+      display-name: Issue a token
+      request:
+        name: TokenRequest
+        body:
+          properties:
+            clientId: optional<string>
+            clientSecret: optional<string>
+        content-type: application/json
+      response:
+        docs: Successful response
+        type: TokenResponse
+        status-code: 200
+      url: auth
+      examples:
+        - request: {}
+          response:
+            body:
+              accessToken: accessToken
+  source:
+    openapi: ../auth-api.yml
+types:
+  Widget:
+    properties:
+      id: optional<string>
+      name: optional<string>
+    source:
+      openapi: ../core-api.yml
+  TokenResponse:
+    properties:
+      accessToken: optional<string>
+    source:
+      openapi: ../auth-api.yml
+",
+    },
+  },
+  "packageMarkers": {},
+  "rootApiFile": {
+    "contents": {
+      "default-environment": "Production",
+      "default-url": "api",
+      "display-name": "Core API",
+      "environments": {
+        "Development": {
+          "urls": {
+            "api": "https://api.dev.example.com",
+            "auth": "https://auth.dev.example.com",
+          },
+        },
+        "Production": {
+          "urls": {
+            "api": "https://api.example.com",
+            "auth": "https://auth.example.com",
+          },
+        },
+        "Staging": {
+          "urls": {
+            "api": "https://api.stage.example.com",
+            "auth": "https://auth.stage.example.com",
+          },
+        },
+      },
+      "error-discrimination": {
+        "strategy": "status-code",
+      },
+      "name": "api",
+    },
+    "defaultUrl": "api",
+    "rawContents": "name: api
+error-discrimination:
+  strategy: status-code
+display-name: Core API
+environments:
+  Production:
+    urls:
+      api: https://api.example.com
+      auth: https://auth.example.com
+  Staging:
+    urls:
+      api: https://api.stage.example.com
+      auth: https://auth.stage.example.com
+  Development:
+    urls:
+      api: https://api.dev.example.com
+      auth: https://auth.dev.example.com
+default-environment: Production
+default-url: api
+",
+  },
+  "specVersion": "1.0.0",
+}

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/fixtures/multi-api-environment-grouping-server-description/auth-api.yml
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/fixtures/multi-api-environment-grouping-server-description/auth-api.yml
@@ -1,0 +1,43 @@
+openapi: 3.0.0
+info:
+  title: Auth API
+  version: 1.0.0
+servers:
+  - url: https://auth.example.com
+    x-fern-server-name: Production
+  - url: https://auth.stage.example.com
+    x-fern-server-name: Staging
+  - url: https://auth.dev.example.com
+    x-fern-server-name: Development
+paths:
+  /token:
+    post:
+      summary: Issue a token
+      operationId: issueToken
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/TokenRequest"
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/TokenResponse"
+components:
+  schemas:
+    TokenRequest:
+      type: object
+      properties:
+        clientId:
+          type: string
+        clientSecret:
+          type: string
+    TokenResponse:
+      type: object
+      properties:
+        accessToken:
+          type: string

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/fixtures/multi-api-environment-grouping-server-description/core-api.yml
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/fixtures/multi-api-environment-grouping-server-description/core-api.yml
@@ -1,0 +1,35 @@
+openapi: 3.0.0
+info:
+  title: Core API
+  version: 1.0.0
+servers:
+  - url: https://api.example.com
+    description: Core Unified API
+    x-fern-server-name: Production
+  - url: https://api.stage.example.com
+    x-fern-server-name: Staging
+  - url: https://api.dev.example.com
+    x-fern-server-name: Development
+paths:
+  /widgets:
+    get:
+      summary: List widgets
+      operationId: listWidgets
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/Widget"
+components:
+  schemas:
+    Widget:
+      type: object
+      properties:
+        id:
+          type: string
+        name:
+          type: string

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/fixtures/multi-api-environment-grouping-server-description/fern.config.json
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/fixtures/multi-api-environment-grouping-server-description/fern.config.json
@@ -1,0 +1,4 @@
+{
+  "organization": "seed",
+  "version": "0.0.0"
+}

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/fixtures/multi-api-environment-grouping-server-description/fern/generators.yml
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/fixtures/multi-api-environment-grouping-server-description/fern/generators.yml
@@ -1,0 +1,9 @@
+# yaml-language-server: $schema=https://schema.buildwithfern.dev/generators-yml.json
+api:
+  specs:
+    - openapi: ../core-api.yml
+      settings:
+        group-multi-api-environments: true
+    - openapi: ../auth-api.yml
+      settings:
+        group-multi-api-environments: true

--- a/packages/cli/cli/changes/unreleased/fix-multi-api-environment-grouping-server-description.yml
+++ b/packages/cli/cli/changes/unreleased/fix-multi-api-environment-grouping-server-description.yml
@@ -1,0 +1,6 @@
+- summary: |
+    Fix `group-multi-api-environments` failing to produce multi-URL environments when a
+    server in one of the specs has a `description` (e.g. "Core Unified API") alongside an
+    explicit `x-fern-server-name`. Environment matching now prefers the explicit server
+    name over the description.
+  type: fix


### PR DESCRIPTION
## Description
Fixes Twilio pilot Issue #16: with `group-multi-api-environments: true`, the CLI fell back to a single-URL environment enum (using only the last spec's oauth URLs) instead of a multi-URL environment, breaking all API calls made via `environment:`.

Root cause: environment-name matching during multi-spec IR merging used `description` before the explicit server name:

```ts
// parse.ts getRawEnvironmentName
- String(server.description || server.name || server["x-fern-server-name"] || "default")
+ String(server.name || server["x-fern-server-name"] || server.description || "default")
```

Twilio's merged specs carry an informational `servers[0].description` (e.g. `"Twilio Communications Unified API"`). Since spec overrides merge arrays element-wise, the override's `x-fern-server-name: Production` landed on the same server object as the spec's description — and the description won, so environment names no longer matched across specs, `detectMultipleBaseUrls` returned false, and grouping never happened. (It was unrelated to the inlined securitySchemes suspected in the report; only the spec descriptions matter.)

## Changes Made
- Prefer the explicit server name (`x-fern-server-name`) over `description` when matching environments across APIs in `openapi-ir-parser/src/parse.ts`
- Added regression fixture `multi-api-environment-grouping-server-description` (two specs sharing named environments, one server with an unrelated `description`) + snapshots
- CLI changelog entry
- [ ] Updated README.md generator (if applicable) — N/A

## Testing
- [x] Unit tests added/updated — `openapi-ir-to-fern-tests` full suite passes (307 tests), new fixture snapshots produce `multipleBaseUrls`
- [x] Manual testing completed — ran `fern ir` on Twilio's issue-16 repro workspace; IR now emits `multipleBaseUrls` with `twilio`/`oauth` URLs per environment (Production/Staging/Development), matching the expected output in their report

Link to Devin session: https://app.devin.ai/sessions/7b10237605394e69a949f45a87bf31c5
Requested by: @iamnamananand996
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/17314" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->