### PR TITLE
chore(cli): add changelog entry for endpoint-security docs auth fix

### DIFF
--- a/packages/cli/cli/changes/unreleased/endpoint-security-docs-auth.yml
+++ b/packages/cli/cli/changes/unreleased/endpoint-security-docs-auth.yml
@@ -1,0 +1,9 @@
+- summary: |
+    Render per-endpoint auth in docs when `api.auth` is `endpoint-security`. The declared
+    `auth-schemes` were dropped and each operation's `security` was discarded, so published API
+    reference pages referenced a scheme id absent from the definition and showed no auth section,
+    no auth headers in copied snippets, and no credential inputs in the API Explorer. Endpoints now
+    document exactly the schemes they declare — either-scheme endpoints render each option
+    separately, single-scheme endpoints render only that scheme, and `security: []` endpoints render
+    none.
+  type: fix

--- a/packages/cli/cli/changes/unreleased/endpoint-security-docs-auth.yml
+++ b/packages/cli/cli/changes/unreleased/endpoint-security-docs-auth.yml
@@ -1,9 +1,8 @@
 - summary: |
     Render per-endpoint auth in docs when `api.auth` is `endpoint-security`. The declared
-    `auth-schemes` were dropped and each operation's `security` was discarded, so published API
-    reference pages referenced a scheme id absent from the definition and showed no auth section,
-    no auth headers in copied snippets, and no credential inputs in the API Explorer. Endpoints now
-    document exactly the schemes they declare — either-scheme endpoints render each option
-    separately, single-scheme endpoints render only that scheme, and `security: []` endpoints render
-    none.
+    `auth-schemes` and each operation's `security` were both dropped while importing OpenAPI, so
+    every endpoint published with no auth section, no auth headers in copied snippets, and no
+    credential inputs in the API Explorer. Endpoints now document exactly the schemes they declare:
+    either-scheme endpoints render each option separately, single-scheme endpoints render only that
+    scheme, and `security: []` endpoints render none.
   type: fix


### PR DESCRIPTION
#17443 merged without a change file under `packages/cli/cli/changes/unreleased/`, so `release-software.yml` never fired and the fix isn't on npm — `5.98.0` was tagged one commit earlier. This adds the missing entry.

`type: fix` → patch bump (5.98.1). One file, no code changes. There are no other unreleased change files on `main`, so this releases only #17443.

**Why it matters:** a customer's API reference currently documents no auth methods at all — no auth section, no auth headers in copied snippets, no credential inputs in the API Explorer — on every endpoint. Their config is correct; the bug was Fern-side, and they can't move until a CLI release carries the fix.

Verified end-to-end before #17443 merged, via `generate --docs --preview` against that customer's real config (270 endpoints): either-scheme endpoints render both options separately, OAuth-only endpoints render only OAuth, `security: []` endpoints render none. The change is gated on the `endpoint-security` variant, so every other auth configuration takes identical code paths — 328 importer tests pass with no pre-existing snapshot modified, and the Fern-definition path used by SDK generation is byte-identical.

Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/17447" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->