### PR TITLE
feat(python): generate invocation-only dynamic snippets

### DIFF
--- a/generators/browser-compatible-base/src/dynamic-snippets/AbstractDynamicSnippetsGenerator.ts
+++ b/generators/browser-compatible-base/src/dynamic-snippets/AbstractDynamicSnippetsGenerator.ts
@@ -105,8 +105,9 @@ export abstract class AbstractDynamicSnippetsGenerator<
      * imports or client instantiation, for callers that render the invocation within code
      * of their own (e.g. a documentation code template).
      *
-     * Returns undefined if this generator does not support invocation-only snippets, so
-     * that callers can fall back to the complete snippet.
+     * Returns undefined if this generator does not support invocation-only snippets, or if
+     * the invocation cannot stand on its own (e.g. its arguments reference imported SDK
+     * types), so that callers can fall back to the complete snippet.
      */
     public generateInvocationSync(
         request: FernIr.dynamic.EndpointSnippetRequest,
@@ -125,6 +126,9 @@ export abstract class AbstractDynamicSnippetsGenerator<
             }
             try {
                 const snippet = snippetGenerator.generateInvocationSnippetSync({ endpoint, request, options });
+                if (snippet == null) {
+                    return undefined;
+                }
                 if (context.errors.empty()) {
                     return {
                         snippet,

--- a/generators/browser-compatible-base/src/dynamic-snippets/AbstractDynamicSnippetsGenerator.ts
+++ b/generators/browser-compatible-base/src/dynamic-snippets/AbstractDynamicSnippetsGenerator.ts
@@ -2,6 +2,7 @@ import { FernIr } from "@fern-api/dynamic-ir-sdk";
 import { AbstractAstNode } from "../ast/index.js";
 import { AbstractDynamicSnippetsGeneratorContext } from "./AbstractDynamicSnippetsGeneratorContext.js";
 import { AbstractEndpointSnippetGenerator } from "./AbstractEndpointSnippetGenerator.js";
+import { InvocationSnippetResponse } from "./InvocationSnippetResponse.js";
 import { Options } from "./Options.js";
 import { Result } from "./Result.js";
 
@@ -101,23 +102,27 @@ export abstract class AbstractDynamicSnippetsGenerator<
     }
 
     /**
-     * Generates just the endpoint invocation (e.g. `client.plants.update(...)`), without
-     * imports or client instantiation, for callers that render the invocation within code
-     * of their own (e.g. a documentation code template).
+     * Generates the structured pieces of an endpoint invocation for callers that render the
+     * invocation within code of their own (e.g. a documentation code template): the bare call
+     * (e.g. `client.plants.update(...)`), the imports the call requires, and the generated
+     * client class/type name.
      *
-     * Returns undefined if this generator does not support invocation-only snippets, or if
-     * the invocation cannot stand on its own (e.g. its arguments reference imported SDK
-     * types), so that callers can fall back to the complete snippet.
+     * Returns undefined only if this generator does not support invocation-only snippets, so
+     * that callers can fall back to the complete snippet. This is the capability check the
+     * multi-language fan-out relies on. When the generator does support them, invocations that
+     * reference imported SDK types (e.g. branded string aliases) return those imports in the
+     * `imports` field rather than bailing out.
      */
     public generateInvocationSync(
         request: FernIr.dynamic.EndpointSnippetRequest,
         options: Options = {}
-    ): FernIr.dynamic.EndpointSnippetResponse | undefined {
+    ): InvocationSnippetResponse | undefined {
         const endpoints = this.resolveEndpoints({ request, options });
         if (endpoints.length === 0) {
             throw new Error(`No endpoints found that match "${request.endpoint.method} ${request.endpoint.path}"`);
         }
-        const result = new Result();
+        let bestResponse: InvocationSnippetResponse | undefined = undefined;
+        let lastError: Error | undefined = undefined;
         for (const endpoint of endpoints) {
             const context = this.context.clone() as Context;
             const snippetGenerator = this.createSnippetGenerator(context);
@@ -125,24 +130,42 @@ export abstract class AbstractDynamicSnippetsGenerator<
                 return undefined;
             }
             try {
-                const snippet = snippetGenerator.generateInvocationSnippetSync({ endpoint, request, options });
-                if (snippet == null) {
+                const response = snippetGenerator.generateInvocationSnippetSync({ endpoint, request, options });
+                if (response == null) {
                     return undefined;
                 }
                 if (context.errors.empty()) {
-                    return {
-                        snippet,
-                        errors: undefined
-                    };
+                    return response;
                 }
-                result.update({ context, snippet });
+                if (this.shouldUpdateInvocationResponse({ candidate: response, current: bestResponse })) {
+                    bestResponse = response;
+                }
             } catch (error) {
-                if (result.err == null) {
-                    result.err = error as Error;
+                if (lastError == null) {
+                    lastError = error as Error;
                 }
             }
         }
-        return result.getResponseOrThrow({ endpoint: request.endpoint });
+        if (bestResponse != null) {
+            return bestResponse;
+        }
+        throw (
+            lastError ??
+            new Error(`Failed to generate snippet for endpoint "${request.endpoint.method} ${request.endpoint.path}"`)
+        );
+    }
+
+    private shouldUpdateInvocationResponse({
+        candidate,
+        current
+    }: {
+        candidate: InvocationSnippetResponse;
+        current: InvocationSnippetResponse | undefined;
+    }): boolean {
+        if (current == null) {
+            return true;
+        }
+        return candidate.snippet.length > current.snippet.length;
     }
 
     /**

--- a/generators/browser-compatible-base/src/dynamic-snippets/AbstractDynamicSnippetsGenerator.ts
+++ b/generators/browser-compatible-base/src/dynamic-snippets/AbstractDynamicSnippetsGenerator.ts
@@ -101,6 +101,47 @@ export abstract class AbstractDynamicSnippetsGenerator<
     }
 
     /**
+     * Generates just the endpoint invocation (e.g. `client.plants.update(...)`), without
+     * imports or client instantiation, for callers that render the invocation within code
+     * of their own (e.g. a documentation code template).
+     *
+     * Returns undefined if this generator does not support invocation-only snippets, so
+     * that callers can fall back to the complete snippet.
+     */
+    public generateInvocationSync(
+        request: FernIr.dynamic.EndpointSnippetRequest,
+        options: Options = {}
+    ): FernIr.dynamic.EndpointSnippetResponse | undefined {
+        const endpoints = this.resolveEndpoints({ request, options });
+        if (endpoints.length === 0) {
+            throw new Error(`No endpoints found that match "${request.endpoint.method} ${request.endpoint.path}"`);
+        }
+        const result = new Result();
+        for (const endpoint of endpoints) {
+            const context = this.context.clone() as Context;
+            const snippetGenerator = this.createSnippetGenerator(context);
+            if (snippetGenerator.generateInvocationSnippetSync == null) {
+                return undefined;
+            }
+            try {
+                const snippet = snippetGenerator.generateInvocationSnippetSync({ endpoint, request, options });
+                if (context.errors.empty()) {
+                    return {
+                        snippet,
+                        errors: undefined
+                    };
+                }
+                result.update({ context, snippet });
+            } catch (error) {
+                if (result.err == null) {
+                    result.err = error as Error;
+                }
+            }
+        }
+        return result.getResponseOrThrow({ endpoint: request.endpoint });
+    }
+
+    /**
      * Resolves endpoints based on the request and options.
      * If an endpointId is specified in options, returns only that specific endpoint.
      * Otherwise, resolves all endpoints matching the endpoint location (method + path).

--- a/generators/browser-compatible-base/src/dynamic-snippets/AbstractEndpointSnippetGenerator.ts
+++ b/generators/browser-compatible-base/src/dynamic-snippets/AbstractEndpointSnippetGenerator.ts
@@ -39,8 +39,8 @@ export abstract class AbstractEndpointSnippetGenerator<Context extends AbstractD
      * imports or client instantiation, for callers that render the invocation within code
      * of their own (e.g. a documentation code template).
      *
-     * Implemented per generator; generators that do not implement it fall back to the
-     * complete snippet.
+     * Implemented per generator; generators that do not implement it, and invocations that
+     * cannot stand on their own, fall back to the complete snippet.
      */
     public generateInvocationSnippetSync?({
         endpoint,
@@ -50,5 +50,5 @@ export abstract class AbstractEndpointSnippetGenerator<Context extends AbstractD
         endpoint: FernIr.dynamic.Endpoint;
         request: FernIr.dynamic.EndpointSnippetRequest;
         options?: Options;
-    }): string;
+    }): string | undefined;
 }

