### PR TITLE
fix(cli): don't bundle test files as mdx components, and allow pre-bundling

### DIFF
--- a/packages/cli/cli/changes/unreleased/mdx-component-bundle-cache.yml
+++ b/packages/cli/cli/changes/unreleased/mdx-component-bundle-cache.yml
@@ -1,0 +1,11 @@
+- summary: |
+    Skip test files (`*.test.*`, `*.spec.*`, `__tests__/`) and node builtin imports when
+    bundling `experimental.mdx-components`, so a component folder containing tests no longer
+    fails docs generation.
+  type: fix
+- summary: |
+    Cache custom MDX component bundles in `FERN_MDX_BUNDLE_CACHE_DIR` when it is set, and
+    populate that cache from `fern install-dependencies`. This lets air-gapped deployments
+    bundle components ahead of time, during a phase that has network access, instead of at
+    generation time.
+  type: feat

--- a/packages/cli/cli/src/commands/install-dependencies/installDependencies.ts
+++ b/packages/cli/cli/src/commands/install-dependencies/installDependencies.ts
@@ -61,8 +61,18 @@ async function bundleDocsMdxComponents(context: TaskContext): Promise<boolean> {
         return true;
     }
 
-    const docsWorkspace = await loadDocsWorkspace({ fernDirectory, context });
-    const mdxComponents = docsWorkspace?.config.experimental?.mdxComponents;
+    let mdxComponents: string[] | undefined;
+    try {
+        const docsWorkspace = await loadDocsWorkspace({ fernDirectory, context });
+        mdxComponents = docsWorkspace?.config.experimental?.mdxComponents;
+    } catch (error) {
+        // An unparseable docs config is not this command's concern; `fern generate` reports it.
+        context.logger.debug(
+            `Skipping custom MDX component bundling, failed to load the docs config: ${error instanceof Error ? error.message : error}`
+        );
+        return true;
+    }
+
     if (mdxComponents == null || mdxComponents.length === 0) {
         return true;
     }

--- a/packages/cli/cli/src/commands/install-dependencies/installDependencies.ts
+++ b/packages/cli/cli/src/commands/install-dependencies/installDependencies.ts
@@ -1,5 +1,8 @@
+import { getFernDirectory } from "@fern-api/configuration-loader";
+import { bundleMdxComponents } from "@fern-api/docs-resolver";
 import { resolveBuf, resolveProtocGenOpenAPI } from "@fern-api/lazy-fern-workspace";
