### PR TITLE
fix(ruby): skip exact Basic Authorization assertion in wire tests when OAuth is configured

### DIFF
--- a/generators/ruby-v2/sdk/changes/unreleased/fix-any-auth-basic-assertion-with-oauth.yml
+++ b/generators/ruby-v2/sdk/changes/unreleased/fix-any-auth-basic-assertion-with-oauth.yml
@@ -1,0 +1,6 @@
+- summary: |
+    Wire tests no longer assert an exact `Basic` Authorization header when an OAuth
+    scheme is also configured: the test client is constructed with client credentials,
+    so the OAuth provider's dynamic Bearer token takes precedence over the static
+    Basic header at request time.
+  type: fix

--- a/generators/ruby-v2/sdk/src/wire-tests/WireTestGenerator.ts
+++ b/generators/ruby-v2/sdk/src/wire-tests/WireTestGenerator.ts
@@ -409,8 +409,12 @@ export class WireTestGenerator {
                 // scheme's header is absent) rather than asserting a single global auth header.
                 lines.push(...this.buildEndpointSecurityAuthAssertion(endpoint, basePath));
             } else {
-                // Verify Authorization header when basic auth is configured
-                const expectedAuthHeader = this.buildExpectedAuthorizationHeader();
+                // Verify Authorization header when basic auth is configured.
+                // Skipped when an OAuth scheme is also configured: the test client is
+                // constructed with client credentials, so the OAuth provider's dynamic
+                // Bearer token overwrites the static Basic header at request time.
+                const hasOAuthScheme = this.context.ir.auth.schemes.some((scheme) => scheme.type === "oauth");
+                const expectedAuthHeader = hasOAuthScheme ? null : this.buildExpectedAuthorizationHeader();
                 if (expectedAuthHeader != null) {
                     lines.push(``);
                     lines.push(`    verify_authorization_header(`);
@@ -779,13 +783,6 @@ export class WireTestGenerator {
      * or null if no basic auth scheme is configured.
      */
     private buildExpectedAuthorizationHeader(): string | null {
-        // When an OAuth scheme is configured, the test client is constructed with
-        // client credentials, so the OAuth provider's resolved Bearer token takes
-        // precedence over the static Basic Authorization header at request time.
-        // The token value is dynamic, so no exact assertion can be made.
-        if (this.context.ir.auth.schemes.some((scheme) => scheme.type === "oauth")) {
-            return null;
-        }
         for (const scheme of this.context.ir.auth.schemes) {
             if (scheme.type === "basic") {
                 if (scheme.usernameOmit && scheme.passwordOmit) {

--- a/generators/ruby-v2/sdk/src/wire-tests/WireTestGenerator.ts
+++ b/generators/ruby-v2/sdk/src/wire-tests/WireTestGenerator.ts
@@ -779,6 +779,13 @@ export class WireTestGenerator {
      * or null if no basic auth scheme is configured.
      */
     private buildExpectedAuthorizationHeader(): string | null {
+        // When an OAuth scheme is configured, the test client is constructed with
+        // client credentials, so the OAuth provider's resolved Bearer token takes
+        // precedence over the static Basic Authorization header at request time.
+        // The token value is dynamic, so no exact assertion can be made.
+        if (this.context.ir.auth.schemes.some((scheme) => scheme.type === "oauth")) {
+            return null;
+        }
         for (const scheme of this.context.ir.auth.schemes) {
             if (scheme.type === "basic") {
                 if (scheme.usernameOmit && scheme.passwordOmit) {

--- a/seed/ruby-sdk-v2/any-auth/test/wire/auth_test.rb
+++ b/seed/ruby-sdk-v2/any-auth/test/wire/auth_test.rb
@@ -39,12 +39,5 @@ class AuthWireTest < WireMockTestCase
       query_params: nil,
       expected: 1
     )
-
-    verify_authorization_header(
-      test_id: test_id,
-      method: "POST",
-      url_path: "/token",
-      expected_value: "Basic dGVzdC11c2VybmFtZTp0ZXN0LXBhc3N3b3Jk"
-    )
   end
 end

--- a/seed/ruby-sdk-v2/any-auth/test/wire/user_test.rb
+++ b/seed/ruby-sdk-v2/any-auth/test/wire/user_test.rb
@@ -33,13 +33,6 @@ class UserWireTest < WireMockTestCase
       query_params: nil,
       expected: 1
     )
-
-    verify_authorization_header(
-      test_id: test_id,
-      method: "POST",
-      url_path: "/users",
-      expected_value: "Basic dGVzdC11c2VybmFtZTp0ZXN0LXBhc3N3b3Jk"
-    )
   end
 
   def test_user_get_admins_with_wiremock
@@ -57,13 +50,6 @@ class UserWireTest < WireMockTestCase
       url_path: "/admins",
       query_params: nil,
       expected: 1
-    )
-
-    verify_authorization_header(
-      test_id: test_id,
-      method: "GET",
-      url_path: "/admins",
-      expected_value: "Basic dGVzdC11c2VybmFtZTp0ZXN0LXBhc3N3b3Jk"
     )
   end
 end


### PR DESCRIPTION
## Description
Generated Ruby wire tests for APIs with `auth: any` combining Basic and OAuth asserted an exact `Basic ...` Authorization header. But the generated client is constructed with OAuth client credentials, and the raw client resolves the OAuth provider's Bearer token per request, which takes precedence over the static Basic header (`@default_headers.merge(auth_headers)`). Every wire test then fails with:

```
Expected Authorization header 'Basic dGVzdC11c2VybmFtZTp0ZXN0LXBhc3N3b3Jk', got 'Bearer eyJ...'
```

Observed against a real config (twilio-core, `auth: any: [BasicAuth, OAuth]`, ruby generator 1.21.2).

## Changes Made
- `WireTestGenerator.buildExpectedAuthorizationHeader` now returns `null` when an OAuth scheme is configured — the Bearer token is dynamic, so no exact assertion is possible.
- Regenerated `seed/ruby-sdk-v2/any-auth` (Basic assertions removed from wire tests).
- Added unreleased changelog entry.

## Testing
- [x] `pnpm seed:local test --generator ruby-sdk-v2 --fixture any-auth` — 1/1 passed
- [x] Verified against twilio-core config: full generated wire-test suite passes with this fix

Link to Devin session: https://app.devin.ai/sessions/0076a65e5b6743f78ba15496f2573f41
Requested by: @iamnamananand996
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/17359" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->