--- a/generators/browser-compatible-base/src/dynamic-snippets/AbstractEndpointSnippetGenerator.ts
+++ b/generators/browser-compatible-base/src/dynamic-snippets/AbstractEndpointSnippetGenerator.ts
@@ -1,6 +1,7 @@
 import { FernIr } from "@fern-api/dynamic-ir-sdk";
 import { AbstractAstNode } from "../ast/index.js";
 import { AbstractDynamicSnippetsGeneratorContext } from "./AbstractDynamicSnippetsGeneratorContext.js";
+import { InvocationSnippetResponse } from "./InvocationSnippetResponse.js";
 import { Options } from "./Options.js";
 
 export abstract class AbstractEndpointSnippetGenerator<Context extends AbstractDynamicSnippetsGeneratorContext> {
@@ -35,12 +36,14 @@ export abstract class AbstractEndpointSnippetGenerator<Context extends AbstractD
     }): Promise<AbstractAstNode>;
 
     /**
-     * Generates just the endpoint invocation (e.g. `client.plants.update(...)`), without
-     * imports or client instantiation, for callers that render the invocation within code
-     * of their own (e.g. a documentation code template).
+     * Generates the structured pieces of an endpoint invocation for callers that render the
+     * invocation within code of their own (e.g. a documentation code template): the bare call
+     * (e.g. `client.plants.update(...)`), the imports the call requires, and the generated
+     * client class/type name.
      *
-     * Implemented per generator; generators that do not implement it, and invocations that
-     * cannot stand on their own, fall back to the complete snippet.
+     * Implemented per generator; generators that do not implement it are detected via the
+     * absence of this method (the capability check callers rely on) and fall back to the
+     * complete snippet.
      */
     public generateInvocationSnippetSync?({
         endpoint,
@@ -50,5 +53,5 @@ export abstract class AbstractEndpointSnippetGenerator<Context extends AbstractD
         endpoint: FernIr.dynamic.Endpoint;
         request: FernIr.dynamic.EndpointSnippetRequest;
         options?: Options;
-    }): string | undefined;
+    }): InvocationSnippetResponse | undefined;
 }

--- a/generators/browser-compatible-base/src/dynamic-snippets/AbstractEndpointSnippetGenerator.ts
+++ b/generators/browser-compatible-base/src/dynamic-snippets/AbstractEndpointSnippetGenerator.ts
@@ -33,4 +33,22 @@ export abstract class AbstractEndpointSnippetGenerator<Context extends AbstractD
         request: FernIr.dynamic.EndpointSnippetRequest;
         options?: Options;
     }): Promise<AbstractAstNode>;
+
+    /**
+     * Generates just the endpoint invocation (e.g. `client.plants.update(...)`), without
+     * imports or client instantiation, for callers that render the invocation within code
+     * of their own (e.g. a documentation code template).
+     *
+     * Implemented per generator; generators that do not implement it fall back to the
+     * complete snippet.
+     */
+    public generateInvocationSnippetSync?({
+        endpoint,
+        request,
+        options
+    }: {
+        endpoint: FernIr.dynamic.Endpoint;
+        request: FernIr.dynamic.EndpointSnippetRequest;
+        options?: Options;
+    }): string;
 }

