### PR TITLE
feat(ruby): invocation-only dynamic snippets + clientImport

### DIFF
--- a/generators/ruby-v2/dynamic-snippets/src/EndpointSnippetGenerator.ts
+++ b/generators/ruby-v2/dynamic-snippets/src/EndpointSnippetGenerator.ts
@@ -6,7 +6,7 @@ import {
 } from "@fern-api/browser-compatible-base-generator";
 import { assertNever } from "@fern-api/core-utils";
 import { FernIr } from "@fern-api/dynamic-ir-sdk";
-import { ruby } from "@fern-api/ruby-ast";
+import { RubyFile, ruby } from "@fern-api/ruby-ast";
 
 import { DynamicSnippetsGeneratorContext } from "./context/DynamicSnippetsGeneratorContext.js";
 
@@ -111,9 +111,26 @@ export class EndpointSnippetGenerator {
             // Always empty for Ruby — see the method doc comment: types are referenced via the gem
             // namespace, so a bare invocation emits no per-symbol requires.
             imports: "",
+            // The Ruby analogue of the root-client import: referencing the root client class requires
+            // the gem's top-level `require`, which {@link constructClient} adds via
+            // `writer.addRequire(this.context.getRootModuleName().toLowerCase())`. We surface the same
+            // require line here so callers embedding a bare invocation can prepend it.
+            clientImport: this.getRootClientRequire(),
             clientName: this.context.getRootClientClassName(),
             errors: this.context.errors.empty() ? undefined : this.context.errors.toDynamicSnippetErrors()
         };
