### PR TITLE
feat(ruby): generate invocation-only dynamic snippets

### DIFF
--- a/generators/browser-compatible-base/src/dynamic-snippets/AbstractDynamicSnippetsGenerator.ts
+++ b/generators/browser-compatible-base/src/dynamic-snippets/AbstractDynamicSnippetsGenerator.ts
@@ -105,8 +105,9 @@ export abstract class AbstractDynamicSnippetsGenerator<
      * imports or client instantiation, for callers that render the invocation within code
      * of their own (e.g. a documentation code template).
      *
-     * Returns undefined if this generator does not support invocation-only snippets, so
-     * that callers can fall back to the complete snippet.
+     * Returns undefined if this generator does not support invocation-only snippets, or if
+     * the invocation cannot stand on its own (e.g. its arguments reference imported SDK
+     * types), so that callers can fall back to the complete snippet.
      */
     public generateInvocationSync(
         request: FernIr.dynamic.EndpointSnippetRequest,
@@ -125,6 +126,9 @@ export abstract class AbstractDynamicSnippetsGenerator<
             }
             try {
                 const snippet = snippetGenerator.generateInvocationSnippetSync({ endpoint, request, options });
+                if (snippet == null) {
+                    return undefined;
+                }
                 if (context.errors.empty()) {
                     return {
                         snippet,

--- a/generators/browser-compatible-base/src/dynamic-snippets/AbstractDynamicSnippetsGenerator.ts
+++ b/generators/browser-compatible-base/src/dynamic-snippets/AbstractDynamicSnippetsGenerator.ts
@@ -2,6 +2,7 @@ import { FernIr } from "@fern-api/dynamic-ir-sdk";
 import { AbstractAstNode } from "../ast/index.js";
 import { AbstractDynamicSnippetsGeneratorContext } from "./AbstractDynamicSnippetsGeneratorContext.js";
 import { AbstractEndpointSnippetGenerator } from "./AbstractEndpointSnippetGenerator.js";
+import { InvocationSnippetResponse } from "./InvocationSnippetResponse.js";
 import { Options } from "./Options.js";
 import { Result } from "./Result.js";
 
@@ -101,23 +102,27 @@ export abstract class AbstractDynamicSnippetsGenerator<
     }
 
     /**
-     * Generates just the endpoint invocation (e.g. `client.plants.update(...)`), without
-     * imports or client instantiation, for callers that render the invocation within code
-     * of their own (e.g. a documentation code template).
+     * Generates the structured pieces of an endpoint invocation for callers that render the
+     * invocation within code of their own (e.g. a documentation code template): the bare call
+     * (e.g. `client.plants.update(...)`), the imports the call requires, and the generated
+     * client class/type name.
      *
-     * Returns undefined if this generator does not support invocation-only snippets, or if
-     * the invocation cannot stand on its own (e.g. its arguments reference imported SDK
-     * types), so that callers can fall back to the complete snippet.
+     * Returns undefined only if this generator does not support invocation-only snippets, so
+     * that callers can fall back to the complete snippet. This is the capability check the
+     * multi-language fan-out relies on. When the generator does support them, invocations that
+     * reference imported SDK types (e.g. branded string aliases) return those imports in the
+     * `imports` field rather than bailing out.
      */
     public generateInvocationSync(
         request: FernIr.dynamic.EndpointSnippetRequest,
         options: Options = {}
-    ): FernIr.dynamic.EndpointSnippetResponse | undefined {
+    ): InvocationSnippetResponse | undefined {
         const endpoints = this.resolveEndpoints({ request, options });
         if (endpoints.length === 0) {
             throw new Error(`No endpoints found that match "${request.endpoint.method} ${request.endpoint.path}"`);
         }
-        const result = new Result();
+        let bestResponse: InvocationSnippetResponse | undefined = undefined;
+        let lastError: Error | undefined = undefined;
         for (const endpoint of endpoints) {
             const context = this.context.clone() as Context;
             const snippetGenerator = this.createSnippetGenerator(context);
@@ -125,24 +130,42 @@ export abstract class AbstractDynamicSnippetsGenerator<
                 return undefined;
             }
             try {
-                const snippet = snippetGenerator.generateInvocationSnippetSync({ endpoint, request, options });
-                if (snippet == null) {
+                const response = snippetGenerator.generateInvocationSnippetSync({ endpoint, request, options });
+                if (response == null) {
                     return undefined;
                 }
                 if (context.errors.empty()) {
-                    return {
-                        snippet,
-                        errors: undefined
-                    };
+                    return response;
                 }
-                result.update({ context, snippet });
+                if (this.shouldUpdateInvocationResponse({ candidate: response, current: bestResponse })) {
+                    bestResponse = response;
+                }
             } catch (error) {
-                if (result.err == null) {
-                    result.err = error as Error;
+                if (lastError == null) {
+                    lastError = error as Error;
                 }
             }
         }
-        return result.getResponseOrThrow({ endpoint: request.endpoint });
+        if (bestResponse != null) {
+            return bestResponse;
+        }
+        throw (
+            lastError ??
+            new Error(`Failed to generate snippet for endpoint "${request.endpoint.method} ${request.endpoint.path}"`)
+        );
+    }
+
+    private shouldUpdateInvocationResponse({
+        candidate,
+        current
+    }: {
+        candidate: InvocationSnippetResponse;
+        current: InvocationSnippetResponse | undefined;
+    }): boolean {
+        if (current == null) {
+            return true;
+        }
+        return candidate.snippet.length > current.snippet.length;
     }
 
     /**

--- a/generators/browser-compatible-base/src/dynamic-snippets/AbstractDynamicSnippetsGenerator.ts
+++ b/generators/browser-compatible-base/src/dynamic-snippets/AbstractDynamicSnippetsGenerator.ts
@@ -101,6 +101,47 @@ export abstract class AbstractDynamicSnippetsGenerator<
     }
 
     /**
+     * Generates just the endpoint invocation (e.g. `client.plants.update(...)`), without
+     * imports or client instantiation, for callers that render the invocation within code
+     * of their own (e.g. a documentation code template).
+     *
+     * Returns undefined if this generator does not support invocation-only snippets, so
+     * that callers can fall back to the complete snippet.
+     */
+    public generateInvocationSync(
+        request: FernIr.dynamic.EndpointSnippetRequest,
+        options: Options = {}
+    ): FernIr.dynamic.EndpointSnippetResponse | undefined {
+        const endpoints = this.resolveEndpoints({ request, options });
+        if (endpoints.length === 0) {
+            throw new Error(`No endpoints found that match "${request.endpoint.method} ${request.endpoint.path}"`);
+        }
+        const result = new Result();
+        for (const endpoint of endpoints) {
+            const context = this.context.clone() as Context;
+            const snippetGenerator = this.createSnippetGenerator(context);
+            if (snippetGenerator.generateInvocationSnippetSync == null) {
+                return undefined;
+            }
+            try {
+                const snippet = snippetGenerator.generateInvocationSnippetSync({ endpoint, request, options });
+                if (context.errors.empty()) {
+                    return {
+                        snippet,
+                        errors: undefined
+                    };
+                }
+                result.update({ context, snippet });
+            } catch (error) {
+                if (result.err == null) {
+                    result.err = error as Error;
+                }
+            }
+        }
+        return result.getResponseOrThrow({ endpoint: request.endpoint });
+    }
+
+    /**
      * Resolves endpoints based on the request and options.
      * If an endpointId is specified in options, returns only that specific endpoint.
      * Otherwise, resolves all endpoints matching the endpoint location (method + path).

--- a/generators/browser-compatible-base/src/dynamic-snippets/AbstractEndpointSnippetGenerator.ts
+++ b/generators/browser-compatible-base/src/dynamic-snippets/AbstractEndpointSnippetGenerator.ts
@@ -39,8 +39,8 @@ export abstract class AbstractEndpointSnippetGenerator<Context extends AbstractD
      * imports or client instantiation, for callers that render the invocation within code
      * of their own (e.g. a documentation code template).
      *
-     * Implemented per generator; generators that do not implement it fall back to the
-     * complete snippet.
+     * Implemented per generator; generators that do not implement it, and invocations that
+     * cannot stand on their own, fall back to the complete snippet.
      */
     public generateInvocationSnippetSync?({
         endpoint,
@@ -50,5 +50,5 @@ export abstract class AbstractEndpointSnippetGenerator<Context extends AbstractD
         endpoint: FernIr.dynamic.Endpoint;
         request: FernIr.dynamic.EndpointSnippetRequest;
         options?: Options;
-    }): string;
+    }): string | undefined;
 }

