### PR TITLE
fix(openapi): avoid OAuth scope type collisions

### DIFF
--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir/oauth-scope-inline-request.json
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir/oauth-scope-inline-request.json
@@ -1,0 +1,139 @@
+{
+  "specVersion": "1.0.0",
+  "title": "OAuth scope inline request",
+  "servers": [],
+  "websocketServers": [],
+  "tags": {
+    "tagsById": {}
+  },
+  "hasEndpointsMarkedInternal": false,
+  "endpoints": [
+    {
+      "audiences": [],
+      "operationId": "createScope",
+      "tags": [],
+      "pathParameters": [],
+      "queryParameters": [],
+      "headers": [],
+      "generatedRequestName": "CreateScopeRequest",
+      "request": {
+        "schema": {
+          "generatedName": "CreateScopeRequest",
+          "schema": "OAuthScope",
+          "source": {
+            "file": "../openapi.yml",
+            "type": "openapi"
+          },
+          "type": "reference"
+        },
+        "contentType": "application/json",
+        "required": true,
+        "fullExamples": [],
+        "additionalProperties": false,
+        "source": {
+          "file": "../openapi.yml",
+          "type": "openapi"
+        },
+        "type": "json"
+      },
+      "errors": {},
+      "servers": [],
+      "authed": true,
+      "security": [
+        {
+          "OAuth2": [
+            "read"
+          ]
+        }
+      ],
+      "method": "POST",
+      "path": "/scope",
+      "examples": [
+        {
+          "pathParameters": [],
+          "queryParameters": [],
+          "headers": [],
+          "request": {
+            "properties": {
+              "value": {
+                "value": {
+                  "value": "value",
+                  "type": "string"
+                },
+                "type": "primitive"
+              }
+            },
+            "type": "object"
+          },
+          "codeSamples": [],
+          "type": "full"
+        }
+      ],
+      "source": {
+        "file": "../openapi.yml",
+        "type": "openapi"
+      }
+    }
+  ],
+  "webhooks": [],
+  "channels": {},
+  "groupedSchemas": {
+    "rootSchemas": {
+      "OAuthScope": {
+        "allOf": [],
+        "properties": [
+          {
+            "conflict": {},
+            "generatedName": "oAuthScopeValue",
+            "key": "value",
+            "schema": {
+              "schema": {
+                "type": "string"
+              },
+              "generatedName": "OAuthScopeValue",
+              "groupName": [],
+              "type": "primitive"
+            },
+            "audiences": []
+          }
+        ],
+        "allOfPropertyConflicts": [],
+        "generatedName": "OAuthScope",
+        "groupName": [],
+        "additionalProperties": false,
+        "source": {
+          "file": "../openapi.yml",
+          "type": "openapi"
+        },
+        "type": "object"
+      }
+    },
+    "namespacedSchemas": {}
+  },
+  "variables": {},
+  "nonRequestReferencedSchemas": {},
+  "securitySchemes": {
+    "OAuth2": {
+      "scopesEnum": {
+        "generatedName": "OauthScope",
+        "values": [
+          {
+            "generatedName": "read",
+            "value": "read",
+            "description": "Read access",
+            "casing": {}
+          }
+        ],
+        "source": {
+          "file": "../openapi.yml",
+          "type": "openapi"
+        },
+        "type": "enum"
+      },
+      "type": "oauth"
+    }
+  },
+  "globalHeaders": [],
+  "idempotencyHeaders": [],
+  "groups": {}
+}

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir/oauth-scope-inline-type.json
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir/oauth-scope-inline-type.json
@@ -1,0 +1,135 @@
+{
+  "specVersion": "1.0.0",
+  "title": "OAuth scope inline type",
+  "servers": [],
+  "websocketServers": [],
+  "tags": {
+    "tagsById": {}
+  },
+  "hasEndpointsMarkedInternal": false,
+  "endpoints": [
+    {
+      "audiences": [],
+      "operationId": "createScope",
+      "tags": [],
+      "pathParameters": [],
+      "queryParameters": [],
+      "headers": [],
+      "generatedRequestName": "CreateScopeRequest",
+      "request": {
+        "schema": {
+          "allOf": [],
+          "properties": [
+            {
+              "conflict": {},
+              "generatedName": "createScopeRequestScope",
+              "key": "scope",
+              "schema": {
+                "generatedName": "CreateScopeRequestScope",
+                "nameOverride": "OAuthScope",
+                "values": [
+                  {
+                    "generatedName": "account",
+                    "value": "account",
+                    "casing": {}
+                  }
+                ],
+                "groupName": [],
+                "source": {
+                  "file": "../openapi.yml",
+                  "type": "openapi"
+                },
+                "type": "enum"
+              },
+              "audiences": []
+            }
+          ],
+          "allOfPropertyConflicts": [],
+          "generatedName": "CreateScopeRequest",
+          "groupName": [],
+          "additionalProperties": false,
+          "source": {
+            "file": "../openapi.yml",
+            "type": "openapi"
+          },
+          "type": "object"
+        },
+        "contentType": "application/json",
+        "required": true,
+        "fullExamples": [],
+        "additionalProperties": false,
+        "source": {
+          "file": "../openapi.yml",
+          "type": "openapi"
+        },
+        "type": "json"
+      },
+      "errors": {},
+      "servers": [],
+      "authed": true,
+      "security": [
+        {
+          "OAuth2": [
+            "read"
+          ]
+        }
+      ],
+      "method": "POST",
+      "path": "/scope",
+      "examples": [
+        {
+          "pathParameters": [],
+          "queryParameters": [],
+          "headers": [],
+          "request": {
+            "properties": {
+              "scope": {
+                "value": "account",
+                "type": "enum"
+              }
+            },
+            "type": "object"
+          },
+          "codeSamples": [],
+          "type": "full"
+        }
+      ],
+      "source": {
+        "file": "../openapi.yml",
+        "type": "openapi"
+      }
+    }
+  ],
+  "webhooks": [],
+  "channels": {},
+  "groupedSchemas": {
+    "rootSchemas": {},
+    "namespacedSchemas": {}
+  },
+  "variables": {},
+  "nonRequestReferencedSchemas": {},
+  "securitySchemes": {
+    "OAuth2": {
+      "scopesEnum": {
+        "generatedName": "OauthScope",
+        "values": [
+          {
+            "generatedName": "read",
+            "value": "read",
+            "description": "Read access",
+            "casing": {}
+          }
+        ],
+        "source": {
+          "file": "../openapi.yml",
+          "type": "openapi"
+        },
+        "type": "enum"
+      },
+      "type": "oauth"
+    }
+  },
+  "globalHeaders": [],
+  "idempotencyHeaders": [],
+  "groups": {}
+}

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir/oauth-scope-name-collision.json
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir/oauth-scope-name-collision.json
@@ -1,0 +1,190 @@
+{
+  "specVersion": "1.0.0",
+  "title": "OAuth scope name collision",
+  "servers": [],
+  "websocketServers": [],
+  "tags": {
+    "tagsById": {}
+  },
+  "hasEndpointsMarkedInternal": false,
+  "endpoints": [
+    {
+      "audiences": [],
+      "operationId": "getScope",
+      "tags": [],
+      "pathParameters": [],
+      "queryParameters": [],
+      "headers": [],
+      "generatedRequestName": "GetScopeRequest",
+      "response": {
+        "description": "Success",
+        "schema": {
+          "generatedName": "GetScopeResponse",
+          "schema": "OAuthScope",
+          "source": {
+            "file": "../openapi.yml",
+            "type": "openapi"
+          },
+          "type": "reference"
+        },
+        "fullExamples": [],
+        "source": {
+          "file": "../openapi.yml",
+          "type": "openapi"
+        },
+        "statusCode": 200,
+        "type": "json"
+      },
+      "errors": {},
+      "servers": [],
+      "authed": true,
+      "security": [
+        {
+          "OAuth2": [
+            "read"
+          ]
+        }
+      ],
+      "method": "GET",
+      "path": "/scope",
+      "examples": [
+        {
+          "pathParameters": [],
+          "queryParameters": [],
+          "headers": [],
+          "response": {
+            "value": {
+              "value": {
+                "value": "string",
+                "type": "string"
+              },
+              "type": "primitive"
+            },
+            "type": "withoutStreaming"
+          },
+          "codeSamples": [],
+          "type": "full"
+        }
+      ],
+      "source": {
+        "file": "../openapi.yml",
+        "type": "openapi"
+      }
+    },
+    {
+      "audiences": [],
+      "operationId": "getGroupedScope",
+      "tags": [],
+      "pathParameters": [],
+      "queryParameters": [],
+      "headers": [],
+      "generatedRequestName": "GetGroupedScopeRequest",
+      "response": {
+        "description": "Success",
+        "schema": {
+          "generatedName": "GetGroupedScopeResponse",
+          "schema": "OauthAuthorizationScope2",
+          "source": {
+            "file": "../openapi.yml",
+            "type": "openapi"
+          },
+          "type": "reference"
+        },
+        "fullExamples": [],
+        "source": {
+          "file": "../openapi.yml",
+          "type": "openapi"
+        },
+        "statusCode": 200,
+        "type": "json"
+      },
+      "errors": {},
+      "servers": [],
+      "authed": false,
+      "method": "GET",
+      "path": "/grouped",
+      "examples": [
+        {
+          "pathParameters": [],
+          "queryParameters": [],
+          "headers": [],
+          "response": {
+            "value": {
+              "value": {
+                "value": "string",
+                "type": "string"
+              },
+              "type": "primitive"
+            },
+            "type": "withoutStreaming"
+          },
+          "codeSamples": [],
+          "type": "full"
+        }
+      ],
+      "source": {
+        "file": "../openapi.yml",
+        "type": "openapi"
+      }
+    }
+  ],
+  "webhooks": [],
+  "channels": {},
+  "groupedSchemas": {
+    "rootSchemas": {
+      "OAuthScope": {
+        "schema": {
+          "type": "string"
+        },
+        "generatedName": "OAuthScope",
+        "groupName": [],
+        "type": "primitive"
+      },
+      "OauthAuthorizationScope": {
+        "schema": {
+          "type": "string"
+        },
+        "generatedName": "OauthAuthorizationScope",
+        "groupName": [],
+        "type": "primitive"
+      },
+      "OauthAuthorizationScope2": {
+        "schema": {
+          "type": "string"
+        },
+        "generatedName": "OauthAuthorizationScope2",
+        "groupName": [
+          "grouped"
+        ],
+        "type": "primitive"
+      }
+    },
+    "namespacedSchemas": {}
+  },
+  "variables": {},
+  "nonRequestReferencedSchemas": {},
+  "securitySchemes": {
+    "OAuth2": {
+      "scopesEnum": {
+        "generatedName": "OauthScope",
+        "values": [
+          {
+            "generatedName": "read",
+            "value": "read",
+            "description": "Read access",
+            "casing": {}
+          }
+        ],
+        "source": {
+          "file": "../openapi.yml",
+          "type": "openapi"
+        },
+        "type": "enum"
+      },
+      "type": "oauth"
+    }
+  },
+  "globalHeaders": [],
+  "idempotencyHeaders": [],
+  "groups": {}
+}

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir/oauth-scope-webhook-response.json
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir/oauth-scope-webhook-response.json
@@ -1,0 +1,125 @@
+{
+  "specVersion": "1.0.0",
+  "title": "OAuth scope webhook response",
+  "servers": [],
+  "websocketServers": [],
+  "tags": {
+    "tagsById": {}
+  },
+  "hasEndpointsMarkedInternal": false,
+  "endpoints": [],
+  "webhooks": [
+    {
+      "audiences": [],
+      "method": "POST",
+      "operationId": "updateStatus",
+      "tags": [],
+      "headers": [],
+      "generatedPayloadName": "UpdateStatusPayload",
+      "payload": {
+        "allOf": [],
+        "properties": [
+          {
+            "conflict": {},
+            "generatedName": "updateStatusPayloadStatus",
+            "key": "status",
+            "schema": {
+              "generatedName": "UpdateStatusPayloadStatus",
+              "value": {
+                "schema": {
+                  "type": "string"
+                },
+                "generatedName": "UpdateStatusPayloadStatus",
+                "groupName": [],
+                "type": "primitive"
+              },
+              "groupName": [],
+              "type": "optional"
+            },
+            "audiences": []
+          }
+        ],
+        "allOfPropertyConflicts": [],
+        "generatedName": "UpdateStatusPayload",
+        "groupName": [],
+        "additionalProperties": false,
+        "source": {
+          "file": "../openapi.yml",
+          "type": "openapi"
+        },
+        "type": "object"
+      },
+      "response": {
+        "description": "Success",
+        "schema": {
+          "generatedName": "UpdateStatusResponse",
+          "schema": "OAuthScope",
+          "source": {
+            "file": "../openapi.yml",
+            "type": "openapi"
+          },
+          "type": "reference"
+        },
+        "fullExamples": [],
+        "source": {
+          "file": "../openapi.yml",
+          "type": "openapi"
+        },
+        "statusCode": 200,
+        "type": "json"
+      },
+      "examples": [
+        {
+          "payload": {
+            "properties": {},
+            "type": "object"
+          }
+        }
+      ],
+      "source": {
+        "file": "../openapi.yml",
+        "type": "openapi"
+      }
+    }
+  ],
+  "channels": {},
+  "groupedSchemas": {
+    "rootSchemas": {
+      "OAuthScope": {
+        "schema": {
+          "type": "string"
+        },
+        "generatedName": "OAuthScope",
+        "groupName": [],
+        "type": "primitive"
+      }
+    },
+    "namespacedSchemas": {}
+  },
+  "variables": {},
+  "nonRequestReferencedSchemas": {},
+  "securitySchemes": {
+    "OAuth2": {
+      "scopesEnum": {
+        "generatedName": "OauthScope",
+        "values": [
+          {
+            "generatedName": "read",
+            "value": "read",
+            "description": "Read access",
+            "casing": {}
+          }
+        ],
+        "source": {
+          "file": "../openapi.yml",
+          "type": "openapi"
+        },
+        "type": "enum"
+      },
+      "type": "oauth"
+    }
+  },
+  "globalHeaders": [],
+  "idempotencyHeaders": [],
+  "groups": {}
+}

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi/oauth-scope-inline-request.json
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi/oauth-scope-inline-request.json
@@ -1,0 +1,127 @@
+{
+  "absoluteFilePath": "/DUMMY_PATH",
+  "importedDefinitions": {},
+  "namedDefinitionFiles": {
+    "__package__.yml": {
+      "absoluteFilepath": "/DUMMY_PATH",
+      "contents": {
+        "service": {
+          "auth": false,
+          "base-path": "",
+          "endpoints": {
+            "createScope": {
+              "auth": [
+                {
+                  "OAuth2": [
+                    "read",
+                  ],
+                },
+              ],
+              "docs": undefined,
+              "examples": [
+                {
+                  "request": {
+                    "value": "value",
+                  },
+                },
+              ],
+              "method": "POST",
+              "pagination": undefined,
+              "path": "/scope",
+              "request": {
+                "body": {
+                  "properties": {
+                    "value": "string",
+                  },
+                },
+                "content-type": "application/json",
+                "headers": undefined,
+                "name": "OAuthScope",
+                "path-parameters": undefined,
+                "query-parameters": undefined,
+              },
+              "source": {
+                "openapi": "../openapi.yml",
+              },
+            },
+          },
+          "source": {
+            "openapi": "../openapi.yml",
+          },
+        },
+        "types": {
+          "OauthScope": {
+            "enum": [
+              {
+                "docs": "Read access",
+                "value": "read",
+              },
+            ],
+            "inline": undefined,
+            "source": {
+              "openapi": "../openapi.yml",
+            },
+          },
+        },
+      },
+      "rawContents": "types:
+  OauthScope:
+    enum:
+      - value: read
+        docs: Read access
+    source:
+      openapi: ../openapi.yml
+service:
+  auth: false
+  base-path: ''
+  endpoints:
+    createScope:
+      path: /scope
+      method: POST
+      auth:
+        - OAuth2:
+            - read
+      source:
+        openapi: ../openapi.yml
+      request:
+        name: OAuthScope
+        body:
+          properties:
+            value: string
+        content-type: application/json
+      examples:
+        - request:
+            value: value
+  source:
+    openapi: ../openapi.yml
+",
+    },
+  },
+  "packageMarkers": {},
+  "rootApiFile": {
+    "contents": {
+      "auth": "OAuth2",
+      "auth-schemes": {
+        "OAuth2": {
+          "scheme": "bearer",
+        },
+      },
+      "display-name": "OAuth scope inline request",
+      "error-discrimination": {
+        "strategy": "status-code",
+      },
+      "name": "api",
+    },
+    "defaultUrl": undefined,
+    "rawContents": "name: api
+error-discrimination:
+  strategy: status-code
+display-name: OAuth scope inline request
+auth-schemes:
+  OAuth2:
+    scheme: bearer
+auth: OAuth2
+",
+  },
+  "specVersion": "1.0.0",
+}

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi/oauth-scope-inline-type.json
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi/oauth-scope-inline-type.json
@@ -1,0 +1,142 @@
+{
+  "absoluteFilePath": "/DUMMY_PATH",
+  "importedDefinitions": {},
+  "namedDefinitionFiles": {
+    "__package__.yml": {
+      "absoluteFilepath": "/DUMMY_PATH",
+      "contents": {
+        "service": {
+          "auth": false,
+          "base-path": "",
+          "endpoints": {
+            "createScope": {
+              "auth": [
+                {
+                  "OAuth2": [
+                    "read",
+                  ],
+                },
+              ],
+              "docs": undefined,
+              "examples": [
+                {
+                  "request": {
+                    "scope": "account",
+                  },
+                },
+              ],
+              "method": "POST",
+              "pagination": undefined,
+              "path": "/scope",
+              "request": {
+                "body": {
+                  "properties": {
+                    "scope": "OAuthScope",
+                  },
+                },
+                "content-type": "application/json",
+                "headers": undefined,
+                "name": "CreateScopeRequest",
+                "path-parameters": undefined,
+                "query-parameters": undefined,
+              },
+              "source": {
+                "openapi": "../openapi.yml",
+              },
+            },
+          },
+          "source": {
+            "openapi": "../openapi.yml",
+          },
+        },
+        "types": {
+          "OAuthScope": {
+            "enum": [
+              "account",
+            ],
+            "inline": true,
+            "source": {
+              "openapi": "../openapi.yml",
+            },
+          },
+          "OauthAuthorizationScope": {
+            "enum": [
+              {
+                "docs": "Read access",
+                "value": "read",
+              },
+            ],
+            "inline": undefined,
+            "source": {
+              "openapi": "../openapi.yml",
+            },
+          },
+        },
+      },
+      "rawContents": "types:
+  OauthAuthorizationScope:
+    enum:
+      - value: read
+        docs: Read access
+    source:
+      openapi: ../openapi.yml
+  OAuthScope:
+    enum:
+      - account
+    inline: true
+    source:
+      openapi: ../openapi.yml
+service:
+  auth: false
+  base-path: ''
+  endpoints:
+    createScope:
+      path: /scope
+      method: POST
+      auth:
+        - OAuth2:
+            - read
+      source:
+        openapi: ../openapi.yml
+      request:
+        name: CreateScopeRequest
+        body:
+          properties:
+            scope: OAuthScope
+        content-type: application/json
+      examples:
+        - request:
+            scope: account
+  source:
+    openapi: ../openapi.yml
+",
+    },
+  },
+  "packageMarkers": {},
+  "rootApiFile": {
+    "contents": {
+      "auth": "OAuth2",
+      "auth-schemes": {
+        "OAuth2": {
+          "scheme": "bearer",
+        },
+      },
+      "display-name": "OAuth scope inline type",
+      "error-discrimination": {
+        "strategy": "status-code",
+      },
+      "name": "api",
+    },
+    "defaultUrl": undefined,
+    "rawContents": "name: api
+error-discrimination:
+  strategy: status-code
+display-name: OAuth scope inline type
+auth-schemes:
+  OAuth2:
+    scheme: bearer
+auth: OAuth2
+",
+  },
+  "specVersion": "1.0.0",
+}

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi/oauth-scope-name-collision.json
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi/oauth-scope-name-collision.json
@@ -1,0 +1,170 @@
+{
+  "absoluteFilePath": "/DUMMY_PATH",
+  "importedDefinitions": {},
+  "namedDefinitionFiles": {
+    "__package__.yml": {
+      "absoluteFilepath": "/DUMMY_PATH",
+      "contents": {
+        "imports": {
+          "grouped": "grouped.yml",
+        },
+        "service": {
+          "auth": false,
+          "base-path": "",
+          "endpoints": {
+            "getGroupedScope": {
+              "auth": undefined,
+              "docs": undefined,
+              "examples": [
+                {
+                  "response": {
+                    "body": "string",
+                  },
+                },
+              ],
+              "method": "GET",
+              "pagination": undefined,
+              "path": "/grouped",
+              "response": {
+                "docs": "Success",
+                "status-code": 200,
+                "type": "grouped.OauthAuthorizationScope2",
+              },
+              "source": {
+                "openapi": "../openapi.yml",
+              },
+            },
+            "getScope": {
+              "auth": [
+                {
+                  "OAuth2": [
+                    "read",
+                  ],
+                },
+              ],
+              "docs": undefined,
+              "examples": [
+                {
+                  "response": {
+                    "body": "string",
+                  },
+                },
+              ],
+              "method": "GET",
+              "pagination": undefined,
+              "path": "/scope",
+              "response": {
+                "docs": "Success",
+                "status-code": 200,
+                "type": "OAuthScope",
+              },
+              "source": {
+                "openapi": "../openapi.yml",
+              },
+            },
+          },
+          "source": {
+            "openapi": "../openapi.yml",
+          },
+        },
+        "types": {
+          "OAuthScope": "string",
+          "OauthAuthorizationScope": {
+            "enum": [
+              {
+                "docs": "Read access",
+                "value": "read",
+              },
+            ],
+            "inline": undefined,
+            "source": {
+              "openapi": "../openapi.yml",
+            },
+          },
+        },
+      },
+      "rawContents": "types:
+  OauthAuthorizationScope:
+    enum:
+      - value: read
+        docs: Read access
+    source:
+      openapi: ../openapi.yml
+  OAuthScope: string
+service:
+  auth: false
+  base-path: ''
+  endpoints:
+    getScope:
+      path: /scope
+      method: GET
+      auth:
+        - OAuth2:
+            - read
+      source:
+        openapi: ../openapi.yml
+      response:
+        docs: Success
+        type: OAuthScope
+        status-code: 200
+      examples:
+        - response:
+            body: string
+    getGroupedScope:
+      path: /grouped
+      method: GET
+      source:
+        openapi: ../openapi.yml
+      response:
+        docs: Success
+        type: grouped.OauthAuthorizationScope2
+        status-code: 200
+      examples:
+        - response:
+            body: string
+  source:
+    openapi: ../openapi.yml
+imports:
+  grouped: grouped.yml
+",
+    },
+    "grouped.yml": {
+      "absoluteFilepath": "/DUMMY_PATH",
+      "contents": {
+        "types": {
+          "OauthAuthorizationScope2": "string",
+        },
+      },
+      "rawContents": "types:
+  OauthAuthorizationScope2: string
+",
+    },
+  },
+  "packageMarkers": {},
+  "rootApiFile": {
+    "contents": {
+      "auth": "OAuth2",
+      "auth-schemes": {
+        "OAuth2": {
+          "scheme": "bearer",
+        },
+      },
+      "display-name": "OAuth scope name collision",
+      "error-discrimination": {
+        "strategy": "status-code",
+      },
+      "name": "api",
+    },
+    "defaultUrl": undefined,
+    "rawContents": "name: api
+error-discrimination:
+  strategy: status-code
+display-name: OAuth scope name collision
+auth-schemes:
+  OAuth2:
+    scheme: bearer
+auth: OAuth2
+",
+  },
+  "specVersion": "1.0.0",
+}

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi/oauth-scope-webhook-response.json
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi/oauth-scope-webhook-response.json
@@ -1,0 +1,111 @@
+{
+  "absoluteFilePath": "/DUMMY_PATH",
+  "importedDefinitions": {},
+  "namedDefinitionFiles": {
+    "__package__.yml": {
+      "absoluteFilepath": "/DUMMY_PATH",
+      "contents": {
+        "types": {
+          "OAuthScope": "string",
+          "OauthAuthorizationScope": {
+            "enum": [
+              {
+                "docs": "Read access",
+                "value": "read",
+              },
+            ],
+            "inline": undefined,
+            "source": {
+              "openapi": "../openapi.yml",
+            },
+          },
+          "UpdateStatusPayload": {
+            "docs": undefined,
+            "inline": undefined,
+            "properties": {
+              "status": "optional<string>",
+            },
+            "source": {
+              "openapi": "../openapi.yml",
+            },
+          },
+        },
+        "webhooks": {
+          "updateStatus": {
+            "audiences": [],
+            "display-name": undefined,
+            "examples": [
+              {
+                "docs": undefined,
+                "name": undefined,
+                "payload": {},
+              },
+            ],
+            "headers": {},
+            "method": "POST",
+            "payload": "UpdateStatusPayload",
+            "response": {
+              "docs": "Success",
+              "status-code": 200,
+              "type": "OAuthScope",
+            },
+            "signature": undefined,
+          },
+        },
+      },
+      "rawContents": "types:
+  OauthAuthorizationScope:
+    enum:
+      - value: read
+        docs: Read access
+    source:
+      openapi: ../openapi.yml
+  UpdateStatusPayload:
+    properties:
+      status: optional<string>
+    source:
+      openapi: ../openapi.yml
+  OAuthScope: string
+webhooks:
+  updateStatus:
+    audiences: []
+    method: POST
+    headers: {}
+    payload: UpdateStatusPayload
+    examples:
+      - payload: {}
+    response:
+      docs: Success
+      type: OAuthScope
+      status-code: 200
+",
+    },
+  },
+  "packageMarkers": {},
+  "rootApiFile": {
+    "contents": {
+      "auth": "OAuth2",
+      "auth-schemes": {
+        "OAuth2": {
+          "scheme": "bearer",
+        },
+      },
+      "display-name": "OAuth scope webhook response",
+      "error-discrimination": {
+        "strategy": "status-code",
+      },
+      "name": "api",
+    },
+    "defaultUrl": undefined,
+    "rawContents": "name: api
+error-discrimination:
+  strategy: status-code
+display-name: OAuth scope webhook response
+auth-schemes:
+  OAuth2:
+    scheme: bearer
+auth: OAuth2
+",
+  },
+  "specVersion": "1.0.0",
+}

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/fixtures/oauth-scope-inline-request/fern/fern.config.json
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/fixtures/oauth-scope-inline-request/fern/fern.config.json
@@ -1,0 +1,4 @@
+{
+    "organization": "fern",
+    "version": "*"
+}

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/fixtures/oauth-scope-inline-request/fern/generators.yml
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/fixtures/oauth-scope-inline-request/fern/generators.yml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://schema.buildwithfern.dev/generators-yml.json
+api:
+  specs:
+    - openapi: ../openapi.yml
+      settings:
+        only-include-referenced-schemas: true

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/fixtures/oauth-scope-inline-request/openapi.yml
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/fixtures/oauth-scope-inline-request/openapi.yml
@@ -1,0 +1,40 @@
+openapi: 3.0.3
+info:
+  title: OAuth scope inline request
+  version: 1.0.0
+
+paths:
+  /scope:
+    post:
+      operationId: createScope
+      security:
+        - OAuth2:
+            - read
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/OAuthScope"
+      responses:
+        "204":
+          description: Success
+
+components:
+  schemas:
+    OAuthScope:
+      type: object
+      required:
+        - value
+      properties:
+        value:
+          type: string
+
+  securitySchemes:
+    OAuth2:
+      type: oauth2
+      flows:
+        clientCredentials:
+          tokenUrl: https://example.com/oauth/token
+          scopes:
+            read: Read access

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/fixtures/oauth-scope-inline-type/fern/fern.config.json
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/fixtures/oauth-scope-inline-type/fern/fern.config.json
@@ -1,0 +1,4 @@
+{
+    "organization": "fern",
+    "version": "*"
+}

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/fixtures/oauth-scope-inline-type/fern/generators.yml
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/fixtures/oauth-scope-inline-type/fern/generators.yml
@@ -1,0 +1,4 @@
+# yaml-language-server: $schema=https://schema.buildwithfern.dev/generators-yml.json
+api:
+  specs:
+    - openapi: ../openapi.yml

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/fixtures/oauth-scope-inline-type/openapi.yml
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/fixtures/oauth-scope-inline-type/openapi.yml
@@ -1,0 +1,39 @@
+openapi: 3.0.3
+info:
+  title: OAuth scope inline type
+  version: 1.0.0
+
+paths:
+  /scope:
+    post:
+      operationId: createScope
+      security:
+        - OAuth2:
+            - read
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - scope
+              properties:
+                scope:
+                  type: string
+                  enum:
+                    - account
+                  x-fern-type-name: OAuthScope
+      responses:
+        "204":
+          description: Success
+
+components:
+  securitySchemes:
+    OAuth2:
+      type: oauth2
+      flows:
+        clientCredentials:
+          tokenUrl: https://example.com/oauth/token
+          scopes:
+            read: Read access

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/fixtures/oauth-scope-name-collision/fern/fern.config.json
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/fixtures/oauth-scope-name-collision/fern/fern.config.json
@@ -1,0 +1,4 @@
+{
+    "organization": "fern",
+    "version": "*"
+}

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/fixtures/oauth-scope-name-collision/fern/generators.yml
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/fixtures/oauth-scope-name-collision/fern/generators.yml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://schema.buildwithfern.dev/generators-yml.json
+api:
+  specs:
+    - openapi: ../openapi.yml
+      settings:
+        only-include-referenced-schemas: true

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/fixtures/oauth-scope-name-collision/openapi.yml
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/fixtures/oauth-scope-name-collision/openapi.yml
@@ -1,0 +1,48 @@
+openapi: 3.0.3
+info:
+  title: OAuth scope name collision
+  version: 1.0.0
+
+paths:
+  /scope:
+    get:
+      operationId: getScope
+      security:
+        - OAuth2:
+            - read
+      responses:
+        "200":
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/OAuthScope"
+  /grouped:
+    get:
+      operationId: getGroupedScope
+      responses:
+        "200":
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/OauthAuthorizationScope2"
+
+components:
+  schemas:
+    OAuthScope:
+      type: string
+    OauthAuthorizationScope:
+      type: string
+    OauthAuthorizationScope2:
+      type: string
+      x-fern-sdk-group-name: grouped
+
+  securitySchemes:
+    OAuth2:
+      type: oauth2
+      flows:
+        clientCredentials:
+          tokenUrl: https://example.com/oauth/token
+          scopes:
+            read: Read access

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/fixtures/oauth-scope-webhook-response/fern/fern.config.json
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/fixtures/oauth-scope-webhook-response/fern/fern.config.json
@@ -1,0 +1,4 @@
+{
+    "organization": "fern",
+    "version": "*"
+}

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/fixtures/oauth-scope-webhook-response/fern/generators.yml
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/fixtures/oauth-scope-webhook-response/fern/generators.yml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://schema.buildwithfern.dev/generators-yml.json
+api:
+  specs:
+    - openapi: ../openapi.yml
+      settings:
+        only-include-referenced-schemas: true

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/fixtures/oauth-scope-webhook-response/openapi.yml
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/fixtures/oauth-scope-webhook-response/openapi.yml
@@ -1,0 +1,41 @@
+openapi: 3.1.0
+info:
+  title: OAuth scope webhook response
+  version: 1.0.0
+
+paths: {}
+
+webhooks:
+  status:
+    post:
+      operationId: updateStatus
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                status:
+                  type: string
+      responses:
+        "200":
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/OAuthScope"
+
+components:
+  schemas:
+    OAuthScope:
+      type: string
+
+  securitySchemes:
+    OAuth2:
+      type: oauth2
+      flows:
+        clientCredentials:
+          tokenUrl: https://example.com/oauth/token
+          scopes:
+            read: Read access

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern/src/buildAuthSchemes.ts
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern/src/buildAuthSchemes.ts
@@ -7,6 +7,7 @@ import { computeSchemaReachability } from "./computeSchemaReachability.js";
 import { OpenApiIrConverterContext } from "./OpenApiIrConverterContext.js";
 import { getDeclarationFileForSchema } from "./utils/getDeclarationFileForSchema.js";
 import { getHeaderName } from "./utils/getHeaderName.js";
