### PR TITLE
feat(python): invocation-only dynamic snippets + clientImport

### DIFF
--- a/generators/python-v2/ast/src/PythonFile.ts
+++ b/generators/python-v2/ast/src/PythonFile.ts
@@ -72,6 +72,22 @@ export class PythonFile extends AstNode {
         writer.unsetRefNameOverrides();
     }
 
+    /**
+     * The rendered import block for the statements in this file, or an empty string when nothing
+     * references an import. This is the Python equivalent of separating a node's imports from its
+     * body: callers that render an invocation inside code they already own (e.g. a documentation
+     * code template) can surface the imports the call needs without the surrounding file scaffold.
+     * The trailing blank line that `write` places between the imports and the body is trimmed.
+     */
+    public getImports(): string {
+        const writer = new Writer();
+        const uniqueReferences = this.deduplicateReferences();
+        this.updateWriterRefNameOverrides({ writer, uniqueReferences });
+        this.writeImports({ writer, uniqueReferences });
+        writer.unsetRefNameOverrides();
+        return writer.toString().trimEnd();
+    }
+
     /*******************************
      * Helper Methods
      *******************************/

--- a/generators/python-v2/ast/src/python.ts
+++ b/generators/python-v2/ast/src/python.ts
@@ -5,6 +5,8 @@ import { Class } from "./Class.js";
 import { ClassInstantiation } from "./ClassInstantiation.js";
 import { CodeBlock } from "./CodeBlock.js";
 import { Comment } from "./Comment.js";
+import { AstNode } from "./core/AstNode.js";
+import { ModulePath } from "./core/types.js";
 import { Decorator } from "./Decorator.js";
 import { Field } from "./Field.js";
 import { Lambda } from "./Lambda.js";
@@ -114,4 +116,27 @@ export function methodArgument(args: MethodArgument.Args): MethodArgument {
 
 export function operator(args: Operator.Args): Operator {
     return new Operator(args);
+}
+
+/**
+ * Renders a node separately from the imports it references, the Python analogue of the
+ * TypeScript AST's `toStringWithoutImports`. `code` is the node's body with no import lines,
+ * and `imports` is the rendered import block the body would otherwise need (empty string when
+ * none). This lets callers embed an invocation inside code they already own (e.g. a
+ * documentation code template) while surfacing the imports the call requires.
+ *
+ * `modulePath` is the module the code is imagined to live in; imports are relativized against it
+ * exactly as they would be in a generated file at that path, so the imports match what the full
+ * snippet would emit.
+ */
+export function renderNodeWithoutImports({ node, modulePath }: { node: AstNode; modulePath: ModulePath }): {
+    code: string;
+    imports: string;
+} {
+    // A bare node's `toString()` only writes its own body — imports are emitted solely by
+    // PythonFile — so the body already excludes them. Wrapping the node in a file at the same
+    // path lets us compute just the import block the body references.
+    const code = node.toString();
+    const file = new PythonFile({ path: modulePath, statements: [node] });
+    return { code, imports: file.getImports() };
 }

--- a/generators/python-v2/dynamic-snippets/src/EndpointSnippetGenerator.ts
+++ b/generators/python-v2/dynamic-snippets/src/EndpointSnippetGenerator.ts
@@ -103,10 +103,19 @@ export class EndpointSnippetGenerator {
             node: invocation,
             modulePath: SNIPPET_MODULE_PATH
         });
+        // Surface the import statement the caller needs to construct the root client
+        // (e.g. `from <sdk> import <RootClient>`) so it can be rendered independently of
+        // the invocation body. Rendering a bare reference to the client class yields just
+        // that import; when the client requires no import this is the empty string.
+        const { imports: clientImport } = python.renderNodeWithoutImports({
+            node: this.context.getRootClientClassReference(),
+            modulePath: SNIPPET_MODULE_PATH
+        });
         return {
             snippet: code.trim(),
             imports,
             clientName: this.context.getRootClientClassName(),
+            clientImport,
             errors: this.context.errors.empty() ? undefined : this.context.errors.toDynamicSnippetErrors()
         };
     }

--- a/generators/python-v2/dynamic-snippets/src/EndpointSnippetGenerator.ts
+++ b/generators/python-v2/dynamic-snippets/src/EndpointSnippetGenerator.ts
@@ -1,4 +1,10 @@
-import { AbstractAstNode, Scope, Severity } from "@fern-api/browser-compatible-base-generator";
+import {
+    AbstractAstNode,
+    InvocationSnippetResponse,
+    Options,
+    Scope,
+    Severity
+} from "@fern-api/browser-compatible-base-generator";
 import { assertNever } from "@fern-api/core-utils";
 import { FernIr } from "@fern-api/dynamic-ir-sdk";
 import { python } from "@fern-api/python-ast";