--- a/generators/browser-compatible-base/src/dynamic-snippets/AbstractEndpointSnippetGenerator.ts
+++ b/generators/browser-compatible-base/src/dynamic-snippets/AbstractEndpointSnippetGenerator.ts
@@ -1,6 +1,7 @@
 import { FernIr } from "@fern-api/dynamic-ir-sdk";
 import { AbstractAstNode } from "../ast/index.js";
 import { AbstractDynamicSnippetsGeneratorContext } from "./AbstractDynamicSnippetsGeneratorContext.js";
+import { InvocationSnippetResponse } from "./InvocationSnippetResponse.js";
 import { Options } from "./Options.js";
 
 export abstract class AbstractEndpointSnippetGenerator<Context extends AbstractDynamicSnippetsGeneratorContext> {
@@ -35,12 +36,14 @@ export abstract class AbstractEndpointSnippetGenerator<Context extends AbstractD
     }): Promise<AbstractAstNode>;
 
     /**
-     * Generates just the endpoint invocation (e.g. `client.plants.update(...)`), without
-     * imports or client instantiation, for callers that render the invocation within code
-     * of their own (e.g. a documentation code template).
+     * Generates the structured pieces of an endpoint invocation for callers that render the
+     * invocation within code of their own (e.g. a documentation code template): the bare call
+     * (e.g. `client.plants.update(...)`), the imports the call requires, and the generated
+     * client class/type name.
      *
-     * Implemented per generator; generators that do not implement it, and invocations that
-     * cannot stand on their own, fall back to the complete snippet.
+     * Implemented per generator; generators that do not implement it are detected via the
+     * absence of this method (the capability check callers rely on) and fall back to the
+     * complete snippet.
      */
     public generateInvocationSnippetSync?({
         endpoint,
@@ -50,5 +53,5 @@ export abstract class AbstractEndpointSnippetGenerator<Context extends AbstractD
         endpoint: FernIr.dynamic.Endpoint;
         request: FernIr.dynamic.EndpointSnippetRequest;
         options?: Options;
-    }): string | undefined;
+    }): InvocationSnippetResponse | undefined;
 }

--- a/generators/browser-compatible-base/src/dynamic-snippets/AbstractEndpointSnippetGenerator.ts
+++ b/generators/browser-compatible-base/src/dynamic-snippets/AbstractEndpointSnippetGenerator.ts
@@ -33,4 +33,22 @@ export abstract class AbstractEndpointSnippetGenerator<Context extends AbstractD
         request: FernIr.dynamic.EndpointSnippetRequest;
         options?: Options;
     }): Promise<AbstractAstNode>;
+
+    /**
+     * Generates just the endpoint invocation (e.g. `client.plants.update(...)`), without
+     * imports or client instantiation, for callers that render the invocation within code
+     * of their own (e.g. a documentation code template).
+     *
+     * Implemented per generator; generators that do not implement it fall back to the
+     * complete snippet.
+     */
+    public generateInvocationSnippetSync?({
+        endpoint,
+        request,
+        options
+    }: {
+        endpoint: FernIr.dynamic.Endpoint;
+        request: FernIr.dynamic.EndpointSnippetRequest;
+        options?: Options;
+    }): string;
 }

