### PR TITLE
fix(cli): resolve Java kebab-case package-name config key — removes misleading "packageName is missing" warning

### DIFF
--- a/packages/cli/cli/changes/unreleased/fix-java-package-name-resolution.yml
+++ b/packages/cli/cli/changes/unreleased/fix-java-package-name-resolution.yml
@@ -1,0 +1,6 @@
+- summary: |
+    Resolve the Java generator's kebab-case `package-name` config key when computing the package
+    name for local-file-system output. Previously configs using `package-name` (without
+    `group`/`artifact`) logged a misleading "package-prefix configured but packageName is missing"
+    warning even though the name was set.
+  type: fix

--- a/packages/commons/api-workspace-commons/src/__test__/checkVersionExists.test.ts
+++ b/packages/commons/api-workspace-commons/src/__test__/checkVersionExists.test.ts
@@ -877,6 +877,14 @@ describe("getPackageNameFromGeneratorConfig", () => {
         expect(getPackageNameFromGeneratorConfig(invocation)).toBe("my_package");
     });
 
+    it("returns package-name from config for Java (kebab-case key)", () => {
+        const invocation = {
+            raw: { config: { "package-name": "twilio-core", "package-prefix": "com.twilio.api" } }
+            // biome-ignore lint/suspicious/noExplicitAny: test stub
+        } as any;
+        expect(getPackageNameFromGeneratorConfig(invocation)).toBe("twilio-core");
+    });
+
     it("returns module.path from config for Go", () => {
         const invocation = {
             raw: { config: { module: { path: "github.com/acme/go-sdk" } } }

--- a/packages/commons/api-workspace-commons/src/checkVersionExists.ts
+++ b/packages/commons/api-workspace-commons/src/checkVersionExists.ts
@@ -15,8 +15,9 @@ import { CliError, TaskContext } from "@fern-api/task-context";
  * 1. `output["package-name"]` — npm, PyPI, NuGet, RubyGems, crates.io
  * 2. `output.coordinate`      — Maven (Java)
  * 3. `config.package_name`    — fallback (some generators)
- * 4. `config.module.path`     — Go SDK generator
- * 5. `config.packageName`     — PHP SDK generator (camelCase config key)
+ * 4. `config["package-name"]` — Java SDK generator (kebab-case config key)
+ * 5. `config.module.path`     — Go SDK generator
+ * 6. `config.packageName`     — PHP SDK generator (camelCase config key)
  *
  * @internal Exported for testing and reuse in generation paths
  */
@@ -42,6 +43,12 @@ export function getPackageNameFromGeneratorConfig(
         const packageName = (generatorInvocation.raw.config as { package_name?: string }).package_name;
         if (packageName != null) {
             return packageName;
+        }
+
+        // java-sdk generator uses the kebab-case package-name config key
+        const kebabCasePackageName = (generatorInvocation.raw.config as { ["package-name"]?: unknown })["package-name"];
+        if (typeof kebabCasePackageName === "string") {
+            return kebabCasePackageName;
         }
 
         // go-sdk generator uses module.path to set the package name

--- a/packages/commons/api-workspace-commons/src/getFilesystemPublishTarget.ts
+++ b/packages/commons/api-workspace-commons/src/getFilesystemPublishTarget.ts
@@ -120,7 +120,10 @@ export function getFilesystemPublishTarget({
                     artifactId: packageName
                 };
             } else if (typeof configObj["package-prefix"] === "string" && !packageName) {
-                context.logger.warn("Java generator has package-prefix configured but packageName is missing");
+                context.logger.warn(
+                    "Java generator has package-prefix configured but no package name could be resolved. " +
+                        "Set 'package-name' (or 'group' and 'artifact') in the generator config to stamp Maven coordinates."
+                );
             }
 
             return undefined;


### PR DESCRIPTION
## Description
For local-file-system output, the Java branch of `getFilesystemPublishTarget` warned `"Java generator has package-prefix configured but packageName is missing"` even when the generator config had `package-name` set. The package-name resolver (`getPackageNameFromGeneratorConfig`) only looked at `config.package_name` (snake_case), `config.module.path` (Go), and `config.packageName` (PHP camelCase) — never the Java generator's kebab-case `config["package-name"]` key.

## Changes Made
- `getPackageNameFromGeneratorConfig` now also resolves `config["package-name"]` (after `package_name`, before Go/PHP keys), so Java configs using `package-name` + `package-prefix` get a proper Maven publish target instead of a warning.
- Reworded the residual Java warning (now only fires when no name can be resolved at all) to say what to set: `package-name` or `group`/`artifact`.
- Unit test for the new lookup; CLI changelog entry.

## Testing
- [x] Unit tests added/updated (`checkVersionExists.test.ts` — all 14 turbo tasks pass with `--force`)
- [x] Manual testing completed (reproduced with twilio-core-fern-config's `java-sdk-local` config: `package-name: twilio-core`, `package-prefix: com.twilio.api`)


Link to Devin session: https://app.devin.ai/sessions/0076a65e5b6743f78ba15496f2573f41
Requested by: @iamnamananand996
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/17361" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->