@@ -66,6 +72,43 @@ export class EndpointSnippetGenerator {
         request: FernIr.dynamic.EndpointSnippetRequest;
     }): python.AstNode {
         return this.callMethod({ endpoint, snippet: request });
+    }
+
+    /**
+     * Generates the structured pieces of an endpoint invocation for callers that render the
+     * invocation within code of their own (e.g. a documentation code template): the bare call
+     * (e.g. `client.plants.update(...)`), the imports the call requires, and the generated root
+     * client class name.
+     */
+    public generateInvocationSnippetSync({
+        endpoint,
+        request,
+        options
+    }: {
+        endpoint: FernIr.dynamic.Endpoint;
+        request: FernIr.dynamic.EndpointSnippetRequest;
+        options?: Options;
+    }): InvocationSnippetResponse {
+        const invocation = this.callMethod({
+            endpoint,
+            snippet: request,
+            clientVariableName: options?.clientVariableName
+        });
+        // The caller supplies the client and terminates the statement themselves, so the
+        // invocation is emitted as a bare expression. When the call references SDK types (e.g.
+        // an enum or an aliased request value) the imports it needs are surfaced separately so
+        // the caller can render them rather than falling back to the complete snippet. Python
+        // statements have no terminator, so no trailing character needs stripping.
+        const { code, imports } = python.renderNodeWithoutImports({
+            node: invocation,
+            modulePath: SNIPPET_MODULE_PATH
+        });
+        return {
+            snippet: code.trim(),
+            imports,
+            clientName: this.context.getRootClientClassName(),
+            errors: this.context.errors.empty() ? undefined : this.context.errors.toDynamicSnippetErrors()
+        };
     }
 
     private buildPythonFile({
@@ -443,13 +486,15 @@ export class EndpointSnippetGenerator {
 
     private callMethod({
         endpoint,
-        snippet
+        snippet,
+        clientVariableName
     }: {
         endpoint: FernIr.dynamic.Endpoint;
         snippet: FernIr.dynamic.EndpointSnippetRequest;
+        clientVariableName?: string;
     }): python.AstNode {
         return python.invokeMethod({
-            on: python.reference({ name: CLIENT_VAR_NAME }),
+            on: python.reference({ name: clientVariableName ?? CLIENT_VAR_NAME }),
             method: this.getMethod({ endpoint }),
             arguments_: this.getMethodArgs({ endpoint, snippet })
                 .filter((arg) => !python.TypeInstantiation.isNop(arg.value))

--- a/generators/python-v2/dynamic-snippets/src/__test__/InvocationSnippet.test.ts
+++ b/generators/python-v2/dynamic-snippets/src/__test__/InvocationSnippet.test.ts
@@ -48,6 +48,13 @@ describe("invocation-only snippets", () => {
         expect(response?.clientName).toBe("Acme");
     });
 
+    it("exposes the import statement needed to construct the root client", () => {
+        const response = generator.generateInvocationSync(request);
+
+        expect(response?.clientImport).toContain("import");
+        expect(response?.clientImport).toContain("Acme");
+    });
+
     it("invokes the endpoint on the requested client variable", () => {
         const response = generator.generateInvocationSync(request, { clientVariableName: "mailchimp" });
 

--- a/generators/python-v2/dynamic-snippets/src/__test__/InvocationSnippet.test.ts
+++ b/generators/python-v2/dynamic-snippets/src/__test__/InvocationSnippet.test.ts
@@ -1,0 +1,100 @@
+import { AbsoluteFilePath, join } from "@fern-api/path-utils";
+
+import { buildDynamicSnippetsGenerator } from "./utils/buildDynamicSnippetsGenerator.js";
+import { buildGeneratorConfig } from "./utils/buildGeneratorConfig.js";
+
+const DYNAMIC_IR_TEST_DEFINITIONS_DIRECTORY = AbsoluteFilePath.of(
+    `${__dirname}/../../../../../packages/cli/generation/ir-generator-tests/src/dynamic-snippets/__test__/test-definitions`
+);
+
+// invocation-only snippets are rendered inside code the caller already owns (e.g. a
+// documentation code template), so they must not include imports or client instantiation
+describe("invocation-only snippets", () => {
+    const generator = buildDynamicSnippetsGenerator({
+        irFilepath: AbsoluteFilePath.of(join(DYNAMIC_IR_TEST_DEFINITIONS_DIRECTORY, "exhaustive.json")),
+        config: buildGeneratorConfig({})
+    });
+
+    const request = {
+        endpoint: {
+            method: "GET" as const,
+            path: "/http-methods/{id}"
+        },
+        baseURL: undefined,
+        environment: undefined,
+        auth: {
+            type: "bearer" as const,
+            token: "<YOUR_API_KEY>"
+        },
+        pathParameters: {
+            id: "id"
+        },
+        queryParameters: undefined,
+        headers: undefined,
+        requestBody: undefined
+    };
+
+    it("generates the invocation without imports or client instantiation", () => {
+        const response = generator.generateInvocationSync(request);
+
+        expect(response?.snippet).toBe('client.endpoints.http_methods.test_get(\n    id="id",\n)');
+        expect(response?.imports).toBe("");
+        expect(response?.errors).toBeUndefined();
+    });
+
+    it("exposes the generated client class name so docs can render the client instantiation", () => {
+        const response = generator.generateInvocationSync(request);
+
+        expect(response?.clientName).toBe("Acme");
+    });
+
+    it("invokes the endpoint on the requested client variable", () => {
+        const response = generator.generateInvocationSync(request, { clientVariableName: "mailchimp" });
+
+        expect(response?.snippet).toBe('mailchimp.endpoints.http_methods.test_get(\n    id="id",\n)');
+    });
+
+    it("returns the imports the invocation references instead of falling back to the full snippet", () => {
+        // This body references stdlib types the call constructs inline (a datetime and a UUID),
+        // so the invocation must carry `import datetime` / `import uuid`. The previous
+        // invocation-only contract had no way to express this; now the imports are surfaced
+        // separately so docs can regenerate both the call and the imports it needs.
+        const response = generator.generateInvocationSync({
+            endpoint: {
+                method: "POST" as const,
+                path: "/object/get-and-return-with-optional-field"
+            },
+            baseURL: undefined,
+            environment: undefined,
+            auth: {
+                type: "bearer" as const,
+                token: "<YOUR_API_KEY>"
+            },
+            pathParameters: undefined,
+            queryParameters: undefined,
+            headers: undefined,
+            requestBody: {
+                string: "string",
+                integer: 1,
+                long: 1000000,
+                double: 1.1,
+                bool: true,
+                datetime: "2024-01-15T09:30:00Z",
+                date: "2023-01-15",
+                uuid: "d5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32",
+                base64: "SGVsbG8gd29ybGQh",
+                list: ["list", "list"],
+                set: ["set"],
+                map: { 1: "map" },
+                bigint: "1000000"
+            }
+        });
+
+        expect(response).not.toBeUndefined();
+        expect(response?.snippet).toContain("datetime.datetime.fromisoformat");
+        expect(response?.snippet).toContain("uuid.UUID");
+        expect(response?.imports).toContain("import datetime");
+        expect(response?.imports).toContain("import uuid");
+        expect(response?.errors).toBeUndefined();
+    });
+});

--- a/generators/python/sdk/changes/unreleased/invocation-only-dynamic-snippets.yml
+++ b/generators/python/sdk/changes/unreleased/invocation-only-dynamic-snippets.yml
@@ -1,0 +1,18 @@
+# yaml-language-server: $schema=../../../../../fern-changes-yml.schema.json
+
+- summary: |
+    Generate invocation-only dynamic snippets. In addition to the full snippet
+    (client construction plus the call), the generator now exposes the structured
+    pieces a caller can render inside code it already owns (e.g. a documentation
+    code template): the bare invocation (`client.plants.update(...)`, honoring a
+    custom client variable name), the Python `import` block that invocation
+    references (empty string when none), and the generated root client class name
+    so docs can render `client = <ClientName>(...)` and track renames.
+
+    Imports are captured separately from the call via a new
+    `python.renderNodeWithoutImports` helper and `PythonFile.getImports()`, the
+    Python analogue of the TypeScript AST's `toStringWithoutImports`. Invocations
+    that reference imported types (e.g. a body value constructed with
+    `datetime.datetime.fromisoformat(...)` / `uuid.UUID(...)`) surface those
+    imports rather than falling back to the complete snippet.
+  type: feat


### PR DESCRIPTION
## What

Populates the optional `clientImport` field on `InvocationSnippetResponse` for the Python dynamic-snippets generator, mirroring the TypeScript implementation.

`generateInvocationSnippetSync` now renders a bare reference to the root client class (`context.getRootClientClassReference()`) via `python.renderNodeWithoutImports` and returns the resulting import string as `clientImport`. When the client requires no import, `clientImport` is the empty string (no crash).

## Testing

- `pnpm turbo run compile --filter @fern-api/python-dynamic-snippets` passes.
- Package vitest suite passes (71 tests). Added an assertion in `InvocationSnippet.test.ts` that `clientImport` contains "import" and the client class name ("Acme").

Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/17449" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->