--- a/generators/browser-compatible-base/src/dynamic-snippets/InvocationSnippetResponse.ts
+++ b/generators/browser-compatible-base/src/dynamic-snippets/InvocationSnippetResponse.ts
@@ -1,0 +1,28 @@
+import { FernIr } from "@fern-api/dynamic-ir-sdk";
+
+/**
+ * The structured result of an invocation-only snippet.
+ *
+ * Unlike {@link FernIr.dynamic.EndpointSnippetResponse}, which returns a single fully-formed
+ * snippet string, this exposes the individual pieces a docs template needs to render (and
+ * keep in sync) an invocation on its own: the bare call, the imports the call requires, and
+ * the generated client class/type name.
+ */
+export interface InvocationSnippetResponse {
+    /**
+     * The bare invocation/call (e.g. `client.plants.update(...)`) with no imports, no client
+     * instantiation, and no trailing statement terminator. Honors `options.clientVariableName`.
+     */
+    snippet: string;
+    /**
+     * The import block the call requires (e.g. an SDK namespace import for a branded string
+     * alias). Empty string when the call references no imports.
+     */
+    imports: string;
+    /**
+     * The generated client class/type name (e.g. `AcmeClient`), so docs can render
+     * `new {{clientName}}(...)` and track renames of the SDK client.
+     */
+    clientName: string;
+    errors: FernIr.dynamic.Error_[] | undefined;
+}

--- a/generators/browser-compatible-base/src/dynamic-snippets/Options.ts
+++ b/generators/browser-compatible-base/src/dynamic-snippets/Options.ts
@@ -29,4 +29,8 @@ export interface Options {
     // This is useful when multiple endpoints have the same HTTP method and path
     // across different namespaces, and we need to generate a snippet for a specific one.
     endpointId?: string;
+
+    // The name of the variable the endpoint is invoked on. Only used when generating
+    // an invocation-only snippet, where the client is instantiated by the caller.
+    clientVariableName?: string;
 }

--- a/generators/browser-compatible-base/src/dynamic-snippets/index.ts
+++ b/generators/browser-compatible-base/src/dynamic-snippets/index.ts
@@ -2,6 +2,7 @@ export { AbstractDynamicSnippetsGenerator } from "./AbstractDynamicSnippetsGener
 export { AbstractDynamicSnippetsGeneratorContext } from "./AbstractDynamicSnippetsGeneratorContext.js";
 export { type DiscriminatedUnionTypeInstance } from "./DiscriminatedUnionTypeInstance.js";
 export { ErrorReporter, Severity } from "./ErrorReporter.js";
+export { type InvocationSnippetResponse } from "./InvocationSnippetResponse.js";
 export { type Options, Style } from "./Options.js";
 export { Result } from "./Result.js";
 export { Scope } from "./Scope.js";

--- a/generators/python-v2/ast/src/PythonFile.ts
+++ b/generators/python-v2/ast/src/PythonFile.ts
@@ -72,6 +72,22 @@ export class PythonFile extends AstNode {
         writer.unsetRefNameOverrides();
     }
 
+    /**
+     * The rendered import block for the statements in this file, or an empty string when nothing
+     * references an import. This is the Python equivalent of separating a node's imports from its
+     * body: callers that render an invocation inside code they already own (e.g. a documentation
+     * code template) can surface the imports the call needs without the surrounding file scaffold.
+     * The trailing blank line that `write` places between the imports and the body is trimmed.
+     */
+    public getImports(): string {
+        const writer = new Writer();
+        const uniqueReferences = this.deduplicateReferences();
+        this.updateWriterRefNameOverrides({ writer, uniqueReferences });
+        this.writeImports({ writer, uniqueReferences });
+        writer.unsetRefNameOverrides();
+        return writer.toString().trimEnd();
+    }
+
     /*******************************
      * Helper Methods
      *******************************/

--- a/generators/python-v2/ast/src/python.ts
+++ b/generators/python-v2/ast/src/python.ts
@@ -5,6 +5,8 @@ import { Class } from "./Class.js";
 import { ClassInstantiation } from "./ClassInstantiation.js";
 import { CodeBlock } from "./CodeBlock.js";
 import { Comment } from "./Comment.js";
+import { AstNode } from "./core/AstNode.js";
+import { ModulePath } from "./core/types.js";
 import { Decorator } from "./Decorator.js";
 import { Field } from "./Field.js";
 import { Lambda } from "./Lambda.js";
