### PR TITLE
feat(csharp): invocation-only dynamic snippets + clientImport

### DIFF
--- a/generators/csharp/codegen/src/ast/core/AstNode.ts
+++ b/generators/csharp/codegen/src/ast/core/AstNode.ts
@@ -140,6 +140,51 @@ export abstract class AstNode extends AbstractAstNode {
         return formatter != null ? formatter.format(stringNode) : Promise.resolve(stringNode);
     }
 
+    /**
+     * Renders the node body separately from the `using ...;` block it references. This is the C#
+     * analogue of the TypeScript AST's `toStringWithoutImports` (and the Java AST's
+     * `renderNodeWithoutImports`): `code` is the node's rendered body with no leading `using`
+     * block, and `imports` is the rendered `using ...;` block the body would otherwise need
+     * (empty string when none). This lets callers embed an invocation inside code they already
+     * own (e.g. a documentation code template) while surfacing the usings the call requires.
+     *
+     * A single write pass populates the writer's references, so `code` and `imports` are computed
+     * from the same render — exactly the split `toString` performs internally when prepending the
+     * using block. `skipGlobalQualifier` matches the user-facing snippet style (no `global::`).
+     */
+    public toStringWithoutImports({
+        namespace,
+        allNamespaceSegments,
+        allTypeClassReferences,
+        generation,
+        formatter,
+        skipGlobalQualifier = false
+    }: {
+        namespace: string;
+        allNamespaceSegments: Set<string>;
+        allTypeClassReferences: Map<string, Set<Namespace>>;
+        generation: Generation;
+        formatter?: AbstractFormatter;
+        skipGlobalQualifier?: boolean;
+    }): { code: string; imports: string } {
+        const writer = new Writer({
+            namespace,
+            allNamespaceSegments,
+            allTypeClassReferences,
+            generation,
+            skipGlobalQualifier
+        });
+        this.write(writer);
+        // `writer.toString(true)` returns only the buffer (skipping the using block), while
+        // `importsToString()` returns the using block the body references.
+        const body = writer.toString(true);
+        const imports = writer.importsToString() ?? "";
+        return {
+            code: formatter != null ? formatter.formatSync(body) : body,
+            imports
+        };
+    }
+
     public toFormattedSnippet({
         allNamespaceSegments,
         allTypeClassReferences,

--- a/generators/csharp/dynamic-snippets/src/EndpointSnippetGenerator.ts
+++ b/generators/csharp/dynamic-snippets/src/EndpointSnippetGenerator.ts
@@ -119,9 +119,22 @@ export class EndpointSnippetGenerator extends WithGeneration {
             // See generateSnippet for rationale: user-facing snippets skip the global:: qualifier.
             skipGlobalQualifier: true
         });
+        // The `using ...;` a caller needs to bring the root client class into scope. Rendering a
+        // bare reference to the root client on its own registers its namespace, so the split render
+        // surfaces just that client `using` block — the C# analogue of the TypeScript port's
+        // `clientImport`, computed exactly like the `imports` field above but for the root client
+        // reference alone. Empty string when the client needs no using (e.g. same namespace).
+        const { imports: clientImport } = this.Types.RootClientForSnippets.toStringWithoutImports({
+            namespace: "Examples",
+            generation: this.generation,
+            allNamespaceSegments: new Set(),
+            allTypeClassReferences: new Map(),
+            skipGlobalQualifier: true
+        });
         return {
             snippet: this.stripTrailingSemicolon(code.trim()),
             imports,
+            clientImport,
             clientName: this.Types.RootClientForSnippets.name,
             errors: this.context.errors.empty() ? undefined : this.context.errors.toDynamicSnippetErrors()
         };

--- a/generators/csharp/dynamic-snippets/src/EndpointSnippetGenerator.ts
+++ b/generators/csharp/dynamic-snippets/src/EndpointSnippetGenerator.ts
@@ -1,4 +1,11 @@
-import { NamedArgument, Options, Scope, Severity, Style } from "@fern-api/browser-compatible-base-generator";
+import {
+    InvocationSnippetResponse,
+    NamedArgument,
+    Options,
+    Scope,
+    Severity,
+    Style
+} from "@fern-api/browser-compatible-base-generator";
 import { assertNever } from "@fern-api/core-utils";
 import { ast, is, WithGeneration } from "@fern-api/csharp-codegen";
 import { FernIr } from "@fern-api/dynamic-ir-sdk";
@@ -11,6 +18,9 @@ import { FilePropertyInfo } from "./context/FilePropertyMapper.js";
 // `SdkRequest.requestParameterName` to the default for both body and wrapped requests (see
 // DEFAULT_REQUEST_PARAMETER_NAME in convertHttpSdkRequest.ts).
 const REQUEST_PARAMETER_NAME = "request";
+
+// The generated full snippet constructs and invokes the client through a local named `client`.
+const CLIENT_VAR_NAME = "client";
 
 export class EndpointSnippetGenerator extends WithGeneration {
     private context: DynamicSnippetsGeneratorContext;
@@ -73,6 +83,52 @@ export class EndpointSnippetGenerator extends WithGeneration {
         options?: Options;
     }): Promise<ast.AstNode> {
         throw new Error("Unsupported");
+    }
+
+    /**
+     * Generates the structured pieces of an endpoint invocation for callers that render the
+     * invocation within code of their own (e.g. a documentation code template): the bare call
+     * (e.g. `client.Plants.Update(...)`), the `using ...;` block the call requires, and the
+     * generated client class name.
+     */
+    public generateInvocationSnippetSync({
+        endpoint,
+        request,
+        options
+    }: {
+        endpoint: FernIr.dynamic.Endpoint;
+        request: FernIr.dynamic.EndpointSnippetRequest;
+        options?: Options;
+    }): InvocationSnippetResponse {
+        const invocation = this.callMethod({
+            endpoint,
+            snippet: request,
+            clientVariableName: options?.clientVariableName
+        });
+        // The caller supplies the client and terminates the statement themselves, so the
+        // invocation is emitted as a bare expression: no `var client = new ...Client()`
+        // construction, no `Examples` class/method scaffold, and no trailing `;`. When the call
+        // references SDK or stdlib types (e.g. a body value constructed with `DateTime` or a
+        // `Guid`) the `using ...;` block it needs is surfaced separately so the caller can render
+        // it rather than falling back to the complete snippet.
+        const { code, imports } = invocation.toStringWithoutImports({
+            namespace: "Examples",
+            generation: this.generation,
+            allNamespaceSegments: new Set(),
+            allTypeClassReferences: new Map(),
+            // See generateSnippet for rationale: user-facing snippets skip the global:: qualifier.
+            skipGlobalQualifier: true
+        });
+        return {
+            snippet: this.stripTrailingSemicolon(code.trim()),
+            imports,
+            clientName: this.Types.RootClientForSnippets.name,
+            errors: this.context.errors.empty() ? undefined : this.context.errors.toDynamicSnippetErrors()
+        };
+    }
+
+    private stripTrailingSemicolon(code: string): string {
+        return code.endsWith(";") ? code.slice(0, -1).trimEnd() : code;
     }
 
     private buildCodeBlock({
@@ -152,17 +208,19 @@ export class EndpointSnippetGenerator extends WithGeneration {
 
     private callMethod({
         endpoint,
-        snippet
+        snippet,
+        clientVariableName
     }: {
         endpoint: FernIr.dynamic.Endpoint;
         snippet: FernIr.dynamic.EndpointSnippetRequest;
+        clientVariableName?: string;
     }): ast.CodeBlock | ast.MethodInvocation {
         // if the example has *any* sample with stream set to true, then the method is an async enumerable
         const isAsyncEnumerable =
             endpoint.response?.type === "streaming" || endpoint.response?.type === "streamParameter";
 
         const invocation = this.csharp.invokeMethod({
-            on: this.csharp.codeblock("client"),
+            on: this.csharp.codeblock(clientVariableName ?? CLIENT_VAR_NAME),
             method: this.getMethod({ endpoint }),
             arguments_: this.getMethodArgs({ endpoint, snippet }),
             async: true,

--- a/generators/csharp/dynamic-snippets/src/__test__/InvocationSnippet.test.ts
+++ b/generators/csharp/dynamic-snippets/src/__test__/InvocationSnippet.test.ts
@@ -66,6 +66,15 @@ describe("invocation-only snippets", () => {
         expect(response?.clientName).toBe("AcmeClient");
     });
 
+    it("exposes the client using so docs can render the client instantiation with the right namespace", () => {
+        const response = generator.generateInvocationSync(request);
+
+        // Distinct from `imports` (the usings the bare call references): `clientImport` is the
+        // `using ...;` that brings the root client class into scope, so a docs template can render
+        // `new AcmeClient(...)` alongside the invocation.
+        expect(response?.clientImport).toBe("using Acme;\n");
+    });
+
     it("invokes the endpoint on the requested client variable", () => {
         const response = generator.generateInvocationSync(request, { clientVariableName: "mailchimp" });
 

--- a/generators/csharp/dynamic-snippets/src/__test__/InvocationSnippet.test.ts
+++ b/generators/csharp/dynamic-snippets/src/__test__/InvocationSnippet.test.ts
@@ -1,0 +1,116 @@
+import { AbsoluteFilePath, join } from "@fern-api/path-utils";
+
+import { buildDynamicSnippetsGenerator } from "./utils/buildDynamicSnippetsGenerator.js";
+import { buildGeneratorConfig } from "./utils/buildGeneratorConfig.js";
+
+const DYNAMIC_IR_TEST_DEFINITIONS_DIRECTORY = AbsoluteFilePath.of(
+    `${__dirname}/../../../../../packages/cli/generation/ir-generator-tests/src/dynamic-snippets/__test__/test-definitions`
+);
+
+// invocation-only snippets are rendered inside code the caller already owns (e.g. a
+// documentation code template), so they must not include client instantiation or the
+// surrounding `Examples` class/method scaffold. The `using ...;` block the call references is
+// surfaced separately in the `imports` field. A plain C# invocation references no usings, so
+// `imports` is empty for a bare call and only populated when the invocation constructs imported
+// types inline.
+describe("invocation-only snippets", () => {
+    const generator = buildDynamicSnippetsGenerator({
+        irFilepath: AbsoluteFilePath.of(join(DYNAMIC_IR_TEST_DEFINITIONS_DIRECTORY, "exhaustive.json")),
+        config: buildGeneratorConfig({})
+    });
+
+    const request = {
+        endpoint: {
+            method: "GET" as const,
+            path: "/http-methods/{id}"
+        },
+        baseURL: undefined,
+        environment: undefined,
+        auth: {
+            type: "bearer" as const,
+            token: "<YOUR_API_KEY>"
+        },
+        pathParameters: {
+            id: "id"
+        },
+        queryParameters: undefined,
+        headers: undefined,
+        requestBody: undefined
+    };
+
+    it("generates the invocation without client instantiation or class scaffold", () => {
+        const response = generator.generateInvocationSync(request);
+
+        // The generated invocation is multiline (matching the full snippet's `invokeMethod`
+        // rendering), so the path argument sits on its own line.
+        expect(response?.snippet).toBe('await client.Endpoints.HTTPMethods.TestGetAsync(\n    "id"\n)');
+        // The invocation is a bare expression: no `var client = new ...Client(...)` construction,
+        // no `Examples` class/method wrapper, no `using ...;` block, and no trailing `;`.
+        expect(response?.snippet).not.toContain("var client");
+        expect(response?.snippet).not.toContain("new ");
+        expect(response?.snippet).not.toContain("class Examples");
+        expect(response?.snippet).not.toContain("using ");
+        expect(response?.snippet.endsWith(";")).toBe(false);
+        expect(response?.errors).toBeUndefined();
+    });
+
+    it("returns no imports for a bare call that references none", () => {
+        const response = generator.generateInvocationSync(request);
+
+        expect(response?.imports).toBe("");
+    });
+
+    it("exposes the generated client class name so docs can render the client instantiation", () => {
+        const response = generator.generateInvocationSync(request);
+
+        expect(response?.clientName).toBe("AcmeClient");
+    });
+
+    it("invokes the endpoint on the requested client variable", () => {
+        const response = generator.generateInvocationSync(request, { clientVariableName: "mailchimp" });
+
+        expect(response?.snippet).toBe('await mailchimp.Endpoints.HTTPMethods.TestGetAsync(\n    "id"\n)');
+    });
+
+    it("surfaces the using block the invocation references instead of falling back to the full snippet", () => {
+        // This body references types the call constructs inline (a DateTime and a Guid), so the
+        // invocation must carry the corresponding `using System;` directive. The previous
+        // invocation-only contract had no way to express this; now the usings are surfaced
+        // separately so docs can regenerate both the call and the usings it needs.
+        const response = generator.generateInvocationSync({
+            endpoint: {
+                method: "POST" as const,
+                path: "/object/get-and-return-with-optional-field"
+            },
+            baseURL: undefined,
+            environment: undefined,
+            auth: {
+                type: "bearer" as const,
+                token: "<YOUR_API_KEY>"
+            },
+            pathParameters: undefined,
+            queryParameters: undefined,
+            headers: undefined,
+            requestBody: {
+                string: "string",
+                integer: 1,
+                long: 1000000,
+                double: 1.1,
+                bool: true,
+                datetime: "2024-01-15T09:30:00Z",
+                date: "2023-01-15",
+                uuid: "d5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32",
+                base64: "SGVsbG8gd29ybGQh",
+                list: ["list", "list"],
+                set: ["set"],
+                map: { 1: "map" },
+                bigint: "1000000"
+            }
+        });
+
+        expect(response).not.toBeUndefined();
+        expect(response?.snippet).toContain("DateTime");
+        expect(response?.imports).toContain("using System;");
+        expect(response?.errors).toBeUndefined();
+    });
+});

--- a/generators/csharp/sdk/changes/unreleased/invocation-only-dynamic-snippets.yml
+++ b/generators/csharp/sdk/changes/unreleased/invocation-only-dynamic-snippets.yml
@@ -1,0 +1,20 @@
+# yaml-language-server: $schema=../../../../../fern-changes-yml.schema.json
+
+- summary: |
+    Generate invocation-only dynamic snippets. In addition to the full snippet
+    (client construction plus the call), the generator now exposes the structured
+    pieces a caller can render inside code it already owns (e.g. a documentation
+    code template): the bare invocation (`await client.Endpoints.Update(...)`,
+    honoring a custom client variable name), the C# `using ...;` block that
+    invocation references (empty string when none), and the generated client class
+    name so docs can render `var client = new <ClientName>(...)` and track renames.
+
+    The `using` block is captured separately from the call via a new
+    `AstNode.toStringWithoutImports` helper, the C# analogue of the TypeScript AST's
+    `toStringWithoutImports` (and the Java AST's `renderNodeWithoutImports`): a single
+    render pass yields the node body and the `using ...;` directives it references.
+    Invocations that construct imported types inline (e.g. a body value built with a
+    `System.DateTime` or `System.Guid`) surface those usings rather than falling back
+    to the complete snippet. A plain C# invocation references no usings, so a bare
+    call returns an empty using block.
+  type: feat


### PR DESCRIPTION
## Summary

Populates the optional `clientImport` field on `InvocationSnippetResponse` for the C# dynamic-snippets generator, mirroring the TypeScript port on the base branch (`cade/clientimport-invocation-snippet`).

Alongside the bare call (`snippet`) and the usings the call references (`imports`), the generator now also returns `clientImport` — the `using ...;` that brings the root client class into scope, so a docs code template can render `new AcmeClient(...)` next to the invocation with the correct namespace.

## How

C# models imports as `using` (namespace) directives. `clientImport` is computed exactly like the existing `imports` field, but from a bare render of the root client class reference (`Types.RootClientForSnippets`, an `ast.ClassReference`) via the C# AST's `toStringWithoutImports` helper. Rendering the reference alone registers its namespace, so the split render surfaces just that client `using` block (e.g. `using Acme;`), and the empty string when none is needed.

## Testing

- `pnpm turbo run compile --filter @fern-api/csharp-dynamic-snippets` — passes.
- Full package vitest — 49 tests pass. Added a `clientImport` assertion to `InvocationSnippet.test.ts` (`using Acme;`).

Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/17450" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->