--- a/generators/browser-compatible-base/src/dynamic-snippets/InvocationSnippetResponse.ts
+++ b/generators/browser-compatible-base/src/dynamic-snippets/InvocationSnippetResponse.ts
@@ -1,0 +1,28 @@
+import { FernIr } from "@fern-api/dynamic-ir-sdk";
+
+/**
+ * The structured result of an invocation-only snippet.
+ *
+ * Unlike {@link FernIr.dynamic.EndpointSnippetResponse}, which returns a single fully-formed
+ * snippet string, this exposes the individual pieces a docs template needs to render (and
+ * keep in sync) an invocation on its own: the bare call, the imports the call requires, and
+ * the generated client class/type name.
+ */
+export interface InvocationSnippetResponse {
+    /**
+     * The bare invocation/call (e.g. `client.plants.update(...)`) with no imports, no client
+     * instantiation, and no trailing statement terminator. Honors `options.clientVariableName`.
+     */
+    snippet: string;
+    /**
+     * The import block the call requires (e.g. an SDK namespace import for a branded string
+     * alias). Empty string when the call references no imports.
+     */
+    imports: string;
+    /**
+     * The generated client class/type name (e.g. `AcmeClient`), so docs can render
+     * `new {{clientName}}(...)` and track renames of the SDK client.
+     */
+    clientName: string;
+    errors: FernIr.dynamic.Error_[] | undefined;
+}

--- a/generators/browser-compatible-base/src/dynamic-snippets/Options.ts
+++ b/generators/browser-compatible-base/src/dynamic-snippets/Options.ts
@@ -29,4 +29,8 @@ export interface Options {
     // This is useful when multiple endpoints have the same HTTP method and path
     // across different namespaces, and we need to generate a snippet for a specific one.
     endpointId?: string;
+
+    // The name of the variable the endpoint is invoked on. Only used when generating
+    // an invocation-only snippet, where the client is instantiated by the caller.
+    clientVariableName?: string;
 }

--- a/generators/browser-compatible-base/src/dynamic-snippets/index.ts
+++ b/generators/browser-compatible-base/src/dynamic-snippets/index.ts
@@ -2,6 +2,7 @@ export { AbstractDynamicSnippetsGenerator } from "./AbstractDynamicSnippetsGener
 export { AbstractDynamicSnippetsGeneratorContext } from "./AbstractDynamicSnippetsGeneratorContext.js";
 export { type DiscriminatedUnionTypeInstance } from "./DiscriminatedUnionTypeInstance.js";
 export { ErrorReporter, Severity } from "./ErrorReporter.js";
+export { type InvocationSnippetResponse } from "./InvocationSnippetResponse.js";
 export { type Options, Style } from "./Options.js";
 export { Result } from "./Result.js";
 export { Scope } from "./Scope.js";

--- a/generators/ruby-v2/dynamic-snippets/src/EndpointSnippetGenerator.ts
+++ b/generators/ruby-v2/dynamic-snippets/src/EndpointSnippetGenerator.ts
@@ -1,4 +1,9 @@
-import { AbstractFormatter, Options, Severity } from "@fern-api/browser-compatible-base-generator";
+import {
+    AbstractFormatter,
+    InvocationSnippetResponse,
+    Options,
+    Severity
+} from "@fern-api/browser-compatible-base-generator";
 import { assertNever } from "@fern-api/core-utils";
 import { FernIr } from "@fern-api/dynamic-ir-sdk";
 import { ruby } from "@fern-api/ruby-ast";
@@ -58,6 +63,57 @@ export class EndpointSnippetGenerator {
             return this.buildCodeBlockWithoutClient({ endpoint, snippet: request });
         }
         return this.buildCodeBlock({ endpoint, snippet: request });
