### PR TITLE
feat(go): invocation-only dynamic snippets + clientImport

### DIFF
--- a/generators/go-v2/ast/src/ast/core/GoFile.ts
+++ b/generators/go-v2/ast/src/ast/core/GoFile.ts
@@ -33,6 +33,17 @@ export class GoFile extends Writer {
         return content;
     }
 
+    /**
+     * The rendered `import (...)` block for the references written to this file, or an empty
+     * string when nothing references an import. This is the Go equivalent of separating a node's
+     * imports from its body: callers that render an invocation inside code they already own (e.g.
+     * a documentation code template) can surface the imports the call needs without the
+     * surrounding package/file scaffold.
+     */
+    public getImports(): string {
+        return this.stringifyImports();
+    }
+
     private getContent(): string {
         const packageStatement = `package ${this.packageName}\n\n`;
         const imports = this.stringifyImports();

--- a/generators/go-v2/ast/src/go.ts
+++ b/generators/go-v2/ast/src/go.ts
@@ -1,3 +1,6 @@
+import { AbstractFormatter } from "@fern-api/browser-compatible-base-generator";
+import { AstNode } from "./ast/core/AstNode.js";
+import { GoFile } from "./ast/core/GoFile.js";
 import {
     Alias,
     CodeBlock,
@@ -17,6 +20,7 @@ import {
     Switch,
     TypeDeclaration
 } from "./ast/index.js";
+import { BaseGoCustomConfigSchema } from "./custom-config/BaseGoCustomConfigSchema.js";
 
 export function alias(args: Alias.Args): Alias {
     return new Alias(args);
@@ -84,6 +88,41 @@ export function typeDeclaration(args: TypeDeclaration.Args): TypeDeclaration {
 
 export function typeReference(args: GoTypeReference.Args): GoTypeReference {
     return new GoTypeReference(args);
+}
+
+/**
+ * Renders a node separately from the imports it references, the Go analogue of separating a
+ * node's body from its `import (...)` block. `code` is the node's rendered body with no package
+ * statement and no import block, and `imports` is the rendered import block the body would
+ * otherwise need (empty string when none). This lets callers embed an invocation inside code
+ * they already own (e.g. a documentation code template) while surfacing the imports the call
+ * requires.
+ *
+ * The node is written into a file at the given `importPath` so imports are computed (and the
+ * target package elided) exactly as they would be in a generated file at that path, matching
+ * what the full snippet would emit.
+ */
+export function renderNodeWithoutImports({
+    node,
+    packageName,
+    rootImportPath,
+    importPath,
+    customConfig,
+    formatter
+}: {
+    node: AstNode;
+    packageName: string;
+    rootImportPath: string;
+    importPath: string;
+    customConfig: BaseGoCustomConfigSchema;
+    formatter?: AbstractFormatter;
+}): { code: string; imports: string } {
+    const file = new GoFile({ packageName, rootImportPath, importPath, customConfig, formatter });
+    node.write(file);
+    // The node's body is the writer buffer alone; the package statement and import block are
+    // added only by GoFile.getContent(). Returning the buffer yields just the invocation, and
+    // getImports() surfaces the import block the body references separately.
+    return { code: file.buffer.trimEnd(), imports: file.getImports() };
 }
 
 export { AstNode } from "./ast/core/AstNode.js";

--- a/generators/go-v2/dynamic-snippets/src/EndpointSnippetGenerator.ts
+++ b/generators/go-v2/dynamic-snippets/src/EndpointSnippetGenerator.ts
@@ -123,10 +123,31 @@ export class EndpointSnippetGenerator {
             customConfig: this.context.customConfig ?? {},
             formatter: this.formatter
         });
+        // The generated client type lives in its own package, so the caller needs the client's
+        // import in addition to any imports the bare call references. Rendering a lone reference
+        // to the root client type (with no other nodes) yields exactly that import block and
+        // nothing else, mirroring how `imports` is captured above.
+        const clientReference = go.codeblock((writer) => {
+            writer.writeNode(
+                go.typeReference({
+                    name: this.context.getClientName(),
+                    importPath: this.context.getClientImportPath()
+                })
+            );
+        });
+        const { imports: clientImport } = go.renderNodeWithoutImports({
+            node: clientReference,
+            packageName: SNIPPET_PACKAGE_NAME,
+            importPath: SNIPPET_IMPORT_PATH,
+            rootImportPath: this.context.rootImportPath,
+            customConfig: this.context.customConfig ?? {},
+            formatter: this.formatter
+        });
         return {
             snippet: code.trim(),
             imports,
             clientName: this.context.getClientName(),
+            clientImport,
             errors: this.context.errors.empty() ? undefined : this.context.errors.toDynamicSnippetErrors()
         };
     }

--- a/generators/go-v2/dynamic-snippets/src/EndpointSnippetGenerator.ts
+++ b/generators/go-v2/dynamic-snippets/src/EndpointSnippetGenerator.ts
@@ -1,4 +1,10 @@
-import { AbstractFormatter, Options, Scope, Severity } from "@fern-api/browser-compatible-base-generator";
+import {
+    AbstractFormatter,
+    InvocationSnippetResponse,
+    Options,
+    Scope,
+    Severity
+} from "@fern-api/browser-compatible-base-generator";
 import { assertNever } from "@fern-api/core-utils";
 import { FernIr } from "@fern-api/dynamic-ir-sdk";
 import { go } from "@fern-api/go-ast";
@@ -81,6 +87,48 @@ export class EndpointSnippetGenerator {
         options?: Options;
     }): Promise<go.AstNode> {
         throw new Error("Unsupported");
+    }
+
+    /**
+     * Generates the structured pieces of an endpoint invocation for callers that render the
+     * invocation within code of their own (e.g. a documentation code template): the bare call
+     * (e.g. `client.plants.Update(...)`), the imports the call requires, and the generated
+     * client type name.
+     */
+    public generateInvocationSnippetSync({
+        endpoint,
+        request,
+        options
+    }: {
+        endpoint: FernIr.dynamic.Endpoint;
+        request: FernIr.dynamic.EndpointSnippetRequest;
+        options?: Options;
+    }): InvocationSnippetResponse {
+        const invocation = this.callMethod({
+            endpoint,
+            snippet: request,
+            clientVariableName: options?.clientVariableName
+        });
+        // The caller supplies the client and terminates the statement themselves, so the
+        // invocation is emitted as a bare expression with no client construction, no package or
+        // import scaffold, and no trailing terminator. When the call references SDK or stdlib
+        // types (e.g. a body value constructed with `time.Time` or a UUID) the imports it needs
+        // are surfaced separately so the caller can render them rather than falling back to the
+        // complete snippet.
+        const { code, imports } = go.renderNodeWithoutImports({
+            node: invocation,
+            packageName: SNIPPET_PACKAGE_NAME,
+            importPath: SNIPPET_IMPORT_PATH,
+            rootImportPath: this.context.rootImportPath,
+            customConfig: this.context.customConfig ?? {},
+            formatter: this.formatter
+        });
+        return {
+            snippet: code.trim(),
+            imports,
+            clientName: this.context.getClientName(),
+            errors: this.context.errors.empty() ? undefined : this.context.errors.toDynamicSnippetErrors()
+        };
     }
 
     private generateWiremockTest({
@@ -214,13 +262,16 @@ export class EndpointSnippetGenerator {
         writer,
         endpoint,
         snippet,
-        includeTestIdHeader
+        includeTestIdHeader,
+        clientVariableName
     }: {
         writer: go.Writer;
         endpoint: FernIr.dynamic.Endpoint;
         snippet: FernIr.dynamic.EndpointSnippetRequest;
         includeTestIdHeader?: boolean;
+        clientVariableName?: string;
     }): void {
+        const clientVar = clientVariableName ?? CLIENT_VAR_NAME;
         const { otherArgs, requestArg } = this.getMethodArgs({ endpoint, snippet });
         const optionArgsInvocation = includeTestIdHeader
             ? [
@@ -242,7 +293,7 @@ export class EndpointSnippetGenerator {
             if (requestArg instanceof go.TypeInstantiation && go.TypeInstantiation.isNop(requestArg)) {
                 writer.writeNode(
                     go.invokeMethod({
-                        on: go.codeblock(CLIENT_VAR_NAME),
+                        on: go.codeblock(clientVar),
                         method: this.getMethod({ endpoint }),
                         arguments_: [
                             this.context.getContextTodoFunctionInvocation(),
@@ -260,7 +311,7 @@ export class EndpointSnippetGenerator {
                 const requestRef = go.codeblock("request");
                 writer.writeNode(
                     go.invokeMethod({
-                        on: go.codeblock(CLIENT_VAR_NAME),
+                        on: go.codeblock(clientVar),
                         method: this.getMethod({ endpoint }),
                         arguments_: [
                             this.context.getContextTodoFunctionInvocation(),
@@ -274,7 +325,7 @@ export class EndpointSnippetGenerator {
         } else {
             writer.writeNode(
                 go.invokeMethod({
-                    on: go.codeblock(CLIENT_VAR_NAME),
+                    on: go.codeblock(clientVar),
                     method: this.getMethod({ endpoint }),
                     arguments_: [this.context.getContextTodoFunctionInvocation(), ...otherArgs, ...optionArgsInvocation]
                 })
@@ -284,13 +335,15 @@ export class EndpointSnippetGenerator {
 
     private callMethod({
         endpoint,
-        snippet
+        snippet,
+        clientVariableName
     }: {
         endpoint: FernIr.dynamic.Endpoint;
         snippet: FernIr.dynamic.EndpointSnippetRequest;
+        clientVariableName?: string;
     }): go.CodeBlock {
         return go.codeblock((writer) => {
-            this.writeMethodInvocation({ writer, endpoint, snippet });
+            this.writeMethodInvocation({ writer, endpoint, snippet, clientVariableName });
         });
     }
 

--- a/generators/go-v2/dynamic-snippets/src/__test__/InvocationSnippet.test.ts
+++ b/generators/go-v2/dynamic-snippets/src/__test__/InvocationSnippet.test.ts
@@ -1,0 +1,116 @@
+import { AbsoluteFilePath, join } from "@fern-api/path-utils";
+
+import { buildDynamicSnippetsGenerator } from "./utils/buildDynamicSnippetsGenerator.js";
+import { buildGeneratorConfig } from "./utils/buildGeneratorConfig.js";
+
+const DYNAMIC_IR_TEST_DEFINITIONS_DIRECTORY = AbsoluteFilePath.of(
+    `${__dirname}/../../../../../packages/cli/generation/ir-generator-tests/src/dynamic-snippets/__test__/test-definitions`
+);
+
+// invocation-only snippets are rendered inside code the caller already owns (e.g. a
+// documentation code template), so they must not include client instantiation or the
+// surrounding package/import scaffold. The imports the call references are surfaced
+// separately in the `imports` field. Note that Go SDK methods always take a leading
+// `context.Context`, so even a "bare" call legitimately references the `context` import.
+describe("invocation-only snippets", () => {
+    const generator = buildDynamicSnippetsGenerator({
+        irFilepath: AbsoluteFilePath.of(join(DYNAMIC_IR_TEST_DEFINITIONS_DIRECTORY, "exhaustive.json")),
+        config: buildGeneratorConfig({})
+    });
+
+    const request = {
+        endpoint: {
+            method: "GET" as const,
+            path: "/http-methods/{id}"
+        },
+        baseURL: undefined,
+        environment: undefined,
+        auth: {
+            type: "bearer" as const,
+            token: "<YOUR_API_KEY>"
+        },
+        pathParameters: {
+            id: "id"
+        },
+        queryParameters: undefined,
+        headers: undefined,
+        requestBody: undefined
+    };
+
+    it("generates the invocation without client instantiation or package scaffold", () => {
+        const response = generator.generateInvocationSync(request);
+
+        expect(response?.snippet).toBe('client.Endpoints.HTTPMethods.TestGet(\n    context.TODO(),\n    "id",\n)');
+        // The invocation is a bare expression: no `client := acme.NewClient(...)` construction,
+        // no `package`/`func` wrapper, and no import block inlined into the call.
+        expect(response?.snippet).not.toContain("NewClient");
+        expect(response?.snippet).not.toContain("package ");
+        expect(response?.snippet).not.toContain("import (");
+        expect(response?.errors).toBeUndefined();
+    });
+
+    it("surfaces the imports the invocation references instead of inlining them", () => {
+        const response = generator.generateInvocationSync(request);
+
+        // Every Go SDK method takes a leading context.Context, so the call references the
+        // `context` import; it is returned separately so docs can render it alongside the call.
+        expect(response?.imports).toContain('context "context"');
+        expect(response?.imports).toContain("import (");
+    });
+
+    it("exposes the generated client type name so docs can render the client instantiation", () => {
+        const response = generator.generateInvocationSync(request);
+
+        expect(response?.clientName).toBe("Client");
+    });
+
+    it("invokes the endpoint on the requested client variable", () => {
+        const response = generator.generateInvocationSync(request, { clientVariableName: "mailchimp" });
+
+        expect(response?.snippet).toBe('mailchimp.Endpoints.HTTPMethods.TestGet(\n    context.TODO(),\n    "id",\n)');
+    });
+
+    it("returns the imports the invocation references instead of falling back to the full snippet", () => {
+        // This body references SDK/stdlib types the call constructs inline (a UUID via
+        // uuid.MustParse and datetimes via the SDK helpers), so the invocation must carry the
+        // corresponding imports. The previous invocation-only contract had no way to express
+        // this; now the imports are surfaced separately so docs can regenerate both the call
+        // and the imports it needs.
+        const response = generator.generateInvocationSync({
+            endpoint: {
+                method: "POST" as const,
+                path: "/object/get-and-return-with-optional-field"
+            },
+            baseURL: undefined,
+            environment: undefined,
+            auth: {
+                type: "bearer" as const,
+                token: "<YOUR_API_KEY>"
+            },
+            pathParameters: undefined,
+            queryParameters: undefined,
+            headers: undefined,
+            requestBody: {
+                string: "string",
+                integer: 1,
+                long: 1000000,
+                double: 1.1,
+                bool: true,
+                datetime: "2024-01-15T09:30:00Z",
+                date: "2023-01-15",
+                uuid: "d5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32",
+                base64: "SGVsbG8gd29ybGQh",
+                list: ["list", "list"],
+                set: ["set"],
+                map: { 1: "map" },
+                bigint: "1000000"
+            }
+        });
+
+        expect(response).not.toBeUndefined();
+        expect(response?.snippet).toContain("uuid.MustParse");
+        expect(response?.imports).toContain('uuid "github.com/google/uuid"');
+        expect(response?.imports).toContain('context "context"');
+        expect(response?.errors).toBeUndefined();
+    });
+});

--- a/generators/go-v2/dynamic-snippets/src/__test__/InvocationSnippet.test.ts
+++ b/generators/go-v2/dynamic-snippets/src/__test__/InvocationSnippet.test.ts
@@ -64,6 +64,16 @@ describe("invocation-only snippets", () => {
         expect(response?.clientName).toBe("Client");
     });
 
+    it("exposes the client import so docs can render the client instantiation", () => {
+        const response = generator.generateInvocationSync(request);
+
+        // clientImport is distinct from `imports`: it carries the import for the generated
+        // client type itself (its own package), so docs can render `client := <pkg>.NewClient(...)`
+        // without hand-authoring the client import.
+        expect(response?.clientImport).toContain("import (");
+        expect(response?.clientImport).toContain("/client");
+    });
+
     it("invokes the endpoint on the requested client variable", () => {
         const response = generator.generateInvocationSync(request, { clientVariableName: "mailchimp" });
 

--- a/generators/go/sdk/changes/unreleased/invocation-only-dynamic-snippets.yml
+++ b/generators/go/sdk/changes/unreleased/invocation-only-dynamic-snippets.yml
@@ -1,0 +1,19 @@
+# yaml-language-server: $schema=../../../../../fern-changes-yml.schema.json
+
+- summary: |
+    Generate invocation-only dynamic snippets. In addition to the full snippet
+    (client construction plus the call), the generator now exposes the structured
+    pieces a caller can render inside code it already owns (e.g. a documentation
+    code template): the bare invocation (`client.Endpoints.Update(...)`, honoring a
+    custom client variable name), the Go `import (...)` block that invocation
+    references (empty string when none), and the generated client type name so docs
+    can render `client := New<ClientName>(...)` and track renames.
+
+    Imports are captured separately from the call via a new
+    `go.renderNodeWithoutImports` helper and `GoFile.getImports()`, the Go analogue
+    of the TypeScript AST's `toStringWithoutImports`. Invocations that reference
+    imported types (e.g. a body value constructed with `uuid.MustParse(...)`)
+    surface those imports rather than falling back to the complete snippet. Because
+    every Go SDK method takes a leading `context.Context`, the returned imports
+    always include the `context` import.
+  type: feat


### PR DESCRIPTION
## Summary

Populates the optional `clientImport` field on `InvocationSnippetResponse` for the Go dynamic-snippets generator, matching the TypeScript implementation on the base branch.

Invocation-only snippets return the bare call plus the pieces a docs template needs to render it. The generated client type lives in its own package (`<root>/client`), so callers rendering an invocation inside their own code need the client's import in addition to any imports the bare call references (`imports`).

## Implementation

In `EndpointSnippetGenerator.generateInvocationSnippetSync`, after capturing `{ code, imports }` for the invocation, we render a lone reference to the root client type (`go.typeReference({ name: getClientName(), importPath: getClientImportPath() })`) through the existing `go.renderNodeWithoutImports` helper — the same mechanism used for `imports` — and surface its import block as `clientImport`. Empty string when there is no import.

## Testing

- `pnpm turbo run compile --filter @fern-api/go-dynamic-snippets` — passes
- `pnpm turbo run test --filter @fern-api/go-dynamic-snippets` — 110/110 tests pass, including a new assertion in `InvocationSnippet.test.ts` that `clientImport` contains `import (` and `/client`.

Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/17455" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->