+    }
+
+    /**
+     * Renders the `require` statement needed to reference the root client class, mirroring the
+     * require {@link constructClient} adds to the writer. Ruby's require set is stringified as
+     * `require "<path>"` (see {@link ruby.RubyFile}), so we render through a `RubyFile` to keep the
+     * exact format in a single source of truth rather than hardcoding the quoting here.
+     */
+    private getRootClientRequire(): string {
+        const file = new RubyFile({ customConfig: this.context.customConfig ?? {} });
+        file.addRequire(this.context.getRootModuleName().toLowerCase());
+        return file.toString().trim();
     }
 
     private buildCodeBlock({

--- a/generators/ruby-v2/dynamic-snippets/src/EndpointSnippetGenerator.ts
+++ b/generators/ruby-v2/dynamic-snippets/src/EndpointSnippetGenerator.ts
@@ -1,4 +1,9 @@
-import { AbstractFormatter, Options, Severity } from "@fern-api/browser-compatible-base-generator";
+import {
+    AbstractFormatter,
+    InvocationSnippetResponse,
+    Options,
+    Severity
+} from "@fern-api/browser-compatible-base-generator";
 import { assertNever } from "@fern-api/core-utils";
 import { FernIr } from "@fern-api/dynamic-ir-sdk";
 import { ruby } from "@fern-api/ruby-ast";
@@ -58,6 +63,57 @@ export class EndpointSnippetGenerator {
             return this.buildCodeBlockWithoutClient({ endpoint, snippet: request });
         }
         return this.buildCodeBlock({ endpoint, snippet: request });
+    }
+
+    /**
+     * Generates the structured pieces of an endpoint invocation for callers that render the
+     * invocation within code of their own (e.g. a documentation code template): the bare call
+     * (e.g. `client.plants.update(...)`, honoring a custom client variable name), the imports the
+     * call requires, and the generated client class name.
+     *
+     * Ruby's `imports` is always the empty string. Unlike TypeScript/PHP/C#/Java — where a call
+     * that references a type from another namespace must emit a per-symbol import/`use` line — a
+     * generated Ruby SDK references every type through the gem's module namespace (e.g.
+     * `Acme::Types::Foo`), so a bare invocation never emits a `require`. The generator's only
+     * `require` (`require "acme"`, added in {@link constructClient}) belongs to the client
+     * construction the caller owns, not to the invocation. There is therefore no import-referencing
+     * invocation case to surface for Ruby, so we return `""` rather than inventing an imports
+     * mechanism the language does not have. This is the Ruby analogue of Go always emitting
+     * `context`, inverted: Ruby's invocation imports are always empty.
+     */
+    public generateInvocationSnippetSync({
+        endpoint,
+        request,
+        options
+    }: {
+        endpoint: FernIr.dynamic.Endpoint;
+        request: FernIr.dynamic.EndpointSnippetRequest;
+        options?: Options;
+    }): InvocationSnippetResponse {
+        const invocation = this.callMethod({
+            endpoint,
+            snippet: request,
+            clientVariableName: options?.clientVariableName
+        });
+        // Render only the invocation node: no `client = Acme::Client.new(...)` construction and no
+        // `require` preamble. Ruby has no statement terminator to strip, but we trim defensively in
+        // case the writer ever introduces trailing whitespace/newlines.
+        const code = ruby
+            .codeblock((writer) => {
+                writer.writeNode(invocation);
+            })
+            .toString({
+                customConfig: this.context.customConfig ?? {},
+                formatter: this.formatter
+            });
+        return {
+            snippet: code.trim(),
+            // Always empty for Ruby — see the method doc comment: types are referenced via the gem
+            // namespace, so a bare invocation emits no per-symbol requires.
+            imports: "",
+            clientName: this.context.getRootClientClassName(),
+            errors: this.context.errors.empty() ? undefined : this.context.errors.toDynamicSnippetErrors()
+        };
     }
 
     private buildCodeBlock({
@@ -355,13 +411,15 @@ export class EndpointSnippetGenerator {
 
     private callMethod({
         endpoint,
-        snippet
+        snippet,
+        clientVariableName
     }: {
         endpoint: FernIr.dynamic.Endpoint;
         snippet: FernIr.dynamic.EndpointSnippetRequest;
+        clientVariableName?: string;
     }): ruby.MethodInvocation {
         const invokeMethodArgs: ruby.MethodInvocation.Args = {
-            on: ruby.codeblock(CLIENT_VAR_NAME),
+            on: ruby.codeblock(clientVariableName ?? CLIENT_VAR_NAME),
             method: this.getMethod({ endpoint }),
             arguments_: []
         };

--- a/generators/ruby-v2/dynamic-snippets/src/__test__/InvocationSnippet.test.ts
+++ b/generators/ruby-v2/dynamic-snippets/src/__test__/InvocationSnippet.test.ts
@@ -1,0 +1,114 @@
+import { AbsoluteFilePath, join } from "@fern-api/path-utils";
+
+import { buildDynamicSnippetsGenerator } from "./utils/buildDynamicSnippetsGenerator.js";
+import { buildGeneratorConfig } from "./utils/buildGeneratorConfig.js";
+
+const DYNAMIC_IR_TEST_DEFINITIONS_DIRECTORY = AbsoluteFilePath.of(
+    `${__dirname}/../../../../../packages/cli/generation/ir-generator-tests/src/dynamic-snippets/__test__/test-definitions`
+);
+
+// Invocation-only snippets are rendered inside code the caller already owns (e.g. a
+// documentation code template), so they must not include the client construction
+// (`client = Acme::Client.new(...)`) or the `require "acme"` preamble that construction emits.
+//
+// Ruby's `imports` field is always the empty string: a generated Ruby SDK references every type
+// through the gem's module namespace (e.g. `Acme::Types::Foo`), so a bare invocation never emits
+// a per-symbol `require`. Unlike TypeScript/PHP/C#/Java, Ruby has no import-referencing invocation
+// case to surface — this is the expected and correct result, the Ruby analogue of Go always
+// emitting `context`, inverted.
+describe("invocation-only snippets", () => {
+    const generator = buildDynamicSnippetsGenerator({
+        irFilepath: AbsoluteFilePath.of(join(DYNAMIC_IR_TEST_DEFINITIONS_DIRECTORY, "exhaustive.json")),
+        config: buildGeneratorConfig()
+    });
+
+    const request = {
+        endpoint: {
+            method: "GET" as const,
+            path: "/http-methods/{id}"
+        },
+        baseURL: undefined,
+        environment: undefined,
+        auth: {
+            type: "bearer" as const,
+            token: "<YOUR_API_KEY>"
+        },
+        pathParameters: {
+            id: "id"
+        },
+        queryParameters: undefined,
+        headers: undefined,
+        requestBody: undefined
+    };
+
+    it("generates the invocation without client construction or require preamble", () => {
+        const response = generator.generateInvocationSync(request);
+
+        expect(response?.snippet).toBe('client.endpoints.http_methods.test_get(id: "id")');
+        // The invocation is a bare expression: no `client = Acme::Client.new(...)` construction and
+        // no `require "..."` preamble (both belong to the client the caller owns).
+        expect(response?.snippet).not.toContain(".new(");
+        expect(response?.snippet).not.toContain("require ");
+        expect(response?.errors).toBeUndefined();
+    });
+
+    it("returns no imports for a Ruby invocation (types are referenced via the gem namespace)", () => {
+        const response = generator.generateInvocationSync(request);
+
+        // Always empty for Ruby: there is no per-symbol require to surface for a bare call.
+        expect(response?.imports).toBe("");
+    });
+
+    it("exposes the generated client class name so docs can render the client construction", () => {
+        const response = generator.generateInvocationSync(request);
+
+        expect(response?.clientName).toBe("Client");
+    });
+
+    it("invokes the endpoint on the requested client variable", () => {
+        const response = generator.generateInvocationSync(request, { clientVariableName: "mailchimp" });
+
+        expect(response?.snippet).toBe('mailchimp.endpoints.http_methods.test_get(id: "id")');
+    });
+
+    it("returns no imports even when the invocation constructs typed body values", () => {
+        // This body constructs typed values (datetime, uuid, nested lists/maps). In
+        // TypeScript/PHP/C#/Java such a call would surface per-symbol imports; in Ruby every type is
+        // referenced through the gem namespace, so `imports` remains empty. This documents that Ruby
+        // has no import-referencing invocation case.
+        const response = generator.generateInvocationSync({
+            endpoint: {
+                method: "POST" as const,
+                path: "/object/get-and-return-with-optional-field"
+            },
+            baseURL: undefined,
+            environment: undefined,
+            auth: {
+                type: "bearer" as const,
+                token: "<YOUR_API_KEY>"
+            },
+            pathParameters: undefined,
+            queryParameters: undefined,
+            headers: undefined,
+            requestBody: {
+                string: "string",
+                integer: 1,
+                long: 1000000,
+                double: 1.1,
+                bool: true,
+                datetime: "2024-01-15T09:30:00Z",
+                date: "2023-01-15",
+                uuid: "d5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32",
+                base64: "SGVsbG8gd29ybGQh",
+                list: ["list", "list"],
+                set: ["set"],
+                map: { 1: "map" },
+                bigint: "1000000"
+            }
+        });
+
+        expect(response).not.toBeUndefined();
+        expect(response?.imports).toBe("");
+        expect(response?.snippet).not.toContain("require ");
+    });
+});

--- a/generators/ruby-v2/dynamic-snippets/src/__test__/InvocationSnippet.test.ts
+++ b/generators/ruby-v2/dynamic-snippets/src/__test__/InvocationSnippet.test.ts
@@ -65,6 +65,17 @@ describe("invocation-only snippets", () => {
         expect(response?.clientName).toBe("Client");
     });
 
+    it("exposes the root-client require so callers can prepend it to a bare invocation", () => {
+        const response = generator.generateInvocationSync(request);
+
+        // Ruby references the root client class through the gem's top-level require. This is the Ruby
+        // analogue of the root-client import surfaced by TypeScript/PHP/C#/Java. Organization "acme"
+        // → module `Acme` → `require "acme"`.
+        expect(response?.clientImport).toBe('require "acme"');
+        // The bare invocation snippet itself still omits the require preamble.
+        expect(response?.snippet).not.toContain("require ");
+    });
+
     it("invokes the endpoint on the requested client variable", () => {
         const response = generator.generateInvocationSync(request, { clientVariableName: "mailchimp" });
 

--- a/generators/ruby/sdk/changes/unreleased/invocation-only-dynamic-snippets.yml
+++ b/generators/ruby/sdk/changes/unreleased/invocation-only-dynamic-snippets.yml
@@ -1,0 +1,21 @@
+# yaml-language-server: $schema=../../../../../fern-changes-yml.schema.json
+
+- summary: |
+    Generate invocation-only dynamic snippets. In addition to the full snippet
+    (client construction plus the call), the generator now exposes the structured
+    pieces a caller can render inside code it already owns (e.g. a documentation
+    code template): the bare invocation (`client.endpoints.update(...)`, honoring a
+    custom client variable name), the imports the invocation references, and the
+    generated client class name so docs can render the client construction and track
+    renames.
+
+    For Ruby the imports field is always the empty string: a generated Ruby SDK
+    references every type through the gem's module namespace (e.g.
+    `Acme::Types::Foo`), so a bare invocation never emits a per-symbol `require`.
+    Unlike TypeScript/PHP/C#/Java — where a call that references a type from another
+    namespace must emit an import/`use` line — Ruby has no import-referencing
+    invocation case to surface, so no imports mechanism is invented for it. The only
+    `require` a generated snippet emits (`require "acme"`) belongs to the client
+    construction the caller owns, not to the invocation, and is therefore omitted
+    from the invocation-only render.
+  type: feat


### PR DESCRIPTION
## Summary

Populates the optional `clientImport` field on the Ruby dynamic-snippets `InvocationSnippetResponse`, mirroring what TypeScript already does on the base branch.

Ruby has no per-symbol imports: a generated Ruby SDK references every type through the gem's module namespace, so the invocation `imports` field is intentionally always `""`. The Ruby analogue of the "import needed to reference the root client" is the gem's top-level `require` — the same require that `constructClient` adds to the writer. `clientImport` now surfaces that line (e.g. `require "acme"`) so callers embedding a bare invocation can prepend it. The bare invocation snippet itself continues to omit the require preamble.

### clientImport line
```ts
clientImport: this.getRootClientRequire(),
```
where
```ts
private getRootClientRequire(): string {
    const file = new RubyFile({ customConfig: this.context.customConfig ?? {} });
    file.addRequire(this.context.getRootModuleName().toLowerCase());
    return file.toString().trim();
}
```

## Testing
- `pnpm turbo run compile --filter @fern-api/ruby-dynamic-snippets` — pass
- `pnpm vitest run src/__test__/InvocationSnippet.test.ts` — 6/6 pass (added a `clientImport` assertion: organization `acme` → `require "acme"`)

Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/17453" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->