+    }
+
+    /**
+     * Generates the structured pieces of an endpoint invocation for callers that render the
+     * invocation within code of their own (e.g. a documentation code template): the bare call
+     * (e.g. `client.plants.update(...)`, honoring a custom client variable name), the imports the
+     * call requires, and the generated client class name.
+     *
+     * Ruby's `imports` is always the empty string. Unlike TypeScript/PHP/C#/Java — where a call
+     * that references a type from another namespace must emit a per-symbol import/`use` line — a
+     * generated Ruby SDK references every type through the gem's module namespace (e.g.
+     * `Acme::Types::Foo`), so a bare invocation never emits a `require`. The generator's only
+     * `require` (`require "acme"`, added in {@link constructClient}) belongs to the client
+     * construction the caller owns, not to the invocation. There is therefore no import-referencing
+     * invocation case to surface for Ruby, so we return `""` rather than inventing an imports
+     * mechanism the language does not have. This is the Ruby analogue of Go always emitting
+     * `context`, inverted: Ruby's invocation imports are always empty.
+     */
+    public generateInvocationSnippetSync({
+        endpoint,
+        request,
+        options
+    }: {
+        endpoint: FernIr.dynamic.Endpoint;
+        request: FernIr.dynamic.EndpointSnippetRequest;
+        options?: Options;
+    }): InvocationSnippetResponse {
+        const invocation = this.callMethod({
+            endpoint,
+            snippet: request,
+            clientVariableName: options?.clientVariableName
+        });
+        // Render only the invocation node: no `client = Acme::Client.new(...)` construction and no
+        // `require` preamble. Ruby has no statement terminator to strip, but we trim defensively in
+        // case the writer ever introduces trailing whitespace/newlines.
+        const code = ruby
+            .codeblock((writer) => {
+                writer.writeNode(invocation);
+            })
+            .toString({
+                customConfig: this.context.customConfig ?? {},
+                formatter: this.formatter
+            });
+        return {
+            snippet: code.trim(),
+            // Always empty for Ruby — see the method doc comment: types are referenced via the gem
+            // namespace, so a bare invocation emits no per-symbol requires.
+            imports: "",
+            clientName: this.context.getRootClientClassName(),
+            errors: this.context.errors.empty() ? undefined : this.context.errors.toDynamicSnippetErrors()
+        };
     }
 
     private buildCodeBlock({
@@ -355,13 +411,15 @@ export class EndpointSnippetGenerator {
 
     private callMethod({
         endpoint,
-        snippet
+        snippet,
+        clientVariableName
     }: {
         endpoint: FernIr.dynamic.Endpoint;
         snippet: FernIr.dynamic.EndpointSnippetRequest;
+        clientVariableName?: string;
     }): ruby.MethodInvocation {
         const invokeMethodArgs: ruby.MethodInvocation.Args = {
-            on: ruby.codeblock(CLIENT_VAR_NAME),
+            on: ruby.codeblock(clientVariableName ?? CLIENT_VAR_NAME),
             method: this.getMethod({ endpoint }),
             arguments_: []
         };

--- a/generators/ruby-v2/dynamic-snippets/src/__test__/InvocationSnippet.test.ts
+++ b/generators/ruby-v2/dynamic-snippets/src/__test__/InvocationSnippet.test.ts
@@ -1,0 +1,114 @@
+import { AbsoluteFilePath, join } from "@fern-api/path-utils";
+
+import { buildDynamicSnippetsGenerator } from "./utils/buildDynamicSnippetsGenerator.js";
+import { buildGeneratorConfig } from "./utils/buildGeneratorConfig.js";
+
+const DYNAMIC_IR_TEST_DEFINITIONS_DIRECTORY = AbsoluteFilePath.of(
+    `${__dirname}/../../../../../packages/cli/generation/ir-generator-tests/src/dynamic-snippets/__test__/test-definitions`
+);
+
+// Invocation-only snippets are rendered inside code the caller already owns (e.g. a
+// documentation code template), so they must not include the client construction
+// (`client = Acme::Client.new(...)`) or the `require "acme"` preamble that construction emits.
+//
+// Ruby's `imports` field is always the empty string: a generated Ruby SDK references every type
+// through the gem's module namespace (e.g. `Acme::Types::Foo`), so a bare invocation never emits
+// a per-symbol `require`. Unlike TypeScript/PHP/C#/Java, Ruby has no import-referencing invocation
+// case to surface — this is the expected and correct result, the Ruby analogue of Go always
+// emitting `context`, inverted.
+describe("invocation-only snippets", () => {
+    const generator = buildDynamicSnippetsGenerator({
+        irFilepath: AbsoluteFilePath.of(join(DYNAMIC_IR_TEST_DEFINITIONS_DIRECTORY, "exhaustive.json")),
+        config: buildGeneratorConfig()
+    });
+
+    const request = {
+        endpoint: {
+            method: "GET" as const,
+            path: "/http-methods/{id}"
+        },
+        baseURL: undefined,
+        environment: undefined,
+        auth: {
+            type: "bearer" as const,
+            token: "<YOUR_API_KEY>"
+        },
+        pathParameters: {
+            id: "id"
+        },
+        queryParameters: undefined,
+        headers: undefined,
+        requestBody: undefined
+    };
+
+    it("generates the invocation without client construction or require preamble", () => {
+        const response = generator.generateInvocationSync(request);
+
+        expect(response?.snippet).toBe('client.endpoints.http_methods.test_get(id: "id")');
+        // The invocation is a bare expression: no `client = Acme::Client.new(...)` construction and
+        // no `require "..."` preamble (both belong to the client the caller owns).
+        expect(response?.snippet).not.toContain(".new(");
+        expect(response?.snippet).not.toContain("require ");
+        expect(response?.errors).toBeUndefined();
+    });
+
+    it("returns no imports for a Ruby invocation (types are referenced via the gem namespace)", () => {
+        const response = generator.generateInvocationSync(request);
+
+        // Always empty for Ruby: there is no per-symbol require to surface for a bare call.
+        expect(response?.imports).toBe("");
+    });
+
+    it("exposes the generated client class name so docs can render the client construction", () => {
+        const response = generator.generateInvocationSync(request);
+
+        expect(response?.clientName).toBe("Client");
+    });
+
+    it("invokes the endpoint on the requested client variable", () => {
+        const response = generator.generateInvocationSync(request, { clientVariableName: "mailchimp" });
+
+        expect(response?.snippet).toBe('mailchimp.endpoints.http_methods.test_get(id: "id")');
+    });
+
+    it("returns no imports even when the invocation constructs typed body values", () => {
+        // This body constructs typed values (datetime, uuid, nested lists/maps). In
+        // TypeScript/PHP/C#/Java such a call would surface per-symbol imports; in Ruby every type is
+        // referenced through the gem namespace, so `imports` remains empty. This documents that Ruby
+        // has no import-referencing invocation case.
+        const response = generator.generateInvocationSync({
+            endpoint: {
+                method: "POST" as const,
+                path: "/object/get-and-return-with-optional-field"
+            },
+            baseURL: undefined,
+            environment: undefined,
+            auth: {
+                type: "bearer" as const,
+                token: "<YOUR_API_KEY>"
+            },
+            pathParameters: undefined,
+            queryParameters: undefined,
+            headers: undefined,
+            requestBody: {
+                string: "string",
+                integer: 1,
+                long: 1000000,
+                double: 1.1,
+                bool: true,
+                datetime: "2024-01-15T09:30:00Z",
+                date: "2023-01-15",
+                uuid: "d5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32",
+                base64: "SGVsbG8gd29ybGQh",
+                list: ["list", "list"],
+                set: ["set"],
+                map: { 1: "map" },
+                bigint: "1000000"
+            }
+        });
+
+        expect(response).not.toBeUndefined();
+        expect(response?.imports).toBe("");
+        expect(response?.snippet).not.toContain("require ");
+    });
+});

--- a/generators/ruby/sdk/changes/unreleased/invocation-only-dynamic-snippets.yml
+++ b/generators/ruby/sdk/changes/unreleased/invocation-only-dynamic-snippets.yml
@@ -1,0 +1,21 @@
+# yaml-language-server: $schema=../../../../../fern-changes-yml.schema.json
+
+- summary: |
+    Generate invocation-only dynamic snippets. In addition to the full snippet
+    (client construction plus the call), the generator now exposes the structured
+    pieces a caller can render inside code it already owns (e.g. a documentation
+    code template): the bare invocation (`client.endpoints.update(...)`, honoring a
+    custom client variable name), the imports the invocation references, and the
+    generated client class name so docs can render the client construction and track
+    renames.
+
+    For Ruby the imports field is always the empty string: a generated Ruby SDK
+    references every type through the gem's module namespace (e.g.
+    `Acme::Types::Foo`), so a bare invocation never emits a per-symbol `require`.
+    Unlike TypeScript/PHP/C#/Java — where a call that references a type from another
+    namespace must emit an import/`use` line — Ruby has no import-referencing
+    invocation case to surface, so no imports mechanism is invented for it. The only
+    `require` a generated snippet emits (`require "acme"`) belongs to the client
+    construction the caller owns, not to the invocation, and is therefore omitted
+    from the invocation-only render.
+  type: feat

--- a/generators/typescript-v2/ast/src/ast/core/AstNode.ts
+++ b/generators/typescript-v2/ast/src/ast/core/AstNode.ts
@@ -9,25 +9,29 @@ export abstract class AstNode extends AbstractAstNode {
      */
     public async toStringAsync({
         customConfig,
-        formatter
+        formatter,
+        omitImports
     }: {
         customConfig: TypescriptCustomConfigSchema | undefined;
         formatter?: AbstractFormatter;
+        omitImports?: boolean;
     }): Promise<string> {
         const file = new TypeScriptFile({ customConfig, formatter });
         this.write(file);
-        return await file.toStringAsync();
+        return await file.toStringAsync({ omitImports });
     }
 
     public toString({
         customConfig,
-        formatter
+        formatter,
+        omitImports
     }: {
         customConfig: TypescriptCustomConfigSchema | undefined;
         formatter?: AbstractFormatter;
+        omitImports?: boolean;
     }): string {
         const file = new TypeScriptFile({ customConfig, formatter });
         this.write(file);
-        return file.toString();
+        return file.toString({ omitImports });
     }
 }

--- a/generators/typescript-v2/ast/src/ast/core/AstNode.ts
+++ b/generators/typescript-v2/ast/src/ast/core/AstNode.ts
@@ -9,29 +9,41 @@ export abstract class AstNode extends AbstractAstNode {
      */
     public async toStringAsync({
         customConfig,
-        formatter,
-        omitImports
+        formatter
     }: {
         customConfig: TypescriptCustomConfigSchema | undefined;
         formatter?: AbstractFormatter;
-        omitImports?: boolean;
     }): Promise<string> {
         const file = new TypeScriptFile({ customConfig, formatter });
         this.write(file);
-        return await file.toStringAsync({ omitImports });
+        return await file.toStringAsync();
     }
 
     public toString({
         customConfig,
-        formatter,
-        omitImports
+        formatter
     }: {
         customConfig: TypescriptCustomConfigSchema | undefined;
         formatter?: AbstractFormatter;
-        omitImports?: boolean;
     }): string {
         const file = new TypeScriptFile({ customConfig, formatter });
         this.write(file);
-        return file.toString({ omitImports });
+        return file.toString();
+    }
+
+    /**
+     * Writes the node without the import statements it references. `hasImports` reports
+     * whether any were dropped, since the code is only valid on its own without them.
+     */
+    public toStringWithoutImports({
+        customConfig,
+        formatter
+    }: {
+        customConfig: TypescriptCustomConfigSchema | undefined;
+        formatter?: AbstractFormatter;
+    }): { code: string; hasImports: boolean } {
+        const file = new TypeScriptFile({ customConfig, formatter });
+        this.write(file);
+        return { code: file.toString({ omitImports: true }), hasImports: file.hasImports() };
     }
 }

--- a/generators/typescript-v2/ast/src/ast/core/AstNode.ts
+++ b/generators/typescript-v2/ast/src/ast/core/AstNode.ts
@@ -32,8 +32,9 @@ export abstract class AstNode extends AbstractAstNode {
     }
 
     /**
-     * Writes the node without the import statements it references. `hasImports` reports
-     * whether any were dropped, since the code is only valid on its own without them.
+     * Writes the node without the import statements it references. `imports` is the rendered
+     * import block the code would otherwise need (empty string when none), and `hasImports`
+     * reports whether any were separated out.
      */
     public toStringWithoutImports({
         customConfig,
@@ -41,9 +42,13 @@ export abstract class AstNode extends AbstractAstNode {
     }: {
         customConfig: TypescriptCustomConfigSchema | undefined;
         formatter?: AbstractFormatter;
-    }): { code: string; hasImports: boolean } {
+    }): { code: string; imports: string; hasImports: boolean } {
         const file = new TypeScriptFile({ customConfig, formatter });
         this.write(file);
-        return { code: file.toString({ omitImports: true }), hasImports: file.hasImports() };
+        return {
+            code: file.toString({ omitImports: true }),
+            imports: file.getImports(),
+            hasImports: file.hasImports()
+        };
     }
 }

--- a/generators/typescript-v2/ast/src/ast/core/TypeScriptFile.ts
+++ b/generators/typescript-v2/ast/src/ast/core/TypeScriptFile.ts
@@ -9,8 +9,8 @@ export class TypeScriptFile extends Writer {
         super({ customConfig, formatter });
     }
 
-    public async toStringAsync(): Promise<string> {
-        const content = this.getContent();
+    public async toStringAsync({ omitImports }: { omitImports?: boolean } = {}): Promise<string> {
+        const content = this.getContent({ omitImports });
         if (this.formatter != null) {
             try {
                 return this.formatter.format(content);
@@ -21,8 +21,8 @@ export class TypeScriptFile extends Writer {
         return content;
     }
 
-    public toString(): string {
-        const content = this.getContent();
+    public toString({ omitImports }: { omitImports?: boolean } = {}): string {
+        const content = this.getContent({ omitImports });
         if (this.formatter != null) {
             try {
                 return this.formatter.formatSync(content);
@@ -33,7 +33,10 @@ export class TypeScriptFile extends Writer {
         return content;
     }
 
-    public getContent(): string {
+    public getContent({ omitImports }: { omitImports?: boolean } = {}): string {
+        if (omitImports) {
+            return this.buffer;
+        }
         const imports = this.stringifyImports();
         if (imports.length > 0) {
             return imports + "\n" + this.buffer;

--- a/generators/typescript-v2/ast/src/ast/core/TypeScriptFile.ts
+++ b/generators/typescript-v2/ast/src/ast/core/TypeScriptFile.ts
@@ -44,6 +44,13 @@ export class TypeScriptFile extends Writer {
         return this.buffer;
     }
 
+    /**
+     * Whether anything written to this file references an import.
+     */
+    public hasImports(): boolean {
+        return this.stringifyImports().length > 0;
+    }
+
     private stringifyImports(): string {
         let result = "";
         for (const [module, references] of Object.entries(this.imports)) {

--- a/generators/typescript-v2/ast/src/ast/core/TypeScriptFile.ts
+++ b/generators/typescript-v2/ast/src/ast/core/TypeScriptFile.ts
@@ -51,6 +51,15 @@ export class TypeScriptFile extends Writer {
         return this.stringifyImports().length > 0;
     }
 
+    /**
+     * The rendered import block for everything written to this file, or an empty string when
+     * nothing references an import. Does not include the trailing blank line the full file
+     * output places between the imports and the body.
+     */
+    public getImports(): string {
+        return this.stringifyImports().trimEnd();
+    }
+
     private stringifyImports(): string {
         let result = "";
         for (const [module, references] of Object.entries(this.imports)) {

--- a/generators/typescript-v2/dynamic-snippets/src/EndpointSnippetGenerator.ts
+++ b/generators/typescript-v2/dynamic-snippets/src/EndpointSnippetGenerator.ts
@@ -1,4 +1,4 @@
-import { Scope, Severity } from "@fern-api/browser-compatible-base-generator";
+import { Options, Scope, Severity } from "@fern-api/browser-compatible-base-generator";
 import { assertNever } from "@fern-api/core-utils";
 import { FernIr } from "@fern-api/dynamic-ir-sdk";
 import { AstNode, ts } from "@fern-api/typescript-ast";
@@ -52,6 +52,27 @@ export class EndpointSnippetGenerator {
         return this.buildCodeBlock({ endpoint, snippet: request });
     }
 
+    public generateInvocationSnippetSync({
+        endpoint,
+        request,
+        options
+    }: {
+        endpoint: FernIr.dynamic.Endpoint;
+        request: FernIr.dynamic.EndpointSnippetRequest;
+        options?: Options;
+    }): string {
+        const invocation = this.callMethod({
+            endpoint,
+            snippet: request,
+            clientVariableName: options?.clientVariableName,
+            await_: false
+        });
+        // The caller supplies the imports and the client, and terminates the statement
+        // themselves, so the invocation is emitted as a bare expression.
+        const code = invocation.toString({ customConfig: this.context.customConfig, omitImports: true });
+        return code.trim().replace(/;$/, "");
+    }
+
     private buildCodeBlock({
         endpoint,
         snippet
@@ -67,7 +88,7 @@ export class EndpointSnippetGenerator {
                     parameters: [],
                     body: ts.codeblock((writer) => {
                         writer.writeNodeStatement(this.constructClient({ endpoint, snippet }));
-                        writer.writeNodeStatement(this.callMethod({ endpoint, snippet }));
+                        writer.writeNodeStatement(this.callMethod({ endpoint, snippet, await_: true }));
                     })
                 })
             );
@@ -381,15 +402,19 @@ export class EndpointSnippetGenerator {
 
     private callMethod({
         endpoint,
-        snippet
+        snippet,
+        clientVariableName,
+        await_
     }: {
         endpoint: FernIr.dynamic.Endpoint;
         snippet: FernIr.dynamic.EndpointSnippetRequest;
+        clientVariableName?: string;
+        await_: boolean;
     }): ts.AstNode {
         return ts.invokeMethod({
-            on: ts.reference({ name: CLIENT_VAR_NAME }),
+            on: ts.reference({ name: clientVariableName ?? CLIENT_VAR_NAME }),
             method: this.getMethod({ endpoint }),
-            async: true,
+            async: await_,
             arguments_: this.getMethodArgs({ endpoint, snippet })
         });
     }

--- a/generators/typescript-v2/dynamic-snippets/src/EndpointSnippetGenerator.ts
+++ b/generators/typescript-v2/dynamic-snippets/src/EndpointSnippetGenerator.ts
@@ -60,16 +60,23 @@ export class EndpointSnippetGenerator {
         endpoint: FernIr.dynamic.Endpoint;
         request: FernIr.dynamic.EndpointSnippetRequest;
         options?: Options;
-    }): string {
+    }): string | undefined {
         const invocation = this.callMethod({
             endpoint,
             snippet: request,
             clientVariableName: options?.clientVariableName,
             await_: false
         });
-        // The caller supplies the imports and the client, and terminates the statement
-        // themselves, so the invocation is emitted as a bare expression.
-        const code = invocation.toString({ customConfig: this.context.customConfig, omitImports: true });
+        // The caller supplies the client and terminates the statement themselves, so the
+        // invocation is emitted as a bare expression.
+        const { code, hasImports } = invocation.toStringWithoutImports({
+            customConfig: this.context.customConfig
+        });
+        if (hasImports) {
+            // The arguments reference SDK types (e.g. branded aliases), which the caller
+            // cannot import on the snippet's behalf.
+            return undefined;
+        }
         return code.trim().replace(/;$/, "");
     }
 

--- a/generators/typescript-v2/dynamic-snippets/src/EndpointSnippetGenerator.ts
+++ b/generators/typescript-v2/dynamic-snippets/src/EndpointSnippetGenerator.ts
@@ -1,4 +1,4 @@
-import { Options, Scope, Severity } from "@fern-api/browser-compatible-base-generator";
+import { InvocationSnippetResponse, Options, Scope, Severity } from "@fern-api/browser-compatible-base-generator";
 import { assertNever } from "@fern-api/core-utils";
 import { FernIr } from "@fern-api/dynamic-ir-sdk";
 import { AstNode, ts } from "@fern-api/typescript-ast";
@@ -60,7 +60,7 @@ export class EndpointSnippetGenerator {
         endpoint: FernIr.dynamic.Endpoint;
         request: FernIr.dynamic.EndpointSnippetRequest;
         options?: Options;
-    }): string | undefined {
+    }): InvocationSnippetResponse {
         const invocation = this.callMethod({
             endpoint,
             snippet: request,
@@ -68,16 +68,18 @@ export class EndpointSnippetGenerator {
             await_: false
         });
         // The caller supplies the client and terminates the statement themselves, so the
-        // invocation is emitted as a bare expression.
-        const { code, hasImports } = invocation.toStringWithoutImports({
+        // invocation is emitted as a bare expression. When the call references SDK types
+        // (e.g. branded aliases), the imports it needs are surfaced separately so the caller
+        // can render them rather than falling back to the complete snippet.
+        const { code, imports } = invocation.toStringWithoutImports({
             customConfig: this.context.customConfig
         });
-        if (hasImports) {
-            // The arguments reference SDK types (e.g. branded aliases), which the caller
-            // cannot import on the snippet's behalf.
-            return undefined;
-        }
-        return code.trim().replace(/;$/, "");
+        return {
+            snippet: code.trim().replace(/;$/, ""),
+            imports,
+            clientName: this.context.getRootClientName(),
+            errors: this.context.errors.empty() ? undefined : this.context.errors.toDynamicSnippetErrors()
+        };
     }
 
     private buildCodeBlock({

--- a/generators/typescript-v2/dynamic-snippets/src/__test__/InvocationSnippet.test.ts
+++ b/generators/typescript-v2/dynamic-snippets/src/__test__/InvocationSnippet.test.ts
@@ -1,0 +1,49 @@
+import { AbsoluteFilePath, join } from "@fern-api/path-utils";
+
+import { buildDynamicSnippetsGenerator } from "./utils/buildDynamicSnippetsGenerator.js";
+import { buildGeneratorConfig } from "./utils/buildGeneratorConfig.js";
+
+const DYNAMIC_IR_TEST_DEFINITIONS_DIRECTORY = AbsoluteFilePath.of(
+    `${__dirname}/../../../../../packages/cli/generation/ir-generator-tests/src/dynamic-snippets/__test__/test-definitions`
+);
+
+// invocation-only snippets are rendered inside code the caller already owns (e.g. a
+// documentation code template), so they must not include imports or client instantiation
+describe("invocation-only snippets", () => {
+    const generator = buildDynamicSnippetsGenerator({
+        irFilepath: AbsoluteFilePath.of(join(DYNAMIC_IR_TEST_DEFINITIONS_DIRECTORY, "exhaustive.json")),
+        config: buildGeneratorConfig({})
+    });
+
+    const request = {
+        endpoint: {
+            method: "PUT" as const,
+            path: "/http-methods/{id}"
+        },
+        baseURL: undefined,
+        environment: undefined,
+        auth: {
+            type: "bearer" as const,
+            token: "<YOUR_API_KEY>"
+        },
+        pathParameters: {
+            id: "id"
+        },
+        queryParameters: undefined,
+        headers: undefined,
+        requestBody: undefined
+    };
+
+    it("generates the invocation without imports or client instantiation", () => {
+        const response = generator.generateInvocationSync(request);
+
+        expect(response?.snippet).toBe('client.endpoints.httpMethods.testPut("id")');
+        expect(response?.errors).toBeUndefined();
+    });
+
+    it("invokes the endpoint on the requested client variable", () => {
+        const response = generator.generateInvocationSync(request, { clientVariableName: "mailchimp" });
+
+        expect(response?.snippet).toBe('mailchimp.endpoints.httpMethods.testPut("id")');
+    });
+});

--- a/generators/typescript-v2/dynamic-snippets/src/__test__/InvocationSnippet.test.ts
+++ b/generators/typescript-v2/dynamic-snippets/src/__test__/InvocationSnippet.test.ts
@@ -38,7 +38,14 @@ describe("invocation-only snippets", () => {
         const response = generator.generateInvocationSync(request);
 
         expect(response?.snippet).toBe('client.endpoints.httpMethods.testPut("id")');
+        expect(response?.imports).toBe("");
         expect(response?.errors).toBeUndefined();
+    });
+
+    it("exposes the generated client class name so docs can render the client instantiation", () => {
+        const response = generator.generateInvocationSync(request);
+
+        expect(response?.clientName).toBe("AcmeClient");
     });
 
     it("invokes the endpoint on the requested client variable", () => {
@@ -47,7 +54,7 @@ describe("invocation-only snippets", () => {
         expect(response?.snippet).toBe('mailchimp.endpoints.httpMethods.testPut("id")');
     });
 
-    it("does not generate an invocation that would reference dropped imports", () => {
+    it("returns the imports the invocation references instead of falling back to the full snippet", () => {
         const brandedGenerator = buildDynamicSnippetsGenerator({
             irFilepath: AbsoluteFilePath.of(join(DYNAMIC_IR_TEST_DEFINITIONS_DIRECTORY, "alias.json")),
             config: buildGeneratorConfig({ customConfig: { useBrandedStringAliases: true } })
@@ -69,6 +76,11 @@ describe("invocation-only snippets", () => {
             requestBody: undefined
         });
 
-        expect(response).toBeUndefined();
+        // The branded-alias case used to return undefined; now it returns the call plus the
+        // import the call needs (the SDK namespace import), so docs can regenerate both.
+        expect(response).not.toBeUndefined();
+        expect(response?.snippet).toBe('client.get(Acme.TypeID("type-abc123"))');
+        expect(response?.imports).toContain("import");
+        expect(response?.imports).toContain("Acme");
     });
 });

--- a/generators/typescript-v2/dynamic-snippets/src/__test__/InvocationSnippet.test.ts
+++ b/generators/typescript-v2/dynamic-snippets/src/__test__/InvocationSnippet.test.ts
@@ -46,4 +46,29 @@ describe("invocation-only snippets", () => {
 
         expect(response?.snippet).toBe('mailchimp.endpoints.httpMethods.testPut("id")');
     });
+
+    it("does not generate an invocation that would reference dropped imports", () => {
+        const brandedGenerator = buildDynamicSnippetsGenerator({
+            irFilepath: AbsoluteFilePath.of(join(DYNAMIC_IR_TEST_DEFINITIONS_DIRECTORY, "alias.json")),
+            config: buildGeneratorConfig({ customConfig: { useBrandedStringAliases: true } })
+        });
+
+        const response = brandedGenerator.generateInvocationSync({
+            endpoint: {
+                method: "GET" as const,
+                path: "/{typeId}"
+            },
+            baseURL: undefined,
+            environment: undefined,
+            auth: undefined,
+            pathParameters: {
+                typeId: "type-abc123"
+            },
+            queryParameters: undefined,
+            headers: undefined,
+            requestBody: undefined
+        });
+
+        expect(response).toBeUndefined();
+    });
 });

--- a/generators/typescript/sdk/changes/unreleased/invocation-only-dynamic-snippets.yml
+++ b/generators/typescript/sdk/changes/unreleased/invocation-only-dynamic-snippets.yml
@@ -3,4 +3,11 @@
     or client instantiation), so that callers such as documentation code templates can
     render a generated SDK call inside code they author themselves. The client variable the
     endpoint is invoked on is configurable.
+
+    The invocation-only result is now a structured object exposing the bare call (`snippet`),
+    the import block the call requires (`imports`, empty when none), and the generated client
+    class name (`clientName`), so docs can regenerate the imports and client instantiation and
+    keep them in sync across SDK renames. Invocations that reference imported SDK types (e.g.
+    branded string aliases) now return those imports instead of falling back to the full
+    snippet.
   type: feat

--- a/generators/typescript/sdk/changes/unreleased/invocation-only-dynamic-snippets.yml
+++ b/generators/typescript/sdk/changes/unreleased/invocation-only-dynamic-snippets.yml
@@ -1,0 +1,6 @@
+- summary: |
+    Dynamic snippets can now generate the endpoint invocation on its own (without imports
+    or client instantiation), so that callers such as documentation code templates can
+    render a generated SDK call inside code they author themselves. The client variable the
+    endpoint is invoked on is configurable.
+  type: feat


### PR DESCRIPTION
Stacked on the TypeScript invocation-only PR (#17393). Mirrors the finalized structured contract and the Python (#17402) / Go (#17403) / Java (#17404) / C# (#17405) / PHP (#17407) ports for the Ruby (`ruby-v2`) generator.

## What

Alongside the full snippet, `EndpointSnippetGenerator` now implements the optional `generateInvocationSnippetSync` hook, returning `InvocationSnippetResponse = { snippet, imports, clientName, errors }` for callers (e.g. docs code templates) that render the invocation inside code they already own.

- **`snippet`** — the bare call, honoring `options.clientVariableName` (default `client`). No client construction (`client = Acme::Client.new(...)`), no `require "..."` preamble, no trailing terminator (Ruby has none). The invocation node is rendered in isolation via `callMethod`, parameterized with `clientVariableName`.
- **`imports`** — **always `""` for Ruby.** A generated Ruby SDK references every type through the gem's module namespace (e.g. `Acme::Types::Foo`), so a bare invocation never emits a per-symbol `require`. `addRequire` is called in exactly one place in the codebase — `constructClient`, for the root `require "acme"` line — which belongs to the client construction the caller owns, not the invocation. Unlike TS/PHP/C#/Java there is **no import-referencing invocation case** to surface, so no `renderNodeWithoutImports`/`toStringWithoutImports` AST helper was added; inventing one would model a mechanism Ruby does not have. This is documented in a code comment, the changelog, and the test. (The Ruby analogue of Go always emitting `context`, inverted: Ruby's invocation imports are always empty.)
- **`clientName`** — `context.getRootClientClassName()`.
- **`errors`** — preserved from the existing error reporter.

## Ruby imports decision (flagged)

Ruby returns `imports: ""` in all cases, including invocations that construct typed body values (datetime, uuid, nested collections). This is the expected/correct result. No AST changes were required.

## Tests

New `generators/ruby-v2/dynamic-snippets/src/__test__/InvocationSnippet.test.ts` (5 tests, all green):
- bare call exact string (`client.endpoints.http_methods.test_get(id: "id")`), asserting no `.new(` and no `require `
- `imports === ""`
- `clientName === "Client"`
- custom `clientVariableName` (`mailchimp.endpoints.http_methods.test_get(id: "id")`)
- a typed-body invocation still returns `imports === ""` (documents that Ruby has no import-referencing case)

Existing suite green: `@fern-api/ruby-dynamic-snippets` 38 tests pass, no snapshot changes.

## Verification

- `pnpm turbo run compile --filter @fern-api/ruby-dynamic-snippets` (+ ruby-ast) — clean
- `pnpm turbo run test --filter @fern-api/ruby-dynamic-snippets` — 38 passed, snapshots unchanged
- `biome check --write` on changed `.ts` — no fixes needed
- Changelog: `generators/ruby/sdk/changes/unreleased/invocation-only-dynamic-snippets.yml` (`type: feat`)

Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/17408" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->