@@ -114,4 +116,27 @@ export function methodArgument(args: MethodArgument.Args): MethodArgument {
 
 export function operator(args: Operator.Args): Operator {
     return new Operator(args);
+}
+
+/**
+ * Renders a node separately from the imports it references, the Python analogue of the
+ * TypeScript AST's `toStringWithoutImports`. `code` is the node's body with no import lines,
+ * and `imports` is the rendered import block the body would otherwise need (empty string when
+ * none). This lets callers embed an invocation inside code they already own (e.g. a
+ * documentation code template) while surfacing the imports the call requires.
+ *
+ * `modulePath` is the module the code is imagined to live in; imports are relativized against it
+ * exactly as they would be in a generated file at that path, so the imports match what the full
+ * snippet would emit.
+ */
+export function renderNodeWithoutImports({ node, modulePath }: { node: AstNode; modulePath: ModulePath }): {
+    code: string;
+    imports: string;
+} {
+    // A bare node's `toString()` only writes its own body — imports are emitted solely by
+    // PythonFile — so the body already excludes them. Wrapping the node in a file at the same
+    // path lets us compute just the import block the body references.
+    const code = node.toString();
+    const file = new PythonFile({ path: modulePath, statements: [node] });
+    return { code, imports: file.getImports() };
 }

--- a/generators/python-v2/dynamic-snippets/src/EndpointSnippetGenerator.ts
+++ b/generators/python-v2/dynamic-snippets/src/EndpointSnippetGenerator.ts
@@ -1,4 +1,10 @@
-import { AbstractAstNode, Scope, Severity } from "@fern-api/browser-compatible-base-generator";
+import {
+    AbstractAstNode,
+    InvocationSnippetResponse,
+    Options,
+    Scope,
+    Severity
+} from "@fern-api/browser-compatible-base-generator";
 import { assertNever } from "@fern-api/core-utils";
 import { FernIr } from "@fern-api/dynamic-ir-sdk";
 import { python } from "@fern-api/python-ast";
@@ -66,6 +72,43 @@ export class EndpointSnippetGenerator {
         request: FernIr.dynamic.EndpointSnippetRequest;
     }): python.AstNode {
         return this.callMethod({ endpoint, snippet: request });
+    }
+
+    /**
+     * Generates the structured pieces of an endpoint invocation for callers that render the
+     * invocation within code of their own (e.g. a documentation code template): the bare call
+     * (e.g. `client.plants.update(...)`), the imports the call requires, and the generated root
+     * client class name.
+     */
+    public generateInvocationSnippetSync({
+        endpoint,
+        request,
+        options
+    }: {
+        endpoint: FernIr.dynamic.Endpoint;
+        request: FernIr.dynamic.EndpointSnippetRequest;
+        options?: Options;
+    }): InvocationSnippetResponse {
+        const invocation = this.callMethod({
+            endpoint,
+            snippet: request,
+            clientVariableName: options?.clientVariableName
+        });
+        // The caller supplies the client and terminates the statement themselves, so the
+        // invocation is emitted as a bare expression. When the call references SDK types (e.g.
+        // an enum or an aliased request value) the imports it needs are surfaced separately so
+        // the caller can render them rather than falling back to the complete snippet. Python
+        // statements have no terminator, so no trailing character needs stripping.
+        const { code, imports } = python.renderNodeWithoutImports({
+            node: invocation,
+            modulePath: SNIPPET_MODULE_PATH
+        });
+        return {
+            snippet: code.trim(),
+            imports,
+            clientName: this.context.getRootClientClassName(),
+            errors: this.context.errors.empty() ? undefined : this.context.errors.toDynamicSnippetErrors()
+        };
     }
 
     private buildPythonFile({
@@ -443,13 +486,15 @@ export class EndpointSnippetGenerator {
 
     private callMethod({
         endpoint,
-        snippet
+        snippet,
+        clientVariableName
     }: {
         endpoint: FernIr.dynamic.Endpoint;
         snippet: FernIr.dynamic.EndpointSnippetRequest;
+        clientVariableName?: string;
     }): python.AstNode {
         return python.invokeMethod({
-            on: python.reference({ name: CLIENT_VAR_NAME }),
+            on: python.reference({ name: clientVariableName ?? CLIENT_VAR_NAME }),
             method: this.getMethod({ endpoint }),
             arguments_: this.getMethodArgs({ endpoint, snippet })
                 .filter((arg) => !python.TypeInstantiation.isNop(arg.value))

--- a/generators/python-v2/dynamic-snippets/src/__test__/InvocationSnippet.test.ts
+++ b/generators/python-v2/dynamic-snippets/src/__test__/InvocationSnippet.test.ts
@@ -1,0 +1,100 @@
+import { AbsoluteFilePath, join } from "@fern-api/path-utils";
+
+import { buildDynamicSnippetsGenerator } from "./utils/buildDynamicSnippetsGenerator.js";
+import { buildGeneratorConfig } from "./utils/buildGeneratorConfig.js";
+
+const DYNAMIC_IR_TEST_DEFINITIONS_DIRECTORY = AbsoluteFilePath.of(
+    `${__dirname}/../../../../../packages/cli/generation/ir-generator-tests/src/dynamic-snippets/__test__/test-definitions`
+);
+
+// invocation-only snippets are rendered inside code the caller already owns (e.g. a
+// documentation code template), so they must not include imports or client instantiation
+describe("invocation-only snippets", () => {
+    const generator = buildDynamicSnippetsGenerator({
+        irFilepath: AbsoluteFilePath.of(join(DYNAMIC_IR_TEST_DEFINITIONS_DIRECTORY, "exhaustive.json")),
+        config: buildGeneratorConfig({})
+    });
+
+    const request = {
+        endpoint: {
+            method: "GET" as const,
+            path: "/http-methods/{id}"
+        },
+        baseURL: undefined,
+        environment: undefined,
+        auth: {
+            type: "bearer" as const,
+            token: "<YOUR_API_KEY>"
+        },
+        pathParameters: {
+            id: "id"
+        },
+        queryParameters: undefined,
+        headers: undefined,
+        requestBody: undefined
+    };
+
+    it("generates the invocation without imports or client instantiation", () => {
+        const response = generator.generateInvocationSync(request);
+
+        expect(response?.snippet).toBe('client.endpoints.http_methods.test_get(\n    id="id",\n)');
+        expect(response?.imports).toBe("");
+        expect(response?.errors).toBeUndefined();
+    });
+
+    it("exposes the generated client class name so docs can render the client instantiation", () => {
+        const response = generator.generateInvocationSync(request);
+
+        expect(response?.clientName).toBe("Acme");
+    });
+
+    it("invokes the endpoint on the requested client variable", () => {
+        const response = generator.generateInvocationSync(request, { clientVariableName: "mailchimp" });
+
+        expect(response?.snippet).toBe('mailchimp.endpoints.http_methods.test_get(\n    id="id",\n)');
+    });
+
+    it("returns the imports the invocation references instead of falling back to the full snippet", () => {
+        // This body references stdlib types the call constructs inline (a datetime and a UUID),
+        // so the invocation must carry `import datetime` / `import uuid`. The previous
+        // invocation-only contract had no way to express this; now the imports are surfaced
+        // separately so docs can regenerate both the call and the imports it needs.
+        const response = generator.generateInvocationSync({
+            endpoint: {
+                method: "POST" as const,
+                path: "/object/get-and-return-with-optional-field"
+            },
+            baseURL: undefined,
+            environment: undefined,
+            auth: {
+                type: "bearer" as const,
+                token: "<YOUR_API_KEY>"
+            },
+            pathParameters: undefined,
+            queryParameters: undefined,
+            headers: undefined,
+            requestBody: {
+                string: "string",
+                integer: 1,
+                long: 1000000,
+                double: 1.1,
+                bool: true,
+                datetime: "2024-01-15T09:30:00Z",
+                date: "2023-01-15",
+                uuid: "d5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32",
+                base64: "SGVsbG8gd29ybGQh",
+                list: ["list", "list"],
+                set: ["set"],
+                map: { 1: "map" },
+                bigint: "1000000"
+            }
+        });
+
+        expect(response).not.toBeUndefined();
+        expect(response?.snippet).toContain("datetime.datetime.fromisoformat");
+        expect(response?.snippet).toContain("uuid.UUID");
+        expect(response?.imports).toContain("import datetime");
+        expect(response?.imports).toContain("import uuid");
+        expect(response?.errors).toBeUndefined();
+    });
+});

--- a/generators/python/sdk/changes/unreleased/invocation-only-dynamic-snippets.yml
+++ b/generators/python/sdk/changes/unreleased/invocation-only-dynamic-snippets.yml
@@ -1,0 +1,18 @@
+# yaml-language-server: $schema=../../../../../fern-changes-yml.schema.json
+
+- summary: |
+    Generate invocation-only dynamic snippets. In addition to the full snippet
+    (client construction plus the call), the generator now exposes the structured
+    pieces a caller can render inside code it already owns (e.g. a documentation
+    code template): the bare invocation (`client.plants.update(...)`, honoring a
+    custom client variable name), the Python `import` block that invocation
+    references (empty string when none), and the generated root client class name
+    so docs can render `client = <ClientName>(...)` and track renames.
+
+    Imports are captured separately from the call via a new
+    `python.renderNodeWithoutImports` helper and `PythonFile.getImports()`, the
+    Python analogue of the TypeScript AST's `toStringWithoutImports`. Invocations
+    that reference imported types (e.g. a body value constructed with
+    `datetime.datetime.fromisoformat(...)` / `uuid.UUID(...)`) surface those
+    imports rather than falling back to the complete snippet.
+  type: feat

--- a/generators/typescript-v2/ast/src/ast/core/AstNode.ts
+++ b/generators/typescript-v2/ast/src/ast/core/AstNode.ts
@@ -9,25 +9,29 @@ export abstract class AstNode extends AbstractAstNode {
      */
     public async toStringAsync({
         customConfig,
-        formatter
+        formatter,
+        omitImports
     }: {
         customConfig: TypescriptCustomConfigSchema | undefined;
         formatter?: AbstractFormatter;
+        omitImports?: boolean;
     }): Promise<string> {
         const file = new TypeScriptFile({ customConfig, formatter });
         this.write(file);
-        return await file.toStringAsync();
+        return await file.toStringAsync({ omitImports });
     }
 
     public toString({
         customConfig,
-        formatter
+        formatter,
+        omitImports
     }: {
         customConfig: TypescriptCustomConfigSchema | undefined;
         formatter?: AbstractFormatter;
+        omitImports?: boolean;
     }): string {
         const file = new TypeScriptFile({ customConfig, formatter });
         this.write(file);
-        return file.toString();
+        return file.toString({ omitImports });
     }
 }

--- a/generators/typescript-v2/ast/src/ast/core/AstNode.ts
+++ b/generators/typescript-v2/ast/src/ast/core/AstNode.ts
@@ -9,29 +9,41 @@ export abstract class AstNode extends AbstractAstNode {
      */
     public async toStringAsync({
         customConfig,
-        formatter,
-        omitImports
+        formatter
     }: {
         customConfig: TypescriptCustomConfigSchema | undefined;
         formatter?: AbstractFormatter;
-        omitImports?: boolean;
     }): Promise<string> {
         const file = new TypeScriptFile({ customConfig, formatter });
         this.write(file);
-        return await file.toStringAsync({ omitImports });
+        return await file.toStringAsync();
     }
 
     public toString({
         customConfig,
-        formatter,
-        omitImports
+        formatter
     }: {
         customConfig: TypescriptCustomConfigSchema | undefined;
         formatter?: AbstractFormatter;
-        omitImports?: boolean;
     }): string {
         const file = new TypeScriptFile({ customConfig, formatter });
         this.write(file);
-        return file.toString({ omitImports });
+        return file.toString();
+    }
+
+    /**
+     * Writes the node without the import statements it references. `hasImports` reports
+     * whether any were dropped, since the code is only valid on its own without them.
+     */
+    public toStringWithoutImports({
+        customConfig,
+        formatter
+    }: {
+        customConfig: TypescriptCustomConfigSchema | undefined;
+        formatter?: AbstractFormatter;
+    }): { code: string; hasImports: boolean } {
+        const file = new TypeScriptFile({ customConfig, formatter });
+        this.write(file);
+        return { code: file.toString({ omitImports: true }), hasImports: file.hasImports() };
     }
 }

--- a/generators/typescript-v2/ast/src/ast/core/AstNode.ts
+++ b/generators/typescript-v2/ast/src/ast/core/AstNode.ts
@@ -32,8 +32,9 @@ export abstract class AstNode extends AbstractAstNode {
     }
 
     /**
-     * Writes the node without the import statements it references. `hasImports` reports
-     * whether any were dropped, since the code is only valid on its own without them.
+     * Writes the node without the import statements it references. `imports` is the rendered
+     * import block the code would otherwise need (empty string when none), and `hasImports`
+     * reports whether any were separated out.
      */
     public toStringWithoutImports({
         customConfig,
@@ -41,9 +42,13 @@ export abstract class AstNode extends AbstractAstNode {
     }: {
         customConfig: TypescriptCustomConfigSchema | undefined;
         formatter?: AbstractFormatter;
-    }): { code: string; hasImports: boolean } {
+    }): { code: string; imports: string; hasImports: boolean } {
         const file = new TypeScriptFile({ customConfig, formatter });
         this.write(file);
-        return { code: file.toString({ omitImports: true }), hasImports: file.hasImports() };
+        return {
+            code: file.toString({ omitImports: true }),
+            imports: file.getImports(),
+            hasImports: file.hasImports()
+        };
     }
 }

--- a/generators/typescript-v2/ast/src/ast/core/TypeScriptFile.ts
+++ b/generators/typescript-v2/ast/src/ast/core/TypeScriptFile.ts
@@ -9,8 +9,8 @@ export class TypeScriptFile extends Writer {
         super({ customConfig, formatter });
     }
 
-    public async toStringAsync(): Promise<string> {
-        const content = this.getContent();
+    public async toStringAsync({ omitImports }: { omitImports?: boolean } = {}): Promise<string> {
+        const content = this.getContent({ omitImports });
         if (this.formatter != null) {
             try {
                 return this.formatter.format(content);
@@ -21,8 +21,8 @@ export class TypeScriptFile extends Writer {
         return content;
     }
 
-    public toString(): string {
-        const content = this.getContent();
+    public toString({ omitImports }: { omitImports?: boolean } = {}): string {
+        const content = this.getContent({ omitImports });
         if (this.formatter != null) {
             try {
                 return this.formatter.formatSync(content);
@@ -33,7 +33,10 @@ export class TypeScriptFile extends Writer {
         return content;
     }
 
-    public getContent(): string {
+    public getContent({ omitImports }: { omitImports?: boolean } = {}): string {
+        if (omitImports) {
+            return this.buffer;
+        }
         const imports = this.stringifyImports();
         if (imports.length > 0) {
             return imports + "\n" + this.buffer;

--- a/generators/typescript-v2/ast/src/ast/core/TypeScriptFile.ts
+++ b/generators/typescript-v2/ast/src/ast/core/TypeScriptFile.ts
@@ -44,6 +44,13 @@ export class TypeScriptFile extends Writer {
         return this.buffer;
     }
 
+    /**
+     * Whether anything written to this file references an import.
+     */
+    public hasImports(): boolean {
+        return this.stringifyImports().length > 0;
+    }
+
     private stringifyImports(): string {
         let result = "";
         for (const [module, references] of Object.entries(this.imports)) {

--- a/generators/typescript-v2/ast/src/ast/core/TypeScriptFile.ts
+++ b/generators/typescript-v2/ast/src/ast/core/TypeScriptFile.ts
@@ -51,6 +51,15 @@ export class TypeScriptFile extends Writer {
         return this.stringifyImports().length > 0;
     }
 
+    /**
+     * The rendered import block for everything written to this file, or an empty string when
+     * nothing references an import. Does not include the trailing blank line the full file
+     * output places between the imports and the body.
+     */
+    public getImports(): string {
+        return this.stringifyImports().trimEnd();
+    }
+
     private stringifyImports(): string {
         let result = "";
         for (const [module, references] of Object.entries(this.imports)) {

--- a/generators/typescript-v2/dynamic-snippets/src/EndpointSnippetGenerator.ts
+++ b/generators/typescript-v2/dynamic-snippets/src/EndpointSnippetGenerator.ts
@@ -1,4 +1,4 @@
-import { Scope, Severity } from "@fern-api/browser-compatible-base-generator";
+import { Options, Scope, Severity } from "@fern-api/browser-compatible-base-generator";
 import { assertNever } from "@fern-api/core-utils";
 import { FernIr } from "@fern-api/dynamic-ir-sdk";
 import { AstNode, ts } from "@fern-api/typescript-ast";
@@ -52,6 +52,27 @@ export class EndpointSnippetGenerator {
         return this.buildCodeBlock({ endpoint, snippet: request });
     }
 
+    public generateInvocationSnippetSync({
+        endpoint,
+        request,
+        options
+    }: {
+        endpoint: FernIr.dynamic.Endpoint;
+        request: FernIr.dynamic.EndpointSnippetRequest;
+        options?: Options;
+    }): string {
+        const invocation = this.callMethod({
+            endpoint,
+            snippet: request,
+            clientVariableName: options?.clientVariableName,
+            await_: false
+        });
+        // The caller supplies the imports and the client, and terminates the statement
+        // themselves, so the invocation is emitted as a bare expression.
+        const code = invocation.toString({ customConfig: this.context.customConfig, omitImports: true });
+        return code.trim().replace(/;$/, "");
+    }
+
     private buildCodeBlock({
         endpoint,
         snippet
@@ -67,7 +88,7 @@ export class EndpointSnippetGenerator {
                     parameters: [],
                     body: ts.codeblock((writer) => {
                         writer.writeNodeStatement(this.constructClient({ endpoint, snippet }));
-                        writer.writeNodeStatement(this.callMethod({ endpoint, snippet }));
+                        writer.writeNodeStatement(this.callMethod({ endpoint, snippet, await_: true }));
                     })
                 })
             );
@@ -381,15 +402,19 @@ export class EndpointSnippetGenerator {
 
     private callMethod({
         endpoint,
-        snippet
+        snippet,
+        clientVariableName,
+        await_
     }: {
         endpoint: FernIr.dynamic.Endpoint;
         snippet: FernIr.dynamic.EndpointSnippetRequest;
+        clientVariableName?: string;
+        await_: boolean;
     }): ts.AstNode {
         return ts.invokeMethod({
-            on: ts.reference({ name: CLIENT_VAR_NAME }),
+            on: ts.reference({ name: clientVariableName ?? CLIENT_VAR_NAME }),
             method: this.getMethod({ endpoint }),
-            async: true,
+            async: await_,
             arguments_: this.getMethodArgs({ endpoint, snippet })
         });
     }

--- a/generators/typescript-v2/dynamic-snippets/src/EndpointSnippetGenerator.ts
+++ b/generators/typescript-v2/dynamic-snippets/src/EndpointSnippetGenerator.ts
@@ -60,16 +60,23 @@ export class EndpointSnippetGenerator {
         endpoint: FernIr.dynamic.Endpoint;
         request: FernIr.dynamic.EndpointSnippetRequest;
         options?: Options;
-    }): string {
+    }): string | undefined {
         const invocation = this.callMethod({
             endpoint,
             snippet: request,
             clientVariableName: options?.clientVariableName,
             await_: false
         });
-        // The caller supplies the imports and the client, and terminates the statement
-        // themselves, so the invocation is emitted as a bare expression.
-        const code = invocation.toString({ customConfig: this.context.customConfig, omitImports: true });
+        // The caller supplies the client and terminates the statement themselves, so the
+        // invocation is emitted as a bare expression.
+        const { code, hasImports } = invocation.toStringWithoutImports({
+            customConfig: this.context.customConfig
+        });
+        if (hasImports) {
+            // The arguments reference SDK types (e.g. branded aliases), which the caller
+            // cannot import on the snippet's behalf.
+            return undefined;
+        }
         return code.trim().replace(/;$/, "");
     }
 

--- a/generators/typescript-v2/dynamic-snippets/src/EndpointSnippetGenerator.ts
+++ b/generators/typescript-v2/dynamic-snippets/src/EndpointSnippetGenerator.ts
@@ -1,4 +1,4 @@
-import { Options, Scope, Severity } from "@fern-api/browser-compatible-base-generator";
+import { InvocationSnippetResponse, Options, Scope, Severity } from "@fern-api/browser-compatible-base-generator";
 import { assertNever } from "@fern-api/core-utils";
 import { FernIr } from "@fern-api/dynamic-ir-sdk";
 import { AstNode, ts } from "@fern-api/typescript-ast";
@@ -60,7 +60,7 @@ export class EndpointSnippetGenerator {
         endpoint: FernIr.dynamic.Endpoint;
         request: FernIr.dynamic.EndpointSnippetRequest;
         options?: Options;
-    }): string | undefined {
+    }): InvocationSnippetResponse {
         const invocation = this.callMethod({
             endpoint,
             snippet: request,
@@ -68,16 +68,18 @@ export class EndpointSnippetGenerator {
             await_: false
         });
         // The caller supplies the client and terminates the statement themselves, so the
-        // invocation is emitted as a bare expression.
-        const { code, hasImports } = invocation.toStringWithoutImports({
+        // invocation is emitted as a bare expression. When the call references SDK types
+        // (e.g. branded aliases), the imports it needs are surfaced separately so the caller
+        // can render them rather than falling back to the complete snippet.
+        const { code, imports } = invocation.toStringWithoutImports({
             customConfig: this.context.customConfig
         });
-        if (hasImports) {
-            // The arguments reference SDK types (e.g. branded aliases), which the caller
-            // cannot import on the snippet's behalf.
-            return undefined;
-        }
-        return code.trim().replace(/;$/, "");
+        return {
+            snippet: code.trim().replace(/;$/, ""),
+            imports,
+            clientName: this.context.getRootClientName(),
+            errors: this.context.errors.empty() ? undefined : this.context.errors.toDynamicSnippetErrors()
+        };
     }
 
     private buildCodeBlock({

--- a/generators/typescript-v2/dynamic-snippets/src/__test__/InvocationSnippet.test.ts
+++ b/generators/typescript-v2/dynamic-snippets/src/__test__/InvocationSnippet.test.ts
@@ -1,0 +1,49 @@
+import { AbsoluteFilePath, join } from "@fern-api/path-utils";
+
+import { buildDynamicSnippetsGenerator } from "./utils/buildDynamicSnippetsGenerator.js";
+import { buildGeneratorConfig } from "./utils/buildGeneratorConfig.js";
+
+const DYNAMIC_IR_TEST_DEFINITIONS_DIRECTORY = AbsoluteFilePath.of(
+    `${__dirname}/../../../../../packages/cli/generation/ir-generator-tests/src/dynamic-snippets/__test__/test-definitions`
+);
+
+// invocation-only snippets are rendered inside code the caller already owns (e.g. a
+// documentation code template), so they must not include imports or client instantiation
+describe("invocation-only snippets", () => {
+    const generator = buildDynamicSnippetsGenerator({
+        irFilepath: AbsoluteFilePath.of(join(DYNAMIC_IR_TEST_DEFINITIONS_DIRECTORY, "exhaustive.json")),
+        config: buildGeneratorConfig({})
+    });
+
+    const request = {
+        endpoint: {
+            method: "PUT" as const,
+            path: "/http-methods/{id}"
+        },
+        baseURL: undefined,
+        environment: undefined,
+        auth: {
+            type: "bearer" as const,
+            token: "<YOUR_API_KEY>"
+        },
+        pathParameters: {
+            id: "id"
+        },
+        queryParameters: undefined,
+        headers: undefined,
+        requestBody: undefined
+    };
+
+    it("generates the invocation without imports or client instantiation", () => {
+        const response = generator.generateInvocationSync(request);
+
+        expect(response?.snippet).toBe('client.endpoints.httpMethods.testPut("id")');
+        expect(response?.errors).toBeUndefined();
+    });
+
+    it("invokes the endpoint on the requested client variable", () => {
+        const response = generator.generateInvocationSync(request, { clientVariableName: "mailchimp" });
+
+        expect(response?.snippet).toBe('mailchimp.endpoints.httpMethods.testPut("id")');
+    });
+});

--- a/generators/typescript-v2/dynamic-snippets/src/__test__/InvocationSnippet.test.ts
+++ b/generators/typescript-v2/dynamic-snippets/src/__test__/InvocationSnippet.test.ts
@@ -38,7 +38,14 @@ describe("invocation-only snippets", () => {
         const response = generator.generateInvocationSync(request);
 
         expect(response?.snippet).toBe('client.endpoints.httpMethods.testPut("id")');
+        expect(response?.imports).toBe("");
         expect(response?.errors).toBeUndefined();
+    });
+
+    it("exposes the generated client class name so docs can render the client instantiation", () => {
+        const response = generator.generateInvocationSync(request);
+
+        expect(response?.clientName).toBe("AcmeClient");
     });
 
     it("invokes the endpoint on the requested client variable", () => {
@@ -47,7 +54,7 @@ describe("invocation-only snippets", () => {
         expect(response?.snippet).toBe('mailchimp.endpoints.httpMethods.testPut("id")');
     });
 
-    it("does not generate an invocation that would reference dropped imports", () => {
+    it("returns the imports the invocation references instead of falling back to the full snippet", () => {
         const brandedGenerator = buildDynamicSnippetsGenerator({
             irFilepath: AbsoluteFilePath.of(join(DYNAMIC_IR_TEST_DEFINITIONS_DIRECTORY, "alias.json")),
             config: buildGeneratorConfig({ customConfig: { useBrandedStringAliases: true } })
@@ -69,6 +76,11 @@ describe("invocation-only snippets", () => {
             requestBody: undefined
         });
 
-        expect(response).toBeUndefined();
+        // The branded-alias case used to return undefined; now it returns the call plus the
+        // import the call needs (the SDK namespace import), so docs can regenerate both.
+        expect(response).not.toBeUndefined();
+        expect(response?.snippet).toBe('client.get(Acme.TypeID("type-abc123"))');
+        expect(response?.imports).toContain("import");
+        expect(response?.imports).toContain("Acme");
     });
 });

--- a/generators/typescript-v2/dynamic-snippets/src/__test__/InvocationSnippet.test.ts
+++ b/generators/typescript-v2/dynamic-snippets/src/__test__/InvocationSnippet.test.ts
@@ -46,4 +46,29 @@ describe("invocation-only snippets", () => {
 
         expect(response?.snippet).toBe('mailchimp.endpoints.httpMethods.testPut("id")');
     });
+
+    it("does not generate an invocation that would reference dropped imports", () => {
+        const brandedGenerator = buildDynamicSnippetsGenerator({
+            irFilepath: AbsoluteFilePath.of(join(DYNAMIC_IR_TEST_DEFINITIONS_DIRECTORY, "alias.json")),
+            config: buildGeneratorConfig({ customConfig: { useBrandedStringAliases: true } })
+        });
+
+        const response = brandedGenerator.generateInvocationSync({
+            endpoint: {
+                method: "GET" as const,
+                path: "/{typeId}"
+            },
+            baseURL: undefined,
+            environment: undefined,
+            auth: undefined,
+            pathParameters: {
+                typeId: "type-abc123"
+            },
+            queryParameters: undefined,
+            headers: undefined,
+            requestBody: undefined
+        });
+
+        expect(response).toBeUndefined();
+    });
 });

--- a/generators/typescript/sdk/changes/unreleased/invocation-only-dynamic-snippets.yml
+++ b/generators/typescript/sdk/changes/unreleased/invocation-only-dynamic-snippets.yml
@@ -3,4 +3,11 @@
     or client instantiation), so that callers such as documentation code templates can
     render a generated SDK call inside code they author themselves. The client variable the
     endpoint is invoked on is configurable.
+
+    The invocation-only result is now a structured object exposing the bare call (`snippet`),
+    the import block the call requires (`imports`, empty when none), and the generated client
+    class name (`clientName`), so docs can regenerate the imports and client instantiation and
+    keep them in sync across SDK renames. Invocations that reference imported SDK types (e.g.
+    branded string aliases) now return those imports instead of falling back to the full
+    snippet.
   type: feat

--- a/generators/typescript/sdk/changes/unreleased/invocation-only-dynamic-snippets.yml
+++ b/generators/typescript/sdk/changes/unreleased/invocation-only-dynamic-snippets.yml
@@ -1,0 +1,6 @@
+- summary: |
+    Dynamic snippets can now generate the endpoint invocation on its own (without imports
+    or client instantiation), so that callers such as documentation code templates can
+    render a generated SDK call inside code they author themselves. The client variable the
+    endpoint is invoked on is configurable.
+  type: feat


### PR DESCRIPTION
Stacks on #17393. Mirrors that PR's finalized structured contract for the **Python** generator.

## What
`EndpointSnippetGenerator.generateInvocationSnippetSync` now returns the structured `InvocationSnippetResponse` = `{ snippet, imports, clientName, errors }`, so callers (e.g. a docs code template) can render an invocation inside code they already own and keep it in sync:

- **snippet** — the bare call, e.g. `client.endpoints.http_methods.test_get(id="id")`, honoring `options.clientVariableName` (default `client`). No client construction, no imports, no terminator (Python statements have none).
- **imports** — the Python `import` block the call references (`""` when none).
- **clientName** — the generated root client class name (`getRootClientClassName()`), so docs can render `client = {{clientName}}(...)` and track renames.
- **errors** — preserved from the existing error reporter.

## How imports are captured (the non-mechanical part)
Python imports are emitted only by `PythonFile` (computed from the `references` collected on AST nodes); a bare node's `toString()` already excludes them. To surface them separately — the Python analogue of the TS AST's `toStringWithoutImports() -> { code, imports }` — this PR adds:

- `PythonFile.getImports()` — renders just the import block for the file's statements (dedup, name-override, and relativization logic reused unchanged), trimming the trailing blank line.
- `python.renderNodeWithoutImports({ node, modulePath })` — returns `{ code: node.toString(), imports: <PythonFile at modulePath>.getImports() }`. Relativizing against the snippet module path keeps imports identical to what the full snippet would emit.

`callMethod` was parameterized with `clientVariableName` (mirroring the TS `callMethod({ clientVariableName })`).

## Before / after
- **Before:** only the full snippet — client construction + call + imports as one string.
- **After (structured invocation):** `snippet = client.endpoints.http_methods.test_get(id="id")`, `imports = ""`, `clientName = "Acme"`.
- **Import-referencing case:** a body built with a datetime and a UUID yields `snippet` containing `datetime.datetime.fromisoformat(...)` / `uuid.UUID(...)` and `imports = "import datetime\nimport uuid"` — no fallback to the full snippet.

## Tests
`src/__test__/InvocationSnippet.test.ts` (all green):
(a) bare call for a normal endpoint (exact string, `imports === ""`, no errors); (b) `clientName` populated; (c) custom `clientVariableName`; (d) import-referencing invocation asserting the `import datetime` / `import uuid` block. Existing dynamic-snippets snapshots and python-ast tests remain green.

## Verify
- `pnpm turbo run compile --filter @fern-api/python-dynamic-snippets` — clean (includes `@fern-api/python-ast`).
- `vitest run` in python-dynamic-snippets (70 passed) and python-ast (156 passed).
- `npx biome check --write` on changed `.ts` — clean.
- Changelog: `generators/python/sdk/changes/unreleased/invocation-only-dynamic-snippets.yml` (`type: feat`).

Auto-retargets to `main` once #17393 merges. Do not merge before it.

Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/17402" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->