### PR TITLE
fix(java): preserve and escape all-underscore discriminator values

### DIFF
--- a/generators/java/generator-utils/src/main/java/com/fern/java/utils/CasingConfiguration.java
+++ b/generators/java/generator-utils/src/main/java/com/fern/java/utils/CasingConfiguration.java
@@ -36,12 +36,18 @@ public final class CasingConfiguration {
 
     private static final Pattern STARTS_WITH_NUMBER = Pattern.compile("^[0-9]");
 
+    // splitWords() (and therefore toCamelCase/toBasicSnakeCase/toSmartSnakeCase) never matches
+    // underscores, so an all-underscore input collapses to "" before sanitizeName ever runs.
+    // Short-circuit that case and keep the literal underscores instead of losing them.
+    private static final Pattern ALL_UNDERSCORES = Pattern.compile("^_+$");
+
     // Match lodash words() regex: [A-Z]+(?=[A-Z][a-z])|[A-Z]?[a-z]+|[A-Z]+|[0-9]+
     private static final Pattern SPLIT_WORDS_PATTERN =
             Pattern.compile("[A-Z]+(?=[A-Z][a-z])|[A-Z]?[a-z]+|[A-Z]+|[0-9]+");
 
     // Java reserved keywords for keyword sanitization
     private static final Set<String> JAVA_RESERVED_KEYWORDS = Set.of(
+            "_", // reserved since Java 9 (unused lambda param), a compile error since Java 21 (JEP 456)
             "abstract",
             "assert",
             "boolean",
@@ -165,6 +171,11 @@ public final class CasingConfiguration {
 
     private NameParts computeNameInternal(String inputName) {
         String name = preprocessName(inputName);
+
+        if (ALL_UNDERSCORES.matcher(name).matches()) {
+            String safeName = sanitizeName(name);
+            return new NameParts(inputName, name, safeName, name, safeName, name, safeName, name, safeName);
+        }
 
         String camelCaseName = toCamelCase(name);
         String pascalCaseName = upperFirst(camelCaseName);

--- a/generators/java/generator-utils/src/main/java/com/fern/java/utils/CasingConfiguration.java
+++ b/generators/java/generator-utils/src/main/java/com/fern/java/utils/CasingConfiguration.java
@@ -36,10 +36,8 @@ public final class CasingConfiguration {
 
     private static final Pattern STARTS_WITH_NUMBER = Pattern.compile("^[0-9]");
 
-    // splitWords() (and therefore toCamelCase/toBasicSnakeCase/toSmartSnakeCase) never matches
-    // underscores, so an all-underscore input collapses to "" before sanitizeName ever runs.
-    // Short-circuit that case and keep the literal underscores instead of losing them.
-    private static final Pattern ALL_UNDERSCORES = Pattern.compile("^_+$");
+    // Characters legal in a Java identifier (the ASCII subset the rest of this class deals in).
+    private static final Pattern ILLEGAL_IDENTIFIER_CHARS = Pattern.compile("[^A-Za-z0-9_$]");
 
     // Match lodash words() regex: [A-Z]+(?=[A-Z][a-z])|[A-Z]?[a-z]+|[A-Z]+|[0-9]+
     private static final Pattern SPLIT_WORDS_PATTERN =
@@ -172,11 +170,6 @@ public final class CasingConfiguration {
     private NameParts computeNameInternal(String inputName) {
         String name = preprocessName(inputName);
 
-        if (ALL_UNDERSCORES.matcher(name).matches()) {
-            String safeName = sanitizeName(name);
-            return new NameParts(inputName, name, safeName, name, safeName, name, safeName, name, safeName);
-        }
-
         String camelCaseName = toCamelCase(name);
         String pascalCaseName = upperFirst(camelCaseName);
         String snakeCaseName;
@@ -197,6 +190,21 @@ public final class CasingConfiguration {
                 camelCaseName = applyInitialismsCamel(camelWords);
                 pascalCaseName = applyInitialismsPascal(camelWords);
             }
+        }
+
+        // splitWords() only recognizes letter/digit runs, so an input made entirely of
+        // separators/symbols (e.g. "_", "-", "@", "-_-") produces zero words and every casing
+        // variant above collapses to "". Recover a usable identifier instead of losing the name
+        // entirely: strip characters that aren't legal in a Java identifier and keep whatever's
+        // left (e.g. "$$" stays "$$", "-_-" becomes "_"); if nothing legal remains, fall back to
+        // "_" (which sanitizeName further escapes to "__", since "_" alone is reserved).
+        if (camelCaseName.isEmpty() && !name.isEmpty()) {
+            String legal = ILLEGAL_IDENTIFIER_CHARS.matcher(name).replaceAll("");
+            String fallback = legal.isEmpty() ? "_" : legal;
+            camelCaseName = fallback;
+            pascalCaseName = fallback;
+            snakeCaseName = fallback;
+            screamingSnakeCaseName = fallback.toUpperCase();
         }
 
         return new NameParts(

--- a/generators/java/generator-utils/src/main/java/com/fern/java/utils/CasingConfiguration.java
+++ b/generators/java/generator-utils/src/main/java/com/fern/java/utils/CasingConfiguration.java
@@ -195,12 +195,9 @@ public final class CasingConfiguration {
         // splitWords() only recognizes letter/digit runs, so an input made entirely of
         // separators/symbols (e.g. "_", "-", "@", "-_-") produces zero words and every casing
         // variant above collapses to "". Recover a usable identifier instead of losing the name
-        // entirely: strip characters that aren't legal in a Java identifier and keep whatever's
-        // left (e.g. "$$" stays "$$", "-_-" becomes "_"); if nothing legal remains, fall back to
-        // "_" (which sanitizeName further escapes to "__", since "_" alone is reserved).
+        // entirely.
         if (camelCaseName.isEmpty() && !name.isEmpty()) {
-            String legal = ILLEGAL_IDENTIFIER_CHARS.matcher(name).replaceAll("");
-            String fallback = legal.isEmpty() ? "_" : legal;
+            String fallback = wordlessFallback(name);
             camelCaseName = fallback;
             pascalCaseName = fallback;
             snakeCaseName = fallback;
@@ -221,6 +218,23 @@ public final class CasingConfiguration {
 
     private String preprocessName(String name) {
         return name.replace("[]", "Array");
+    }
+
+    /**
+     * Fallback identifier for names that produce zero words via splitWords() (e.g. "_", "-", "@", "-_-"). Strips
+     * characters that aren't legal in a Java identifier and keeps whatever's left (e.g. "$$" stays "$$", "-_-" becomes
+     * "_"). If nothing legal remains, encodes each stripped character's code point instead of collapsing to a single
+     * shared placeholder - otherwise distinct inputs like "-" and "@" would both fall back to the same identifier and
+     * silently collide (two identically-named methods/classes) if used as sibling discriminants in the same union.
+     */
+    private static String wordlessFallback(String name) {
+        String legal = ILLEGAL_IDENTIFIER_CHARS.matcher(name).replaceAll("");
+        if (!legal.isEmpty()) {
+            return legal;
+        }
+        StringBuilder encoded = new StringBuilder("_");
+        name.codePoints().forEach(cp -> encoded.append('_').append(Integer.toHexString(cp)));
+        return encoded.toString();
     }
 
     private String sanitizeName(String name) {

--- a/generators/java/generator-utils/src/test/java/com/fern/java/utils/CasingConfigurationTest.java
+++ b/generators/java/generator-utils/src/test/java/com/fern/java/utils/CasingConfigurationTest.java
@@ -991,4 +991,42 @@ public class CasingConfigurationTest {
             assertThat(config.computeName("user_id").camelSafe).isEqualTo("userId");
         }
     }
+
+    // ===== keyword sanitization: inputs with no letters/digits (wordless names) =====
+
+    @Nested
+    class WordlessNameTests {
+
+        @Test
+        void computeName_dash_fallsBackToUnderscore() {
+            CasingConfiguration.NameParts parts =
+                    buildConfig(true, "java", null).computeName("-");
+            assertThat(parts.camelSafe).isEqualTo("__");
+            assertThat(parts.pascalSafe).isEqualTo("__");
+            assertThat(parts.snakeSafe).isEqualTo("__");
+            assertThat(parts.screamingSnakeSafe).isEqualTo("__");
+        }
+
+        @Test
+        void computeName_at_fallsBackToUnderscore() {
+            assertThat(buildConfig(true, "java", null).computeName("@").camelSafe)
+                    .isEqualTo("__");
+        }
+
+        @Test
+        void computeName_dashUnderscoreDash_keepsLegalUnderscore() {
+            // "-_-" has its illegal '-' characters stripped, leaving "_", which is itself reserved.
+            assertThat(buildConfig(true, "java", null).computeName("-_-").camelSafe)
+                    .isEqualTo("__");
+        }
+
+        @Test
+        void computeName_dollarSign_isAlreadyValid() {
+            // '$' is a legal Java identifier character, so it's kept as-is (not a reserved word).
+            CasingConfiguration.NameParts parts =
+                    buildConfig(true, "java", null).computeName("$$");
+            assertThat(parts.camelUnsafe).isEqualTo("$$");
+            assertThat(parts.camelSafe).isEqualTo("$$");
+        }
+    }
 }

--- a/generators/java/generator-utils/src/test/java/com/fern/java/utils/CasingConfigurationTest.java
+++ b/generators/java/generator-utils/src/test/java/com/fern/java/utils/CasingConfigurationTest.java
@@ -957,4 +957,38 @@ public class CasingConfigurationTest {
         root.set("casingsConfig", casingsConfig);
         return CasingConfiguration.fromIrJson(root);
     }
+
+    // ===== keyword sanitization: all-underscore inputs =====
+
+    @Nested
+    class UnderscoreTests {
+
+        @Test
+        void computeName_singleUnderscore_isEscaped() {
+            CasingConfiguration config = buildConfig(true, "java", null);
+            CasingConfiguration.NameParts parts = config.computeName("_");
+            assertThat(parts.camelUnsafe).isEqualTo("_");
+            assertThat(parts.camelSafe).isEqualTo("__");
+        }
+
+        @Test
+        void computeName_doubleUnderscore_isAlreadyValid() {
+            CasingConfiguration config = buildConfig(true, "java", null);
+            CasingConfiguration.NameParts parts = config.computeName("__");
+            assertThat(parts.camelUnsafe).isEqualTo("__");
+            assertThat(parts.camelSafe).isEqualTo("__");
+        }
+
+        @Test
+        void computeName_tripleUnderscore_isAlreadyValid() {
+            CasingConfiguration config = buildConfig(true, "java", null);
+            assertThat(config.computeName("___").camelSafe).isEqualTo("___");
+        }
+
+        @Test
+        void computeName_ordinaryUnderscoreSeparatedName_unaffected() {
+            CasingConfiguration config = buildConfig(true, "java", null);
+            assertThat(config.computeName("user_id").camelSafe).isEqualTo("userId");
+        }
+    }
 }

--- a/generators/java/generator-utils/src/test/java/com/fern/java/utils/CasingConfigurationTest.java
+++ b/generators/java/generator-utils/src/test/java/com/fern/java/utils/CasingConfigurationTest.java
@@ -998,19 +998,29 @@ public class CasingConfigurationTest {
     class WordlessNameTests {
 
         @Test
-        void computeName_dash_fallsBackToUnderscore() {
+        void computeName_dash_encodesCodePoint() {
+            // No legal characters remain, so the code point (0x2d) is encoded instead of
+            // collapsing to a shared placeholder - see computeName_dashAndAt_dontCollide below.
             CasingConfiguration.NameParts parts =
                     buildConfig(true, "java", null).computeName("-");
-            assertThat(parts.camelSafe).isEqualTo("__");
-            assertThat(parts.pascalSafe).isEqualTo("__");
-            assertThat(parts.snakeSafe).isEqualTo("__");
-            assertThat(parts.screamingSnakeSafe).isEqualTo("__");
+            assertThat(parts.camelSafe).isEqualTo("__2d");
+            assertThat(parts.pascalSafe).isEqualTo("__2d");
+            assertThat(parts.snakeSafe).isEqualTo("__2d");
+            assertThat(parts.screamingSnakeSafe).isEqualTo("__2D");
         }
 
         @Test
-        void computeName_at_fallsBackToUnderscore() {
+        void computeName_at_encodesCodePoint() {
             assertThat(buildConfig(true, "java", null).computeName("@").camelSafe)
-                    .isEqualTo("__");
+                    .isEqualTo("__40");
+        }
+
+        @Test
+        void computeName_dashAndAt_dontCollide() {
+            // Distinct wordless inputs must not fall back to the same identifier - that would
+            // silently generate two identically-named methods/classes for sibling discriminants.
+            CasingConfiguration config = buildConfig(true, "java", null);
+            assertThat(config.computeName("-").camelSafe).isNotEqualTo(config.computeName("@").camelSafe);
         }
 
         @Test

--- a/generators/java/sdk/changes/unreleased/fix-underscore-discriminator.yml
+++ b/generators/java/sdk/changes/unreleased/fix-underscore-discriminator.yml
@@ -1,11 +1,11 @@
 # yaml-language-server: $schema=../../../../../fern-changes-yml.schema.json
 
 - summary: |
-    Fix generation failure when a discriminated union's discriminator value is a
-    single underscore (`_`). Previously the compressed-name casing logic (used to
-    reconstruct Java identifiers from the IR) collapsed an all-underscore input to
-    an empty string before it could reach the reserved-keyword check, so JavaPoet
-    rejected the resulting empty method name. All-underscore inputs are now kept
-    intact, and `_` is escaped to `__` (matching the existing convention used for
-    other reserved words), while the serialized discriminator value is unchanged.
+    Fix generation failure when a discriminated union's discriminator value has no
+    letters or digits (e.g. `_`, `-`, `@`, `-_-`). Previously the compressed-name
+    casing logic (used to reconstruct Java identifiers from the IR) collapsed such
+    values to an empty string before it could reach the reserved-keyword check, so
+    JavaPoet rejected the resulting empty method name. These values now fall back
+    to their legal Java-identifier characters (or `_`, escaped to `__`, if none
+    remain), while the serialized discriminator value is unchanged.
   type: fix

--- a/generators/java/sdk/changes/unreleased/fix-underscore-discriminator.yml
+++ b/generators/java/sdk/changes/unreleased/fix-underscore-discriminator.yml
@@ -1,0 +1,11 @@
+# yaml-language-server: $schema=../../../../../fern-changes-yml.schema.json
+
+- summary: |
+    Fix generation failure when a discriminated union's discriminator value is a
+    single underscore (`_`). Previously the compressed-name casing logic (used to
+    reconstruct Java identifiers from the IR) collapsed an all-underscore input to
+    an empty string before it could reach the reserved-keyword check, so JavaPoet
+    rejected the resulting empty method name. All-underscore inputs are now kept
+    intact, and `_` is escaped to `__` (matching the existing convention used for
+    other reserved words), while the serialized discriminator value is unchanged.
+  type: fix

--- a/generators/java/sdk/changes/unreleased/fix-underscore-discriminator.yml
+++ b/generators/java/sdk/changes/unreleased/fix-underscore-discriminator.yml
@@ -6,6 +6,8 @@
     casing logic (used to reconstruct Java identifiers from the IR) collapsed such
     values to an empty string before it could reach the reserved-keyword check, so
     JavaPoet rejected the resulting empty method name. These values now fall back
-    to their legal Java-identifier characters (or `_`, escaped to `__`, if none
-    remain), while the serialized discriminator value is unchanged.
+    to their legal Java-identifier characters, or - if none remain - an encoding of
+    their code points (e.g. `-` becomes `__2d`, `@` becomes `__40`) so that distinct
+    values never collide on the same generated identifier, while the serialized
+    discriminator value is unchanged.
   type: fix


### PR DESCRIPTION
## Description
Closes #17431

`CasingConfiguration.computeName()` builds Java identifiers via `toCamelCase()`, whose word-splitting regex only recognizes letter/digit runs. Any discriminator value with no letters or digits at all (e.g. `"_"`, `"-"`, `"@"`, `"-_-"`) therefore collapsed to `""` before the reserved-keyword check ever ran, so JavaPoet rejected the resulting empty method name (`IllegalArgumentException: not a valid name: `), aborting generation.

This is a different root cause from #17430 (missing `null`/`true`/`false` entries in the same keyword set) — here the keyword list is never even reached, since the input is discarded earlier in casing conversion.

The fix went through two iterations, both included in this PR:
1. Initially special-cased all-underscore input only. A reviewer correctly pointed out this was too narrow — any wordless input hits the same bug.
2. Generalized to strip illegal characters and keep whatever's left, falling back to `_` when nothing legal remains. Verifying this end-to-end (a union with two wordless variants, `"-"` and `"@"`, as siblings) surfaced a follow-on bug: distinct wordless values all fell back to the *same* identifier, so generation "succeeded" but silently emitted non-compiling Java (duplicate method signatures, a duplicate nested class name). Fixed by encoding the stripped characters' code points instead of collapsing to a shared placeholder, so distinct inputs never collide.

## Changes Made
- `CasingConfiguration.computeNameInternal()`: when casing produces an empty name, fall back to legal Java-identifier characters stripped from the input, or an encoding of the input's code points (e.g. `-` → `__2d`, `@` → `__40`) if none remain, so distinct wordless discriminants never collide
- Added `"_"` to `JAVA_RESERVED_KEYWORDS` so a preserved `"_"` gets escaped to `"__"`, consistent with how other reserved words are handled
- Added tests covering `_`/`__`/`___` (escaped/already-valid), ordinary underscore-separated names (unaffected), wordless symbols (`-`, `@`, `-_-`, `$$`), and a non-collision assertion between distinct wordless inputs
- Added a changelog entry under `generators/java/sdk/changes/unreleased/`

## Testing
- [x] Unit tests added/updated (247 tests across `generator-utils`/`model`/`sdk`, all passing; `spotlessCheck` passing)
- [x] Manual testing completed — rebuilt the `fernapi/fern-java-sdk` Docker image from this branch's source at each iteration and ran `fern generate --local` against:
  - the `"_"` repro from #17431 → succeeds, `public static Filter __(UnderscoreFilter value)`, `@JsonTypeName("_")`
  - a `"-"`-only repro → succeeds, `public static Filter __2d(DashFilter value)`, `@JsonTypeName("-")`
  - a union with both `"-"` and `"@"` variants → succeeds with **distinct** identifiers (`__2d`/`__40`, `is__2d()`/`is__40()`, `__2dValue`/`__40Value`), confirming the collision is fixed
  - re-ran the #17429/#17430 repro (`null`/`true`/`false`) against a combined build to confirm the two PRs don't interact
