### PR TITLE
fix(cli): ship runnable package artifacts from fern generate --package

### DIFF
--- a/packages/cli/cli/changes/unreleased/improve-package-artifacts.yml
+++ b/packages/cli/cli/changes/unreleased/improve-package-artifacts.yml
@@ -1,0 +1,7 @@
+- summary: |
+    Improve `fern generate --package` artifacts: TypeScript tarballs are compiled before
+    packing so they ship runnable JavaScript (falling back to `tsc` when the package has no
+    build script), Java packaging emits a POM with dependency metadata next to the JAR, and
+    Python host-mode packaging retries in an isolated venv (`python -m build`) when `pip wheel`
+    fails on the host toolchain.
+  type: fix

--- a/packages/cli/cli/src/commands/generate/__test__/packLocalOutput.test.ts
+++ b/packages/cli/cli/src/commands/generate/__test__/packLocalOutput.test.ts
@@ -90,8 +90,77 @@ describe("packLocalOutputForGroup", () => {
 
         const commands = loggingExecaMock.mock.calls.map(([, command, args]) => [command, ...(args ?? [])].join(" "));
         expect(commands[0]).toBe("npm install");
-        expect(commands[1]).toBe("npm run build");
+        expect(commands[1]).toBe("npx --yes pnpm run build");
         expect(commands[2]).toContain("npm pack");
+    });
+
+    it("compiles with tsc before packing when a typescript package has no build script", async () => {
+        await writeFile(path.join(outputDir, "package.json"), JSON.stringify({ name: "acme" }));
+        await writeFile(path.join(outputDir, "tsconfig.cjs.json"), "{}");
+        const group = {
+            groupName: "test",
+            audiences: { type: "all" },
+            generators: [
+                createGenerator({
+                    name: "fernapi/fern-typescript-node-sdk",
+                    language: "typescript",
+                    outputPath: outputDir
+                })
+            ]
+        } as unknown as generatorsYml.GeneratorGroup;
+
+        await packLocalOutputForGroup({ group, context: createMockTaskContext() });
+
+        const commands = loggingExecaMock.mock.calls.map(([, command, args]) => [command, ...(args ?? [])].join(" "));
+        expect(commands[0]).toBe("npm install");
+        expect(commands[1]).toBe("npx --yes --package typescript tsc --project tsconfig.cjs.json");
+        expect(commands[2]).toContain("npm pack");
+    });
+
+    it("falls back to an isolated venv build when host pip wheel fails for python generators", async () => {
+        loggingExecaMock.mockRejectedValueOnce(new Error("No module named pip"));
+        const group = {
+            groupName: "test",
+            audiences: { type: "all" },
+            generators: [
+                createGenerator({ name: "fernapi/fern-python-sdk", language: "python", outputPath: outputDir })
+            ]
+        } as unknown as generatorsYml.GeneratorGroup;
+
+        await packLocalOutputForGroup({ group, context: createMockTaskContext() });
+
+        const commands = loggingExecaMock.mock.calls.map(([, command, args]) => [command, ...(args ?? [])].join(" "));
+        expect(commands[0]).toContain("wheel");
+        expect(commands[1]).toBe("python3 -m venv .fern-pack-venv");
+        expect(commands[2]).toBe(".fern-pack-venv/bin/python -m pip install --quiet build");
+        expect(commands[3]).toBe(".fern-pack-venv/bin/python -m build --wheel --outdir fern-dist");
+    });
+
+    it("generates a POM alongside the jar for java generators", async () => {
+        await mkdir(path.join(outputDir, "build", "libs"), { recursive: true });
+        await writeFile(path.join(outputDir, "build", "libs", "acme-sdk.jar"), "jar-bytes");
+        await mkdir(path.join(outputDir, "build", "publications", "fernLocalPack"), { recursive: true });
+        await writeFile(
+            path.join(outputDir, "build", "publications", "fernLocalPack", "pom-default.xml"),
+            "<project />"
+        );
+        const group = {
+            groupName: "test",
+            audiences: { type: "all" },
+            generators: [createGenerator({ name: "fernapi/fern-java-sdk", language: "java", outputPath: outputDir })]
+        } as unknown as generatorsYml.GeneratorGroup;
+
+        await packLocalOutputForGroup({ group, context: createMockTaskContext() });
+
+        expect(loggingExecaMock).toHaveBeenCalledTimes(1);
+        const [, command, args] = loggingExecaMock.mock.calls[0] ?? [];
+        expect(command).toBe("gradle");
+        expect(args).toContain("--init-script");
+        expect(args).toContain("generatePomFileForFernLocalPackPublication");
+        const distFiles = (await readdir(path.join(outputDir, "fern-dist"))).sort();
+        expect(distFiles).toEqual(["acme-sdk.jar", "acme-sdk.pom"]);
+        // the init script is temporary and must not linger in the output directory
+        expect(await readdir(outputDir)).not.toContain(".fern-pack-pom-init.gradle");
     });
 
     it("zips the module source for go generators without running any toolchain command", async () => {
@@ -154,7 +223,7 @@ describe("packLocalOutputForGroup", () => {
         expect(command).toBe("docker");
         expect(args?.[0]).toBe("run");
         expect(args).toContain("python:3.12");
-        expect(args).toContain(`${outputDir}:/workspace`);
+        expect(args).toContain(`${outputDir}:/workspace/${path.basename(outputDir)}`);
         expect(args).toContain("wheel");
     });
 
@@ -235,6 +304,7 @@ describe("packLocalOutputForGroup", () => {
     });
 
     it("fails when packaging a generator errors", async () => {
+        loggingExecaMock.mockRejectedValueOnce(new Error("python3 not found"));
         loggingExecaMock.mockRejectedValueOnce(new Error("python3 not found"));
         const group = {
             groupName: "test",

--- a/packages/cli/cli/src/commands/generate/__test__/packLocalOutput.test.ts
+++ b/packages/cli/cli/src/commands/generate/__test__/packLocalOutput.test.ts
@@ -117,6 +117,58 @@ describe("packLocalOutputForGroup", () => {
         expect(commands[2]).toContain("npm pack");
     });
 
+    it("fails typescript packaging when tsc fails and no output was emitted", async () => {
+        await writeFile(path.join(outputDir, "package.json"), JSON.stringify({ name: "acme" }));
+        await writeFile(path.join(outputDir, "tsconfig.json"), "{}");
+        loggingExecaMock
+            .mockResolvedValueOnce({ stdout: "", stderr: "" } as never)
+            .mockRejectedValueOnce(new Error("npx could not fetch typescript"));
+        const group = {
+            groupName: "test",
+            audiences: { type: "all" },
+            generators: [
+                createGenerator({
+                    name: "fernapi/fern-typescript-node-sdk",
+                    language: "typescript",
+                    outputPath: outputDir
+                })
+            ]
+        } as unknown as generatorsYml.GeneratorGroup;
+
+        await expect(packLocalOutputForGroup({ group, context: createMockTaskContext() })).rejects.toThrow();
+        const commands = loggingExecaMock.mock.calls.map(([, command, args]) => [command, ...(args ?? [])].join(" "));
+        expect(commands.find((command) => command.includes("npm pack"))).toBeUndefined();
+    });
+
+    it("packs the emitted output when tsc reports errors but still emitted to the outDir", async () => {
+        await writeFile(path.join(outputDir, "package.json"), JSON.stringify({ name: "acme" }));
+        await writeFile(
+            path.join(outputDir, "tsconfig.cjs.json"),
+            JSON.stringify({ compilerOptions: { outDir: "dist/cjs" } })
+        );
+        await mkdir(path.join(outputDir, "dist", "cjs"), { recursive: true });
+        await writeFile(path.join(outputDir, "dist", "cjs", "index.js"), "module.exports = {};");
+        loggingExecaMock
+            .mockResolvedValueOnce({ stdout: "", stderr: "" } as never)
+            .mockRejectedValueOnce(new Error("tsc exited with code 2"));
+        const group = {
+            groupName: "test",
+            audiences: { type: "all" },
+            generators: [
+                createGenerator({
+                    name: "fernapi/fern-typescript-node-sdk",
+                    language: "typescript",
+                    outputPath: outputDir
+                })
+            ]
+        } as unknown as generatorsYml.GeneratorGroup;
+
+        await packLocalOutputForGroup({ group, context: createMockTaskContext() });
+
+        const commands = loggingExecaMock.mock.calls.map(([, command, args]) => [command, ...(args ?? [])].join(" "));
+        expect(commands.find((command) => command.includes("npm pack"))).toBeDefined();
+    });
+
     it("falls back to an isolated venv build when host pip wheel fails for python generators", async () => {
         loggingExecaMock.mockRejectedValueOnce(new Error("No module named pip"));
         const group = {
@@ -161,6 +213,28 @@ describe("packLocalOutputForGroup", () => {
         expect(distFiles).toEqual(["acme-sdk.jar", "acme-sdk.pom"]);
         // the init script is temporary and must not linger in the output directory
         expect(await readdir(outputDir)).not.toContain(".fern-pack-pom-init.gradle");
+    });
+
+    it("names the POM after the main jar, not sources/javadoc jars", async () => {
+        await mkdir(path.join(outputDir, "build", "libs"), { recursive: true });
+        await writeFile(path.join(outputDir, "build", "libs", "acme-sdk-javadoc.jar"), "jar-bytes");
+        await writeFile(path.join(outputDir, "build", "libs", "acme-sdk-sources.jar"), "jar-bytes");
+        await writeFile(path.join(outputDir, "build", "libs", "acme-sdk.jar"), "jar-bytes");
+        await mkdir(path.join(outputDir, "build", "publications", "fernLocalPack"), { recursive: true });
+        await writeFile(
+            path.join(outputDir, "build", "publications", "fernLocalPack", "pom-default.xml"),
+            "<project />"
+        );
+        const group = {
+            groupName: "test",
+            audiences: { type: "all" },
+            generators: [createGenerator({ name: "fernapi/fern-java-sdk", language: "java", outputPath: outputDir })]
+        } as unknown as generatorsYml.GeneratorGroup;
+
+        await packLocalOutputForGroup({ group, context: createMockTaskContext() });
+
+        const distFiles = (await readdir(path.join(outputDir, "fern-dist"))).sort();
+        expect(distFiles).toEqual(["acme-sdk-javadoc.jar", "acme-sdk-sources.jar", "acme-sdk.jar", "acme-sdk.pom"]);
     });
 
     it("zips the module source for go generators without running any toolchain command", async () => {

--- a/packages/cli/cli/src/commands/generate/generateAPIWorkspace.ts
+++ b/packages/cli/cli/src/commands/generate/generateAPIWorkspace.ts
@@ -242,7 +242,14 @@ export async function generateWorkspace({
                     });
                 }
                 if (pack) {
-                    await packLocalOutputForGroup({ group, context: groupContext, mode: packMode, runner, packOnly });
+                    await packLocalOutputForGroup({
+                        group,
+                        context: groupContext,
+                        mode: packMode,
+                        runner,
+                        packOnly,
+                        version
+                    });
                 }
             })
         )

--- a/packages/cli/cli/src/commands/generate/packLocalOutput.ts
+++ b/packages/cli/cli/src/commands/generate/packLocalOutput.ts
@@ -4,7 +4,7 @@ import { AbsoluteFilePath, doesPathExist, join, RelativeFilePath } from "@fern-a
 import { loggingExeca } from "@fern-api/logging-execa";
 import { TaskContext } from "@fern-api/task-context";
 import { createWriteStream } from "fs";
-import { copyFile, mkdir, readdir, readFile, rename, rm, rmdir } from "fs/promises";
+import { copyFile, mkdir, readdir, readFile, rename, rm, rmdir, writeFile } from "fs/promises";
 import { basename } from "path";
 import { ZipFile } from "yazl";
 
@@ -40,7 +40,8 @@ export async function packLocalOutputForGroup({
     context,
     mode = "host",
     runner,
-    packOnly = false
+    packOnly = false,
+    version
 }: {
     group: generatorsYml.GeneratorGroup;
     context: TaskContext;
@@ -48,6 +49,8 @@ export async function packLocalOutputForGroup({
     runner?: ContainerRunner;
     /** Keep only the fern-dist/ artifact in each output directory, removing the generated SDK source. */
     packOnly?: boolean;
+    /** The version the SDKs were generated with (from --version), used in package metadata. */
+    version?: string;
 }): Promise<void> {
     const failures: string[] = [];
     for (const generator of group.generators) {
@@ -69,7 +72,8 @@ export async function packLocalOutputForGroup({
                 outputPath,
                 context,
                 mode,
-                runner: runner ?? "docker"
+                runner: runner ?? "docker",
+                version
             });
             if (packOnly) {
                 if (artifactProduced) {
@@ -98,13 +102,15 @@ async function packOutputForLanguage({
     outputPath,
     context,
     mode,
-    runner
+    runner,
+    version
 }: {
     language: generatorsYml.GenerationLanguage;
     outputPath: AbsoluteFilePath;
     context: TaskContext;
     mode: PackMode;
     runner: ContainerRunner;
+    version: string | undefined;
 }): Promise<boolean> {
     const distDir = join(outputPath, RelativeFilePath.of(PACK_OUTPUT_DIRECTORY));
     const run = async (commands: string[][]) => {
@@ -113,26 +119,121 @@ async function packOutputForLanguage({
     switch (language) {
         case "typescript": {
             await mkdir(distDir, { recursive: true });
-            const commands: string[][] = [["npm", "install"]];
+            await run([["npm", "install"]]);
+            // Compile the package before packing so the tarball ships runnable JavaScript and
+            // consumers can require() it right after npm install, without a post-install build.
             if (await hasNpmScript({ outputPath, script: "build" })) {
-                commands.push(["npm", "run", "build"]);
+                // Generated build scripts invoke pnpm, which isn't preinstalled on the host or in
+                // the node toolchain image — npx fetches it on demand and puts it on PATH for the
+                // nested `pnpm build:*` invocations.
+                await run([["npx", "--yes", "pnpm", "run", "build"]]);
+            } else {
+                const tsconfig = await findTsconfig(outputPath);
+                if (tsconfig != null) {
+                    try {
+                        await run([["npx", "--yes", "--package", "typescript", "tsc", "--project", tsconfig]]);
+                    } catch {
+                        // tsc emits output even when type errors are reported (noEmitOnError is off
+                        // by default); pack whatever was produced rather than failing the build.
+                        context.logger.warn(
+                            `tsc reported errors while compiling ${tsconfig}; packing the emitted output anyway.`
+                        );
+                    }
+                }
             }
-            commands.push(["npm", "pack", "--pack-destination", PACK_OUTPUT_DIRECTORY]);
-            await run(commands);
+            // Without a "files" field, npm pack falls back to .gitignore, which typically lists
+            // dist/ — silently dropping the compiled output from the tarball. An .npmignore takes
+            // precedence over .gitignore, so drop a temporary one that only excludes fern-dist.
+            const npmignorePath = join(outputPath, RelativeFilePath.of(".npmignore"));
+            const shouldWriteNpmignore =
+                !(await doesPathExist(npmignorePath)) &&
+                !(await hasPackageJsonFilesField(outputPath)) &&
+                (await doesPathExist(join(outputPath, RelativeFilePath.of(".gitignore"))));
+            if (shouldWriteNpmignore) {
+                await writeFile(npmignorePath, `${PACK_OUTPUT_DIRECTORY}/\n`);
+            }
+            try {
+                await run([["npm", "pack", "--pack-destination", PACK_OUTPUT_DIRECTORY]]);
+            } finally {
+                if (shouldWriteNpmignore) {
+                    await rm(npmignorePath, { force: true });
+                }
+            }
             logArtifacts({ distDir, context });
             return true;
         }
         case "python": {
             await mkdir(distDir, { recursive: true });
-            await run([["python3", "-m", "pip", "wheel", ".", "--no-deps", "--wheel-dir", PACK_OUTPUT_DIRECTORY]]);
+            const pipWheelCommand = [
+                "python3",
+                "-m",
+                "pip",
+                "wheel",
+                ".",
+                "--no-deps",
+                "--wheel-dir",
+                PACK_OUTPUT_DIRECTORY
+            ];
+            if (mode === "host") {
+                try {
+                    await run([pipWheelCommand]);
+                } catch {
+                    // Host pythons frequently can't run `pip wheel` directly (no pip module, old
+                    // interpreter, missing build tooling). Retry inside a throwaway venv with the
+                    // PyPA `build` frontend, which performs an isolated, PEP 517 build.
+                    context.logger.warn(
+                        "pip wheel failed on the host toolchain; retrying in an isolated build environment (python -m venv + python -m build)."
+                    );
+                    const venvDirectory = ".fern-pack-venv";
+                    const venvPython =
+                        process.platform === "win32"
+                            ? `${venvDirectory}/Scripts/python`
+                            : `${venvDirectory}/bin/python`;
+                    try {
+                        await run([
+                            ["python3", "-m", "venv", venvDirectory],
+                            [venvPython, "-m", "pip", "install", "--quiet", "build"],
+                            [venvPython, "-m", "build", "--wheel", "--outdir", PACK_OUTPUT_DIRECTORY]
+                        ]);
+                    } finally {
+                        await rm(join(outputPath, RelativeFilePath.of(venvDirectory)), {
+                            recursive: true,
+                            force: true
+                        });
+                    }
+                }
+            } else {
+                await run([pipWheelCommand]);
+            }
             logArtifacts({ distDir, context });
             return true;
         }
         case "java": {
             await mkdir(distDir, { recursive: true });
-            await run([["gradle", "jar", "-x", "test"]]);
+            // A bare JAR carries no dependency metadata, so consumers would have to declare every
+            // transitive dependency by hand. Generate a POM alongside it via an init script that
+            // registers a maven-publish publication (local outputs have no publishing config).
+            const initScriptName = ".fern-pack-pom-init.gradle";
+            const initScriptPath = join(outputPath, RelativeFilePath.of(initScriptName));
+            await writeFile(initScriptPath, getJavaPomInitScript({ fallbackVersion: version ?? "0.0.0" }));
+            try {
+                await run([
+                    [
+                        "gradle",
+                        "--init-script",
+                        initScriptName,
+                        "jar",
+                        `generatePomFileFor${JAVA_POM_PUBLICATION_NAME_CAPITALIZED}Publication`,
+                        "-x",
+                        "test"
+                    ]
+                ]);
+            } finally {
+                await rm(initScriptPath, { force: true });
+            }
             const libsDir = join(outputPath, RelativeFilePath.of("build/libs"));
             await copyMatchingFiles({ fromDir: libsDir, toDir: distDir, extension: ".jar" });
+            await copyGeneratedPom({ outputPath, distDir, context });
             logArtifacts({ distDir, context });
             return true;
         }
@@ -235,7 +336,11 @@ async function runPackCommands({
         if (image == null) {
             throw new Error(`No Docker toolchain image is configured for ${language}.`);
         }
-        const containerArgs = ["run", "--rm", "-v", `${outputPath}:/workspace`, "-w", "/workspace", "-e", "HOME=/tmp"];
+        // Mount under a directory that keeps the output folder's name so toolchains that derive
+        // package identity from the directory name (e.g. Gradle's project name) behave the same
+        // as on the host.
+        const workdir = `/workspace/${basename(outputPath)}`;
+        const containerArgs = ["run", "--rm", "-v", `${outputPath}:${workdir}`, "-w", workdir, "-e", "HOME=/tmp"];
         // Run as the invoking user on POSIX hosts so artifacts in the mounted volume aren't root-owned.
         if (process.getuid != null && process.getgid != null) {
             containerArgs.push("--user", `${process.getuid()}:${process.getgid()}`);
@@ -325,6 +430,80 @@ async function removeDistDirIfEmpty(outputPath: AbsoluteFilePath): Promise<void>
     } catch {
         // dist dir was never created (or was removed concurrently) — nothing to clean up
     }
+}
+
+const JAVA_POM_PUBLICATION_NAME = "fernLocalPack";
+const JAVA_POM_PUBLICATION_NAME_CAPITALIZED = "FernLocalPack";
+
+/**
+ * Gradle init script that registers a maven-publish publication on every java project so
+ * `generatePomFileFor...Publication` can emit a POM with the project's dependencies, even when
+ * the generated build.gradle has no publishing configuration (the local-file-system case).
+ */
+function getJavaPomInitScript({ fallbackVersion }: { fallbackVersion: string }): string {
+    return `allprojects { project ->
+    project.plugins.withId("java") {
+        project.apply plugin: "maven-publish"
+        project.afterEvaluate {
+            if (project.group == null || project.group.toString().isEmpty()) {
+                project.group = project.name
+            }
+            if (project.version == null || project.version.toString() == "unspecified") {
+                project.version = "${fallbackVersion}"
+            }
+            if (project.publishing.publications.findByName("${JAVA_POM_PUBLICATION_NAME}") == null) {
+                project.publishing.publications.create("${JAVA_POM_PUBLICATION_NAME}", MavenPublication) {
+                    from project.components.java
+                }
+            }
+        }
+    }
+}
+`;
+}
+
+/** Copies the POM emitted by the init-script publication into fern-dist, named after the jar. */
+async function copyGeneratedPom({
+    outputPath,
+    distDir,
+    context
+}: {
+    outputPath: AbsoluteFilePath;
+    distDir: AbsoluteFilePath;
+    context: TaskContext;
+}): Promise<void> {
+    const pomPath = join(
+        outputPath,
+        RelativeFilePath.of(`build/publications/${JAVA_POM_PUBLICATION_NAME}/pom-default.xml`)
+    );
+    if (!(await doesPathExist(pomPath))) {
+        context.logger.warn(
+            "No POM was generated for the Java package; the JAR is packaged without dependency metadata."
+        );
+        return;
+    }
+    const jarName = (await readdir(distDir)).find((file) => file.endsWith(".jar"));
+    const pomName = jarName != null ? `${jarName.slice(0, -".jar".length)}.pom` : "pom.xml";
+    await copyFile(pomPath, join(distDir, RelativeFilePath.of(pomName)));
+}
+
+/** Returns the tsconfig to compile with when the package has no build script, if one exists. */
+async function findTsconfig(outputPath: AbsoluteFilePath): Promise<string | undefined> {
+    for (const candidate of ["tsconfig.cjs.json", "tsconfig.json"]) {
+        if (await doesPathExist(join(outputPath, RelativeFilePath.of(candidate)))) {
+            return candidate;
+        }
+    }
+    return undefined;
+}
+
+async function hasPackageJsonFilesField(outputPath: AbsoluteFilePath): Promise<boolean> {
+    const packageJsonPath = join(outputPath, RelativeFilePath.of("package.json"));
+    if (!(await doesPathExist(packageJsonPath))) {
+        return false;
+    }
+    const parsed: unknown = JSON.parse(await readFile(packageJsonPath, "utf-8"));
+    return typeof parsed === "object" && parsed != null && "files" in parsed;
 }
 
 async function hasNpmScript({

--- a/packages/cli/cli/src/commands/generate/packLocalOutput.ts
+++ b/packages/cli/cli/src/commands/generate/packLocalOutput.ts
@@ -132,9 +132,14 @@ async function packOutputForLanguage({
                 if (tsconfig != null) {
                     try {
                         await run([["npx", "--yes", "--package", "typescript", "tsc", "--project", tsconfig]]);
-                    } catch {
+                    } catch (error) {
                         // tsc emits output even when type errors are reported (noEmitOnError is off
-                        // by default); pack whatever was produced rather than failing the build.
+                        // by default); pack whatever was produced rather than failing the build. If
+                        // nothing was emitted at all, the failure was real (e.g. npx couldn't fetch
+                        // typescript), so don't ship a tarball with no compiled code.
+                        if (!(await hasEmittedCompilerOutput({ outputPath, tsconfig }))) {
+                            throw error;
+                        }
                         context.logger.warn(
                             `tsc reported errors while compiling ${tsconfig}; packing the emitted output anyway.`
                         );
@@ -482,9 +487,44 @@ async function copyGeneratedPom({
         );
         return;
     }
-    const jarName = (await readdir(distDir)).find((file) => file.endsWith(".jar"));
+    const jarNames = (await readdir(distDir)).filter((file) => file.endsWith(".jar"));
+    const jarName =
+        jarNames.find((file) => !file.endsWith("-sources.jar") && !file.endsWith("-javadoc.jar")) ?? jarNames[0];
     const pomName = jarName != null ? `${jarName.slice(0, -".jar".length)}.pom` : "pom.xml";
     await copyFile(pomPath, join(distDir, RelativeFilePath.of(pomName)));
+}
+
+/** Whether the tsconfig's outDir (or ./dist by default) exists and is non-empty. */
+async function hasEmittedCompilerOutput({
+    outputPath,
+    tsconfig
+}: {
+    outputPath: AbsoluteFilePath;
+    tsconfig: string;
+}): Promise<boolean> {
+    let outDir = "dist";
+    try {
+        const parsed: unknown = JSON.parse(await readFile(join(outputPath, RelativeFilePath.of(tsconfig)), "utf-8"));
+        if (typeof parsed === "object" && parsed != null && "compilerOptions" in parsed) {
+            const compilerOptions = (parsed as { compilerOptions: unknown }).compilerOptions;
+            if (
+                typeof compilerOptions === "object" &&
+                compilerOptions != null &&
+                "outDir" in compilerOptions &&
+                typeof (compilerOptions as { outDir: unknown }).outDir === "string"
+            ) {
+                outDir = (compilerOptions as { outDir: string }).outDir;
+            }
+        }
+    } catch {
+        // tsconfig files may contain comments or be otherwise unparseable as plain JSON;
+        // fall back to the conventional ./dist output directory.
+    }
+    const outDirPath = join(outputPath, RelativeFilePath.of(outDir));
+    if (!(await doesPathExist(outDirPath))) {
+        return false;
+    }
+    return (await readdir(outDirPath)).length > 0;
 }
 
 /** Returns the tsconfig to compile with when the package has no build script, if one exists. */


### PR DESCRIPTION
## Description
Fixes three gaps in `fern generate --package` / `--package-only` artifacts (reported against the Twilio local-packaging workflow):

1. **TypeScript tarballs shipped only `.ts` source** — no prebuilt `dist/`, so `require()` failed right after `npm install`.
2. **Java JARs had no POM/dependency metadata** — consumers had to hand-declare every transitive dependency.
3. **Python host-mode packaging failed on hosts with old/incomplete Python tooling**, forcing manual wheel-build fallbacks in user scripts.

## Changes Made
- TypeScript packaging now compiles before `npm pack`:
  - with a `build` script: runs it via `npx --yes pnpm run build` (generated build scripts invoke pnpm, which isn't preinstalled on hosts or in `node:22`)
  - without one: falls back to `npx --yes --package typescript tsc --project tsconfig.cjs.json|tsconfig.json` (tolerating type errors, since tsc still emits)
  - writes a temporary `.npmignore` (only excluding `fern-dist/`) when the package has no `files` field but has a `.gitignore` — otherwise `npm pack` honors `.gitignore` and silently drops `dist/` from the tarball
- Java packaging runs gradle with a temporary init script that applies `maven-publish`, registers a `fernLocalPack` publication (`from components.java`), and copies the generated POM into `fern-dist/` next to the JAR (named `<jar-base>.pom`); falls back to the generated `--version` (or `0.0.0`) when the project has no version
- Python host-mode packaging retries in a throwaway `.fern-pack-venv` with the PyPA `build` frontend (`python -m build --wheel`) when `pip wheel` fails
- Docker mode now mounts the output directory at `/workspace/<dirname>` so toolchains that derive package identity from the directory name (Gradle project name → JAR/POM coordinates) behave the same as on the host
- `packLocalOutputForGroup` now receives the generation `--version` for use in package metadata

## Testing
- [x] Unit tests added/updated (15/15 pass: tsc fallback, pnpm-via-npx build, python venv fallback, java POM generation + init-script cleanup, docker mount path)
- [x] Manual testing completed against `fern-demo/twilio-core-fern-config` with a locally built CLI:
  - Node: tarball now contains 1092 `dist/cjs` files; `npm install <tgz> && require("twilio-core")` works with no post-install compile
  - Java: `twilio-core-java-sdk-0.0.1.jar` + `twilio-core-java-sdk.pom` with the full dependency list (okhttp, jackson, …) generated in-container
  - Python & C#: artifacts unchanged and still build with the new mount path


Link to Devin session: https://app.devin.ai/sessions/0076a65e5b6743f78ba15496f2573f41
Requested by: @iamnamananand996
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/17323" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->