### PR TITLE
feat(php): invocation-only dynamic snippets + clientImport

### DIFF
--- a/generators/php/codegen/src/ast/core/AstNode.ts
+++ b/generators/php/codegen/src/ast/core/AstNode.ts
@@ -34,6 +34,40 @@ export abstract class AstNode extends AbstractAstNode {
     }
 
     /**
+     * Renders the node body separately from the `use ...;` block it references. This is the PHP
+     * analogue of the TypeScript AST's `toStringWithoutImports` (and the C# AST's
+     * `toStringWithoutImports` / the Java AST's `renderNodeWithoutImports`): `code` is the node's
+     * rendered body with no `namespace ...;` header and no leading `use` block, and `imports` is
+     * the rendered `use ...;` block the body would otherwise need (empty string when none).
+     *
+     * A single write pass populates the writer's references, so `code` and `imports` are computed
+     * from the same render — exactly the split `toString` performs internally when prepending the
+     * `use` block. This lets callers embed an invocation inside code they already own (e.g. a
+     * documentation code template) while surfacing the `use` statements the call requires.
+     */
+    public toStringWithoutImports({
+        namespace,
+        rootNamespace,
+        customConfig
+    }: {
+        namespace: string;
+        rootNamespace: string;
+        customConfig: BasePhpCustomConfigSchema;
+    }): { code: string; imports: string } {
+        const writer = new Writer({
+            namespace,
+            rootNamespace,
+            customConfig
+        });
+        this.write(writer);
+        return {
+            // `toString(true)` returns only the buffer (skipping the `namespace`/`use` block).
+            code: writer.toString(true),
+            imports: writer.importsToString()
+        };
+    }
+
+    /**
      * Writes the node to a string.
      */
     public async toStringAsync({

--- a/generators/php/codegen/src/ast/core/Writer.ts
+++ b/generators/php/codegen/src/ast/core/Writer.ts
@@ -90,6 +90,16 @@ ${this.buffer}`;
         return namespace + "\n\n" + this.buffer;
     }
 
+    /**
+     * Returns only the `use ...;` import block the written buffer references (no `namespace ...;`
+     * header and no body), or an empty string when the buffer references no imports. This lets a
+     * caller render a node's body separately from the imports it requires — see
+     * {@link AstNode.toStringWithoutImports}.
+     */
+    public importsToString(): string {
+        return this.stringifyImports();
+    }
+
     private stringifyImports(): string {
         const referenceKeys = Object.keys(this.references);
         if (referenceKeys.length === 0) {

--- a/generators/php/dynamic-snippets/src/EndpointSnippetGenerator.ts
+++ b/generators/php/dynamic-snippets/src/EndpointSnippetGenerator.ts
@@ -1,4 +1,11 @@
-import { AbstractAstNode, NamedArgument, Options, Scope, Severity } from "@fern-api/browser-compatible-base-generator";
+import {
+    AbstractAstNode,
+    InvocationSnippetResponse,
+    NamedArgument,
+    Options,
+    Scope,
+    Severity
+} from "@fern-api/browser-compatible-base-generator";
 import { assertNever } from "@fern-api/core-utils";
 import { FernIr } from "@fern-api/dynamic-ir-sdk";
 import { php } from "@fern-api/php-codegen";
@@ -68,6 +75,49 @@ export class EndpointSnippetGenerator {
         return this.buildCodeBlock({ endpoint, snippet: request });
     }
 
+    /**
+     * Generates the structured pieces of an endpoint invocation for callers that render the
+     * invocation within code of their own (e.g. a documentation code template): the bare call
+     * (e.g. `$client->plants->update(...)`), the `use ...;` block the call requires, and the
+     * generated client class name.
+     */
+    public generateInvocationSnippetSync({
+        endpoint,
+        request,
+        options
+    }: {
+        endpoint: FernIr.dynamic.Endpoint;
+        request: FernIr.dynamic.EndpointSnippetRequest;
+        options?: Options;
+    }): InvocationSnippetResponse {
+        const invocation = this.callMethod({
+            endpoint,
+            snippet: request,
+            clientVariableName: options?.clientVariableName
+        });
+        // The caller supplies the client and terminates the statement themselves, so the
+        // invocation is emitted as a bare expression: no `$client = new ...Client(...)`
+        // construction, no `<?php` prefix or `namespace ...;` header, and no trailing `;`. When
+        // the call references types from another namespace (e.g. an inlined request class or a
+        // typed body value) the `use ...;` block it needs is surfaced separately so the caller
+        // can render it rather than falling back to the complete snippet.
+        const { code, imports } = invocation.toStringWithoutImports({
+            namespace: SNIPPET_NAMESPACE,
+            rootNamespace: SNIPPET_NAMESPACE,
+            customConfig: this.context.customConfig ?? {}
+        });
+        return {
+            snippet: this.stripTrailingSemicolon(code.trim()),
+            imports,
+            clientName: this.context.getRootClientClassName(),
+            errors: this.context.errors.empty() ? undefined : this.context.errors.toDynamicSnippetErrors()
+        };
+    }
+
+    private stripTrailingSemicolon(code: string): string {
+        return code.endsWith(";") ? code.slice(0, -1).trimEnd() : code;
+    }
+
     public buildCodeBlock({
         endpoint,
         snippet
@@ -109,13 +159,15 @@ export class EndpointSnippetGenerator {
 
     private callMethod({
         endpoint,
-        snippet
+        snippet,
+        clientVariableName
     }: {
         endpoint: FernIr.dynamic.Endpoint;
         snippet: FernIr.dynamic.EndpointSnippetRequest;
+        clientVariableName?: string;
     }): php.MethodInvocation {
         return php.invokeMethod({
-            on: php.codeblock(CLIENT_VAR_NAME),
+            on: php.codeblock(clientVariableName ?? CLIENT_VAR_NAME),
             method: this.getMethod({ endpoint }),
             arguments_: this.getMethodArgs({ endpoint, snippet }),
             multiline: true

--- a/generators/php/dynamic-snippets/src/EndpointSnippetGenerator.ts
+++ b/generators/php/dynamic-snippets/src/EndpointSnippetGenerator.ts
@@ -106,10 +106,28 @@ export class EndpointSnippetGenerator {
             rootNamespace: SNIPPET_NAMESPACE,
             customConfig: this.context.customConfig ?? {}
         });
+        // Render a bare reference to the generated root client class and capture the `use ...;`
+        // statement it requires, so docs can render the client import (e.g. `use Acme\AcmeClient;`)
+        // without hand-authoring it. Distinct from `imports`, which only carries the imports the
+        // bare call itself references. Empty string when the client needs no import.
+        const clientReference = php.codeblock((writer) => {
+            writer.writeNode(
+                php.classReference({
+                    name: this.context.getRootClientClassName(),
+                    namespace: this.context.rootNamespace
+                })
+            );
+        });
+        const { imports: clientImport } = clientReference.toStringWithoutImports({
+            namespace: SNIPPET_NAMESPACE,
+            rootNamespace: SNIPPET_NAMESPACE,
+            customConfig: this.context.customConfig ?? {}
+        });
         return {
             snippet: this.stripTrailingSemicolon(code.trim()),
             imports,
             clientName: this.context.getRootClientClassName(),
+            clientImport,
             errors: this.context.errors.empty() ? undefined : this.context.errors.toDynamicSnippetErrors()
         };
     }

--- a/generators/php/dynamic-snippets/src/__test__/InvocationSnippet.test.ts
+++ b/generators/php/dynamic-snippets/src/__test__/InvocationSnippet.test.ts
@@ -64,6 +64,14 @@ describe("invocation-only snippets", () => {
         expect(response?.clientName).toBe("AcmeClient");
     });
 
+    it("exposes the client's own `use` statement so docs can render the client import", () => {
+        const response = generator.generateInvocationSync(request);
+
+        // Distinct from `imports` (which only carries what the bare call references), `clientImport`
+        // is the `use ...;` statement for the generated root client class itself.
+        expect(response?.clientImport).toBe("use Acme\\AcmeClient;");
+    });
+
     it("invokes the endpoint on the requested client variable", () => {
         const response = generator.generateInvocationSync(request, { clientVariableName: "$mailchimp" });
 

--- a/generators/php/dynamic-snippets/src/__test__/InvocationSnippet.test.ts
+++ b/generators/php/dynamic-snippets/src/__test__/InvocationSnippet.test.ts
@@ -1,0 +1,117 @@
+import { AbsoluteFilePath, join } from "@fern-api/path-utils";
+
+import { buildDynamicSnippetsGenerator } from "./utils/buildDynamicSnippetsGenerator.js";
+import { buildGeneratorConfig } from "./utils/buildGeneratorConfig.js";
+
+const DYNAMIC_IR_TEST_DEFINITIONS_DIRECTORY = AbsoluteFilePath.of(
+    `${__dirname}/../../../../../packages/cli/generation/ir-generator-tests/src/dynamic-snippets/__test__/test-definitions`
+);
+
+// invocation-only snippets are rendered inside code the caller already owns (e.g. a
+// documentation code template), so they must not include client instantiation, the `<?php`
+// prefix, or the `namespace ...;` header. The `use ...;` block the call references is surfaced
+// separately in the `imports` field. A plain PHP invocation references no imports, so `imports`
+// is empty for a bare call and only populated when the invocation constructs types from another
+// namespace inline (e.g. an inlined request class).
+describe("invocation-only snippets", () => {
+    const generator = buildDynamicSnippetsGenerator({
+        irFilepath: AbsoluteFilePath.of(join(DYNAMIC_IR_TEST_DEFINITIONS_DIRECTORY, "exhaustive.json")),
+        config: buildGeneratorConfig({})
+    });
+
+    const request = {
+        endpoint: {
+            method: "GET" as const,
+            path: "/http-methods/{id}"
+        },
+        baseURL: undefined,
+        environment: undefined,
+        auth: {
+            type: "bearer" as const,
+            token: "<YOUR_API_KEY>"
+        },
+        pathParameters: {
+            id: "id"
+        },
+        queryParameters: undefined,
+        headers: undefined,
+        requestBody: undefined
+    };
+
+    it("generates the invocation without client instantiation, php prefix, or namespace header", () => {
+        const response = generator.generateInvocationSync(request);
+
+        expect(response?.snippet).toBe("$client->endpoints->httpMethods->testGet(\n    'id',\n)");
+        // The invocation is a bare expression: no `$client = new ...Client(...)` construction, no
+        // `<?php` prefix, no `namespace ...;` / `use ...;` block, and no trailing `;`.
+        expect(response?.snippet).not.toContain("= new ");
+        expect(response?.snippet).not.toContain("<?php");
+        expect(response?.snippet).not.toContain("namespace ");
+        expect(response?.snippet).not.toContain("use ");
+        expect(response?.snippet.endsWith(";")).toBe(false);
+        expect(response?.errors).toBeUndefined();
+    });
+
+    it("returns no imports for a bare call that references none", () => {
+        const response = generator.generateInvocationSync(request);
+
+        expect(response?.imports).toBe("");
+    });
+
+    it("exposes the generated client class name so docs can render the client instantiation", () => {
+        const response = generator.generateInvocationSync(request);
+
+        expect(response?.clientName).toBe("AcmeClient");
+    });
+
+    it("invokes the endpoint on the requested client variable", () => {
+        const response = generator.generateInvocationSync(request, { clientVariableName: "$mailchimp" });
+
+        expect(response?.snippet).toBe("$mailchimp->endpoints->httpMethods->testGet(\n    'id',\n)");
+    });
+
+    it("surfaces the use block the invocation references instead of falling back to the full snippet", () => {
+        // This body constructs an inlined request class that lives in another namespace, so the
+        // invocation must carry the corresponding `use ...;` statement. The previous
+        // invocation-only contract had no way to express this; now the imports are surfaced
+        // separately so docs can regenerate both the call and the `use` statements it needs.
+        const response = generator.generateInvocationSync({
+            endpoint: {
+                method: "POST" as const,
+                path: "/object/get-and-return-with-optional-field"
+            },
+            baseURL: undefined,
+            environment: undefined,
+            auth: {
+                type: "bearer" as const,
+                token: "<YOUR_API_KEY>"
+            },
+            pathParameters: undefined,
+            queryParameters: undefined,
+            headers: undefined,
+            requestBody: {
+                string: "string",
+                integer: 1,
+                long: 1000000,
+                double: 1.1,
+                bool: true,
+                datetime: "2024-01-15T09:30:00Z",
+                date: "2023-01-15",
+                uuid: "d5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32",
+                base64: "SGVsbG8gd29ybGQh",
+                list: ["list", "list"],
+                set: ["set"],
+                map: { 1: "map" },
+                bigint: "1000000"
+            }
+        });
+
+        expect(response).not.toBeUndefined();
+        // The call constructs the inlined request class inline, so its `use` is surfaced.
+        expect(response?.snippet).toContain("new ObjectWithOptionalField(");
+        expect(response?.imports).toContain("use Acme\\Types\\Object\\Types\\ObjectWithOptionalField;");
+        // The datetime body value constructs a `DateTime`, whose `use` is surfaced too.
+        expect(response?.imports).toContain("use DateTime;");
+        expect(response?.errors).toBeUndefined();
+    });
+});

--- a/generators/php/sdk/changes/unreleased/invocation-only-dynamic-snippets.yml
+++ b/generators/php/sdk/changes/unreleased/invocation-only-dynamic-snippets.yml
@@ -1,0 +1,22 @@
+# yaml-language-server: $schema=../../../../../fern-changes-yml.schema.json
+
+- summary: |
+    Generate invocation-only dynamic snippets. In addition to the full snippet
+    (client construction plus the call), the generator now exposes the structured
+    pieces a caller can render inside code it already owns (e.g. a documentation
+    code template): the bare invocation (`$client->endpoints->update(...)`,
+    honoring a custom client variable name), the PHP `use ...;` block that
+    invocation references (empty string when none), and the generated client class
+    name so docs can render `$client = new <ClientName>(...)` and track renames.
+
+    The `use` block is captured separately from the call via a new
+    `AstNode.toStringWithoutImports` helper (backed by `Writer.importsToString`),
+    the PHP analogue of the TypeScript AST's `toStringWithoutImports` (and the C#
+    AST's `toStringWithoutImports` / the Java AST's `renderNodeWithoutImports`): a
+    single render pass yields the node body (without the `<?php` prefix or
+    `namespace ...;` header) and the `use ...;` statements it references.
+    Invocations that construct types from another namespace inline (e.g. an inlined
+    request class or a `DateTime` body value) surface those `use` statements rather
+    than falling back to the complete snippet. A plain PHP invocation that
+    references no other namespaces returns an empty `use` block.
+  type: feat


### PR DESCRIPTION
## Summary

Populates the optional `clientImport` field on `InvocationSnippetResponse` for the PHP dynamic-snippets invocation generator, mirroring the TypeScript port on the base branch.

The PHP generator now renders a bare reference to the generated root client class and captures the `use ...;` statement it requires via `AstNode.toStringWithoutImports` — the same helper that already backs the existing `imports` field. This is distinct from `imports`, which only carries imports the bare call itself references; `clientImport` is the client's own import. Empty string when the client needs no import. This lets docs render the client import (e.g. `use Acme\AcmeClient;`) without hand-authoring it.

## Changes

- `generators/php/dynamic-snippets/src/EndpointSnippetGenerator.ts`: build a bare root-client-class reference and set `clientImport` from its rendered `use ...;` block.
- `generators/php/dynamic-snippets/src/__test__/InvocationSnippet.test.ts`: assert `clientImport === "use Acme\\AcmeClient;"`.

## Testing

- `pnpm turbo run compile --filter @fern-api/php-dynamic-snippets` — passes.
- Package vitest suite — 44/44 pass (including the new `clientImport` assertion). No snapshot churn.

Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/17452" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->