### PR TITLE
feat(java): invocation-only dynamic snippets + clientImport

### DIFF
--- a/generators/java-v2/ast/src/ast/core/JavaFile.ts
+++ b/generators/java-v2/ast/src/ast/core/JavaFile.ts
@@ -33,6 +33,18 @@ export class JavaFile extends Writer {
         return content;
     }
 
+    /**
+     * The rendered `import ...;` block for the references written to this file, or an empty
+     * string when nothing references an import. This is the Java equivalent of separating a
+     * node's imports from its body: callers that render an invocation inside code they already
+     * own (e.g. a documentation code template) can surface the imports the call needs without the
+     * surrounding package/file scaffold. (Distinct from {@link Writer.getImports}, which returns
+     * the raw set of imported package names.)
+     */
+    public getRenderedImports(): string {
+        return this.stringifyImports();
+    }
+
     private getContent(): string {
         const packageStatement = `package ${this.packageName};\n\n`;
         const imports = this.stringifyImports();

--- a/generators/java-v2/ast/src/java.ts
+++ b/generators/java-v2/ast/src/java.ts
@@ -1,7 +1,12 @@
+import { AbstractFormatter } from "@fern-api/browser-compatible-base-generator";
+
 import { Class } from "./ast/Class.js";
+import { AstNode } from "./ast/core/AstNode.js";
+import { JavaFile } from "./ast/core/JavaFile.js";
 import { ClassInstantiation, ClassReference, CodeBlock, MethodInvocation } from "./ast/index.js";
 import { Method } from "./ast/Method.js";
 import { Parameter } from "./ast/Parameter.js";
+import { BaseJavaCustomConfigSchema } from "./custom-config/BaseJavaCustomConfigSchema.js";
 
 export function codeblock(arg: CodeBlock.Arg): CodeBlock {
     return new CodeBlock(arg);
@@ -29,6 +34,36 @@ export function method(args: Method.Args): Method {
 
 export function parameter(args: Parameter.Args): Parameter {
     return new Parameter(args);
+}
+
+/**
+ * Renders a node separately from the imports it references, the Java analogue of the TypeScript
+ * AST's `toStringWithoutImports`. `code` is the node's rendered body with no `package` statement
+ * and no `import ...;` block, and `imports` is the rendered import block the body would otherwise
+ * need (empty string when none). This lets callers embed an invocation inside code they already
+ * own (e.g. a documentation code template) while surfacing the imports the call requires.
+ *
+ * The node is written into a file at the given `packageName` so imports are computed (and the
+ * target package elided) exactly as they would be in a generated file, matching what the full
+ * snippet would emit.
+ */
+export function renderNodeWithoutImports({
+    node,
+    packageName,
+    customConfig,
+    formatter
+}: {
+    node: AstNode;
+    packageName: string;
+    customConfig: BaseJavaCustomConfigSchema;
+    formatter?: AbstractFormatter;
+}): { code: string; imports: string } {
+    const file = new JavaFile({ packageName, customConfig, formatter });
+    node.write(file);
+    // The node's body is the writer buffer alone; the package statement and import block are
+    // added only by JavaFile's getContent(). Returning the buffer yields just the invocation, and
+    // getRenderedImports() surfaces the import block the body references separately.
+    return { code: file.buffer.trimEnd(), imports: file.getRenderedImports() };
 }
 
 export { AstNode } from "./ast/core/AstNode.js";

--- a/generators/java-v2/dynamic-snippets/src/EndpointSnippetGenerator.ts
+++ b/generators/java-v2/dynamic-snippets/src/EndpointSnippetGenerator.ts
@@ -1,4 +1,11 @@
-import { AbstractFormatter, Options, Scope, Severity, Style } from "@fern-api/browser-compatible-base-generator";
+import {
+    AbstractFormatter,
+    InvocationSnippetResponse,
+    Options,
+    Scope,
+    Severity,
+    Style
+} from "@fern-api/browser-compatible-base-generator";
 import { assertNever } from "@fern-api/core-utils";
 import { FernIr } from "@fern-api/dynamic-ir-sdk";
 import { java } from "@fern-api/java-ast";
@@ -105,6 +112,47 @@ export class EndpointSnippetGenerator {
         options?: Options;
     }): Promise<java.AstNode> {
         throw new Error("Unsupported");
+    }
+
+    /**
+     * Generates the structured pieces of an endpoint invocation for callers that render the
+     * invocation within code of their own (e.g. a documentation code template): the bare call
+     * (e.g. `client.plants().update(...)`), the imports the call requires, and the generated
+     * client class name.
+     */
+    public generateInvocationSnippetSync({
+        endpoint,
+        request,
+        options
+    }: {
+        endpoint: FernIr.dynamic.Endpoint;
+        request: FernIr.dynamic.EndpointSnippetRequest;
+        options?: Options;
+    }): InvocationSnippetResponse {
+        const config = this.getConfig(options ?? {});
+        const invocation = this.callMethod({
+            endpoint,
+            snippet: request,
+            clientVariableName: options?.clientVariableName
+        });
+        // The caller supplies the client and terminates the statement themselves, so the
+        // invocation is emitted as a bare expression: no `Client client = Client.builder()...`
+        // construction, no `package`/class/method scaffold, and no trailing `;`. When the call
+        // references SDK or stdlib types (e.g. a body value constructed with `Optional`, a date,
+        // or a UUID) the imports it needs are surfaced separately so the caller can render them
+        // rather than falling back to the complete snippet.
+        const { code, imports } = java.renderNodeWithoutImports({
+            node: invocation,
+            packageName: config.fullStylePackageName ?? SNIPPET_PACKAGE_NAME,
+            customConfig: this.context.customConfig,
+            formatter: this.formatter
+        });
+        return {
+            snippet: code.trim(),
+            imports,
+            clientName: this.context.getRootClientClassNameForSnippets(),
+            errors: this.context.errors.empty() ? undefined : this.context.errors.toDynamicSnippetErrors()
+        };
     }
 
     private buildCodeBlock({
@@ -555,13 +603,15 @@ export class EndpointSnippetGenerator {
 
     private callMethod({
         endpoint,
-        snippet
+        snippet,
+        clientVariableName
     }: {
         endpoint: FernIr.dynamic.Endpoint;
         snippet: FernIr.dynamic.EndpointSnippetRequest;
+        clientVariableName?: string;
     }): java.MethodInvocation {
         return java.invokeMethod({
-            on: java.codeblock(CLIENT_VAR_NAME),
+            on: java.codeblock(clientVariableName ?? CLIENT_VAR_NAME),
             method: this.getMethod({ endpoint }),
             arguments_: this.getMethodArgs({ endpoint, snippet })
         });

--- a/generators/java-v2/dynamic-snippets/src/EndpointSnippetGenerator.ts
+++ b/generators/java-v2/dynamic-snippets/src/EndpointSnippetGenerator.ts
@@ -147,10 +147,21 @@ export class EndpointSnippetGenerator {
             customConfig: this.context.customConfig,
             formatter: this.formatter
         });
+        // Render a bare reference to the generated root client class so its `import ...;` can be
+        // surfaced on its own. This lets docs render the client import (e.g. to construct the
+        // client themselves) without hand-authoring it. Rendered at the snippet package so the
+        // client's own package is not elided; empty string when the client needs no import.
+        const { imports: clientImport } = java.renderNodeWithoutImports({
+            node: this.context.getRootClientClassReference(),
+            packageName: config.fullStylePackageName ?? SNIPPET_PACKAGE_NAME,
+            customConfig: this.context.customConfig,
+            formatter: this.formatter
+        });
         return {
             snippet: code.trim(),
             imports,
             clientName: this.context.getRootClientClassNameForSnippets(),
+            clientImport,
             errors: this.context.errors.empty() ? undefined : this.context.errors.toDynamicSnippetErrors()
         };
     }

--- a/generators/java-v2/dynamic-snippets/src/__test__/InvocationSnippet.test.ts
+++ b/generators/java-v2/dynamic-snippets/src/__test__/InvocationSnippet.test.ts
@@ -1,0 +1,117 @@
+import { AbsoluteFilePath, join } from "@fern-api/path-utils";
+
+import { buildDynamicSnippetsGenerator } from "./utils/buildDynamicSnippetsGenerator.js";
+import { buildGeneratorConfig } from "./utils/buildGeneratorConfig.js";
+
+const DYNAMIC_IR_TEST_DEFINITIONS_DIRECTORY = AbsoluteFilePath.of(
+    `${__dirname}/../../../../../packages/cli/generation/ir-generator-tests/src/dynamic-snippets/__test__/test-definitions`
+);
+
+// invocation-only snippets are rendered inside code the caller already owns (e.g. a
+// documentation code template), so they must not include client instantiation or the
+// surrounding package/class/method scaffold. The imports the call references are surfaced
+// separately in the `imports` field. Unlike Go (whose SDK methods take a leading
+// context.Context), a plain Java invocation references no imports, so `imports` is empty for a
+// bare call and only populated when the invocation constructs imported types inline.
+describe("invocation-only snippets", () => {
+    const generator = buildDynamicSnippetsGenerator({
+        irFilepath: AbsoluteFilePath.of(join(DYNAMIC_IR_TEST_DEFINITIONS_DIRECTORY, "exhaustive.json")),
+        config: buildGeneratorConfig({})
+    });
+
+    const request = {
+        endpoint: {
+            method: "GET" as const,
+            path: "/http-methods/{id}"
+        },
+        baseURL: undefined,
+        environment: undefined,
+        auth: {
+            type: "bearer" as const,
+            token: "<YOUR_API_KEY>"
+        },
+        pathParameters: {
+            id: "id"
+        },
+        queryParameters: undefined,
+        headers: undefined,
+        requestBody: undefined
+    };
+
+    it("generates the invocation without client instantiation or package scaffold", () => {
+        const response = generator.generateInvocationSync(request);
+
+        expect(response?.snippet).toBe('client.endpoints().httpMethods().testGet("id")');
+        // The invocation is a bare expression: no `Client client = Client.builder()...`
+        // construction, no `package`/class/method wrapper, no import block, and no trailing `;`.
+        expect(response?.snippet).not.toContain(".builder()");
+        expect(response?.snippet).not.toContain("package ");
+        expect(response?.snippet).not.toContain("import ");
+        expect(response?.snippet.endsWith(";")).toBe(false);
+        expect(response?.errors).toBeUndefined();
+    });
+
+    it("returns no imports for a bare call that references none", () => {
+        const response = generator.generateInvocationSync(request);
+
+        expect(response?.imports).toBe("");
+    });
+
+    it("exposes the generated client class name so docs can render the client instantiation", () => {
+        const response = generator.generateInvocationSync(request);
+
+        expect(response?.clientName).toBe("AcmeAcmeClient");
+    });
+
+    it("invokes the endpoint on the requested client variable", () => {
+        const response = generator.generateInvocationSync(request, { clientVariableName: "mailchimp" });
+
+        expect(response?.snippet).toBe('mailchimp.endpoints().httpMethods().testGet("id")');
+    });
+
+    it("surfaces the imports the invocation references instead of falling back to the full snippet", () => {
+        // This body references SDK/stdlib types the call constructs inline (a UUID via
+        // UUID.fromString, a datetime via OffsetDateTime.parse, and an Optional wrapper), so the
+        // invocation must carry the corresponding imports. The previous invocation-only contract
+        // had no way to express this; now the imports are surfaced separately so docs can
+        // regenerate both the call and the imports it needs.
+        const response = generator.generateInvocationSync({
+            endpoint: {
+                method: "POST" as const,
+                path: "/object/get-and-return-with-optional-field"
+            },
+            baseURL: undefined,
+            environment: undefined,
+            auth: {
+                type: "bearer" as const,
+                token: "<YOUR_API_KEY>"
+            },
+            pathParameters: undefined,
+            queryParameters: undefined,
+            headers: undefined,
+            requestBody: {
+                string: "string",
+                integer: 1,
+                long: 1000000,
+                double: 1.1,
+                bool: true,
+                datetime: "2024-01-15T09:30:00Z",
+                date: "2023-01-15",
+                uuid: "d5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32",
+                base64: "SGVsbG8gd29ybGQh",
+                list: ["list", "list"],
+                set: ["set"],
+                map: { 1: "map" },
+                bigint: "1000000"
+            }
+        });
+
+        expect(response).not.toBeUndefined();
+        expect(response?.snippet).toContain("UUID.fromString");
+        expect(response?.snippet).toContain("OffsetDateTime.parse");
+        expect(response?.imports).toContain("import java.util.UUID;");
+        expect(response?.imports).toContain("import java.time.OffsetDateTime;");
+        expect(response?.imports).toContain("import java.util.Optional;");
+        expect(response?.errors).toBeUndefined();
+    });
+});

--- a/generators/java-v2/dynamic-snippets/src/__test__/InvocationSnippet.test.ts
+++ b/generators/java-v2/dynamic-snippets/src/__test__/InvocationSnippet.test.ts
@@ -63,6 +63,17 @@ describe("invocation-only snippets", () => {
         expect(response?.clientName).toBe("AcmeAcmeClient");
     });
 
+    it("exposes the client import so docs can render the client construction without authoring it", () => {
+        const response = generator.generateInvocationSync(request);
+
+        // The client import is distinct from `imports` (which only carries imports the bare call
+        // references). It imports the generated client class itself so docs can render `new
+        // AcmeAcmeClient(...)` alongside the invocation.
+        expect(response?.clientImport).toContain("import ");
+        expect(response?.clientImport).toContain(`${response?.clientName};`);
+        expect(response?.clientImport?.trim().endsWith(";")).toBe(true);
+    });
+
     it("invokes the endpoint on the requested client variable", () => {
         const response = generator.generateInvocationSync(request, { clientVariableName: "mailchimp" });
 

--- a/generators/java/sdk/changes/unreleased/invocation-only-dynamic-snippets.yml
+++ b/generators/java/sdk/changes/unreleased/invocation-only-dynamic-snippets.yml
@@ -1,0 +1,21 @@
+# yaml-language-server: $schema=../../../../../fern-changes-yml.schema.json
+
+- summary: |
+    Generate invocation-only dynamic snippets. In addition to the full snippet
+    (client construction plus the call), the generator now exposes the structured
+    pieces a caller can render inside code it already owns (e.g. a documentation
+    code template): the bare invocation (`client.endpoints().update(...)`, honoring
+    a custom client variable name), the Java `import ...;` block that invocation
+    references (empty string when none), and the generated client class name so
+    docs can render `<ClientName> client = <ClientName>.builder()...` and track
+    renames.
+
+    Imports are captured separately from the call via a new
+    `java.renderNodeWithoutImports` helper and `JavaFile.getRenderedImports()`, the
+    Java analogue of the TypeScript AST's `toStringWithoutImports`. Invocations that
+    construct imported types inline (e.g. a body value built with
+    `UUID.fromString(...)`, `OffsetDateTime.parse(...)`, or `Optional.of(...)`)
+    surface those imports rather than falling back to the complete snippet. Unlike
+    the Go SDK (whose methods take a leading `context.Context`), a plain Java
+    invocation references no imports, so a bare call returns an empty import block.
+  type: feat


### PR DESCRIPTION
## Summary

Populates the optional `clientImport` field on `InvocationSnippetResponse` for the **Java** dynamic-snippets invocation generator, mirroring the TypeScript implementation on the base branch.

`generateInvocationSnippetSync` now renders a bare reference to the generated root client class (`getRootClientClassReference`) via the existing `java.renderNodeWithoutImports` helper — rendered at the snippet package so the client's own package is not elided — and returns the resulting `import ...;` line as `clientImport`. This is distinct from `imports`, which only carries imports the bare call itself references. It lets docs render the client construction (`new AcmeAcmeClient(...)`) without hand-authoring the import. Empty string when the client needs no import.

The exact line(s) added:

```ts
const { imports: clientImport } = java.renderNodeWithoutImports({
    node: this.context.getRootClientClassReference(),
    packageName: config.fullStylePackageName ?? SNIPPET_PACKAGE_NAME,
    customConfig: this.context.customConfig,
    formatter: this.formatter
});
// returned as: clientImport
```

This PR also carries the cherry-picked Java invocation-only snippet commit (base for this work).

## Testing

- `pnpm turbo run compile --filter @fern-api/java-dynamic-snippets` — passes
- `vitest run src/__test__/InvocationSnippet.test.ts` — 6/6 pass, including a new `clientImport` assertion

Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/17451" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->