### PR TITLE
feat(rust): invocation-only dynamic snippets + clientImport

### DIFF
--- a/generators/rust/dynamic-snippets/src/EndpointSnippetGenerator.ts
+++ b/generators/rust/dynamic-snippets/src/EndpointSnippetGenerator.ts
@@ -1,4 +1,10 @@
-import { AbstractAstNode, Options, Scope, Severity } from "@fern-api/browser-compatible-base-generator";
+import {
+    AbstractAstNode,
+    InvocationSnippetResponse,
+    Options,
+    Scope,
+    Severity
+} from "@fern-api/browser-compatible-base-generator";
 import { assertNever } from "@fern-api/core-utils";
 import { FernIr } from "@fern-api/dynamic-ir-sdk";
 import { formatRustSnippet, formatRustSnippetAsync } from "@fern-api/rust-base";
@@ -53,6 +59,56 @@ export class EndpointSnippetGenerator {
         options?: Options;
     }): Promise<AbstractAstNode> {
         throw new Error("Unsupported");
+    }
+
+    /**
+     * Generates the structured pieces of an endpoint invocation for callers that render the
+     * invocation within code of their own (e.g. a documentation code template): the bare call
+     * (e.g. `client.endpoints.foo(...).await`, honoring a custom client variable name), the imports
+     * the call requires, and the generated client struct name.
+     *
+     * Rust's `imports` is always the empty string. Unlike TypeScript/PHP/C#/Java — whose AST tracks
+     * per-symbol imports and can surface the `use`/`import` lines a call references — the Rust AST
+     * (`@fern-api/rust-codegen`) has no per-node import mechanism at all: there is no
+     * `importsToString`/`getImports`/`addImport`, and generated snippets reference every SDK type by
+     * a bare name that resolves through a single blanket glob, `use <crate>::prelude::*;`, which
+     * re-exports the whole crate. That glob is emitted once by the scaffold (see
+     * {@link getUseStatements}) and belongs to the client construction the caller owns, not to the
+     * invocation. A bare invocation therefore emits no per-symbol `use`, so we return `""` rather
+     * than inventing an imports mechanism the language and its AST do not have. This mirrors the
+     * Ruby port (types referenced via the gem namespace), not the C#/Java/PHP `{ code, imports }`
+     * helper pattern.
+     */
+    public generateInvocationSnippetSync({
+        endpoint,
+        request,
+        options
+    }: {
+        endpoint: FernIr.dynamic.Endpoint;
+        request: FernIr.dynamic.EndpointSnippetRequest;
+        options?: Options;
+    }): InvocationSnippetResponse {
+        // Render ONLY the invocation expression: no `let config = ...;`/`let client = ...;`
+        // construction, no `#[tokio::main] async fn main()` scaffold, and no
+        // `use <crate>::prelude::*;` preamble. We render the underlying Expression (not the
+        // `Statement`, which would append a trailing `;`).
+        const invocation = this.buildInvocationExpression({
+            endpoint,
+            snippet: request,
+            clientVariableName: options?.clientVariableName
+        });
+        const rawCode = invocation.toString();
+        // Strip a trailing statement terminator defensively; the bare Expression does not emit one,
+        // but formatting/whitespace should never leak a `;` into the invocation-only snippet.
+        const snippet = rawCode.trim().replace(/;$/, "").trim();
+        return {
+            snippet,
+            // Always empty for Rust — see the method doc comment: the AST has no per-symbol import
+            // mechanism and types resolve through the scaffold's `use <crate>::prelude::*;` glob.
+            imports: "",
+            clientName: this.getClientName(),
+            errors: this.context.errors.empty() ? undefined : this.context.errors.toDynamicSnippetErrors()
+        };
     }
 
     public buildCodeComponents({
@@ -490,19 +546,38 @@ export class EndpointSnippetGenerator {
 
     private callMethod({
         endpoint,
-        snippet
+        snippet,
+        clientVariableName
     }: {
         endpoint: FernIr.dynamic.Endpoint;
         snippet: FernIr.dynamic.EndpointSnippetRequest;
+        clientVariableName?: string;
     }): rust.Statement {
         return rust.Statement.expression(
-            rust.Expression.methodCall({
-                target: rust.Expression.reference(CLIENT_VAR_NAME),
-                method: this.getMethodName({ endpoint }),
-                args: this.getMethodArgs({ endpoint, snippet }),
-                isAsync: true
-            })
+            this.buildInvocationExpression({ endpoint, snippet, clientVariableName })
         );
+    }
+
+    /**
+     * Builds the bare invocation expression (`<client>.<method>(...).await`), honoring a custom
+     * client variable name. Shared between the full snippet (wrapped in a statement) and the
+     * invocation-only snippet (rendered on its own).
+     */
+    private buildInvocationExpression({
+        endpoint,
+        snippet,
+        clientVariableName
+    }: {
+        endpoint: FernIr.dynamic.Endpoint;
+        snippet: FernIr.dynamic.EndpointSnippetRequest;
+        clientVariableName?: string;
+    }): rust.Expression {
+        return rust.Expression.methodCall({
+            target: rust.Expression.reference(clientVariableName ?? CLIENT_VAR_NAME),
+            method: this.getMethodName({ endpoint }),
+            args: this.getMethodArgs({ endpoint, snippet }),
+            isAsync: true
+        });
     }
 
     private getBaseUrlValue({

--- a/generators/rust/dynamic-snippets/src/EndpointSnippetGenerator.ts
+++ b/generators/rust/dynamic-snippets/src/EndpointSnippetGenerator.ts
@@ -78,6 +78,13 @@ export class EndpointSnippetGenerator {
      * than inventing an imports mechanism the language and its AST do not have. This mirrors the
      * Ruby port (types referenced via the gem namespace), not the C#/Java/PHP `{ code, imports }`
      * helper pattern.
+     *
+     * `clientImport`, by contrast, is well-defined for Rust: the generated root client resolves
+     * through that same blanket glob, `use <crate>::prelude::*;`. Unlike the per-symbol `imports`
+     * the call references — which the AST cannot surface — the client's import is a single,
+     * deterministic `use` statement (the very one {@link getUseStatements} emits into the
+     * scaffold). We render it here so docs can construct the client themselves without
+     * hand-authoring the import.
      */
     public generateInvocationSnippetSync({
         endpoint,
@@ -101,12 +108,21 @@ export class EndpointSnippetGenerator {
         // Strip a trailing statement terminator defensively; the bare Expression does not emit one,
         // but formatting/whitespace should never leak a `;` into the invocation-only snippet.
         const snippet = rawCode.trim().replace(/;$/, "").trim();
+        // The generated root client is imported via the scaffold's blanket prelude glob
+        // `use <crate>::prelude::*;` — the same statement `getUseStatements` emits. Build that
+        // bare reference and render it with the same `UseStatement.toString()` helper the scaffold
+        // uses, so `clientImport` stays consistent with how the client is actually imported.
+        const clientImport = new rust.UseStatement({
+            path: `${this.context.getCrateName()}::prelude`,
+            items: ["*"]
+        }).toString();
         return {
             snippet,
             // Always empty for Rust — see the method doc comment: the AST has no per-symbol import
             // mechanism and types resolve through the scaffold's `use <crate>::prelude::*;` glob.
             imports: "",
             clientName: this.getClientName(),
+            clientImport,
             errors: this.context.errors.empty() ? undefined : this.context.errors.toDynamicSnippetErrors()
         };
     }

--- a/generators/rust/dynamic-snippets/src/__test__/InvocationSnippet.test.ts
+++ b/generators/rust/dynamic-snippets/src/__test__/InvocationSnippet.test.ts
@@ -74,6 +74,15 @@ describe("invocation-only snippets", () => {
         expect(response?.clientName).toBe("AcmeClient");
     });
 
+    it("exposes the client import (the crate prelude glob) so docs can import the client", () => {
+        const response = generator.generateInvocationSync(request);
+
+        // The generated root client resolves through the scaffold's blanket prelude glob, the same
+        // `use <crate>::prelude::*;` statement `getUseStatements` emits. Unlike `imports` (per-symbol,
+        // which the Rust AST cannot surface), the client's own import is a single deterministic `use`.
+        expect(response?.clientImport).toBe("use acme_api::prelude::{*};");
+    });
+
     it("invokes the endpoint on the requested client variable", () => {
         const response = generator.generateInvocationSync(request, { clientVariableName: "mailchimp" });
 

--- a/generators/rust/dynamic-snippets/src/__test__/InvocationSnippet.test.ts
+++ b/generators/rust/dynamic-snippets/src/__test__/InvocationSnippet.test.ts
@@ -1,0 +1,126 @@
+import { AbsoluteFilePath, join } from "@fern-api/path-utils";
+
+import { buildDynamicSnippetsGenerator } from "./utils/buildDynamicSnippetsGenerator.js";
+import { buildGeneratorConfig } from "./utils/buildGeneratorConfig.js";
+
+const DYNAMIC_IR_TEST_DEFINITIONS_DIRECTORY = AbsoluteFilePath.of(
+    `${__dirname}/../../../../../packages/cli/generation/ir-generator-tests/src/dynamic-snippets/__test__/test-definitions`
+);
+
+// Invocation-only snippets are rendered inside code the caller already owns (e.g. a
+// documentation code template), so they must not include the client construction
+// (`let config = ...; let client = AcmeClient::new(config)...;`), the `#[tokio::main] async fn main()`
+// scaffold, or the `use <crate>::prelude::*;` preamble that construction emits.
+//
+// Rust's `imports` field is always the empty string. The Rust AST (`@fern-api/rust-codegen`) has no
+// per-node import mechanism (no `importsToString`/`getImports`/`addImport`); generated snippets
+// reference every SDK type by a bare name that resolves through a single blanket glob,
+// `use <crate>::prelude::*;`, which re-exports the whole crate. That glob belongs to the client
+// construction the caller owns, so a bare invocation surfaces no per-symbol `use`. This mirrors the
+// Ruby port (types referenced via the gem namespace), not the C#/Java/PHP `{ code, imports }` helper
+// pattern.
+describe("invocation-only snippets", () => {
+    const generator = buildDynamicSnippetsGenerator({
+        irFilepath: AbsoluteFilePath.of(join(DYNAMIC_IR_TEST_DEFINITIONS_DIRECTORY, "exhaustive.json")),
+        config: buildGeneratorConfig()
+    });
+
+    const request = {
+        endpoint: {
+            method: "GET" as const,
+            path: "/http-methods/{id}"
+        },
+        baseURL: undefined,
+        environment: undefined,
+        auth: {
+            type: "bearer" as const,
+            token: "<YOUR_API_KEY>"
+        },
+        pathParameters: {
+            id: "id"
+        },
+        queryParameters: undefined,
+        headers: undefined,
+        requestBody: undefined
+    };
+
+    it("generates the invocation without client construction or scaffold", () => {
+        const response = generator.generateInvocationSync(request);
+
+        expect(response?.snippet).toBe('client.endpoints.http_methods.test_get(&"id".to_string(), None).await');
+        // The invocation is a bare expression: no `let config`/`let client = AcmeClient::new(...)`
+        // construction, no `fn main` scaffold, and no `use ...;` preamble (all belong to the client
+        // the caller owns).
+        expect(response?.snippet).not.toContain("let config");
+        expect(response?.snippet).not.toContain("::new(");
+        expect(response?.snippet).not.toContain("fn main");
+        expect(response?.snippet).not.toContain("use ");
+        // No trailing statement terminator.
+        expect(response?.snippet.endsWith(";")).toBe(false);
+        expect(response?.errors).toBeUndefined();
+    });
+
+    it("returns no imports for a Rust invocation (types resolve via the prelude glob)", () => {
+        const response = generator.generateInvocationSync(request);
+
+        // Always empty for Rust: the AST has no per-symbol import mechanism, and types resolve
+        // through the scaffold's `use <crate>::prelude::*;` glob.
+        expect(response?.imports).toBe("");
+    });
+
+    it("exposes the generated client struct name so docs can render the client construction", () => {
+        const response = generator.generateInvocationSync(request);
+
+        expect(response?.clientName).toBe("AcmeClient");
+    });
+
+    it("invokes the endpoint on the requested client variable", () => {
+        const response = generator.generateInvocationSync(request, { clientVariableName: "mailchimp" });
+
+        expect(response?.snippet).toBe('mailchimp.endpoints.http_methods.test_get(&"id".to_string(), None).await');
+    });
+
+    it("returns no imports even when the invocation constructs typed body values", () => {
+        // This body constructs typed values (DateTime, NaiveDate, Uuid, HashSet, HashMap, BigInt,
+        // base64). In TypeScript/PHP/C#/Java such a call would surface per-symbol imports; in Rust
+        // every type resolves through the prelude glob, so `imports` remains empty. This documents
+        // that Rust has no import-referencing invocation case.
+        const response = generator.generateInvocationSync({
+            endpoint: {
+                method: "POST" as const,
+                path: "/object/get-and-return-with-optional-field"
+            },
+            baseURL: undefined,
+            environment: undefined,
+            auth: {
+                type: "bearer" as const,
+                token: "<YOUR_API_KEY>"
+            },
+            pathParameters: undefined,
+            queryParameters: undefined,
+            headers: undefined,
+            requestBody: {
+                string: "string",
+                integer: 1,
+                long: 1000000,
+                double: 1.1,
+                bool: true,
+                datetime: "2024-01-15T09:30:00Z",
+                date: "2023-01-15",
+                uuid: "d5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32",
+                base64: "SGVsbG8gd29ybGQh",
+                list: ["list", "list"],
+                set: ["set"],
+                map: { 1: "map" },
+                bigint: "1000000"
+            }
+        });
+
+        expect(response).not.toBeUndefined();
+        expect(response?.imports).toBe("");
+        expect(response?.snippet).not.toContain("use ");
+        // References typed values inline (proof the invocation would need imports in an
+        // import-tracking language) yet emits none, because Rust resolves them via the prelude glob.
+        expect(response?.snippet).toContain("DateTime::parse_from_rfc3339");
+    });
+});

--- a/generators/rust/dynamic-snippets/tsconfig.json
+++ b/generators/rust/dynamic-snippets/tsconfig.json
@@ -2,7 +2,8 @@
   "extends": "@fern-api/configs/tsconfig/main.json",
   "compilerOptions": {
     "outDir": "lib",
-    "rootDir": "src"
+    "rootDir": "src",
+    "types": ["node", "vitest/globals"]
   },
   "include": [
     "src/**/*"

--- a/generators/rust/sdk/changes/unreleased/invocation-only-dynamic-snippets.yml
+++ b/generators/rust/sdk/changes/unreleased/invocation-only-dynamic-snippets.yml
@@ -1,0 +1,19 @@
+# yaml-language-server: $schema=../../../../../fern-changes-yml.schema.json
+
+- summary: |
+    Generate invocation-only dynamic snippets. In addition to the full snippet
+    (client construction plus the call), the generator now exposes the structured
+    pieces a caller can render inside code it already owns (e.g. a documentation
+    code template): the bare invocation (`client.endpoints.update(...).await`,
+    honoring a custom client variable name), the imports the invocation references,
+    and the generated client struct name so docs can render the client construction
+    and track renames.
+
+    For Rust the imports field is always the empty string: the Rust AST has no
+    per-symbol import mechanism, and a generated Rust SDK resolves every type through
+    a single blanket glob (`use <crate>::prelude::*;`) emitted once by the client
+    scaffold. That glob belongs to the client construction the caller owns, not to
+    the invocation, so a bare invocation never emits a per-symbol `use` and no imports
+    mechanism is invented for it. This mirrors the Ruby port (types referenced via the
+    gem namespace), not the C#/Java/PHP `{ code, imports }` helper pattern.
+  type: feat


### PR DESCRIPTION
## What

Populates the optional `clientImport` field on the Rust invocation-only snippet response (`InvocationSnippetResponse`), mirroring what TypeScript/Java already do.

## Why

The base branch `cade/clientimport-invocation-snippet` added `clientImport?: string` so docs templates can render the client's own import without hand-authoring it. TypeScript populates it; this brings Rust to parity.

## How

For Rust, the generated root client resolves through the scaffold's blanket prelude glob `use <crate>::prelude::*;` — the same `UseStatement` that `getUseStatements` emits. We build that bare reference and render it via the same `UseStatement.toString()` helper, so `clientImport` stays consistent with how the client is actually imported. (This is distinct from `imports`, which remains `""` for Rust because the AST has no per-symbol import mechanism.)

`clientImport` renders as `use acme_api::prelude::{*};` — the exact form the existing scaffold produces.

## Testing

- `pnpm turbo run compile --filter @fern-api/rust-dynamic-snippets` — passes
- `pnpm turbo run test --filter @fern-api/rust-dynamic-snippets -- InvocationSnippet` — 6/6 pass (added a `clientImport` assertion)

Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/17456" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->