+import { getEndpointNamespace } from "./utils/getNamespaceFromGroup.js";
 
 const BASIC_AUTH_SCHEME = "BasicAuthScheme";
 const BEARER_AUTH_SCHEME = "BearerAuthScheme";
@@ -204,11 +205,13 @@ function getOauthScopeTypeName(context: OpenApiIrConverterContext): string {
         reachableSchemaIds == null
             ? undefined
             : new Set([...reachableSchemaIds.requestReachable, ...reachableSchemaIds.responseReachable]);
+    const inlinedRequestSchemaIds = getInlinedRequestSchemaIds(context);
     const occupiedTypeNames = new Set(
         Object.entries(context.ir.groupedSchemas.rootSchemas)
             .filter(
                 ([id, schema]) =>
                     (referencedSchemaIds == null || referencedSchemaIds.has(id)) &&
+                    !inlinedRequestSchemaIds.has(id) &&
                     getDeclarationFileForSchema(schema) === RelativeFilePath.of(FERN_PACKAGE_MARKER_FILENAME)
             )
             .map(([, schema]) => getSchemaName(schema).toLowerCase())
@@ -225,6 +228,35 @@ function getOauthScopeTypeName(context: OpenApiIrConverterContext): string {
         suffix++;
     }
     return `${OAUTH_SCOPE_FALLBACK_TYPE_NAME}${suffix}`;
+}
+
+function getInlinedRequestSchemaIds(context: OpenApiIrConverterContext): Set<string> {
+    // buildEndpoint turns these component schemas into request bodies and excludes their top-level declarations.
+    const schemaIds = new Set<string>();
+    for (const endpoint of context.ir.endpoints) {
+        const request = endpoint.request;
+        if (request == null) {
+            continue;
+        }
+        if (request.type === "multipart") {
+            if (request.name != null) {
+                schemaIds.add(request.name);
+            }
+            continue;
+        }
+        if (
+            (request.type === "json" || request.type === "formUrlEncoded") &&
+            request.schema.type === "reference" &&
+            context.getSchema(
+                request.schema.schema,
+                getEndpointNamespace(endpoint.sdkName, endpoint.namespace)
+            )?.type === "object" &&
+            !context.isResponseReachable(request.schema.schema)
+        ) {
+            schemaIds.add(request.schema.schema);
+        }
+    }
+    return schemaIds;
 }
 
 function getSchemaName(schema: Schema): string {

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern/src/buildAuthSchemes.ts
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern/src/buildAuthSchemes.ts
@@ -1,11 +1,17 @@
+import { FERN_PACKAGE_MARKER_FILENAME } from "@fern-api/configuration";
 import { RawSchemas } from "@fern-api/fern-definition-schema";
+import type { Schema } from "@fern-api/openapi-ir";
 import { RelativeFilePath } from "@fern-api/path-utils";
 import { buildEnumTypeDeclaration } from "./buildTypeDeclaration.js";
+import { computeSchemaReachability } from "./computeSchemaReachability.js";
 import { OpenApiIrConverterContext } from "./OpenApiIrConverterContext.js";
+import { getDeclarationFileForSchema } from "./utils/getDeclarationFileForSchema.js";
 import { getHeaderName } from "./utils/getHeaderName.js";
 
 const BASIC_AUTH_SCHEME = "BasicAuthScheme";
 const BEARER_AUTH_SCHEME = "BearerAuthScheme";
+const OAUTH_SCOPE_TYPE_NAME = "OauthScope";
+const OAUTH_SCOPE_FALLBACK_TYPE_NAME = "OauthAuthorizationScope";
 
 export function buildAuthSchemes(context: OpenApiIrConverterContext): void {
     if (context.authOverrides != null) {
@@ -22,6 +28,7 @@ export function buildAuthSchemes(context: OpenApiIrConverterContext): void {
     }
 
     let setAuth = false;
+    let oauthScopeTypeName: string | undefined;
 
     for (const [id, securityScheme] of Object.entries(context.ir.securitySchemes)) {
         if (securityScheme.type === "basic") {
@@ -179,11 +186,48 @@ export function buildAuthSchemes(context: OpenApiIrConverterContext): void {
                 setAuth = true;
             }
             if (securityScheme.scopesEnum != null && securityScheme.scopesEnum.values.length > 0) {
-                context.builder.addType(RelativeFilePath.of("__package__.yml"), {
-                    name: "OauthScope",
+                oauthScopeTypeName ??= getOauthScopeTypeName(context);
+                context.builder.addType(RelativeFilePath.of(FERN_PACKAGE_MARKER_FILENAME), {
+                    name: oauthScopeTypeName,
                     schema: buildEnumTypeDeclaration(securityScheme.scopesEnum, 0).schema
                 });
             }
         }
     }
+}
+
+function getOauthScopeTypeName(context: OpenApiIrConverterContext): string {
+    const reachableSchemaIds = context.options.onlyIncludeReferencedSchemas
+        ? computeSchemaReachability(context.ir)
+        : undefined;
+    const referencedSchemaIds =
+        reachableSchemaIds == null
+            ? undefined
+            : new Set([...reachableSchemaIds.requestReachable, ...reachableSchemaIds.responseReachable]);
+    const occupiedTypeNames = new Set(
+        Object.entries(context.ir.groupedSchemas.rootSchemas)
+            .filter(
+                ([id, schema]) =>
+                    (referencedSchemaIds == null || referencedSchemaIds.has(id)) &&
+                    getDeclarationFileForSchema(schema) === RelativeFilePath.of(FERN_PACKAGE_MARKER_FILENAME)
+            )
+            .map(([, schema]) => getSchemaName(schema).toLowerCase())
+    );
+    if (!occupiedTypeNames.has(OAUTH_SCOPE_TYPE_NAME.toLowerCase())) {
+        return OAUTH_SCOPE_TYPE_NAME;
+    }
+    if (!occupiedTypeNames.has(OAUTH_SCOPE_FALLBACK_TYPE_NAME.toLowerCase())) {
+        return OAUTH_SCOPE_FALLBACK_TYPE_NAME;
+    }
+
+    let suffix = 2;
+    while (occupiedTypeNames.has(`${OAUTH_SCOPE_FALLBACK_TYPE_NAME}${suffix}`.toLowerCase())) {
+        suffix++;
+    }
+    return `${OAUTH_SCOPE_FALLBACK_TYPE_NAME}${suffix}`;
+}
+
+function getSchemaName(schema: Schema): string {
+    const namedSchema = schema.type === "oneOf" ? schema.value : schema;
+    return namedSchema.nameOverride ?? namedSchema.generatedName;
 }

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern/src/buildAuthSchemes.ts
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern/src/buildAuthSchemes.ts
@@ -1,20 +1,15 @@
-import { FERN_PACKAGE_MARKER_FILENAME } from "@fern-api/configuration";
 import { RawSchemas } from "@fern-api/fern-definition-schema";
-import type { Schema } from "@fern-api/openapi-ir";
-import { RelativeFilePath } from "@fern-api/path-utils";
+import type { FernDefinition } from "@fern-api/importer-commons";
 import { buildEnumTypeDeclaration } from "./buildTypeDeclaration.js";
-import { computeSchemaReachability } from "./computeSchemaReachability.js";
 import { OpenApiIrConverterContext } from "./OpenApiIrConverterContext.js";
-import { getDeclarationFileForSchema } from "./utils/getDeclarationFileForSchema.js";
 import { getHeaderName } from "./utils/getHeaderName.js";
-import { getEndpointNamespace } from "./utils/getNamespaceFromGroup.js";
 
 const BASIC_AUTH_SCHEME = "BasicAuthScheme";
 const BEARER_AUTH_SCHEME = "BearerAuthScheme";
 const OAUTH_SCOPE_TYPE_NAME = "OauthScope";
 const OAUTH_SCOPE_FALLBACK_TYPE_NAME = "OauthAuthorizationScope";
 
-export function buildAuthSchemes(context: OpenApiIrConverterContext): void {
+export function buildAuthSchemes(context: OpenApiIrConverterContext): RawSchemas.TypeDeclarationSchema | undefined {
     if (context.authOverrides != null) {
         for (const [name, declaration] of Object.entries(context.authOverrides["auth-schemes"] ?? {})) {
             context.builder.addAuthScheme({
@@ -25,12 +20,11 @@ export function buildAuthSchemes(context: OpenApiIrConverterContext): void {
         if (context.authOverrides.auth != null) {
             context.builder.setAuth(context.authOverrides.auth);
         }
-        return;
+        return undefined;
     }
 
     let setAuth = false;
-    let oauthScopeTypeName: string | undefined;
-
+    let oauthScopeType: RawSchemas.TypeDeclarationSchema | undefined;
     for (const [id, securityScheme] of Object.entries(context.ir.securitySchemes)) {
         if (securityScheme.type === "basic") {
             const basicAuthScheme: RawSchemas.BasicAuthSchemeSchema = {
@@ -187,35 +181,33 @@ export function buildAuthSchemes(context: OpenApiIrConverterContext): void {
                 setAuth = true;
             }
             if (securityScheme.scopesEnum != null && securityScheme.scopesEnum.values.length > 0) {
-                oauthScopeTypeName ??= getOauthScopeTypeName(context);
-                context.builder.addType(RelativeFilePath.of(FERN_PACKAGE_MARKER_FILENAME), {
-                    name: oauthScopeTypeName,
-                    schema: buildEnumTypeDeclaration(securityScheme.scopesEnum, 0).schema
-                });
+                // Preserve the existing behavior for multiple OAuth schemes: the last non-empty scope enum wins.
+                oauthScopeType = buildEnumTypeDeclaration(securityScheme.scopesEnum, 0).schema;
             }
         }
     }
+    return oauthScopeType;
 }
 
-function getOauthScopeTypeName(context: OpenApiIrConverterContext): string {
-    const reachableSchemaIds = context.options.onlyIncludeReferencedSchemas
-        ? computeSchemaReachability(context.ir)
-        : undefined;
-    const referencedSchemaIds =
-        reachableSchemaIds == null
-            ? undefined
-            : new Set([...reachableSchemaIds.requestReachable, ...reachableSchemaIds.responseReachable]);
-    const inlinedRequestSchemaIds = getInlinedRequestSchemaIds(context);
-    const occupiedTypeNames = new Set(
-        Object.entries(context.ir.groupedSchemas.rootSchemas)
-            .filter(
-                ([id, schema]) =>
-                    (referencedSchemaIds == null || referencedSchemaIds.has(id)) &&
-                    !inlinedRequestSchemaIds.has(id) &&
-                    getDeclarationFileForSchema(schema) === RelativeFilePath.of(FERN_PACKAGE_MARKER_FILENAME)
-            )
-            .map(([, schema]) => getSchemaName(schema).toLowerCase())
-    );
+/**
+ * Adds the OAuth scope enum after all other types have been built, so its name can be deconflicted against the
+ * declarations that were actually emitted rather than a parallel approximation.
+ */
+export function addOauthScopeType(definition: FernDefinition, oauthScopeType: RawSchemas.TypeDeclarationSchema): void {
+    const existingTypes = definition.packageMarkerFile.types ?? {};
+    const oauthScopeTypeName = getOauthScopeTypeName(Object.keys(existingTypes));
+    const { types: _, ...packageMarkerFile } = definition.packageMarkerFile;
+    definition.packageMarkerFile = {
+        types: {
+            [oauthScopeTypeName]: oauthScopeType,
+            ...existingTypes
+        },
+        ...packageMarkerFile
+    };
+}
+
+function getOauthScopeTypeName(typeNames: Iterable<string>): string {
+    const occupiedTypeNames = new Set([...typeNames].map((name) => name.toLowerCase()));
     if (!occupiedTypeNames.has(OAUTH_SCOPE_TYPE_NAME.toLowerCase())) {
         return OAUTH_SCOPE_TYPE_NAME;
     }
@@ -228,38 +220,4 @@ function getOauthScopeTypeName(context: OpenApiIrConverterContext): string {
         suffix++;
     }
     return `${OAUTH_SCOPE_FALLBACK_TYPE_NAME}${suffix}`;
-}
-
-function getInlinedRequestSchemaIds(context: OpenApiIrConverterContext): Set<string> {
-    // buildEndpoint turns these component schemas into request bodies and excludes their top-level declarations.
-    const schemaIds = new Set<string>();
-    for (const endpoint of context.ir.endpoints) {
-        const request = endpoint.request;
-        if (request == null) {
-            continue;
-        }
-        if (request.type === "multipart") {
-            if (request.name != null) {
-                schemaIds.add(request.name);
-            }
-            continue;
-        }
-        if (
-            (request.type === "json" || request.type === "formUrlEncoded") &&
-            request.schema.type === "reference" &&
-            context.getSchema(
-                request.schema.schema,
-                getEndpointNamespace(endpoint.sdkName, endpoint.namespace)
-            )?.type === "object" &&
-            !context.isResponseReachable(request.schema.schema)
-        ) {
-            schemaIds.add(request.schema.schema);
-        }
-    }
-    return schemaIds;
-}
-
-function getSchemaName(schema: Schema): string {
-    const namedSchema = schema.type === "oneOf" ? schema.value : schema;
-    return namedSchema.nameOverride ?? namedSchema.generatedName;
 }

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern/src/buildFernDefinition.ts
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern/src/buildFernDefinition.ts
@@ -3,7 +3,7 @@ import { isRawAliasDefinition, RawSchemas } from "@fern-api/fern-definition-sche
 import { FernDefinition } from "@fern-api/importer-commons";
 import { Schema } from "@fern-api/openapi-ir";
 import { RelativeFilePath } from "@fern-api/path-utils";
-import { buildAuthSchemes } from "./buildAuthSchemes.js";
+import { addOauthScopeType, buildAuthSchemes } from "./buildAuthSchemes.js";
 import { buildChannel } from "./buildChannel.js";
 import { buildEnvironments } from "./buildEnvironments.js";
 import { buildGlobalHeaders } from "./buildGlobalHeaders.js";
@@ -145,7 +145,7 @@ export function buildFernDefinition(context: OpenApiIrConverterContext): FernDef
     buildGlobalHeaders(context);
     buildGlobalParameters(context);
     buildIdempotencyHeaders(context);
-    buildAuthSchemes(context);
+    const oauthScopeType = buildAuthSchemes(context);
     buildVariables(context);
     if (context.ir.basePath != null) {
         context.builder.setBasePath(context.ir.basePath);
@@ -227,7 +227,11 @@ export function buildFernDefinition(context: OpenApiIrConverterContext): FernDef
 
     context.builder.optimizeServiceAuth();
 
-    return context.builder.build();
+    const definition = context.builder.build();
+    if (oauthScopeType != null) {
+        addOauthScopeType(definition, oauthScopeType);
+    }
+    return definition;
 }
 
 function getSchemaIdsToExclude({

--- a/packages/cli/cli/changes/unreleased/fix-openapi-oauth-scope-name-collision.yml
+++ b/packages/cli/cli/changes/unreleased/fix-openapi-oauth-scope-name-collision.yml
@@ -1,5 +1,5 @@
 # yaml-language-server: $schema=../../../../../fern-changes-yml.schema.json
 
 - summary: |
-    Avoid collisions between OpenAPI component names and the generated OAuth scope enum.
+    Avoid collisions between emitted OpenAPI type names and the generated OAuth scope enum.
   type: fix

--- a/packages/cli/cli/changes/unreleased/fix-openapi-oauth-scope-name-collision.yml
+++ b/packages/cli/cli/changes/unreleased/fix-openapi-oauth-scope-name-collision.yml
@@ -1,0 +1,5 @@
+# yaml-language-server: $schema=../../../../../fern-changes-yml.schema.json
+
+- summary: |
+    Avoid collisions between OpenAPI component names and the generated OAuth scope enum.
+  type: fix


### PR DESCRIPTION
Closes #17411. The OpenAPI importer now preserves a user-defined `OAuthScope` instead of letting Fern's synthetic `OauthScope` enum converge on the same generated file path.

- Defer the synthetic enum until all definitions are emitted, then deconflict its name against the actual root-package types.
- Keep `OauthScope` for unaffected APIs and choose a deterministic `OauthAuthorizationScope` fallback only on a genuine case-insensitive collision.
- Cover component, inline-generated, and webhook-response collisions while preserving existing grouped, unreferenced, and request-inline behavior.