-import { CliError } from "@fern-api/task-context";
+import { CliError, TaskContext } from "@fern-api/task-context";
+import { loadDocsWorkspace } from "@fern-api/workspace-loader";
 import { CliContext } from "../../cli-context/CliContext.js";
 
 export async function installDependencies({ cliContext }: { cliContext: CliContext }): Promise<void> {
@@ -30,6 +33,9 @@ export async function installDependencies({ cliContext }: { cliContext: CliConte
             context.logger.error("Failed to install protoc-gen-openapi");
         }
 
+        // Pre-bundle custom MDX components so `fern generate` doesn't need network for them
+        results.push({ name: "mdx-components", success: await bundleDocsMdxComponents(context) });
+
         // Summary
         const failed = results.filter((r) => !r.success);
         if (failed.length > 0) {
@@ -42,4 +48,38 @@ export async function installDependencies({ cliContext }: { cliContext: CliConte
 
         context.logger.info("All dependencies installed successfully.");
     });
+}
+
+/**
+ * Bundles the docs project's custom MDX components, if any. This is a no-op
+ * unless the project has `experimental.mdx-components` whose files import
+ * third-party libraries.
+ */
+async function bundleDocsMdxComponents(context: TaskContext): Promise<boolean> {
+    const fernDirectory = await getFernDirectory();
+    if (fernDirectory == null) {
+        return true;
+    }
+
+    const docsWorkspace = await loadDocsWorkspace({ fernDirectory, context });
+    const mdxComponents = docsWorkspace?.config.experimental?.mdxComponents;
+    if (mdxComponents == null || mdxComponents.length === 0) {
+        return true;
+    }
+
+    context.logger.info("Bundling custom MDX components...");
+    try {
+        const count = await bundleMdxComponents({
+            absolutePathToDocsWorkspace: fernDirectory,
+            mdxComponents,
+            context
+        });
+        context.logger.info(`Bundled ${count} custom MDX component(s)`);
+        return true;
+    } catch (error) {
+        context.logger.error(
+            `Failed to bundle custom MDX components: ${error instanceof Error ? error.message : error}`
+        );
+        return false;
+    }
 }

--- a/packages/cli/docs-resolver/src/DocsDefinitionResolver.ts
+++ b/packages/cli/docs-resolver/src/DocsDefinitionResolver.ts
@@ -21,7 +21,7 @@ import {
     transformAtPrefixImports
 } from "@fern-api/docs-markdown-utils";
 import { APIV1Write, DocsV1Write, FdrAPI, FernNavigation } from "@fern-api/fdr-sdk";
-import { AbsoluteFilePath, join, listFiles, RelativeFilePath, relative, resolve } from "@fern-api/fs-utils";
+import { AbsoluteFilePath, join, RelativeFilePath, relative, resolve } from "@fern-api/fs-utils";
 import { GraphQLConverter, type GraphQlOperationExamplesInput } from "@fern-api/graphql-to-fdr";
 import { generateIntermediateRepresentation } from "@fern-api/ir-generator";
 import { IntermediateRepresentation } from "@fern-api/ir-sdk";
@@ -34,7 +34,7 @@ import { AbstractAPIWorkspace, DocsWorkspace, FernWorkspace } from "@fern-api/wo
 import dayjs from "dayjs";
 import utc from "dayjs/plugin/utc";
 import { existsSync } from "fs";
-import { readFile, stat } from "fs/promises";
+import { readFile } from "fs/promises";
 import matter from "gray-matter";
 import jsYaml from "js-yaml";
 import { camelCase, kebabCase } from "lodash-es";
@@ -78,6 +78,7 @@ import { ApiReferenceNodeConverter } from "./ApiReferenceNodeConverter.js";
 import { ChangelogNodeConverter } from "./ChangelogNodeConverter.js";
 import { NodeIdGenerator } from "./NodeIdGenerator.js";
 import { maybeBundleMdxComponent } from "./utils/bundleMdxComponent.js";
+import { collectMdxComponentFiles } from "./utils/collectMdxComponentFiles.js";
 import { collectWellKnownSkillsFiles } from "./utils/collectWellKnownSkillsFiles.js";
 import { convertDocsAvailability } from "./utils/convertDocsAvailability.js";
 import { convertDocsSnippetsConfigToFdr } from "./utils/convertDocsSnippetsConfigToFdr.js";
@@ -771,29 +772,14 @@ export class DocsDefinitionResolver {
         if (this._parsedDocsConfig.experimental?.mdxComponents != null) {
             this.taskContext.logger.debug("Processing MDX components...");
             const mdxStart = performance.now();
-            const jsFilePaths = new Set<AbsoluteFilePath>();
-            await Promise.all(
-                this._parsedDocsConfig.experimental.mdxComponents.map(async (filepath) => {
-                    const absoluteFilePath = resolve(this.docsWorkspace.absoluteFilePath, filepath);
-
-                    // check if absoluteFilePath is a directory or a file
-                    const stats = await stat(absoluteFilePath);
-
-                    if (stats.isDirectory()) {
-                        const files = await listFiles(absoluteFilePath, "{js,ts,jsx,tsx,md,mdx}");
-
-                        files.forEach((file) => {
-                            jsFilePaths.add(file);
-                        });
-                    } else if (absoluteFilePath.match(/\.(js|ts|jsx|tsx|md|mdx)$/) != null) {
-                        jsFilePaths.add(absoluteFilePath);
-                    }
-                })
-            );
+            const jsFilePaths = await collectMdxComponentFiles({
+                absolutePathToDocsWorkspace: this.docsWorkspace.absoluteFilePath,
+                mdxComponents: this._parsedDocsConfig.experimental.mdxComponents
+            });
 
             jsFiles = Object.fromEntries(
                 await Promise.all(
-                    [...jsFilePaths].map(async (filePath): Promise<[string, string]> => {
+                    jsFilePaths.map(async (filePath): Promise<[string, string]> => {
                         const relativeFilePath = this.toRelativeFilepath(filePath);
                         const contents = (await readFile(filePath)).toString();
                         return [relativeFilePath, await this.bundleJsFileContents(filePath, contents)];
@@ -802,7 +788,7 @@ export class DocsDefinitionResolver {
             );
             const mdxTime = performance.now() - mdxStart;
             this.taskContext.logger.debug(
-                `Processed ${jsFilePaths.size} MDX component files in ${mdxTime.toFixed(0)}ms`
+                `Processed ${jsFilePaths.length} MDX component files in ${mdxTime.toFixed(0)}ms`
             );
         }
 

--- a/packages/cli/docs-resolver/src/bundleMdxComponents.ts
+++ b/packages/cli/docs-resolver/src/bundleMdxComponents.ts
@@ -1,0 +1,42 @@
+import { AbsoluteFilePath } from "@fern-api/fs-utils";
+import { TaskContext } from "@fern-api/task-context";
+import { readFile } from "fs/promises";
+
+import { getBundleCacheDir, maybeBundleMdxComponent } from "./utils/bundleMdxComponent.js";
+import { collectMdxComponentFiles } from "./utils/collectMdxComponentFiles.js";
+
+/**
+ * Bundles every `experimental.mdx-components` file that imports third-party
+ * libraries, populating the bundle cache (`FERN_MDX_BUNDLE_CACHE_DIR`) so a
+ * later `fern generate` reuses the output instead of invoking rolldown — which
+ * needs network — itself.
+ *
+ * Returns the number of components that were bundled.
+ */
+export async function bundleMdxComponents({
+    absolutePathToDocsWorkspace,
+    mdxComponents,
+    context
+}: {
+    absolutePathToDocsWorkspace: AbsoluteFilePath;
+    mdxComponents: readonly string[];
+    context: TaskContext;
+}): Promise<number> {
+    const cacheDir = getBundleCacheDir();
+    if (cacheDir == null) {
+        context.logger.debug("Skipping MDX component bundling: no bundle cache directory is configured.");
+        return 0;
+    }
+    context.logger.debug(`Writing MDX component bundles to ${cacheDir}`);
+
+    const filePaths = await collectMdxComponentFiles({ absolutePathToDocsWorkspace, mdxComponents });
+
+    const bundled = await Promise.all(
+        filePaths.map(async (absoluteFilePath) => {
+            const contents = (await readFile(absoluteFilePath)).toString();
+            return await maybeBundleMdxComponent({ absoluteFilePath, contents, context });
+        })
+    );
+
+    return bundled.filter((result) => result != null).length;
+}

--- a/packages/cli/docs-resolver/src/index.ts
+++ b/packages/cli/docs-resolver/src/index.ts
@@ -18,6 +18,7 @@ export {
     getTranslatedAnnouncement
 } from "./applyTranslatedNavigationOverlays.js";
 export type TranslationNavigationOverlay = docsYml.TranslationNavigationOverlay;
+export { bundleMdxComponents } from "./bundleMdxComponents.js";
 export {
     DocsDefinitionResolver,
     type RegisterApiFn,

--- a/packages/cli/docs-resolver/src/utils/__test__/bundleMdxComponent.test.ts
+++ b/packages/cli/docs-resolver/src/utils/__test__/bundleMdxComponent.test.ts
@@ -1,12 +1,14 @@
 import { AbsoluteFilePath } from "@fern-api/fs-utils";
 import { createMockTaskContext } from "@fern-api/task-context";
-import { mkdir, writeFile } from "fs/promises";
+import { mkdir, rm, writeFile } from "fs/promises";
 import path from "path";
 import tmp from "tmp-promise";
 
 import { getThirdPartyImports, maybeBundleMdxComponent } from "../bundleMdxComponent.js";
 
 const context = createMockTaskContext();
+
+const BUNDLE_CACHE_DIR_ENV_VAR = "FERN_MDX_BUNDLE_CACHE_DIR";
 
 describe("getThirdPartyImports", () => {
     it("detects bare imports", () => {
@@ -55,6 +57,17 @@ describe("getThirdPartyImports", () => {
 
     it("returns empty for code without imports", () => {
         expect(getThirdPartyImports("export const Foo = () => null;")).toEqual([]);
+    });
+
+    it("ignores node builtins", () => {
+        expect(
+            getThirdPartyImports(`
+                import { test } from "node:test";
+                import assert from "node:assert/strict";
+                import path from "path";
+                import { readFile } from "fs/promises";
+            `)
+        ).toEqual([]);
     });
 });
 
@@ -121,6 +134,50 @@ describe("maybeBundleMdxComponent", () => {
             expect(bundled).toContain("./constants");
         } finally {
             await cleanup();
+        }
+    }, 120_000);
+
+    it("reuses a cached bundle instead of running rolldown again", async () => {
+        const { path: projectDir, cleanup: cleanupProject } = await tmp.dir({ unsafeCleanup: true });
+        const { path: cacheDir, cleanup: cleanupCache } = await tmp.dir({ unsafeCleanup: true });
+        const originalCacheDir = process.env[BUNDLE_CACHE_DIR_ENV_VAR];
+        process.env[BUNDLE_CACHE_DIR_ENV_VAR] = cacheDir;
+        try {
+            const packageDir = path.join(projectDir, "node_modules", "fake-greeting-lib");
+            await mkdir(packageDir, { recursive: true });
+            await writeFile(
+                path.join(packageDir, "package.json"),
+                JSON.stringify({ name: "fake-greeting-lib", version: "1.0.0", main: "index.js" })
+            );
+            await writeFile(
+                path.join(packageDir, "index.js"),
+                `export function greet(name) { return "MARKER_FROM_FAKE_LIB " + name; }`
+            );
+
+            const componentsDir = path.join(projectDir, "components");
+            await mkdir(componentsDir, { recursive: true });
+            const componentPath = path.join(componentsDir, "Greeting.tsx");
+            const contents = [
+                `import { greet } from "fake-greeting-lib";`,
+                `export const Greeting = ({ name }) => greet(name);`
+            ].join("\n");
+            await writeFile(componentPath, contents);
+
+            const args = { absoluteFilePath: AbsoluteFilePath.of(componentPath), contents, context };
+            const bundled = await maybeBundleMdxComponent(args);
+            expect(bundled).toContain("MARKER_FROM_FAKE_LIB");
+
+            // The library is gone, so this only succeeds by reading the cache
+            await rm(path.join(projectDir, "node_modules"), { recursive: true });
+            expect(await maybeBundleMdxComponent(args)).toBe(bundled);
+        } finally {
+            if (originalCacheDir == null) {
+                delete process.env[BUNDLE_CACHE_DIR_ENV_VAR];
+            } else {
+                process.env[BUNDLE_CACHE_DIR_ENV_VAR] = originalCacheDir;
+            }
+            await cleanupCache();
+            await cleanupProject();
         }
     }, 120_000);
 });

--- a/packages/cli/docs-resolver/src/utils/__test__/collectMdxComponentFiles.test.ts
+++ b/packages/cli/docs-resolver/src/utils/__test__/collectMdxComponentFiles.test.ts
@@ -41,6 +41,19 @@ describe("collectMdxComponentFiles", () => {
         }
     });
 
+    it("accepts an absolute component path", async () => {
+        const { dir, cleanup } = await createDocsWorkspace();
+        try {
+            const files = await collectMdxComponentFiles({
+                absolutePathToDocsWorkspace: AbsoluteFilePath.of(dir),
+                mdxComponents: [path.join(dir, "components", "Banner.tsx")]
+            });
+            expect(files.map((file) => path.relative(dir, file))).toEqual(["components/Banner.tsx"]);
+        } finally {
+            await cleanup();
+        }
+    });
+
     it("includes a directly referenced file", async () => {
         const { dir, cleanup } = await createDocsWorkspace();
         try {

--- a/packages/cli/docs-resolver/src/utils/__test__/collectMdxComponentFiles.test.ts
+++ b/packages/cli/docs-resolver/src/utils/__test__/collectMdxComponentFiles.test.ts
@@ -1,0 +1,56 @@
+import { AbsoluteFilePath } from "@fern-api/fs-utils";
+import { mkdir, writeFile } from "fs/promises";
+import path from "path";
+import tmp from "tmp-promise";
+
+import { collectMdxComponentFiles } from "../collectMdxComponentFiles.js";
+
+async function createDocsWorkspace(): Promise<{ dir: string; cleanup: () => Promise<void> }> {
+    const { path: dir, cleanup } = await tmp.dir({ unsafeCleanup: true });
+    const componentsDir = path.join(dir, "components");
+    await mkdir(path.join(componentsDir, "__tests__"), { recursive: true });
+    await Promise.all(
+        [
+            "components/Banner.tsx",
+            "components/helpers.ts",
+            "components/notes.mdx",
+            "components/Banner.test.tsx",
+            "components/helpers.spec.ts",
+            "components/__tests__/Banner.tsx",
+            "components/README.txt"
+        ].map((relativePath) => writeFile(path.join(dir, relativePath), ""))
+    );
+    return { dir, cleanup };
+}
+
+describe("collectMdxComponentFiles", () => {
+    it("excludes test files when expanding a directory", async () => {
+        const { dir, cleanup } = await createDocsWorkspace();
+        try {
+            const files = await collectMdxComponentFiles({
+                absolutePathToDocsWorkspace: AbsoluteFilePath.of(dir),
+                mdxComponents: ["./components"]
+            });
+            expect(files.map((file) => path.relative(dir, file)).sort()).toEqual([
+                "components/Banner.tsx",
+                "components/helpers.ts",
+                "components/notes.mdx"
+            ]);
+        } finally {
+            await cleanup();
+        }
+    });
+
+    it("includes a directly referenced file", async () => {
+        const { dir, cleanup } = await createDocsWorkspace();
+        try {
+            const files = await collectMdxComponentFiles({
+                absolutePathToDocsWorkspace: AbsoluteFilePath.of(dir),
+                mdxComponents: ["./components/Banner.tsx", "./components/README.txt"]
+            });
+            expect(files.map((file) => path.relative(dir, file))).toEqual(["components/Banner.tsx"]);
+        } finally {
+            await cleanup();
+        }
+    });
+});

--- a/packages/cli/docs-resolver/src/utils/bundleMdxComponent.ts
+++ b/packages/cli/docs-resolver/src/utils/bundleMdxComponent.ts
@@ -1,7 +1,9 @@
 import { AbsoluteFilePath } from "@fern-api/fs-utils";
 import { loggingExeca } from "@fern-api/logging-execa";
 import { TaskContext } from "@fern-api/task-context";
-import { readFile, writeFile } from "fs/promises";
+import { createHash } from "crypto";
+import { mkdir, readFile, writeFile } from "fs/promises";
+import { builtinModules } from "module";
 import path from "path";
 import tmp from "tmp-promise";
 
@@ -17,6 +19,13 @@ const BUNDLEABLE_EXTENSIONS_REGEX = /\.(js|jsx|ts|tsx)$/;
  * copy of react would break hooks and context.
  */
 const RENDERER_PROVIDED_MODULES = ["react", "react-dom", "@mdx-js/react", "next"];
+
+/**
+ * Directory holding bundles produced by a previous `bundleMdxComponents` run.
+ * Set by environments that bundle ahead of time (e.g. self-hosted images bundle
+ * during the networked build phase) so that generation itself needs no network.
+ */
+const BUNDLE_CACHE_DIR_ENV_VAR = "FERN_MDX_BUNDLE_CACHE_DIR";
 
 /**
  * The rolldown version invoked via npx. Pinned so bundling is reproducible
@@ -43,16 +52,25 @@ function isRendererProvidedModule(specifier: string): boolean {
     return RENDERER_PROVIDED_MODULES.includes(getModuleName(specifier));
 }
 
+function isNodeBuiltin(specifier: string): boolean {
+    return specifier.startsWith("node:") || builtinModules.includes(getModuleName(specifier));
+}
+
 /**
  * Returns the bare (non-relative) import specifiers in the file that are not
- * provided by the docs renderer, i.e. third-party libraries that must be
- * bundled into the uploaded component source.
+ * provided by the docs renderer or by node itself, i.e. third-party libraries
+ * that must be bundled into the uploaded component source.
  */
 export function getThirdPartyImports(contents: string): string[] {
     const specifiers = new Set<string>();
     for (const match of contents.matchAll(IMPORT_SPECIFIER_REGEX)) {
         const specifier = match[1] ?? match[2] ?? match[3];
-        if (specifier == null || isRelativeImport(specifier) || isRendererProvidedModule(specifier)) {
+        if (
+            specifier == null ||
+            isRelativeImport(specifier) ||
+            isRendererProvidedModule(specifier) ||
+            isNodeBuiltin(specifier)
+        ) {
             continue;
         }
         specifiers.add(specifier);
@@ -65,6 +83,46 @@ export declare namespace maybeBundleMdxComponent {
         absoluteFilePath: AbsoluteFilePath;
         contents: string;
         context: TaskContext;
+    }
+}
+
+export function getBundleCacheDir(): string | undefined {
+    const cacheDir = process.env[BUNDLE_CACHE_DIR_ENV_VAR];
+    return cacheDir != null && cacheDir !== "" ? cacheDir : undefined;
+}
+
+/**
+ * Bundles are keyed by their input alone, so a bundle written during a build
+ * phase is reused by a later `fern generate` as long as the component source
+ * (and the rolldown version producing it) is unchanged.
+ */
+function getBundleCacheFilePath(cacheDir: string, contents: string): string {
+    const hash = createHash("sha256").update(ROLLDOWN_VERSION).update("\u0000").update(contents).digest("hex");
+    return path.join(cacheDir, `${hash}.js`);
+}
+
+async function readCachedBundle(contents: string): Promise<string | undefined> {
+    const cacheDir = getBundleCacheDir();
+    if (cacheDir == null) {
+        return undefined;
+    }
+    try {
+        return await readFile(getBundleCacheFilePath(cacheDir, contents), "utf-8");
+    } catch {
+        return undefined;
+    }
+}
+
+async function writeCachedBundle(contents: string, bundle: string, context: TaskContext): Promise<void> {
+    const cacheDir = getBundleCacheDir();
+    if (cacheDir == null) {
+        return;
+    }
+    try {
+        await mkdir(cacheDir, { recursive: true });
+        await writeFile(getBundleCacheFilePath(cacheDir, contents), bundle);
+    } catch (error) {
+        context.logger.debug(`Failed to cache MDX component bundle in ${cacheDir}: ${String(error)}`);
     }
 }
 
@@ -90,6 +148,12 @@ export async function maybeBundleMdxComponent({
     const thirdPartyImports = getThirdPartyImports(contents);
     if (thirdPartyImports.length === 0) {
         return undefined;
+    }
+
+    const cachedBundle = await readCachedBundle(contents);
+    if (cachedBundle != null) {
+        context.logger.debug(`Using pre-bundled output for ${absoluteFilePath}`);
+        return cachedBundle;
     }
 
     context.logger.debug(`Bundling ${absoluteFilePath} to inline third-party imports: ${thirdPartyImports.join(", ")}`);
@@ -124,7 +188,9 @@ export async function maybeBundleMdxComponent({
             );
         }
 
-        return await readFile(outputFilePath, "utf-8");
+        const bundle = await readFile(outputFilePath, "utf-8");
+        await writeCachedBundle(contents, bundle, context);
+        return bundle;
     } finally {
         await cleanup();
     }
@@ -138,6 +204,7 @@ function buildRolldownConfig({
     outputFilePath: string;
 }): string {
     return `const RENDERER_PROVIDED_MODULES = ${JSON.stringify(RENDERER_PROVIDED_MODULES)};
+const NODE_BUILTIN_MODULES = ${JSON.stringify(builtinModules)};
 
 function getModuleName(specifier) {
     const parts = specifier.split("/");
@@ -153,8 +220,13 @@ export default {
     tsconfig: false,
     // Relative imports resolve against the other uploaded component files in
     // the docs renderer, and renderer-provided modules (and their subpaths,
-    // e.g. react/jsx-runtime) are supplied by the renderer itself.
-    external: (id) => id.startsWith(".") || RENDERER_PROVIDED_MODULES.includes(getModuleName(id)),
+    // e.g. react/jsx-runtime) are supplied by the renderer itself. Node
+    // builtins can't be bundled for the browser and are left as-is.
+    external: (id) =>
+        id.startsWith(".") ||
+        RENDERER_PROVIDED_MODULES.includes(getModuleName(id)) ||
+        NODE_BUILTIN_MODULES.includes(getModuleName(id)) ||
+        id.startsWith("node:"),
     output: {
         file: ${JSON.stringify(outputFilePath)},
         format: "esm",

--- a/packages/cli/docs-resolver/src/utils/collectMdxComponentFiles.ts
+++ b/packages/cli/docs-resolver/src/utils/collectMdxComponentFiles.ts
@@ -1,4 +1,4 @@
-import { AbsoluteFilePath, listFiles, RelativeFilePath, resolve } from "@fern-api/fs-utils";
+import { AbsoluteFilePath, listFiles, resolve } from "@fern-api/fs-utils";
 import { stat } from "fs/promises";
 
 const MDX_COMPONENT_EXTENSIONS = "{js,ts,jsx,tsx,md,mdx}";
@@ -8,7 +8,7 @@ const MDX_COMPONENT_EXTENSIONS_REGEX = /\.(js|ts|jsx|tsx|md|mdx)$/;
  * Test files live alongside components but are not components: they import test
  * runners and other dev-only libraries that don't belong in the docs bundle.
  */
-const TEST_FILE_REGEX = /(\.(test|spec)\.[^.]+$|(^|\/)__tests__\/)/;
+const TEST_FILE_REGEX = /(\.(test|spec)\.[^.]+$|(^|[/\\])__tests__[/\\])/;
 
 /**
  * Resolves the `experimental.mdx-components` entries of a docs config to the
@@ -26,7 +26,7 @@ export async function collectMdxComponentFiles({
 
     await Promise.all(
         mdxComponents.map(async (filepath) => {
-            const absoluteFilePath = resolve(absolutePathToDocsWorkspace, RelativeFilePath.of(filepath));
+            const absoluteFilePath = resolve(absolutePathToDocsWorkspace, filepath);
             const stats = await stat(absoluteFilePath);
 
             if (stats.isDirectory()) {

--- a/packages/cli/docs-resolver/src/utils/collectMdxComponentFiles.ts
+++ b/packages/cli/docs-resolver/src/utils/collectMdxComponentFiles.ts
@@ -1,0 +1,46 @@
+import { AbsoluteFilePath, listFiles, RelativeFilePath, resolve } from "@fern-api/fs-utils";
+import { stat } from "fs/promises";
+
+const MDX_COMPONENT_EXTENSIONS = "{js,ts,jsx,tsx,md,mdx}";
+const MDX_COMPONENT_EXTENSIONS_REGEX = /\.(js|ts|jsx|tsx|md|mdx)$/;
+
+/**
+ * Test files live alongside components but are not components: they import test
+ * runners and other dev-only libraries that don't belong in the docs bundle.
+ */
+const TEST_FILE_REGEX = /(\.(test|spec)\.[^.]+$|(^|\/)__tests__\/)/;
+
+/**
+ * Resolves the `experimental.mdx-components` entries of a docs config to the
+ * component files to upload. Directory entries are expanded to every component
+ * file they contain; a file referenced directly is always included.
+ */
+export async function collectMdxComponentFiles({
+    absolutePathToDocsWorkspace,
+    mdxComponents
+}: {
+    absolutePathToDocsWorkspace: AbsoluteFilePath;
+    mdxComponents: readonly string[];
+}): Promise<AbsoluteFilePath[]> {
+    const filePaths = new Set<AbsoluteFilePath>();
+
+    await Promise.all(
+        mdxComponents.map(async (filepath) => {
+            const absoluteFilePath = resolve(absolutePathToDocsWorkspace, RelativeFilePath.of(filepath));
+            const stats = await stat(absoluteFilePath);
+
+            if (stats.isDirectory()) {
+                const files = await listFiles(absoluteFilePath, MDX_COMPONENT_EXTENSIONS);
+                for (const file of files) {
+                    if (!TEST_FILE_REGEX.test(file)) {
+                        filePaths.add(file);
+                    }
+                }
+            } else if (absoluteFilePath.match(MDX_COMPONENT_EXTENSIONS_REGEX) != null) {
+                filePaths.add(absoluteFilePath);
+            }
+        })
+    );
+
+    return [...filePaths];
+}


### PR DESCRIPTION
## Description
Linear ticket: Refs

Self-hosted (air-gapped) docs generation failed with:

```
CliError: Failed to bundle third-party imports in /fern/components/code-variables/variables-store.test.ts:
rolldown exited with code 1 ... (node:test, node:assert/strict) ... npm error code EAI_AGAIN
```

Two separate problems:

1. `experimental.mdx-components` globs a component directory for `{js,ts,jsx,tsx,md,mdx}`, so `variables-store.test.ts` was collected as a component, and its `node:test` / `node:assert/strict` imports looked like third-party libraries — triggering rolldown, which needs network access. (The tests were never *run*, just bundled.)
2. Bundling inherently needs network (npx downloads rolldown, and the imported libraries come from `node_modules`), so it can't happen at air-gapped generation time at all. It now can be done ahead of time, during a build phase that does have network, and reused.

Component collection moved out of `DocsDefinitionResolver` into `collectMdxComponentFiles`, which skips `*.test.*`, `*.spec.*` and `__tests__/`, and is shared with the new pre-bundling entrypoint. `getThirdPartyImports` now ignores node builtins (`node:` specifiers and bare builtins), and rolldown is told to keep them external.

Pre-bundling is opt-in via `FERN_MDX_BUNDLE_CACHE_DIR`:

```
maybeBundleMdxComponent(file):
    key = sha256(ROLLDOWN_VERSION, contents)
    if $FERN_MDX_BUNDLE_CACHE_DIR/<key>.js exists -> return it       # no network
    bundle with rolldown, write it to the cache, return it
```

`fern install-dependencies` (already the "prepare a build with network" command) now also walks `experimental.mdx-components` and populates that cache, so a later `fern generate --docs` in the same image reads bundles off disk. When the env var is unset, behavior is unchanged. Self-hosted side: fern-api/fern-platform#13795.

## Changes Made
- `collectMdxComponentFiles` — shared component discovery that excludes test/spec files
- `getThirdPartyImports` ignores node builtins; rolldown keeps them external
- `maybeBundleMdxComponent` reads/writes a bundle cache when `FERN_MDX_BUNDLE_CACHE_DIR` is set
- `bundleMdxComponents` exported and called from `fern install-dependencies`
- Changelog entry

## Testing
- [x] Unit tests added/updated

`pnpm vitest --run src/utils/__test__/bundleMdxComponent.test.ts src/utils/__test__/collectMdxComponentFiles.test.ts` in `packages/cli/docs-resolver`:

```
✓ src/utils/__test__/collectMdxComponentFiles.test.ts (2 tests)
✓ src/utils/__test__/bundleMdxComponent.test.ts (10 tests)
    ✓ inlines third-party imports resolved from node_modules  1421ms
    ✓ reuses a cached bundle instead of running rolldown again  418ms
Test Files  2 passed (2)
     Tests  12 passed (12)
```

The cache test bundles a component against a fake package in `node_modules`, deletes `node_modules`, and asserts the second call still returns the same bundle (i.e. from the cache, without rolldown). Also ran `pnpm turbo run test --filter @fern-api/docs-resolver` (111 passed), the `install-dependencies` suite (8 passed), `pnpm turbo run compile`, `pnpm lint:biome` and `pnpm format:fix`.


Link to Devin session: https://app.devin.ai/sessions/c7ab074c7aed4e92b77d8d1983358b1e
Requested by: @thesandlord
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/17376" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->