### PR TITLE
feat(swift): invocation-only dynamic snippets + clientImport

### DIFF
--- a/generators/swift/dynamic-snippets/src/EndpointSnippetGenerator.ts
+++ b/generators/swift/dynamic-snippets/src/EndpointSnippetGenerator.ts
@@ -1,4 +1,10 @@
-import { AbstractAstNode, Options, Scope, Severity } from "@fern-api/browser-compatible-base-generator";
+import {
+    AbstractAstNode,
+    InvocationSnippetResponse,
+    Options,
+    Scope,
+    Severity
+} from "@fern-api/browser-compatible-base-generator";
 import { assertNever } from "@fern-api/core-utils";
 import { FernIr } from "@fern-api/dynamic-ir-sdk";
 import { swift } from "@fern-api/swift-codegen";
@@ -48,6 +54,60 @@ export class EndpointSnippetGenerator {
         options?: Options;
     }): Promise<AbstractAstNode> {
         throw new Error("Unsupported");
+    }
+
+    /**
+     * Generates the structured pieces of an endpoint invocation for callers that render the
+     * invocation within code of their own (e.g. a documentation code template): the bare call
+     * (e.g. `try await client.endpoints.httpMethods.testGet(id: "id")`, honoring a custom client
+     * variable name), the imports the call requires, and the generated client class name.
+     *
+     * Swift's `imports` is always the empty string. Unlike TypeScript/PHP/C#/Java — whose AST tracks
+     * per-symbol imports and can surface the `import`/`using` lines a call references — the Swift AST
+     * (`@fern-api/swift-codegen`) has no per-node import mechanism at all: its {@link swift.Writer}
+     * is a plain buffer (no `getImports`/`importsToString`/`addImport`), and generated snippets
+     * reference every SDK type by a bare name that resolves through the two module-level imports
+     * emitted once by the scaffold — `import Foundation` and `import <Module>` (see
+     * {@link generateImportFoundationStatement} / {@link generateImportModuleStatement}). Those
+     * belong to the client construction the caller owns, not to the invocation. A bare invocation
+     * therefore emits no per-symbol `import`, so we return `""` rather than inventing an imports
+     * mechanism the language and its AST do not have. This mirrors the Ruby/Rust ports (types
+     * referenced via the module/gem namespace), not the C#/Java/PHP `{ code, imports }` helper
+     * pattern.
+     */
+    public generateInvocationSnippetSync({
+        endpoint,
+        request,
+        options
+    }: {
+        endpoint: FernIr.dynamic.Endpoint;
+        request: FernIr.dynamic.EndpointSnippetRequest;
+        options?: Options;
+    }): InvocationSnippetResponse {
+        // Render ONLY the invocation expression: no `let client = <Root>Client(...)` construction,
+        // no `private func main() async throws { ... }` scaffold, and no `import Foundation` /
+        // `import <Module>` preamble. We render the underlying Expression (not the Statement, which
+        // for a discard-assignment would prefix `_ = `).
+        const invocation = this.generateEndpointMethodCallExpression({
+            endpoint,
+            snippet: request,
+            clientVariableName: options?.clientVariableName
+        });
+        // Swift has no statement terminator, but strip a trailing `;` defensively so formatting or
+        // whitespace can never leak one into the invocation-only snippet.
+        const snippet = invocation.toString().trim().replace(/;$/, "").trim();
+        return {
+            snippet,
+            // Always empty for Swift — see the method doc comment: the AST has no per-symbol import
+            // mechanism and types resolve through the scaffold's module-level imports.
+            imports: "",
+            clientName: this.getClientName(),
+            errors: this.context.errors.empty() ? undefined : this.context.errors.toDynamicSnippetErrors()
+        };
+    }
+
+    private getClientName(): string {
+        return this.context.nameRegistry.getRootClientSymbolOrThrow().name;
     }
 
     private buildCodeBlock({
@@ -320,11 +380,13 @@ export class EndpointSnippetGenerator {
     public generateEndpointMethodCallExpression({
         endpoint,
         snippet,
-        additionalArguments = []
+        additionalArguments = [],
+        clientVariableName
     }: {
         endpoint: FernIr.dynamic.Endpoint;
         snippet: FernIr.dynamic.EndpointSnippetRequest;
         additionalArguments?: swift.FunctionArgument[];
+        clientVariableName?: string;
     }) {
         const nonNopArguments = this.getEndpointMethodArguments({ endpoint, snippet }).filter(
             (arg) => !arg.value.isNop()
@@ -333,7 +395,7 @@ export class EndpointSnippetGenerator {
         return swift.Expression.try(
             swift.Expression.await(
                 swift.Expression.methodCall({
-                    target: swift.Expression.rawValue(CLIENT_CONST_NAME),
+                    target: swift.Expression.rawValue(clientVariableName ?? CLIENT_CONST_NAME),
                     methodName: this.getEndpointMethodName({ endpoint }),
                     arguments_: arguments_,
                     multiline: arguments_.length > 1 ? true : undefined

--- a/generators/swift/dynamic-snippets/src/EndpointSnippetGenerator.ts
+++ b/generators/swift/dynamic-snippets/src/EndpointSnippetGenerator.ts
@@ -102,8 +102,19 @@ export class EndpointSnippetGenerator {
             // mechanism and types resolve through the scaffold's module-level imports.
             imports: "",
             clientName: this.getClientName(),
+            // The import a docs template needs to construct the root client. In Swift, both the
+            // client type and every SDK type it references resolve through a single whole-module
+            // import (`import <Module>`) — the same statement the full scaffold emits via
+            // `generateImportModuleStatement`. Unlike TypeScript/PHP/C#/Java (which import the
+            // client by symbol), Swift imports the whole module, so this is the module import
+            // rather than a per-symbol one. Rendered without a trailing newline for embedding.
+            clientImport: this.getClientImport(),
             errors: this.context.errors.empty() ? undefined : this.context.errors.toDynamicSnippetErrors()
         };
+    }
+
+    private getClientImport(): string {
+        return this.generateImportModuleStatement().toString().trim();
     }
 
     private getClientName(): string {

--- a/generators/swift/dynamic-snippets/src/__test__/InvocationSnippet.test.ts
+++ b/generators/swift/dynamic-snippets/src/__test__/InvocationSnippet.test.ts
@@ -74,6 +74,16 @@ describe("invocation-only snippets", () => {
         expect(response?.clientName).toBe("AcmeClient");
     });
 
+    it("exposes the whole-module import needed to construct the client", () => {
+        const response = generator.generateInvocationSync(request);
+
+        // Swift imports the whole module (not the client by symbol), so `clientImport` is the
+        // `import <Module>` statement the scaffold emits — the import a docs template needs to
+        // construct the client. Rendered without a trailing newline for embedding.
+        expect(response?.clientImport).toBe("import Acme");
+        expect(response?.clientImport?.endsWith("\n")).toBe(false);
+    });
+
     it("invokes the endpoint on the requested client variable", () => {
         const response = generator.generateInvocationSync(request, { clientVariableName: "mailchimp" });
 

--- a/generators/swift/dynamic-snippets/src/__test__/InvocationSnippet.test.ts
+++ b/generators/swift/dynamic-snippets/src/__test__/InvocationSnippet.test.ts
@@ -1,0 +1,123 @@
+import { AbsoluteFilePath, join } from "@fern-api/path-utils";
+
+import { buildDynamicSnippetsGenerator } from "./utils/buildDynamicSnippetsGenerator.js";
+import { buildGeneratorConfig } from "./utils/buildGeneratorConfig.js";
+
+const DYNAMIC_IR_TEST_DEFINITIONS_DIRECTORY = AbsoluteFilePath.of(
+    `${__dirname}/../../../../../packages/cli/generation/ir-generator-tests/src/dynamic-snippets/__test__/test-definitions`
+);
+
+// Invocation-only snippets are rendered inside code the caller already owns (e.g. a
+// documentation code template), so they must not include the client construction
+// (`let client = AcmeClient(...)`), the `private func main() async throws { ... }` scaffold, or the
+// `import Foundation` / `import <Module>` preamble that construction emits.
+//
+// Swift's `imports` field is always the empty string. The Swift AST (`@fern-api/swift-codegen`) has
+// no per-node import mechanism (its `Writer` is a plain buffer with no `getImports`/`addImport`);
+// generated snippets reference every SDK type by a bare name that resolves through the two
+// module-level imports emitted once by the scaffold (`import Foundation`, `import <Module>`). Those
+// belong to the client construction the caller owns, so a bare invocation surfaces no per-symbol
+// `import`. This mirrors the Ruby/Rust ports (types referenced via the module/gem namespace), not
+// the C#/Java/PHP `{ code, imports }` helper pattern.
+describe("invocation-only snippets", () => {
+    const generator = buildDynamicSnippetsGenerator({
+        irFilepath: AbsoluteFilePath.of(join(DYNAMIC_IR_TEST_DEFINITIONS_DIRECTORY, "exhaustive.json")),
+        config: buildGeneratorConfig()
+    });
+
+    const request = {
+        endpoint: {
+            method: "GET" as const,
+            path: "/http-methods/{id}"
+        },
+        baseURL: undefined,
+        environment: undefined,
+        auth: {
+            type: "bearer" as const,
+            token: "<YOUR_API_KEY>"
+        },
+        pathParameters: {
+            id: "id"
+        },
+        queryParameters: undefined,
+        headers: undefined,
+        requestBody: undefined
+    };
+
+    it("generates the invocation without client construction or scaffold", () => {
+        const response = generator.generateInvocationSync(request);
+
+        expect(response?.snippet).toBe('try await client.endpoints.httpMethods.testGet(id: "id")');
+        // The invocation is a bare expression: no `let client = AcmeClient(...)` construction, no
+        // `func main` scaffold, and no `import ...` preamble (all belong to the client the caller
+        // owns).
+        expect(response?.snippet).not.toContain("let client");
+        expect(response?.snippet).not.toContain("Client(");
+        expect(response?.snippet).not.toContain("func main");
+        expect(response?.snippet).not.toContain("import ");
+        // Swift has no statement terminator; ensure none leaks.
+        expect(response?.snippet.endsWith(";")).toBe(false);
+        expect(response?.errors).toBeUndefined();
+    });
+
+    it("returns no imports for a Swift invocation (types resolve via module-level imports)", () => {
+        const response = generator.generateInvocationSync(request);
+
+        // Always empty for Swift: the AST has no per-symbol import mechanism, and types resolve
+        // through the scaffold's `import Foundation` / `import <Module>` statements.
+        expect(response?.imports).toBe("");
+    });
+
+    it("exposes the generated client class name so docs can render the client construction", () => {
+        const response = generator.generateInvocationSync(request);
+
+        expect(response?.clientName).toBe("AcmeClient");
+    });
+
+    it("invokes the endpoint on the requested client variable", () => {
+        const response = generator.generateInvocationSync(request, { clientVariableName: "mailchimp" });
+
+        expect(response?.snippet).toBe('try await mailchimp.endpoints.httpMethods.testGet(id: "id")');
+    });
+
+    it("returns no imports even when the invocation constructs typed body values", () => {
+        // This body constructs typed values (Date, UUID, Data, dictionaries). In
+        // TypeScript/PHP/C#/Java such a call would surface per-symbol imports; in Swift every type
+        // resolves through the module-level imports, so `imports` remains empty. This documents that
+        // Swift has no import-referencing invocation case.
+        const response = generator.generateInvocationSync({
+            endpoint: {
+                method: "POST" as const,
+                path: "/object/get-and-return-with-optional-field"
+            },
+            baseURL: undefined,
+            environment: undefined,
+            auth: {
+                type: "bearer" as const,
+                token: "<YOUR_API_KEY>"
+            },
+            pathParameters: undefined,
+            queryParameters: undefined,
+            headers: undefined,
+            requestBody: {
+                string: "string",
+                integer: 1,
+                long: 1000000,
+                double: 1.1,
+                bool: true,
+                datetime: "2024-01-15T09:30:00Z",
+                date: "2023-01-15",
+                uuid: "d5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32",
+                base64: "SGVsbG8gd29ybGQh",
+                list: ["list", "list"],
+                set: ["set"],
+                map: { 1: "map" },
+                bigint: "1000000"
+            }
+        });
+
+        expect(response).not.toBeUndefined();
+        expect(response?.imports).toBe("");
+        expect(response?.snippet).not.toContain("import ");
+    });
+});

--- a/generators/swift/sdk/changes/unreleased/invocation-only-dynamic-snippets.yml
+++ b/generators/swift/sdk/changes/unreleased/invocation-only-dynamic-snippets.yml
@@ -1,0 +1,21 @@
+# yaml-language-server: $schema=../../../../../fern-changes-yml.schema.json
+
+- summary: |
+    Generate invocation-only dynamic snippets. In addition to the full snippet
+    (client construction plus the call), the generator now exposes the structured
+    pieces a caller can render inside code it already owns (e.g. a documentation
+    code template): the bare invocation
+    (`try await client.endpoints.httpMethods.testGet(id: "id")`, honoring a custom
+    client variable name), the imports the invocation references, and the generated
+    client class name so docs can render the client construction and track renames.
+
+    For Swift the imports field is always the empty string: the Swift AST has no
+    per-symbol import mechanism (its `Writer` is a plain buffer with no
+    `getImports`/`addImport`), and a generated Swift SDK resolves every type through
+    the two module-level imports (`import Foundation`, `import <Module>`) emitted once
+    by the client scaffold. Those belong to the client construction the caller owns,
+    not to the invocation, so a bare invocation never emits a per-symbol `import` and
+    no imports mechanism is invented for it. This mirrors the Ruby/Rust ports (types
+    referenced via the module/gem namespace), not the C#/Java/PHP `{ code, imports }`
+    helper pattern.
+  type: feat


### PR DESCRIPTION
## What

Populates the optional `clientImport` field on `InvocationSnippetResponse` for the Swift dynamic-snippets invocation generator, mirroring the TypeScript port.

## Details

Swift imports whole modules (`import <Module>`) rather than importing the client by symbol (as TS/PHP/C#/Java do). The client type and every SDK type it references resolve through a single module import. So `clientImport` is the `import <Module>` statement the scaffold already emits via `generateImportModuleStatement()`, rendered without a trailing newline for embedding in a docs template.

This is the import a docs template needs to construct the root client. It is distinct from the always-empty per-symbol `imports` field (a bare Swift invocation references no per-symbol import, since the Swift AST has no per-node import mechanism).

## Testing

- `pnpm turbo run compile --filter @fern-api/swift-dynamic-snippets` — passes (10/10 tasks)
- Package vitest — 39/39 pass, including a new assertion that `clientImport === "import Acme"` (and does not end in a newline)

Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/17454" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->