### PR TITLE
fix(cli-generator): make credential temp-file writes unique per writer

### DIFF
--- a/generators/cli/changes/unreleased/keyring-atomic-write-race.yml
+++ b/generators/cli/changes/unreleased/keyring-atomic-write-race.yml
@@ -1,0 +1,25 @@
+# yaml-language-server: $schema=../../../../fern-changes-yml.schema.json
+
+- summary: |
+    Fix a race in credential storage that made `auth login --with-token` fail
+    intermittently when several CLI processes ran at once.
+
+    `atomic_write` derived its temp file name from the target alone, so every
+    concurrent writer used the same sibling path (`auth-keyring.tmp`). Whichever
+    process renamed first moved it away and the rest failed with
+    `error[auth]: Failed to rename .../auth-keyring.tmp: No such file or
+    directory (os error 2)`. The temp name now carries the writer's pid plus a
+    process-local counter.
+
+    This surfaced as flaky generated wire-test suites: on a workspace with ~680
+    cases, the harness seeds a token per authenticated case, cargo runs those in
+    parallel, and a different subset of tests died on each run. Small fixtures
+    have too little concurrency to hit it, which is why it reached a real
+    workspace before ours.
+
+    `rename` was already atomic for readers, so no partially written credential
+    file was ever observable — only writer-vs-writer collisions were affected.
+    `FileKeyringStore::set` is still an unlocked read-modify-write of the whole
+    map, so simultaneous writers can clobber one another's entries; that needs
+    file locking and is left alone here.
+  type: fix

--- a/generators/cli/changes/unreleased/keyring-atomic-write-race.yml
+++ b/generators/cli/changes/unreleased/keyring-atomic-write-race.yml
@@ -9,13 +9,18 @@
     process renamed first moved it away and the rest failed with
     `error[auth]: Failed to rename .../auth-keyring.tmp: No such file or
     directory (os error 2)`. The temp name now carries the writer's pid plus a
-    process-local counter.
+    process-local counter, and a drop guard unlinks it on any early return or
+    panic so unique names can't accumulate orphaned credential files.
 
-    This surfaced as flaky generated wire-test suites: on a workspace with ~680
-    cases, the harness seeds a token per authenticated case, cargo runs those in
-    parallel, and a different subset of tests died on each run. Small fixtures
-    have too little concurrency to hit it, which is why it reached a real
-    workspace before ours.
+    This surfaced as flaky generated wire-test suites. The harness gives each
+    case its own temp `HOME`, but `config_dir()` consults `$XDG_CONFIG_HOME`
+    first on Linux and CI runners set it to the real config directory — so the
+    `HOME` override was inert, every authenticated case shared one
+    `auth-keyring.json`, and `cargo test` ran them in parallel. On a workspace
+    with ~680 cases a different subset died on each run. macOS never consults
+    `$XDG_CONFIG_HOME`, so the isolation holds there and the bug cannot
+    reproduce locally on a Mac, which is why it reached a real workspace before
+    ours.
 
     `rename` was already atomic for readers, so no partially written credential
     file was ever observable — only writer-vs-writer collisions were affected.

--- a/generators/cli/sdk/src/auth/oauth_common.rs
+++ b/generators/cli/sdk/src/auth/oauth_common.rs
@@ -224,27 +224,6 @@ pub(crate) fn config_dir() -> Option<PathBuf> {
     }
 }
 
-/// Write `data` to `path` atomically: sibling temp file → owner-only
-/// permissions (0600 on Unix) → rename into place.
-///
-/// The temp file name is unique per writer — pid plus a process-local
-/// counter. Deriving it from the target alone meant every concurrent writer
-/// used the *same* sibling (`auth-keyring.tmp`): whichever one renamed first
-/// moved it away, and the rest failed with `ENOENT` from `rename`. That
-/// surfaced as intermittent `auth login --with-token` failures across a
-/// wire-test suite large enough to run many CLI processes at once, killing a
-/// different subset of cases on each run.
-///
-/// The pid covers the case that actually bit us (separate CLI processes); the
-/// counter covers two writers inside one process, and is what makes the
-/// behavior unit-testable without spawning subprocesses.
-///
-/// `rename` is still atomic for readers, which is what keeps a partially
-/// written credential file unobservable. This only fixes writer-vs-writer
-/// collisions on the temp path. `FileKeyringStore::set` remains a
-/// read-modify-write of the whole map with no lock, so simultaneous writers
-/// can still clobber one another's *entries*; making that safe needs file
-/// locking, which is a larger change.
 /// Unlinks a temp file on drop unless [`TempFileGuard::disarm`]ed. Covers
 /// every early return *and* a panic between creating the temp file and
 /// renaming it into place.
@@ -278,6 +257,30 @@ impl Drop for TempFileGuard {
     }
 }
 
+/// Write `data` to `path` atomically: sibling temp file → owner-only
+/// permissions (0600 on Unix) → rename into place.
+///
+/// The temp file name is unique per writer — pid plus a process-local
+/// counter. Deriving it from the target alone meant every concurrent writer
+/// used the *same* sibling (`auth-keyring.tmp`): whichever one renamed first
+/// moved it away, and the rest failed with `ENOENT` from `rename`. That
+/// surfaced as intermittent `auth login --with-token` failures across a
+/// wire-test suite large enough to run many CLI processes at once, killing a
+/// different subset of cases on each run.
+///
+/// The pid covers the case that actually bit us (separate CLI processes); the
+/// counter covers two writers inside one process, and is what makes the
+/// behavior unit-testable without spawning subprocesses.
+///
+/// A [`TempFileGuard`] unlinks the temp file if anything between creating it
+/// and renaming it fails, so unique names cannot accumulate as orphans.
+///
+/// `rename` is still atomic for readers, which is what keeps a partially
+/// written credential file unobservable. This only fixes writer-vs-writer
+/// collisions on the temp path. `FileKeyringStore::set` remains a
+/// read-modify-write of the whole map with no lock, so simultaneous writers
+/// can still clobber one another's *entries*; making that safe needs file
+/// locking, which is a larger change.
 pub(crate) fn atomic_write(path: &Path, data: &[u8]) -> Result<(), CliError> {
     static TMP_SEQ: std::sync::atomic::AtomicUsize = std::sync::atomic::AtomicUsize::new(0);
     let seq = TMP_SEQ.fetch_add(1, std::sync::atomic::Ordering::Relaxed);

--- a/generators/cli/sdk/src/auth/oauth_common.rs
+++ b/generators/cli/sdk/src/auth/oauth_common.rs
@@ -245,23 +245,56 @@ pub(crate) fn config_dir() -> Option<PathBuf> {
 /// read-modify-write of the whole map with no lock, so simultaneous writers
 /// can still clobber one another's *entries*; making that safe needs file
 /// locking, which is a larger change.
+/// Unlinks a temp file on drop unless [`TempFileGuard::disarm`]ed. Covers
+/// every early return *and* a panic between creating the temp file and
+/// renaming it into place.
+///
+/// This exists because the temp name is unique per writer. The old shared
+/// `auth-keyring.tmp` was self-limiting — a failed write left one stale file
+/// that the next write reused — whereas unique names would leak a distinct
+/// credential-bearing file on every failure, in a directory nothing prunes. A
+/// `SIGKILL` still leaks, since no in-process guard can cover that.
+struct TempFileGuard {
+    path: PathBuf,
+    armed: bool,
+}
+
+impl TempFileGuard {
+    fn new(path: PathBuf) -> Self {
+        Self { path, armed: true }
+    }
+
+    /// Relinquish the file — call once `rename` has moved it into place.
+    fn disarm(&mut self) {
+        self.armed = false;
+    }
+}
+
+impl Drop for TempFileGuard {
+    fn drop(&mut self) {
+        if self.armed {
+            let _ = std::fs::remove_file(&self.path);
+        }
+    }
+}
+
 pub(crate) fn atomic_write(path: &Path, data: &[u8]) -> Result<(), CliError> {
-    static TMP_SEQ: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+    static TMP_SEQ: std::sync::atomic::AtomicUsize = std::sync::atomic::AtomicUsize::new(0);
     let seq = TMP_SEQ.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
     let tmp = path.with_extension(format!("tmp.{}.{}", std::process::id(), seq));
-    std::fs::write(&tmp, data).map_err(|e| {
-        CliError::Auth(format!("Failed to write {}: {e}", tmp.display()))
-    })?;
+    let mut guard = TempFileGuard::new(tmp.clone());
+    std::fs::write(&tmp, data)
+        .map_err(|e| CliError::Auth(format!("Failed to write {}: {e}", tmp.display())))?;
     #[cfg(unix)]
     {
         use std::os::unix::fs::PermissionsExt;
         let perms = std::fs::Permissions::from_mode(0o600);
         let _ = std::fs::set_permissions(&tmp, perms);
     }
-    std::fs::rename(&tmp, path).map_err(|e| {
-        let _ = std::fs::remove_file(&tmp);
-        CliError::Auth(format!("Failed to rename {}: {e}", tmp.display()))
-    })
+    std::fs::rename(&tmp, path)
+        .map_err(|e| CliError::Auth(format!("Failed to rename {}: {e}", tmp.display())))?;
+    guard.disarm();
+    Ok(())
 }
 
 // ---------------------------------------------------------------------------
@@ -315,6 +348,56 @@ mod tests {
             .filter(|n| n.contains(".tmp"))
             .collect();
         assert!(leftovers.is_empty(), "temp files left behind: {leftovers:?}");
+    }
+
+    /// A failed write must not leave its temp file behind. Renaming a file onto
+    /// an existing directory fails on every platform, which drives the error
+    /// path without mocking the filesystem.
+    ///
+    /// The pre-`TempFileGuard` code already cleaned up on a `rename` error, so
+    /// this pins an invariant rather than catching a regression — see
+    /// `temp_file_guard_unlinks_unless_disarmed` for the guard's own coverage.
+    #[test]
+    fn atomic_write_cleans_up_temp_file_on_failure() {
+        let dir = tempfile::tempdir().unwrap();
+
+        // The target is a *directory*, so `rename` cannot replace it.
+        let target = dir.path().join("auth-keyring.json");
+        std::fs::create_dir(&target).unwrap();
+        std::fs::write(target.join("occupant"), b"x").unwrap();
+
+        let result = atomic_write(&target, br#"{"writer":0}"#);
+        assert!(result.is_err(), "expected rename onto a directory to fail");
+
+        let leftovers: Vec<String> = std::fs::read_dir(dir.path())
+            .unwrap()
+            .filter_map(|e| e.ok())
+            .map(|e| e.file_name().to_string_lossy().into_owned())
+            .filter(|n| n.contains(".tmp"))
+            .collect();
+        assert!(leftovers.is_empty(), "temp file leaked after a failed write: {leftovers:?}");
+    }
+
+    /// Pins [`TempFileGuard`]: armed drops unlink, disarmed drops don't. Drop
+    /// running on an armed guard is what covers early returns and unwinding
+    /// panics between `write` and `rename` — paths the old `rename`-only
+    /// cleanup missed. Deleting the guard or the `disarm()` call fails this.
+    #[test]
+    fn temp_file_guard_unlinks_unless_disarmed() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("auth-keyring.tmp.0.0");
+
+        std::fs::write(&path, b"x").unwrap();
+        drop(TempFileGuard::new(path.clone()));
+        assert!(!path.exists(), "armed guard must unlink on drop");
+
+        // The post-`rename` case: the file has been moved away, so the guard
+        // must not touch whatever now sits at that path.
+        std::fs::write(&path, b"x").unwrap();
+        let mut guard = TempFileGuard::new(path.clone());
+        guard.disarm();
+        drop(guard);
+        assert!(path.exists(), "disarmed guard must not unlink");
     }
 
     #[test]

--- a/generators/cli/sdk/src/auth/oauth_common.rs
+++ b/generators/cli/sdk/src/auth/oauth_common.rs
@@ -226,8 +226,29 @@ pub(crate) fn config_dir() -> Option<PathBuf> {
 
 /// Write `data` to `path` atomically: sibling temp file → owner-only
 /// permissions (0600 on Unix) → rename into place.
+///
+/// The temp file name is unique per writer — pid plus a process-local
+/// counter. Deriving it from the target alone meant every concurrent writer
+/// used the *same* sibling (`auth-keyring.tmp`): whichever one renamed first
+/// moved it away, and the rest failed with `ENOENT` from `rename`. That
+/// surfaced as intermittent `auth login --with-token` failures across a
+/// wire-test suite large enough to run many CLI processes at once, killing a
+/// different subset of cases on each run.
+///
+/// The pid covers the case that actually bit us (separate CLI processes); the
+/// counter covers two writers inside one process, and is what makes the
+/// behavior unit-testable without spawning subprocesses.
+///
+/// `rename` is still atomic for readers, which is what keeps a partially
+/// written credential file unobservable. This only fixes writer-vs-writer
+/// collisions on the temp path. `FileKeyringStore::set` remains a
+/// read-modify-write of the whole map with no lock, so simultaneous writers
+/// can still clobber one another's *entries*; making that safe needs file
+/// locking, which is a larger change.
 pub(crate) fn atomic_write(path: &Path, data: &[u8]) -> Result<(), CliError> {
-    let tmp = path.with_extension("tmp");
+    static TMP_SEQ: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+    let seq = TMP_SEQ.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+    let tmp = path.with_extension(format!("tmp.{}.{}", std::process::id(), seq));
     std::fs::write(&tmp, data).map_err(|e| {
         CliError::Auth(format!("Failed to write {}: {e}", tmp.display()))
     })?;
@@ -250,6 +271,51 @@ pub(crate) fn atomic_write(path: &Path, data: &[u8]) -> Result<(), CliError> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// Regression test for the temp-file collision that made
+    /// `auth login --with-token` fail intermittently: every writer derived the
+    /// same sibling path from the target, so the first `rename` moved it away
+    /// and the rest got `ENOENT`.
+    ///
+    /// Reverting `atomic_write` to a target-derived temp name fails this with
+    /// "Failed to rename ...: No such file or directory".
+    #[test]
+    fn atomic_write_tolerates_concurrent_writers() {
+        let dir = tempfile::tempdir().unwrap();
+        let target = dir.path().join("auth-keyring.json");
+
+        let results: Vec<Result<(), CliError>> = std::thread::scope(|scope| {
+            let handles: Vec<_> = (0..16)
+                .map(|i| {
+                    let target = target.clone();
+                    scope.spawn(move || atomic_write(&target, format!(r#"{{"writer":{i}}}"#).as_bytes()))
+                })
+                .collect();
+            handles.into_iter().map(|h| h.join().unwrap()).collect()
+        });
+
+        let failed: Vec<String> = results
+            .iter()
+            .filter_map(|r| r.as_ref().err().map(|e| e.to_string()))
+            .collect();
+        assert!(failed.is_empty(), "concurrent writers failed: {failed:?}");
+
+        // Last writer wins, but the file must always be one writer's complete
+        // payload — never a mix, and never absent.
+        let contents = std::fs::read_to_string(&target).unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(&contents)
+            .unwrap_or_else(|e| panic!("target is not valid JSON after concurrent writes: {e} in {contents:?}"));
+        assert!(parsed.get("writer").is_some(), "unexpected payload: {contents}");
+
+        // No temp files orphaned in the directory.
+        let leftovers: Vec<String> = std::fs::read_dir(dir.path())
+            .unwrap()
+            .filter_map(|e| e.ok())
+            .map(|e| e.file_name().to_string_lossy().into_owned())
+            .filter(|n| n.contains(".tmp"))
+            .collect();
+        assert!(leftovers.is_empty(), "temp files left behind: {leftovers:?}");
+    }
 
     #[test]
     fn token_bundle_roundtrip() {

--- a/seed/cli/allof-inline/src/auth/oauth_common.rs
+++ b/seed/cli/allof-inline/src/auth/oauth_common.rs
@@ -224,27 +224,6 @@ pub(crate) fn config_dir() -> Option<PathBuf> {
     }
 }
 
-/// Write `data` to `path` atomically: sibling temp file → owner-only
-/// permissions (0600 on Unix) → rename into place.
-///
-/// The temp file name is unique per writer — pid plus a process-local
-/// counter. Deriving it from the target alone meant every concurrent writer
-/// used the *same* sibling (`auth-keyring.tmp`): whichever one renamed first
-/// moved it away, and the rest failed with `ENOENT` from `rename`. That
-/// surfaced as intermittent `auth login --with-token` failures across a
-/// wire-test suite large enough to run many CLI processes at once, killing a
-/// different subset of cases on each run.
-///
-/// The pid covers the case that actually bit us (separate CLI processes); the
-/// counter covers two writers inside one process, and is what makes the
-/// behavior unit-testable without spawning subprocesses.
-///
-/// `rename` is still atomic for readers, which is what keeps a partially
-/// written credential file unobservable. This only fixes writer-vs-writer
-/// collisions on the temp path. `FileKeyringStore::set` remains a
-/// read-modify-write of the whole map with no lock, so simultaneous writers
-/// can still clobber one another's *entries*; making that safe needs file
-/// locking, which is a larger change.
 /// Unlinks a temp file on drop unless [`TempFileGuard::disarm`]ed. Covers
 /// every early return *and* a panic between creating the temp file and
 /// renaming it into place.
@@ -278,6 +257,30 @@ impl Drop for TempFileGuard {
     }
 }
 
+/// Write `data` to `path` atomically: sibling temp file → owner-only
+/// permissions (0600 on Unix) → rename into place.
+///
+/// The temp file name is unique per writer — pid plus a process-local
+/// counter. Deriving it from the target alone meant every concurrent writer
+/// used the *same* sibling (`auth-keyring.tmp`): whichever one renamed first
+/// moved it away, and the rest failed with `ENOENT` from `rename`. That
+/// surfaced as intermittent `auth login --with-token` failures across a
+/// wire-test suite large enough to run many CLI processes at once, killing a
+/// different subset of cases on each run.
+///
+/// The pid covers the case that actually bit us (separate CLI processes); the
+/// counter covers two writers inside one process, and is what makes the
+/// behavior unit-testable without spawning subprocesses.
+///
+/// A [`TempFileGuard`] unlinks the temp file if anything between creating it
+/// and renaming it fails, so unique names cannot accumulate as orphans.
+///
+/// `rename` is still atomic for readers, which is what keeps a partially
+/// written credential file unobservable. This only fixes writer-vs-writer
+/// collisions on the temp path. `FileKeyringStore::set` remains a
+/// read-modify-write of the whole map with no lock, so simultaneous writers
+/// can still clobber one another's *entries*; making that safe needs file
+/// locking, which is a larger change.
 pub(crate) fn atomic_write(path: &Path, data: &[u8]) -> Result<(), CliError> {
     static TMP_SEQ: std::sync::atomic::AtomicUsize = std::sync::atomic::AtomicUsize::new(0);
     let seq = TMP_SEQ.fetch_add(1, std::sync::atomic::Ordering::Relaxed);

--- a/seed/cli/allof-inline/src/auth/oauth_common.rs
+++ b/seed/cli/allof-inline/src/auth/oauth_common.rs
@@ -245,23 +245,56 @@ pub(crate) fn config_dir() -> Option<PathBuf> {
 /// read-modify-write of the whole map with no lock, so simultaneous writers
 /// can still clobber one another's *entries*; making that safe needs file
 /// locking, which is a larger change.
+/// Unlinks a temp file on drop unless [`TempFileGuard::disarm`]ed. Covers
+/// every early return *and* a panic between creating the temp file and
+/// renaming it into place.
+///
+/// This exists because the temp name is unique per writer. The old shared
+/// `auth-keyring.tmp` was self-limiting — a failed write left one stale file
+/// that the next write reused — whereas unique names would leak a distinct
+/// credential-bearing file on every failure, in a directory nothing prunes. A
+/// `SIGKILL` still leaks, since no in-process guard can cover that.
+struct TempFileGuard {
+    path: PathBuf,
+    armed: bool,
+}
+
+impl TempFileGuard {
+    fn new(path: PathBuf) -> Self {
+        Self { path, armed: true }
+    }
+
+    /// Relinquish the file — call once `rename` has moved it into place.
+    fn disarm(&mut self) {
+        self.armed = false;
+    }
+}
+
+impl Drop for TempFileGuard {
+    fn drop(&mut self) {
+        if self.armed {
+            let _ = std::fs::remove_file(&self.path);
+        }
+    }
+}
+
 pub(crate) fn atomic_write(path: &Path, data: &[u8]) -> Result<(), CliError> {
-    static TMP_SEQ: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+    static TMP_SEQ: std::sync::atomic::AtomicUsize = std::sync::atomic::AtomicUsize::new(0);
     let seq = TMP_SEQ.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
     let tmp = path.with_extension(format!("tmp.{}.{}", std::process::id(), seq));
-    std::fs::write(&tmp, data).map_err(|e| {
-        CliError::Auth(format!("Failed to write {}: {e}", tmp.display()))
-    })?;
+    let mut guard = TempFileGuard::new(tmp.clone());
+    std::fs::write(&tmp, data)
+        .map_err(|e| CliError::Auth(format!("Failed to write {}: {e}", tmp.display())))?;
     #[cfg(unix)]
     {
         use std::os::unix::fs::PermissionsExt;
         let perms = std::fs::Permissions::from_mode(0o600);
         let _ = std::fs::set_permissions(&tmp, perms);
     }
-    std::fs::rename(&tmp, path).map_err(|e| {
-        let _ = std::fs::remove_file(&tmp);
-        CliError::Auth(format!("Failed to rename {}: {e}", tmp.display()))
-    })
+    std::fs::rename(&tmp, path)
+        .map_err(|e| CliError::Auth(format!("Failed to rename {}: {e}", tmp.display())))?;
+    guard.disarm();
+    Ok(())
 }
 
 // ---------------------------------------------------------------------------
@@ -315,6 +348,56 @@ mod tests {
             .filter(|n| n.contains(".tmp"))
             .collect();
         assert!(leftovers.is_empty(), "temp files left behind: {leftovers:?}");
+    }
+
+    /// A failed write must not leave its temp file behind. Renaming a file onto
+    /// an existing directory fails on every platform, which drives the error
+    /// path without mocking the filesystem.
+    ///
+    /// The pre-`TempFileGuard` code already cleaned up on a `rename` error, so
+    /// this pins an invariant rather than catching a regression — see
+    /// `temp_file_guard_unlinks_unless_disarmed` for the guard's own coverage.
+    #[test]
+    fn atomic_write_cleans_up_temp_file_on_failure() {
+        let dir = tempfile::tempdir().unwrap();
+
+        // The target is a *directory*, so `rename` cannot replace it.
+        let target = dir.path().join("auth-keyring.json");
+        std::fs::create_dir(&target).unwrap();
+        std::fs::write(target.join("occupant"), b"x").unwrap();
+
+        let result = atomic_write(&target, br#"{"writer":0}"#);
+        assert!(result.is_err(), "expected rename onto a directory to fail");
+
+        let leftovers: Vec<String> = std::fs::read_dir(dir.path())
+            .unwrap()
+            .filter_map(|e| e.ok())
+            .map(|e| e.file_name().to_string_lossy().into_owned())
+            .filter(|n| n.contains(".tmp"))
+            .collect();
+        assert!(leftovers.is_empty(), "temp file leaked after a failed write: {leftovers:?}");
+    }
+
+    /// Pins [`TempFileGuard`]: armed drops unlink, disarmed drops don't. Drop
+    /// running on an armed guard is what covers early returns and unwinding
+    /// panics between `write` and `rename` — paths the old `rename`-only
+    /// cleanup missed. Deleting the guard or the `disarm()` call fails this.
+    #[test]
+    fn temp_file_guard_unlinks_unless_disarmed() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("auth-keyring.tmp.0.0");
+
+        std::fs::write(&path, b"x").unwrap();
+        drop(TempFileGuard::new(path.clone()));
+        assert!(!path.exists(), "armed guard must unlink on drop");
+
+        // The post-`rename` case: the file has been moved away, so the guard
+        // must not touch whatever now sits at that path.
+        std::fs::write(&path, b"x").unwrap();
+        let mut guard = TempFileGuard::new(path.clone());
+        guard.disarm();
+        drop(guard);
+        assert!(path.exists(), "disarmed guard must not unlink");
     }
 
     #[test]

--- a/seed/cli/allof-inline/src/auth/oauth_common.rs
+++ b/seed/cli/allof-inline/src/auth/oauth_common.rs
@@ -226,8 +226,29 @@ pub(crate) fn config_dir() -> Option<PathBuf> {
 
 /// Write `data` to `path` atomically: sibling temp file → owner-only
 /// permissions (0600 on Unix) → rename into place.
+///
+/// The temp file name is unique per writer — pid plus a process-local
+/// counter. Deriving it from the target alone meant every concurrent writer
+/// used the *same* sibling (`auth-keyring.tmp`): whichever one renamed first
+/// moved it away, and the rest failed with `ENOENT` from `rename`. That
+/// surfaced as intermittent `auth login --with-token` failures across a
+/// wire-test suite large enough to run many CLI processes at once, killing a
+/// different subset of cases on each run.
+///
+/// The pid covers the case that actually bit us (separate CLI processes); the
+/// counter covers two writers inside one process, and is what makes the
+/// behavior unit-testable without spawning subprocesses.
+///
+/// `rename` is still atomic for readers, which is what keeps a partially
+/// written credential file unobservable. This only fixes writer-vs-writer
+/// collisions on the temp path. `FileKeyringStore::set` remains a
+/// read-modify-write of the whole map with no lock, so simultaneous writers
+/// can still clobber one another's *entries*; making that safe needs file
+/// locking, which is a larger change.
 pub(crate) fn atomic_write(path: &Path, data: &[u8]) -> Result<(), CliError> {
-    let tmp = path.with_extension("tmp");
+    static TMP_SEQ: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+    let seq = TMP_SEQ.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+    let tmp = path.with_extension(format!("tmp.{}.{}", std::process::id(), seq));
     std::fs::write(&tmp, data).map_err(|e| {
         CliError::Auth(format!("Failed to write {}: {e}", tmp.display()))
     })?;
@@ -250,6 +271,51 @@ pub(crate) fn atomic_write(path: &Path, data: &[u8]) -> Result<(), CliError> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// Regression test for the temp-file collision that made
+    /// `auth login --with-token` fail intermittently: every writer derived the
+    /// same sibling path from the target, so the first `rename` moved it away
+    /// and the rest got `ENOENT`.
+    ///
+    /// Reverting `atomic_write` to a target-derived temp name fails this with
+    /// "Failed to rename ...: No such file or directory".
+    #[test]
+    fn atomic_write_tolerates_concurrent_writers() {
+        let dir = tempfile::tempdir().unwrap();
+        let target = dir.path().join("auth-keyring.json");
+
+        let results: Vec<Result<(), CliError>> = std::thread::scope(|scope| {
+            let handles: Vec<_> = (0..16)
+                .map(|i| {
+                    let target = target.clone();
+                    scope.spawn(move || atomic_write(&target, format!(r#"{{"writer":{i}}}"#).as_bytes()))
+                })
+                .collect();
+            handles.into_iter().map(|h| h.join().unwrap()).collect()
+        });
+
+        let failed: Vec<String> = results
+            .iter()
+            .filter_map(|r| r.as_ref().err().map(|e| e.to_string()))
+            .collect();
+        assert!(failed.is_empty(), "concurrent writers failed: {failed:?}");
+
+        // Last writer wins, but the file must always be one writer's complete
+        // payload — never a mix, and never absent.
+        let contents = std::fs::read_to_string(&target).unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(&contents)
+            .unwrap_or_else(|e| panic!("target is not valid JSON after concurrent writes: {e} in {contents:?}"));
+        assert!(parsed.get("writer").is_some(), "unexpected payload: {contents}");
+
+        // No temp files orphaned in the directory.
+        let leftovers: Vec<String> = std::fs::read_dir(dir.path())
+            .unwrap()
+            .filter_map(|e| e.ok())
+            .map(|e| e.file_name().to_string_lossy().into_owned())
+            .filter(|n| n.contains(".tmp"))
+            .collect();
+        assert!(leftovers.is_empty(), "temp files left behind: {leftovers:?}");
+    }
 
     #[test]
     fn token_bundle_roundtrip() {

--- a/seed/cli/allof/src/auth/oauth_common.rs
+++ b/seed/cli/allof/src/auth/oauth_common.rs
@@ -224,27 +224,6 @@ pub(crate) fn config_dir() -> Option<PathBuf> {
     }
 }
 
-/// Write `data` to `path` atomically: sibling temp file → owner-only
-/// permissions (0600 on Unix) → rename into place.
-///
-/// The temp file name is unique per writer — pid plus a process-local
-/// counter. Deriving it from the target alone meant every concurrent writer
-/// used the *same* sibling (`auth-keyring.tmp`): whichever one renamed first
-/// moved it away, and the rest failed with `ENOENT` from `rename`. That
-/// surfaced as intermittent `auth login --with-token` failures across a
-/// wire-test suite large enough to run many CLI processes at once, killing a
-/// different subset of cases on each run.
-///
-/// The pid covers the case that actually bit us (separate CLI processes); the
-/// counter covers two writers inside one process, and is what makes the
-/// behavior unit-testable without spawning subprocesses.
-///
-/// `rename` is still atomic for readers, which is what keeps a partially
-/// written credential file unobservable. This only fixes writer-vs-writer
-/// collisions on the temp path. `FileKeyringStore::set` remains a
-/// read-modify-write of the whole map with no lock, so simultaneous writers
-/// can still clobber one another's *entries*; making that safe needs file
-/// locking, which is a larger change.
 /// Unlinks a temp file on drop unless [`TempFileGuard::disarm`]ed. Covers
 /// every early return *and* a panic between creating the temp file and
 /// renaming it into place.
@@ -278,6 +257,30 @@ impl Drop for TempFileGuard {
     }
 }
 
+/// Write `data` to `path` atomically: sibling temp file → owner-only
+/// permissions (0600 on Unix) → rename into place.
+///
+/// The temp file name is unique per writer — pid plus a process-local
+/// counter. Deriving it from the target alone meant every concurrent writer
+/// used the *same* sibling (`auth-keyring.tmp`): whichever one renamed first
+/// moved it away, and the rest failed with `ENOENT` from `rename`. That
+/// surfaced as intermittent `auth login --with-token` failures across a
+/// wire-test suite large enough to run many CLI processes at once, killing a
+/// different subset of cases on each run.
+///
+/// The pid covers the case that actually bit us (separate CLI processes); the
+/// counter covers two writers inside one process, and is what makes the
+/// behavior unit-testable without spawning subprocesses.
+///
+/// A [`TempFileGuard`] unlinks the temp file if anything between creating it
+/// and renaming it fails, so unique names cannot accumulate as orphans.
+///
+/// `rename` is still atomic for readers, which is what keeps a partially
+/// written credential file unobservable. This only fixes writer-vs-writer
+/// collisions on the temp path. `FileKeyringStore::set` remains a
+/// read-modify-write of the whole map with no lock, so simultaneous writers
+/// can still clobber one another's *entries*; making that safe needs file
+/// locking, which is a larger change.
 pub(crate) fn atomic_write(path: &Path, data: &[u8]) -> Result<(), CliError> {
     static TMP_SEQ: std::sync::atomic::AtomicUsize = std::sync::atomic::AtomicUsize::new(0);
     let seq = TMP_SEQ.fetch_add(1, std::sync::atomic::Ordering::Relaxed);

--- a/seed/cli/allof/src/auth/oauth_common.rs
+++ b/seed/cli/allof/src/auth/oauth_common.rs
@@ -245,23 +245,56 @@ pub(crate) fn config_dir() -> Option<PathBuf> {
 /// read-modify-write of the whole map with no lock, so simultaneous writers
 /// can still clobber one another's *entries*; making that safe needs file
 /// locking, which is a larger change.
+/// Unlinks a temp file on drop unless [`TempFileGuard::disarm`]ed. Covers
+/// every early return *and* a panic between creating the temp file and
+/// renaming it into place.
+///
+/// This exists because the temp name is unique per writer. The old shared
+/// `auth-keyring.tmp` was self-limiting — a failed write left one stale file
+/// that the next write reused — whereas unique names would leak a distinct
+/// credential-bearing file on every failure, in a directory nothing prunes. A
+/// `SIGKILL` still leaks, since no in-process guard can cover that.
+struct TempFileGuard {
+    path: PathBuf,
+    armed: bool,
+}
+
+impl TempFileGuard {
+    fn new(path: PathBuf) -> Self {
+        Self { path, armed: true }
+    }
+
+    /// Relinquish the file — call once `rename` has moved it into place.
+    fn disarm(&mut self) {
+        self.armed = false;
+    }
+}
+
+impl Drop for TempFileGuard {
+    fn drop(&mut self) {
+        if self.armed {
+            let _ = std::fs::remove_file(&self.path);
+        }
+    }
+}
+
 pub(crate) fn atomic_write(path: &Path, data: &[u8]) -> Result<(), CliError> {
-    static TMP_SEQ: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+    static TMP_SEQ: std::sync::atomic::AtomicUsize = std::sync::atomic::AtomicUsize::new(0);
     let seq = TMP_SEQ.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
     let tmp = path.with_extension(format!("tmp.{}.{}", std::process::id(), seq));
-    std::fs::write(&tmp, data).map_err(|e| {
-        CliError::Auth(format!("Failed to write {}: {e}", tmp.display()))
-    })?;
+    let mut guard = TempFileGuard::new(tmp.clone());
+    std::fs::write(&tmp, data)
+        .map_err(|e| CliError::Auth(format!("Failed to write {}: {e}", tmp.display())))?;
     #[cfg(unix)]
     {
         use std::os::unix::fs::PermissionsExt;
         let perms = std::fs::Permissions::from_mode(0o600);
         let _ = std::fs::set_permissions(&tmp, perms);
     }
-    std::fs::rename(&tmp, path).map_err(|e| {
-        let _ = std::fs::remove_file(&tmp);
-        CliError::Auth(format!("Failed to rename {}: {e}", tmp.display()))
-    })
+    std::fs::rename(&tmp, path)
+        .map_err(|e| CliError::Auth(format!("Failed to rename {}: {e}", tmp.display())))?;
+    guard.disarm();
+    Ok(())
 }
 
 // ---------------------------------------------------------------------------
@@ -315,6 +348,56 @@ mod tests {
             .filter(|n| n.contains(".tmp"))
             .collect();
         assert!(leftovers.is_empty(), "temp files left behind: {leftovers:?}");
+    }
+
+    /// A failed write must not leave its temp file behind. Renaming a file onto
+    /// an existing directory fails on every platform, which drives the error
+    /// path without mocking the filesystem.
+    ///
+    /// The pre-`TempFileGuard` code already cleaned up on a `rename` error, so
+    /// this pins an invariant rather than catching a regression — see
+    /// `temp_file_guard_unlinks_unless_disarmed` for the guard's own coverage.
+    #[test]
+    fn atomic_write_cleans_up_temp_file_on_failure() {
+        let dir = tempfile::tempdir().unwrap();
+
+        // The target is a *directory*, so `rename` cannot replace it.
+        let target = dir.path().join("auth-keyring.json");
+        std::fs::create_dir(&target).unwrap();
+        std::fs::write(target.join("occupant"), b"x").unwrap();
+
+        let result = atomic_write(&target, br#"{"writer":0}"#);
+        assert!(result.is_err(), "expected rename onto a directory to fail");
+
+        let leftovers: Vec<String> = std::fs::read_dir(dir.path())
+            .unwrap()
+            .filter_map(|e| e.ok())
+            .map(|e| e.file_name().to_string_lossy().into_owned())
+            .filter(|n| n.contains(".tmp"))
+            .collect();
+        assert!(leftovers.is_empty(), "temp file leaked after a failed write: {leftovers:?}");
+    }
+
+    /// Pins [`TempFileGuard`]: armed drops unlink, disarmed drops don't. Drop
+    /// running on an armed guard is what covers early returns and unwinding
+    /// panics between `write` and `rename` — paths the old `rename`-only
+    /// cleanup missed. Deleting the guard or the `disarm()` call fails this.
+    #[test]
+    fn temp_file_guard_unlinks_unless_disarmed() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("auth-keyring.tmp.0.0");
+
+        std::fs::write(&path, b"x").unwrap();
+        drop(TempFileGuard::new(path.clone()));
+        assert!(!path.exists(), "armed guard must unlink on drop");
+
+        // The post-`rename` case: the file has been moved away, so the guard
+        // must not touch whatever now sits at that path.
+        std::fs::write(&path, b"x").unwrap();
+        let mut guard = TempFileGuard::new(path.clone());
+        guard.disarm();
+        drop(guard);
+        assert!(path.exists(), "disarmed guard must not unlink");
     }
 
     #[test]

--- a/seed/cli/allof/src/auth/oauth_common.rs
+++ b/seed/cli/allof/src/auth/oauth_common.rs
@@ -226,8 +226,29 @@ pub(crate) fn config_dir() -> Option<PathBuf> {
 
 /// Write `data` to `path` atomically: sibling temp file → owner-only
 /// permissions (0600 on Unix) → rename into place.
+///
+/// The temp file name is unique per writer — pid plus a process-local
+/// counter. Deriving it from the target alone meant every concurrent writer
+/// used the *same* sibling (`auth-keyring.tmp`): whichever one renamed first
+/// moved it away, and the rest failed with `ENOENT` from `rename`. That
+/// surfaced as intermittent `auth login --with-token` failures across a
+/// wire-test suite large enough to run many CLI processes at once, killing a
+/// different subset of cases on each run.
+///
+/// The pid covers the case that actually bit us (separate CLI processes); the
+/// counter covers two writers inside one process, and is what makes the
+/// behavior unit-testable without spawning subprocesses.
+///
+/// `rename` is still atomic for readers, which is what keeps a partially
+/// written credential file unobservable. This only fixes writer-vs-writer
+/// collisions on the temp path. `FileKeyringStore::set` remains a
+/// read-modify-write of the whole map with no lock, so simultaneous writers
+/// can still clobber one another's *entries*; making that safe needs file
+/// locking, which is a larger change.
 pub(crate) fn atomic_write(path: &Path, data: &[u8]) -> Result<(), CliError> {
-    let tmp = path.with_extension("tmp");
+    static TMP_SEQ: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+    let seq = TMP_SEQ.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+    let tmp = path.with_extension(format!("tmp.{}.{}", std::process::id(), seq));
     std::fs::write(&tmp, data).map_err(|e| {
         CliError::Auth(format!("Failed to write {}: {e}", tmp.display()))
     })?;
@@ -250,6 +271,51 @@ pub(crate) fn atomic_write(path: &Path, data: &[u8]) -> Result<(), CliError> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// Regression test for the temp-file collision that made
+    /// `auth login --with-token` fail intermittently: every writer derived the
+    /// same sibling path from the target, so the first `rename` moved it away
+    /// and the rest got `ENOENT`.
+    ///
+    /// Reverting `atomic_write` to a target-derived temp name fails this with
+    /// "Failed to rename ...: No such file or directory".
+    #[test]
+    fn atomic_write_tolerates_concurrent_writers() {
+        let dir = tempfile::tempdir().unwrap();
+        let target = dir.path().join("auth-keyring.json");
+
+        let results: Vec<Result<(), CliError>> = std::thread::scope(|scope| {
+            let handles: Vec<_> = (0..16)
+                .map(|i| {
+                    let target = target.clone();
+                    scope.spawn(move || atomic_write(&target, format!(r#"{{"writer":{i}}}"#).as_bytes()))
+                })
+                .collect();
+            handles.into_iter().map(|h| h.join().unwrap()).collect()
+        });
+
+        let failed: Vec<String> = results
+            .iter()
+            .filter_map(|r| r.as_ref().err().map(|e| e.to_string()))
+            .collect();
+        assert!(failed.is_empty(), "concurrent writers failed: {failed:?}");
+
+        // Last writer wins, but the file must always be one writer's complete
+        // payload — never a mix, and never absent.
+        let contents = std::fs::read_to_string(&target).unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(&contents)
+            .unwrap_or_else(|e| panic!("target is not valid JSON after concurrent writes: {e} in {contents:?}"));
+        assert!(parsed.get("writer").is_some(), "unexpected payload: {contents}");
+
+        // No temp files orphaned in the directory.
+        let leftovers: Vec<String> = std::fs::read_dir(dir.path())
+            .unwrap()
+            .filter_map(|e| e.ok())
+            .map(|e| e.file_name().to_string_lossy().into_owned())
+            .filter(|n| n.contains(".tmp"))
+            .collect();
+        assert!(leftovers.is_empty(), "temp files left behind: {leftovers:?}");
+    }
 
     #[test]
     fn token_bundle_roundtrip() {

--- a/seed/cli/api-wide-base-path-with-default/src/auth/oauth_common.rs
+++ b/seed/cli/api-wide-base-path-with-default/src/auth/oauth_common.rs
@@ -224,27 +224,6 @@ pub(crate) fn config_dir() -> Option<PathBuf> {
     }
 }
 
-/// Write `data` to `path` atomically: sibling temp file → owner-only
-/// permissions (0600 on Unix) → rename into place.
-///
-/// The temp file name is unique per writer — pid plus a process-local
-/// counter. Deriving it from the target alone meant every concurrent writer
-/// used the *same* sibling (`auth-keyring.tmp`): whichever one renamed first
-/// moved it away, and the rest failed with `ENOENT` from `rename`. That
-/// surfaced as intermittent `auth login --with-token` failures across a
-/// wire-test suite large enough to run many CLI processes at once, killing a
-/// different subset of cases on each run.
-///
-/// The pid covers the case that actually bit us (separate CLI processes); the
-/// counter covers two writers inside one process, and is what makes the
-/// behavior unit-testable without spawning subprocesses.
-///
-/// `rename` is still atomic for readers, which is what keeps a partially
-/// written credential file unobservable. This only fixes writer-vs-writer
-/// collisions on the temp path. `FileKeyringStore::set` remains a
-/// read-modify-write of the whole map with no lock, so simultaneous writers
-/// can still clobber one another's *entries*; making that safe needs file
-/// locking, which is a larger change.
 /// Unlinks a temp file on drop unless [`TempFileGuard::disarm`]ed. Covers
 /// every early return *and* a panic between creating the temp file and
 /// renaming it into place.
@@ -278,6 +257,30 @@ impl Drop for TempFileGuard {
     }
 }
 
+/// Write `data` to `path` atomically: sibling temp file → owner-only
+/// permissions (0600 on Unix) → rename into place.
+///
+/// The temp file name is unique per writer — pid plus a process-local
+/// counter. Deriving it from the target alone meant every concurrent writer
+/// used the *same* sibling (`auth-keyring.tmp`): whichever one renamed first
+/// moved it away, and the rest failed with `ENOENT` from `rename`. That
+/// surfaced as intermittent `auth login --with-token` failures across a
+/// wire-test suite large enough to run many CLI processes at once, killing a
+/// different subset of cases on each run.
+///
+/// The pid covers the case that actually bit us (separate CLI processes); the
+/// counter covers two writers inside one process, and is what makes the
+/// behavior unit-testable without spawning subprocesses.
+///
+/// A [`TempFileGuard`] unlinks the temp file if anything between creating it
+/// and renaming it fails, so unique names cannot accumulate as orphans.
+///
+/// `rename` is still atomic for readers, which is what keeps a partially
+/// written credential file unobservable. This only fixes writer-vs-writer
+/// collisions on the temp path. `FileKeyringStore::set` remains a
+/// read-modify-write of the whole map with no lock, so simultaneous writers
+/// can still clobber one another's *entries*; making that safe needs file
+/// locking, which is a larger change.
 pub(crate) fn atomic_write(path: &Path, data: &[u8]) -> Result<(), CliError> {
     static TMP_SEQ: std::sync::atomic::AtomicUsize = std::sync::atomic::AtomicUsize::new(0);
     let seq = TMP_SEQ.fetch_add(1, std::sync::atomic::Ordering::Relaxed);

--- a/seed/cli/api-wide-base-path-with-default/src/auth/oauth_common.rs
+++ b/seed/cli/api-wide-base-path-with-default/src/auth/oauth_common.rs
@@ -245,23 +245,56 @@ pub(crate) fn config_dir() -> Option<PathBuf> {
 /// read-modify-write of the whole map with no lock, so simultaneous writers
 /// can still clobber one another's *entries*; making that safe needs file
 /// locking, which is a larger change.
+/// Unlinks a temp file on drop unless [`TempFileGuard::disarm`]ed. Covers
+/// every early return *and* a panic between creating the temp file and
+/// renaming it into place.
+///
+/// This exists because the temp name is unique per writer. The old shared
+/// `auth-keyring.tmp` was self-limiting — a failed write left one stale file
+/// that the next write reused — whereas unique names would leak a distinct
+/// credential-bearing file on every failure, in a directory nothing prunes. A
+/// `SIGKILL` still leaks, since no in-process guard can cover that.
+struct TempFileGuard {
+    path: PathBuf,
+    armed: bool,
+}
+
+impl TempFileGuard {
+    fn new(path: PathBuf) -> Self {
+        Self { path, armed: true }
+    }
+
+    /// Relinquish the file — call once `rename` has moved it into place.
+    fn disarm(&mut self) {
+        self.armed = false;
+    }
+}
+
+impl Drop for TempFileGuard {
+    fn drop(&mut self) {
+        if self.armed {
+            let _ = std::fs::remove_file(&self.path);
+        }
+    }
+}
+
 pub(crate) fn atomic_write(path: &Path, data: &[u8]) -> Result<(), CliError> {
-    static TMP_SEQ: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+    static TMP_SEQ: std::sync::atomic::AtomicUsize = std::sync::atomic::AtomicUsize::new(0);
     let seq = TMP_SEQ.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
     let tmp = path.with_extension(format!("tmp.{}.{}", std::process::id(), seq));
-    std::fs::write(&tmp, data).map_err(|e| {
-        CliError::Auth(format!("Failed to write {}: {e}", tmp.display()))
-    })?;
+    let mut guard = TempFileGuard::new(tmp.clone());
+    std::fs::write(&tmp, data)
+        .map_err(|e| CliError::Auth(format!("Failed to write {}: {e}", tmp.display())))?;
     #[cfg(unix)]
     {
         use std::os::unix::fs::PermissionsExt;
         let perms = std::fs::Permissions::from_mode(0o600);
         let _ = std::fs::set_permissions(&tmp, perms);
     }
-    std::fs::rename(&tmp, path).map_err(|e| {
-        let _ = std::fs::remove_file(&tmp);
-        CliError::Auth(format!("Failed to rename {}: {e}", tmp.display()))
-    })
+    std::fs::rename(&tmp, path)
+        .map_err(|e| CliError::Auth(format!("Failed to rename {}: {e}", tmp.display())))?;
+    guard.disarm();
+    Ok(())
 }
 
 // ---------------------------------------------------------------------------
@@ -315,6 +348,56 @@ mod tests {
             .filter(|n| n.contains(".tmp"))
             .collect();
         assert!(leftovers.is_empty(), "temp files left behind: {leftovers:?}");
+    }
+
+    /// A failed write must not leave its temp file behind. Renaming a file onto
+    /// an existing directory fails on every platform, which drives the error
+    /// path without mocking the filesystem.
+    ///
+    /// The pre-`TempFileGuard` code already cleaned up on a `rename` error, so
+    /// this pins an invariant rather than catching a regression — see
+    /// `temp_file_guard_unlinks_unless_disarmed` for the guard's own coverage.
+    #[test]
+    fn atomic_write_cleans_up_temp_file_on_failure() {
+        let dir = tempfile::tempdir().unwrap();
+
+        // The target is a *directory*, so `rename` cannot replace it.
+        let target = dir.path().join("auth-keyring.json");
+        std::fs::create_dir(&target).unwrap();
+        std::fs::write(target.join("occupant"), b"x").unwrap();
+
+        let result = atomic_write(&target, br#"{"writer":0}"#);
+        assert!(result.is_err(), "expected rename onto a directory to fail");
+
+        let leftovers: Vec<String> = std::fs::read_dir(dir.path())
+            .unwrap()
+            .filter_map(|e| e.ok())
+            .map(|e| e.file_name().to_string_lossy().into_owned())
+            .filter(|n| n.contains(".tmp"))
+            .collect();
+        assert!(leftovers.is_empty(), "temp file leaked after a failed write: {leftovers:?}");
+    }
+
+    /// Pins [`TempFileGuard`]: armed drops unlink, disarmed drops don't. Drop
+    /// running on an armed guard is what covers early returns and unwinding
+    /// panics between `write` and `rename` — paths the old `rename`-only
+    /// cleanup missed. Deleting the guard or the `disarm()` call fails this.
+    #[test]
+    fn temp_file_guard_unlinks_unless_disarmed() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("auth-keyring.tmp.0.0");
+
+        std::fs::write(&path, b"x").unwrap();
+        drop(TempFileGuard::new(path.clone()));
+        assert!(!path.exists(), "armed guard must unlink on drop");
+
+        // The post-`rename` case: the file has been moved away, so the guard
+        // must not touch whatever now sits at that path.
+        std::fs::write(&path, b"x").unwrap();
+        let mut guard = TempFileGuard::new(path.clone());
+        guard.disarm();
+        drop(guard);
+        assert!(path.exists(), "disarmed guard must not unlink");
     }
 
     #[test]

--- a/seed/cli/api-wide-base-path-with-default/src/auth/oauth_common.rs
+++ b/seed/cli/api-wide-base-path-with-default/src/auth/oauth_common.rs
@@ -226,8 +226,29 @@ pub(crate) fn config_dir() -> Option<PathBuf> {
 
 /// Write `data` to `path` atomically: sibling temp file → owner-only
 /// permissions (0600 on Unix) → rename into place.
+///
+/// The temp file name is unique per writer — pid plus a process-local
+/// counter. Deriving it from the target alone meant every concurrent writer
+/// used the *same* sibling (`auth-keyring.tmp`): whichever one renamed first
+/// moved it away, and the rest failed with `ENOENT` from `rename`. That
+/// surfaced as intermittent `auth login --with-token` failures across a
+/// wire-test suite large enough to run many CLI processes at once, killing a
+/// different subset of cases on each run.
+///
+/// The pid covers the case that actually bit us (separate CLI processes); the
+/// counter covers two writers inside one process, and is what makes the
+/// behavior unit-testable without spawning subprocesses.
+///
+/// `rename` is still atomic for readers, which is what keeps a partially
+/// written credential file unobservable. This only fixes writer-vs-writer
+/// collisions on the temp path. `FileKeyringStore::set` remains a
+/// read-modify-write of the whole map with no lock, so simultaneous writers
+/// can still clobber one another's *entries*; making that safe needs file
+/// locking, which is a larger change.
 pub(crate) fn atomic_write(path: &Path, data: &[u8]) -> Result<(), CliError> {
-    let tmp = path.with_extension("tmp");
+    static TMP_SEQ: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+    let seq = TMP_SEQ.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+    let tmp = path.with_extension(format!("tmp.{}.{}", std::process::id(), seq));
     std::fs::write(&tmp, data).map_err(|e| {
         CliError::Auth(format!("Failed to write {}: {e}", tmp.display()))
     })?;
@@ -250,6 +271,51 @@ pub(crate) fn atomic_write(path: &Path, data: &[u8]) -> Result<(), CliError> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// Regression test for the temp-file collision that made
+    /// `auth login --with-token` fail intermittently: every writer derived the
+    /// same sibling path from the target, so the first `rename` moved it away
+    /// and the rest got `ENOENT`.
+    ///
+    /// Reverting `atomic_write` to a target-derived temp name fails this with
+    /// "Failed to rename ...: No such file or directory".
+    #[test]
+    fn atomic_write_tolerates_concurrent_writers() {
+        let dir = tempfile::tempdir().unwrap();
+        let target = dir.path().join("auth-keyring.json");
+
+        let results: Vec<Result<(), CliError>> = std::thread::scope(|scope| {
+            let handles: Vec<_> = (0..16)
+                .map(|i| {
+                    let target = target.clone();
+                    scope.spawn(move || atomic_write(&target, format!(r#"{{"writer":{i}}}"#).as_bytes()))
+                })
+                .collect();
+            handles.into_iter().map(|h| h.join().unwrap()).collect()
+        });
+
+        let failed: Vec<String> = results
+            .iter()
+            .filter_map(|r| r.as_ref().err().map(|e| e.to_string()))
+            .collect();
+        assert!(failed.is_empty(), "concurrent writers failed: {failed:?}");
+
+        // Last writer wins, but the file must always be one writer's complete
+        // payload — never a mix, and never absent.
+        let contents = std::fs::read_to_string(&target).unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(&contents)
+            .unwrap_or_else(|e| panic!("target is not valid JSON after concurrent writes: {e} in {contents:?}"));
+        assert!(parsed.get("writer").is_some(), "unexpected payload: {contents}");
+
+        // No temp files orphaned in the directory.
+        let leftovers: Vec<String> = std::fs::read_dir(dir.path())
+            .unwrap()
+            .filter_map(|e| e.ok())
+            .map(|e| e.file_name().to_string_lossy().into_owned())
+            .filter(|n| n.contains(".tmp"))
+            .collect();
+        assert!(leftovers.is_empty(), "temp files left behind: {leftovers:?}");
+    }
 
     #[test]
     fn token_bundle_roundtrip() {

--- a/seed/cli/cli-basic-auth/with-split-type-crates/src/auth/oauth_common.rs
+++ b/seed/cli/cli-basic-auth/with-split-type-crates/src/auth/oauth_common.rs
@@ -224,27 +224,6 @@ pub(crate) fn config_dir() -> Option<PathBuf> {
     }
 }
 
-/// Write `data` to `path` atomically: sibling temp file → owner-only
-/// permissions (0600 on Unix) → rename into place.
-///
-/// The temp file name is unique per writer — pid plus a process-local
-/// counter. Deriving it from the target alone meant every concurrent writer
-/// used the *same* sibling (`auth-keyring.tmp`): whichever one renamed first
-/// moved it away, and the rest failed with `ENOENT` from `rename`. That
-/// surfaced as intermittent `auth login --with-token` failures across a
-/// wire-test suite large enough to run many CLI processes at once, killing a
-/// different subset of cases on each run.
-///
-/// The pid covers the case that actually bit us (separate CLI processes); the
-/// counter covers two writers inside one process, and is what makes the
-/// behavior unit-testable without spawning subprocesses.
-///
-/// `rename` is still atomic for readers, which is what keeps a partially
-/// written credential file unobservable. This only fixes writer-vs-writer
-/// collisions on the temp path. `FileKeyringStore::set` remains a
-/// read-modify-write of the whole map with no lock, so simultaneous writers
-/// can still clobber one another's *entries*; making that safe needs file
-/// locking, which is a larger change.
 /// Unlinks a temp file on drop unless [`TempFileGuard::disarm`]ed. Covers
 /// every early return *and* a panic between creating the temp file and
 /// renaming it into place.
@@ -278,6 +257,30 @@ impl Drop for TempFileGuard {
     }
 }
 
+/// Write `data` to `path` atomically: sibling temp file → owner-only
+/// permissions (0600 on Unix) → rename into place.
+///
+/// The temp file name is unique per writer — pid plus a process-local
+/// counter. Deriving it from the target alone meant every concurrent writer
+/// used the *same* sibling (`auth-keyring.tmp`): whichever one renamed first
+/// moved it away, and the rest failed with `ENOENT` from `rename`. That
+/// surfaced as intermittent `auth login --with-token` failures across a
+/// wire-test suite large enough to run many CLI processes at once, killing a
+/// different subset of cases on each run.
+///
+/// The pid covers the case that actually bit us (separate CLI processes); the
+/// counter covers two writers inside one process, and is what makes the
+/// behavior unit-testable without spawning subprocesses.
+///
+/// A [`TempFileGuard`] unlinks the temp file if anything between creating it
+/// and renaming it fails, so unique names cannot accumulate as orphans.
+///
+/// `rename` is still atomic for readers, which is what keeps a partially
+/// written credential file unobservable. This only fixes writer-vs-writer
+/// collisions on the temp path. `FileKeyringStore::set` remains a
+/// read-modify-write of the whole map with no lock, so simultaneous writers
+/// can still clobber one another's *entries*; making that safe needs file
+/// locking, which is a larger change.
 pub(crate) fn atomic_write(path: &Path, data: &[u8]) -> Result<(), CliError> {
     static TMP_SEQ: std::sync::atomic::AtomicUsize = std::sync::atomic::AtomicUsize::new(0);
     let seq = TMP_SEQ.fetch_add(1, std::sync::atomic::Ordering::Relaxed);

--- a/seed/cli/cli-basic-auth/with-split-type-crates/src/auth/oauth_common.rs
+++ b/seed/cli/cli-basic-auth/with-split-type-crates/src/auth/oauth_common.rs
@@ -245,23 +245,56 @@ pub(crate) fn config_dir() -> Option<PathBuf> {
 /// read-modify-write of the whole map with no lock, so simultaneous writers
 /// can still clobber one another's *entries*; making that safe needs file
 /// locking, which is a larger change.
+/// Unlinks a temp file on drop unless [`TempFileGuard::disarm`]ed. Covers
+/// every early return *and* a panic between creating the temp file and
+/// renaming it into place.
+///
+/// This exists because the temp name is unique per writer. The old shared
+/// `auth-keyring.tmp` was self-limiting — a failed write left one stale file
+/// that the next write reused — whereas unique names would leak a distinct
+/// credential-bearing file on every failure, in a directory nothing prunes. A
+/// `SIGKILL` still leaks, since no in-process guard can cover that.
+struct TempFileGuard {
+    path: PathBuf,
+    armed: bool,
+}
+
+impl TempFileGuard {
+    fn new(path: PathBuf) -> Self {
+        Self { path, armed: true }
+    }
+
+    /// Relinquish the file — call once `rename` has moved it into place.
+    fn disarm(&mut self) {
+        self.armed = false;
+    }
+}
+
+impl Drop for TempFileGuard {
+    fn drop(&mut self) {
+        if self.armed {
+            let _ = std::fs::remove_file(&self.path);
+        }
+    }
+}
+
 pub(crate) fn atomic_write(path: &Path, data: &[u8]) -> Result<(), CliError> {
-    static TMP_SEQ: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+    static TMP_SEQ: std::sync::atomic::AtomicUsize = std::sync::atomic::AtomicUsize::new(0);
     let seq = TMP_SEQ.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
     let tmp = path.with_extension(format!("tmp.{}.{}", std::process::id(), seq));
-    std::fs::write(&tmp, data).map_err(|e| {
-        CliError::Auth(format!("Failed to write {}: {e}", tmp.display()))
-    })?;
+    let mut guard = TempFileGuard::new(tmp.clone());
+    std::fs::write(&tmp, data)
+        .map_err(|e| CliError::Auth(format!("Failed to write {}: {e}", tmp.display())))?;
     #[cfg(unix)]
     {
         use std::os::unix::fs::PermissionsExt;
         let perms = std::fs::Permissions::from_mode(0o600);
         let _ = std::fs::set_permissions(&tmp, perms);
     }
-    std::fs::rename(&tmp, path).map_err(|e| {
-        let _ = std::fs::remove_file(&tmp);
-        CliError::Auth(format!("Failed to rename {}: {e}", tmp.display()))
-    })
+    std::fs::rename(&tmp, path)
+        .map_err(|e| CliError::Auth(format!("Failed to rename {}: {e}", tmp.display())))?;
+    guard.disarm();
+    Ok(())
 }
 
 // ---------------------------------------------------------------------------
@@ -315,6 +348,56 @@ mod tests {
             .filter(|n| n.contains(".tmp"))
             .collect();
         assert!(leftovers.is_empty(), "temp files left behind: {leftovers:?}");
+    }
+
+    /// A failed write must not leave its temp file behind. Renaming a file onto
+    /// an existing directory fails on every platform, which drives the error
+    /// path without mocking the filesystem.
+    ///
+    /// The pre-`TempFileGuard` code already cleaned up on a `rename` error, so
+    /// this pins an invariant rather than catching a regression — see
+    /// `temp_file_guard_unlinks_unless_disarmed` for the guard's own coverage.
+    #[test]
+    fn atomic_write_cleans_up_temp_file_on_failure() {
+        let dir = tempfile::tempdir().unwrap();
+
+        // The target is a *directory*, so `rename` cannot replace it.
+        let target = dir.path().join("auth-keyring.json");
+        std::fs::create_dir(&target).unwrap();
+        std::fs::write(target.join("occupant"), b"x").unwrap();
+
+        let result = atomic_write(&target, br#"{"writer":0}"#);
+        assert!(result.is_err(), "expected rename onto a directory to fail");
+
+        let leftovers: Vec<String> = std::fs::read_dir(dir.path())
+            .unwrap()
+            .filter_map(|e| e.ok())
+            .map(|e| e.file_name().to_string_lossy().into_owned())
+            .filter(|n| n.contains(".tmp"))
+            .collect();
+        assert!(leftovers.is_empty(), "temp file leaked after a failed write: {leftovers:?}");
+    }
+
+    /// Pins [`TempFileGuard`]: armed drops unlink, disarmed drops don't. Drop
+    /// running on an armed guard is what covers early returns and unwinding
+    /// panics between `write` and `rename` — paths the old `rename`-only
+    /// cleanup missed. Deleting the guard or the `disarm()` call fails this.
+    #[test]
+    fn temp_file_guard_unlinks_unless_disarmed() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("auth-keyring.tmp.0.0");
+
+        std::fs::write(&path, b"x").unwrap();
+        drop(TempFileGuard::new(path.clone()));
+        assert!(!path.exists(), "armed guard must unlink on drop");
+
+        // The post-`rename` case: the file has been moved away, so the guard
+        // must not touch whatever now sits at that path.
+        std::fs::write(&path, b"x").unwrap();
+        let mut guard = TempFileGuard::new(path.clone());
+        guard.disarm();
+        drop(guard);
+        assert!(path.exists(), "disarmed guard must not unlink");
     }
 
     #[test]

--- a/seed/cli/cli-basic-auth/with-split-type-crates/src/auth/oauth_common.rs
+++ b/seed/cli/cli-basic-auth/with-split-type-crates/src/auth/oauth_common.rs
@@ -226,8 +226,29 @@ pub(crate) fn config_dir() -> Option<PathBuf> {
 
 /// Write `data` to `path` atomically: sibling temp file → owner-only
 /// permissions (0600 on Unix) → rename into place.
+///
+/// The temp file name is unique per writer — pid plus a process-local
+/// counter. Deriving it from the target alone meant every concurrent writer
+/// used the *same* sibling (`auth-keyring.tmp`): whichever one renamed first
+/// moved it away, and the rest failed with `ENOENT` from `rename`. That
+/// surfaced as intermittent `auth login --with-token` failures across a
+/// wire-test suite large enough to run many CLI processes at once, killing a
+/// different subset of cases on each run.
+///
+/// The pid covers the case that actually bit us (separate CLI processes); the
+/// counter covers two writers inside one process, and is what makes the
+/// behavior unit-testable without spawning subprocesses.
+///
+/// `rename` is still atomic for readers, which is what keeps a partially
+/// written credential file unobservable. This only fixes writer-vs-writer
+/// collisions on the temp path. `FileKeyringStore::set` remains a
+/// read-modify-write of the whole map with no lock, so simultaneous writers
+/// can still clobber one another's *entries*; making that safe needs file
+/// locking, which is a larger change.
 pub(crate) fn atomic_write(path: &Path, data: &[u8]) -> Result<(), CliError> {
-    let tmp = path.with_extension("tmp");
+    static TMP_SEQ: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+    let seq = TMP_SEQ.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+    let tmp = path.with_extension(format!("tmp.{}.{}", std::process::id(), seq));
     std::fs::write(&tmp, data).map_err(|e| {
         CliError::Auth(format!("Failed to write {}: {e}", tmp.display()))
     })?;
@@ -250,6 +271,51 @@ pub(crate) fn atomic_write(path: &Path, data: &[u8]) -> Result<(), CliError> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// Regression test for the temp-file collision that made
+    /// `auth login --with-token` fail intermittently: every writer derived the
+    /// same sibling path from the target, so the first `rename` moved it away
+    /// and the rest got `ENOENT`.
+    ///
+    /// Reverting `atomic_write` to a target-derived temp name fails this with
+    /// "Failed to rename ...: No such file or directory".
+    #[test]
+    fn atomic_write_tolerates_concurrent_writers() {
+        let dir = tempfile::tempdir().unwrap();
+        let target = dir.path().join("auth-keyring.json");
+
+        let results: Vec<Result<(), CliError>> = std::thread::scope(|scope| {
+            let handles: Vec<_> = (0..16)
+                .map(|i| {
+                    let target = target.clone();
+                    scope.spawn(move || atomic_write(&target, format!(r#"{{"writer":{i}}}"#).as_bytes()))
+                })
+                .collect();
+            handles.into_iter().map(|h| h.join().unwrap()).collect()
+        });
+
+        let failed: Vec<String> = results
+            .iter()
+            .filter_map(|r| r.as_ref().err().map(|e| e.to_string()))
+            .collect();
+        assert!(failed.is_empty(), "concurrent writers failed: {failed:?}");
+
+        // Last writer wins, but the file must always be one writer's complete
+        // payload — never a mix, and never absent.
+        let contents = std::fs::read_to_string(&target).unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(&contents)
+            .unwrap_or_else(|e| panic!("target is not valid JSON after concurrent writes: {e} in {contents:?}"));
+        assert!(parsed.get("writer").is_some(), "unexpected payload: {contents}");
+
+        // No temp files orphaned in the directory.
+        let leftovers: Vec<String> = std::fs::read_dir(dir.path())
+            .unwrap()
+            .filter_map(|e| e.ok())
+            .map(|e| e.file_name().to_string_lossy().into_owned())
+            .filter(|n| n.contains(".tmp"))
+            .collect();
+        assert!(leftovers.is_empty(), "temp files left behind: {leftovers:?}");
+    }
 
     #[test]
     fn token_bundle_roundtrip() {

--- a/seed/cli/cli-basic-auth/with-wire-tests/src/auth/oauth_common.rs
+++ b/seed/cli/cli-basic-auth/with-wire-tests/src/auth/oauth_common.rs
@@ -224,27 +224,6 @@ pub(crate) fn config_dir() -> Option<PathBuf> {
     }
 }
 
-/// Write `data` to `path` atomically: sibling temp file → owner-only
-/// permissions (0600 on Unix) → rename into place.
-///
-/// The temp file name is unique per writer — pid plus a process-local
-/// counter. Deriving it from the target alone meant every concurrent writer
-/// used the *same* sibling (`auth-keyring.tmp`): whichever one renamed first
-/// moved it away, and the rest failed with `ENOENT` from `rename`. That
-/// surfaced as intermittent `auth login --with-token` failures across a
-/// wire-test suite large enough to run many CLI processes at once, killing a
-/// different subset of cases on each run.
-///
-/// The pid covers the case that actually bit us (separate CLI processes); the
-/// counter covers two writers inside one process, and is what makes the
-/// behavior unit-testable without spawning subprocesses.
-///
-/// `rename` is still atomic for readers, which is what keeps a partially
-/// written credential file unobservable. This only fixes writer-vs-writer
-/// collisions on the temp path. `FileKeyringStore::set` remains a
-/// read-modify-write of the whole map with no lock, so simultaneous writers
-/// can still clobber one another's *entries*; making that safe needs file
-/// locking, which is a larger change.
 /// Unlinks a temp file on drop unless [`TempFileGuard::disarm`]ed. Covers
 /// every early return *and* a panic between creating the temp file and
 /// renaming it into place.
@@ -278,6 +257,30 @@ impl Drop for TempFileGuard {
     }
 }
 
+/// Write `data` to `path` atomically: sibling temp file → owner-only
+/// permissions (0600 on Unix) → rename into place.
+///
+/// The temp file name is unique per writer — pid plus a process-local
+/// counter. Deriving it from the target alone meant every concurrent writer
+/// used the *same* sibling (`auth-keyring.tmp`): whichever one renamed first
+/// moved it away, and the rest failed with `ENOENT` from `rename`. That
+/// surfaced as intermittent `auth login --with-token` failures across a
+/// wire-test suite large enough to run many CLI processes at once, killing a
+/// different subset of cases on each run.
+///
+/// The pid covers the case that actually bit us (separate CLI processes); the
+/// counter covers two writers inside one process, and is what makes the
+/// behavior unit-testable without spawning subprocesses.
+///
+/// A [`TempFileGuard`] unlinks the temp file if anything between creating it
+/// and renaming it fails, so unique names cannot accumulate as orphans.
+///
+/// `rename` is still atomic for readers, which is what keeps a partially
+/// written credential file unobservable. This only fixes writer-vs-writer
+/// collisions on the temp path. `FileKeyringStore::set` remains a
+/// read-modify-write of the whole map with no lock, so simultaneous writers
+/// can still clobber one another's *entries*; making that safe needs file
+/// locking, which is a larger change.
 pub(crate) fn atomic_write(path: &Path, data: &[u8]) -> Result<(), CliError> {
     static TMP_SEQ: std::sync::atomic::AtomicUsize = std::sync::atomic::AtomicUsize::new(0);
     let seq = TMP_SEQ.fetch_add(1, std::sync::atomic::Ordering::Relaxed);

--- a/seed/cli/cli-basic-auth/with-wire-tests/src/auth/oauth_common.rs
+++ b/seed/cli/cli-basic-auth/with-wire-tests/src/auth/oauth_common.rs
@@ -245,23 +245,56 @@ pub(crate) fn config_dir() -> Option<PathBuf> {
 /// read-modify-write of the whole map with no lock, so simultaneous writers
 /// can still clobber one another's *entries*; making that safe needs file
 /// locking, which is a larger change.
+/// Unlinks a temp file on drop unless [`TempFileGuard::disarm`]ed. Covers
+/// every early return *and* a panic between creating the temp file and
+/// renaming it into place.
+///
+/// This exists because the temp name is unique per writer. The old shared
+/// `auth-keyring.tmp` was self-limiting — a failed write left one stale file
+/// that the next write reused — whereas unique names would leak a distinct
+/// credential-bearing file on every failure, in a directory nothing prunes. A
+/// `SIGKILL` still leaks, since no in-process guard can cover that.
+struct TempFileGuard {
+    path: PathBuf,
+    armed: bool,
+}
+
+impl TempFileGuard {
+    fn new(path: PathBuf) -> Self {
+        Self { path, armed: true }
+    }
+
+    /// Relinquish the file — call once `rename` has moved it into place.
+    fn disarm(&mut self) {
+        self.armed = false;
+    }
+}
+
+impl Drop for TempFileGuard {
+    fn drop(&mut self) {
+        if self.armed {
+            let _ = std::fs::remove_file(&self.path);
+        }
+    }
+}
+
 pub(crate) fn atomic_write(path: &Path, data: &[u8]) -> Result<(), CliError> {
-    static TMP_SEQ: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+    static TMP_SEQ: std::sync::atomic::AtomicUsize = std::sync::atomic::AtomicUsize::new(0);
     let seq = TMP_SEQ.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
     let tmp = path.with_extension(format!("tmp.{}.{}", std::process::id(), seq));
-    std::fs::write(&tmp, data).map_err(|e| {
-        CliError::Auth(format!("Failed to write {}: {e}", tmp.display()))
-    })?;
+    let mut guard = TempFileGuard::new(tmp.clone());
+    std::fs::write(&tmp, data)
+        .map_err(|e| CliError::Auth(format!("Failed to write {}: {e}", tmp.display())))?;
     #[cfg(unix)]
     {
         use std::os::unix::fs::PermissionsExt;
         let perms = std::fs::Permissions::from_mode(0o600);
         let _ = std::fs::set_permissions(&tmp, perms);
     }
-    std::fs::rename(&tmp, path).map_err(|e| {
-        let _ = std::fs::remove_file(&tmp);
-        CliError::Auth(format!("Failed to rename {}: {e}", tmp.display()))
-    })
+    std::fs::rename(&tmp, path)
+        .map_err(|e| CliError::Auth(format!("Failed to rename {}: {e}", tmp.display())))?;
+    guard.disarm();
+    Ok(())
 }
 
 // ---------------------------------------------------------------------------
@@ -315,6 +348,56 @@ mod tests {
             .filter(|n| n.contains(".tmp"))
             .collect();
         assert!(leftovers.is_empty(), "temp files left behind: {leftovers:?}");
+    }
+
+    /// A failed write must not leave its temp file behind. Renaming a file onto
+    /// an existing directory fails on every platform, which drives the error
+    /// path without mocking the filesystem.
+    ///
+    /// The pre-`TempFileGuard` code already cleaned up on a `rename` error, so
+    /// this pins an invariant rather than catching a regression — see
+    /// `temp_file_guard_unlinks_unless_disarmed` for the guard's own coverage.
+    #[test]
+    fn atomic_write_cleans_up_temp_file_on_failure() {
+        let dir = tempfile::tempdir().unwrap();
+
+        // The target is a *directory*, so `rename` cannot replace it.
+        let target = dir.path().join("auth-keyring.json");
+        std::fs::create_dir(&target).unwrap();
+        std::fs::write(target.join("occupant"), b"x").unwrap();
+
+        let result = atomic_write(&target, br#"{"writer":0}"#);
+        assert!(result.is_err(), "expected rename onto a directory to fail");
+
+        let leftovers: Vec<String> = std::fs::read_dir(dir.path())
+            .unwrap()
+            .filter_map(|e| e.ok())
+            .map(|e| e.file_name().to_string_lossy().into_owned())
+            .filter(|n| n.contains(".tmp"))
+            .collect();
+        assert!(leftovers.is_empty(), "temp file leaked after a failed write: {leftovers:?}");
+    }
+
+    /// Pins [`TempFileGuard`]: armed drops unlink, disarmed drops don't. Drop
+    /// running on an armed guard is what covers early returns and unwinding
+    /// panics between `write` and `rename` — paths the old `rename`-only
+    /// cleanup missed. Deleting the guard or the `disarm()` call fails this.
+    #[test]
+    fn temp_file_guard_unlinks_unless_disarmed() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("auth-keyring.tmp.0.0");
+
+        std::fs::write(&path, b"x").unwrap();
+        drop(TempFileGuard::new(path.clone()));
+        assert!(!path.exists(), "armed guard must unlink on drop");
+
+        // The post-`rename` case: the file has been moved away, so the guard
+        // must not touch whatever now sits at that path.
+        std::fs::write(&path, b"x").unwrap();
+        let mut guard = TempFileGuard::new(path.clone());
+        guard.disarm();
+        drop(guard);
+        assert!(path.exists(), "disarmed guard must not unlink");
     }
 
     #[test]

--- a/seed/cli/cli-basic-auth/with-wire-tests/src/auth/oauth_common.rs
+++ b/seed/cli/cli-basic-auth/with-wire-tests/src/auth/oauth_common.rs
@@ -226,8 +226,29 @@ pub(crate) fn config_dir() -> Option<PathBuf> {
 
 /// Write `data` to `path` atomically: sibling temp file → owner-only
 /// permissions (0600 on Unix) → rename into place.
+///
+/// The temp file name is unique per writer — pid plus a process-local
+/// counter. Deriving it from the target alone meant every concurrent writer
+/// used the *same* sibling (`auth-keyring.tmp`): whichever one renamed first
+/// moved it away, and the rest failed with `ENOENT` from `rename`. That
+/// surfaced as intermittent `auth login --with-token` failures across a
+/// wire-test suite large enough to run many CLI processes at once, killing a
+/// different subset of cases on each run.
+///
+/// The pid covers the case that actually bit us (separate CLI processes); the
+/// counter covers two writers inside one process, and is what makes the
+/// behavior unit-testable without spawning subprocesses.
+///
+/// `rename` is still atomic for readers, which is what keeps a partially
+/// written credential file unobservable. This only fixes writer-vs-writer
+/// collisions on the temp path. `FileKeyringStore::set` remains a
+/// read-modify-write of the whole map with no lock, so simultaneous writers
+/// can still clobber one another's *entries*; making that safe needs file
+/// locking, which is a larger change.
 pub(crate) fn atomic_write(path: &Path, data: &[u8]) -> Result<(), CliError> {
-    let tmp = path.with_extension("tmp");
+    static TMP_SEQ: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+    let seq = TMP_SEQ.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+    let tmp = path.with_extension(format!("tmp.{}.{}", std::process::id(), seq));
     std::fs::write(&tmp, data).map_err(|e| {
         CliError::Auth(format!("Failed to write {}: {e}", tmp.display()))
     })?;
@@ -250,6 +271,51 @@ pub(crate) fn atomic_write(path: &Path, data: &[u8]) -> Result<(), CliError> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// Regression test for the temp-file collision that made
+    /// `auth login --with-token` fail intermittently: every writer derived the
+    /// same sibling path from the target, so the first `rename` moved it away
+    /// and the rest got `ENOENT`.
+    ///
+    /// Reverting `atomic_write` to a target-derived temp name fails this with
+    /// "Failed to rename ...: No such file or directory".
+    #[test]
+    fn atomic_write_tolerates_concurrent_writers() {
+        let dir = tempfile::tempdir().unwrap();
+        let target = dir.path().join("auth-keyring.json");
+
+        let results: Vec<Result<(), CliError>> = std::thread::scope(|scope| {
+            let handles: Vec<_> = (0..16)
+                .map(|i| {
+                    let target = target.clone();
+                    scope.spawn(move || atomic_write(&target, format!(r#"{{"writer":{i}}}"#).as_bytes()))
+                })
+                .collect();
+            handles.into_iter().map(|h| h.join().unwrap()).collect()
+        });
+
+        let failed: Vec<String> = results
+            .iter()
+            .filter_map(|r| r.as_ref().err().map(|e| e.to_string()))
+            .collect();
+        assert!(failed.is_empty(), "concurrent writers failed: {failed:?}");
+
+        // Last writer wins, but the file must always be one writer's complete
+        // payload — never a mix, and never absent.
+        let contents = std::fs::read_to_string(&target).unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(&contents)
+            .unwrap_or_else(|e| panic!("target is not valid JSON after concurrent writes: {e} in {contents:?}"));
+        assert!(parsed.get("writer").is_some(), "unexpected payload: {contents}");
+
+        // No temp files orphaned in the directory.
+        let leftovers: Vec<String> = std::fs::read_dir(dir.path())
+            .unwrap()
+            .filter_map(|e| e.ok())
+            .map(|e| e.file_name().to_string_lossy().into_owned())
+            .filter(|n| n.contains(".tmp"))
+            .collect();
+        assert!(leftovers.is_empty(), "temp files left behind: {leftovers:?}");
+    }
 
     #[test]
     fn token_bundle_roundtrip() {

--- a/seed/cli/cli-header-auth/with-wire-tests/src/auth/oauth_common.rs
+++ b/seed/cli/cli-header-auth/with-wire-tests/src/auth/oauth_common.rs
@@ -224,27 +224,6 @@ pub(crate) fn config_dir() -> Option<PathBuf> {
     }
 }
 
-/// Write `data` to `path` atomically: sibling temp file → owner-only
-/// permissions (0600 on Unix) → rename into place.
-///
-/// The temp file name is unique per writer — pid plus a process-local
-/// counter. Deriving it from the target alone meant every concurrent writer
-/// used the *same* sibling (`auth-keyring.tmp`): whichever one renamed first
-/// moved it away, and the rest failed with `ENOENT` from `rename`. That
-/// surfaced as intermittent `auth login --with-token` failures across a
-/// wire-test suite large enough to run many CLI processes at once, killing a
-/// different subset of cases on each run.
-///
-/// The pid covers the case that actually bit us (separate CLI processes); the
-/// counter covers two writers inside one process, and is what makes the
-/// behavior unit-testable without spawning subprocesses.
-///
-/// `rename` is still atomic for readers, which is what keeps a partially
-/// written credential file unobservable. This only fixes writer-vs-writer
-/// collisions on the temp path. `FileKeyringStore::set` remains a
-/// read-modify-write of the whole map with no lock, so simultaneous writers
-/// can still clobber one another's *entries*; making that safe needs file
-/// locking, which is a larger change.
 /// Unlinks a temp file on drop unless [`TempFileGuard::disarm`]ed. Covers
 /// every early return *and* a panic between creating the temp file and
 /// renaming it into place.
@@ -278,6 +257,30 @@ impl Drop for TempFileGuard {
     }
 }
 
+/// Write `data` to `path` atomically: sibling temp file → owner-only
+/// permissions (0600 on Unix) → rename into place.
+///
+/// The temp file name is unique per writer — pid plus a process-local
+/// counter. Deriving it from the target alone meant every concurrent writer
+/// used the *same* sibling (`auth-keyring.tmp`): whichever one renamed first
+/// moved it away, and the rest failed with `ENOENT` from `rename`. That
+/// surfaced as intermittent `auth login --with-token` failures across a
+/// wire-test suite large enough to run many CLI processes at once, killing a
+/// different subset of cases on each run.
+///
+/// The pid covers the case that actually bit us (separate CLI processes); the
+/// counter covers two writers inside one process, and is what makes the
+/// behavior unit-testable without spawning subprocesses.
+///
+/// A [`TempFileGuard`] unlinks the temp file if anything between creating it
+/// and renaming it fails, so unique names cannot accumulate as orphans.
+///
+/// `rename` is still atomic for readers, which is what keeps a partially
+/// written credential file unobservable. This only fixes writer-vs-writer
+/// collisions on the temp path. `FileKeyringStore::set` remains a
+/// read-modify-write of the whole map with no lock, so simultaneous writers
+/// can still clobber one another's *entries*; making that safe needs file
+/// locking, which is a larger change.
 pub(crate) fn atomic_write(path: &Path, data: &[u8]) -> Result<(), CliError> {
     static TMP_SEQ: std::sync::atomic::AtomicUsize = std::sync::atomic::AtomicUsize::new(0);
     let seq = TMP_SEQ.fetch_add(1, std::sync::atomic::Ordering::Relaxed);

--- a/seed/cli/cli-header-auth/with-wire-tests/src/auth/oauth_common.rs
+++ b/seed/cli/cli-header-auth/with-wire-tests/src/auth/oauth_common.rs
@@ -245,23 +245,56 @@ pub(crate) fn config_dir() -> Option<PathBuf> {
 /// read-modify-write of the whole map with no lock, so simultaneous writers
 /// can still clobber one another's *entries*; making that safe needs file
 /// locking, which is a larger change.
+/// Unlinks a temp file on drop unless [`TempFileGuard::disarm`]ed. Covers
+/// every early return *and* a panic between creating the temp file and
+/// renaming it into place.
+///
+/// This exists because the temp name is unique per writer. The old shared
+/// `auth-keyring.tmp` was self-limiting — a failed write left one stale file
+/// that the next write reused — whereas unique names would leak a distinct
+/// credential-bearing file on every failure, in a directory nothing prunes. A
+/// `SIGKILL` still leaks, since no in-process guard can cover that.
+struct TempFileGuard {
+    path: PathBuf,
+    armed: bool,
+}
+
+impl TempFileGuard {
+    fn new(path: PathBuf) -> Self {
+        Self { path, armed: true }
+    }
+
+    /// Relinquish the file — call once `rename` has moved it into place.
+    fn disarm(&mut self) {
+        self.armed = false;
+    }
+}
+
+impl Drop for TempFileGuard {
+    fn drop(&mut self) {
+        if self.armed {
+            let _ = std::fs::remove_file(&self.path);
+        }
+    }
+}
+
 pub(crate) fn atomic_write(path: &Path, data: &[u8]) -> Result<(), CliError> {
-    static TMP_SEQ: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+    static TMP_SEQ: std::sync::atomic::AtomicUsize = std::sync::atomic::AtomicUsize::new(0);
     let seq = TMP_SEQ.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
     let tmp = path.with_extension(format!("tmp.{}.{}", std::process::id(), seq));
-    std::fs::write(&tmp, data).map_err(|e| {
-        CliError::Auth(format!("Failed to write {}: {e}", tmp.display()))
-    })?;
+    let mut guard = TempFileGuard::new(tmp.clone());
+    std::fs::write(&tmp, data)
+        .map_err(|e| CliError::Auth(format!("Failed to write {}: {e}", tmp.display())))?;
     #[cfg(unix)]
     {
         use std::os::unix::fs::PermissionsExt;
         let perms = std::fs::Permissions::from_mode(0o600);
         let _ = std::fs::set_permissions(&tmp, perms);
     }
-    std::fs::rename(&tmp, path).map_err(|e| {
-        let _ = std::fs::remove_file(&tmp);
-        CliError::Auth(format!("Failed to rename {}: {e}", tmp.display()))
-    })
+    std::fs::rename(&tmp, path)
+        .map_err(|e| CliError::Auth(format!("Failed to rename {}: {e}", tmp.display())))?;
+    guard.disarm();
+    Ok(())
 }
 
 // ---------------------------------------------------------------------------
@@ -315,6 +348,56 @@ mod tests {
             .filter(|n| n.contains(".tmp"))
             .collect();
         assert!(leftovers.is_empty(), "temp files left behind: {leftovers:?}");
+    }
+
+    /// A failed write must not leave its temp file behind. Renaming a file onto
+    /// an existing directory fails on every platform, which drives the error
+    /// path without mocking the filesystem.
+    ///
+    /// The pre-`TempFileGuard` code already cleaned up on a `rename` error, so
+    /// this pins an invariant rather than catching a regression — see
+    /// `temp_file_guard_unlinks_unless_disarmed` for the guard's own coverage.
+    #[test]
+    fn atomic_write_cleans_up_temp_file_on_failure() {
+        let dir = tempfile::tempdir().unwrap();
+
+        // The target is a *directory*, so `rename` cannot replace it.
+        let target = dir.path().join("auth-keyring.json");
+        std::fs::create_dir(&target).unwrap();
+        std::fs::write(target.join("occupant"), b"x").unwrap();
+
+        let result = atomic_write(&target, br#"{"writer":0}"#);
+        assert!(result.is_err(), "expected rename onto a directory to fail");
+
+        let leftovers: Vec<String> = std::fs::read_dir(dir.path())
+            .unwrap()
+            .filter_map(|e| e.ok())
+            .map(|e| e.file_name().to_string_lossy().into_owned())
+            .filter(|n| n.contains(".tmp"))
+            .collect();
+        assert!(leftovers.is_empty(), "temp file leaked after a failed write: {leftovers:?}");
+    }
+
+    /// Pins [`TempFileGuard`]: armed drops unlink, disarmed drops don't. Drop
+    /// running on an armed guard is what covers early returns and unwinding
+    /// panics between `write` and `rename` — paths the old `rename`-only
+    /// cleanup missed. Deleting the guard or the `disarm()` call fails this.
+    #[test]
+    fn temp_file_guard_unlinks_unless_disarmed() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("auth-keyring.tmp.0.0");
+
+        std::fs::write(&path, b"x").unwrap();
+        drop(TempFileGuard::new(path.clone()));
+        assert!(!path.exists(), "armed guard must unlink on drop");
+
+        // The post-`rename` case: the file has been moved away, so the guard
+        // must not touch whatever now sits at that path.
+        std::fs::write(&path, b"x").unwrap();
+        let mut guard = TempFileGuard::new(path.clone());
+        guard.disarm();
+        drop(guard);
+        assert!(path.exists(), "disarmed guard must not unlink");
     }
 
     #[test]

--- a/seed/cli/cli-header-auth/with-wire-tests/src/auth/oauth_common.rs
+++ b/seed/cli/cli-header-auth/with-wire-tests/src/auth/oauth_common.rs
@@ -226,8 +226,29 @@ pub(crate) fn config_dir() -> Option<PathBuf> {
 
 /// Write `data` to `path` atomically: sibling temp file → owner-only
 /// permissions (0600 on Unix) → rename into place.
+///
+/// The temp file name is unique per writer — pid plus a process-local
+/// counter. Deriving it from the target alone meant every concurrent writer
+/// used the *same* sibling (`auth-keyring.tmp`): whichever one renamed first
+/// moved it away, and the rest failed with `ENOENT` from `rename`. That
+/// surfaced as intermittent `auth login --with-token` failures across a
+/// wire-test suite large enough to run many CLI processes at once, killing a
+/// different subset of cases on each run.
+///
+/// The pid covers the case that actually bit us (separate CLI processes); the
+/// counter covers two writers inside one process, and is what makes the
+/// behavior unit-testable without spawning subprocesses.
+///
+/// `rename` is still atomic for readers, which is what keeps a partially
+/// written credential file unobservable. This only fixes writer-vs-writer
+/// collisions on the temp path. `FileKeyringStore::set` remains a
+/// read-modify-write of the whole map with no lock, so simultaneous writers
+/// can still clobber one another's *entries*; making that safe needs file
+/// locking, which is a larger change.
 pub(crate) fn atomic_write(path: &Path, data: &[u8]) -> Result<(), CliError> {
-    let tmp = path.with_extension("tmp");
+    static TMP_SEQ: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+    let seq = TMP_SEQ.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+    let tmp = path.with_extension(format!("tmp.{}.{}", std::process::id(), seq));
     std::fs::write(&tmp, data).map_err(|e| {
         CliError::Auth(format!("Failed to write {}: {e}", tmp.display()))
     })?;
@@ -250,6 +271,51 @@ pub(crate) fn atomic_write(path: &Path, data: &[u8]) -> Result<(), CliError> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// Regression test for the temp-file collision that made
+    /// `auth login --with-token` fail intermittently: every writer derived the
+    /// same sibling path from the target, so the first `rename` moved it away
+    /// and the rest got `ENOENT`.
+    ///
+    /// Reverting `atomic_write` to a target-derived temp name fails this with
+    /// "Failed to rename ...: No such file or directory".
+    #[test]
+    fn atomic_write_tolerates_concurrent_writers() {
+        let dir = tempfile::tempdir().unwrap();
+        let target = dir.path().join("auth-keyring.json");
+
+        let results: Vec<Result<(), CliError>> = std::thread::scope(|scope| {
+            let handles: Vec<_> = (0..16)
+                .map(|i| {
+                    let target = target.clone();
+                    scope.spawn(move || atomic_write(&target, format!(r#"{{"writer":{i}}}"#).as_bytes()))
+                })
+                .collect();
+            handles.into_iter().map(|h| h.join().unwrap()).collect()
+        });
+
+        let failed: Vec<String> = results
+            .iter()
+            .filter_map(|r| r.as_ref().err().map(|e| e.to_string()))
+            .collect();
+        assert!(failed.is_empty(), "concurrent writers failed: {failed:?}");
+
+        // Last writer wins, but the file must always be one writer's complete
+        // payload — never a mix, and never absent.
+        let contents = std::fs::read_to_string(&target).unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(&contents)
+            .unwrap_or_else(|e| panic!("target is not valid JSON after concurrent writes: {e} in {contents:?}"));
+        assert!(parsed.get("writer").is_some(), "unexpected payload: {contents}");
+
+        // No temp files orphaned in the directory.
+        let leftovers: Vec<String> = std::fs::read_dir(dir.path())
+            .unwrap()
+            .filter_map(|e| e.ok())
+            .map(|e| e.file_name().to_string_lossy().into_owned())
+            .filter(|n| n.contains(".tmp"))
+            .collect();
+        assert!(leftovers.is_empty(), "temp files left behind: {leftovers:?}");
+    }
 
     #[test]
     fn token_bundle_roundtrip() {

--- a/seed/cli/cli-multi-spec-namespaced/no-custom-config/src/auth/oauth_common.rs
+++ b/seed/cli/cli-multi-spec-namespaced/no-custom-config/src/auth/oauth_common.rs
@@ -224,27 +224,6 @@ pub(crate) fn config_dir() -> Option<PathBuf> {
     }
 }
 
-/// Write `data` to `path` atomically: sibling temp file → owner-only
-/// permissions (0600 on Unix) → rename into place.
-///
-/// The temp file name is unique per writer — pid plus a process-local
-/// counter. Deriving it from the target alone meant every concurrent writer
-/// used the *same* sibling (`auth-keyring.tmp`): whichever one renamed first
-/// moved it away, and the rest failed with `ENOENT` from `rename`. That
-/// surfaced as intermittent `auth login --with-token` failures across a
-/// wire-test suite large enough to run many CLI processes at once, killing a
-/// different subset of cases on each run.
-///
-/// The pid covers the case that actually bit us (separate CLI processes); the
-/// counter covers two writers inside one process, and is what makes the
-/// behavior unit-testable without spawning subprocesses.
-///
-/// `rename` is still atomic for readers, which is what keeps a partially
-/// written credential file unobservable. This only fixes writer-vs-writer
-/// collisions on the temp path. `FileKeyringStore::set` remains a
-/// read-modify-write of the whole map with no lock, so simultaneous writers
-/// can still clobber one another's *entries*; making that safe needs file
-/// locking, which is a larger change.
 /// Unlinks a temp file on drop unless [`TempFileGuard::disarm`]ed. Covers
 /// every early return *and* a panic between creating the temp file and
 /// renaming it into place.
@@ -278,6 +257,30 @@ impl Drop for TempFileGuard {
     }
 }
 
+/// Write `data` to `path` atomically: sibling temp file → owner-only
+/// permissions (0600 on Unix) → rename into place.
+///
+/// The temp file name is unique per writer — pid plus a process-local
+/// counter. Deriving it from the target alone meant every concurrent writer
+/// used the *same* sibling (`auth-keyring.tmp`): whichever one renamed first
+/// moved it away, and the rest failed with `ENOENT` from `rename`. That
+/// surfaced as intermittent `auth login --with-token` failures across a
+/// wire-test suite large enough to run many CLI processes at once, killing a
+/// different subset of cases on each run.
+///
+/// The pid covers the case that actually bit us (separate CLI processes); the
+/// counter covers two writers inside one process, and is what makes the
+/// behavior unit-testable without spawning subprocesses.
+///
+/// A [`TempFileGuard`] unlinks the temp file if anything between creating it
+/// and renaming it fails, so unique names cannot accumulate as orphans.
+///
+/// `rename` is still atomic for readers, which is what keeps a partially
+/// written credential file unobservable. This only fixes writer-vs-writer
+/// collisions on the temp path. `FileKeyringStore::set` remains a
+/// read-modify-write of the whole map with no lock, so simultaneous writers
+/// can still clobber one another's *entries*; making that safe needs file
+/// locking, which is a larger change.
 pub(crate) fn atomic_write(path: &Path, data: &[u8]) -> Result<(), CliError> {
     static TMP_SEQ: std::sync::atomic::AtomicUsize = std::sync::atomic::AtomicUsize::new(0);
     let seq = TMP_SEQ.fetch_add(1, std::sync::atomic::Ordering::Relaxed);

--- a/seed/cli/cli-multi-spec-namespaced/no-custom-config/src/auth/oauth_common.rs
+++ b/seed/cli/cli-multi-spec-namespaced/no-custom-config/src/auth/oauth_common.rs
@@ -245,23 +245,56 @@ pub(crate) fn config_dir() -> Option<PathBuf> {
 /// read-modify-write of the whole map with no lock, so simultaneous writers
 /// can still clobber one another's *entries*; making that safe needs file
 /// locking, which is a larger change.
+/// Unlinks a temp file on drop unless [`TempFileGuard::disarm`]ed. Covers
+/// every early return *and* a panic between creating the temp file and
+/// renaming it into place.
+///
+/// This exists because the temp name is unique per writer. The old shared
+/// `auth-keyring.tmp` was self-limiting — a failed write left one stale file
+/// that the next write reused — whereas unique names would leak a distinct
+/// credential-bearing file on every failure, in a directory nothing prunes. A
+/// `SIGKILL` still leaks, since no in-process guard can cover that.
+struct TempFileGuard {
+    path: PathBuf,
+    armed: bool,
+}
+
+impl TempFileGuard {
+    fn new(path: PathBuf) -> Self {
+        Self { path, armed: true }
+    }
+
+    /// Relinquish the file — call once `rename` has moved it into place.
+    fn disarm(&mut self) {
+        self.armed = false;
+    }
+}
+
+impl Drop for TempFileGuard {
+    fn drop(&mut self) {
+        if self.armed {
+            let _ = std::fs::remove_file(&self.path);
+        }
+    }
+}
+
 pub(crate) fn atomic_write(path: &Path, data: &[u8]) -> Result<(), CliError> {
-    static TMP_SEQ: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+    static TMP_SEQ: std::sync::atomic::AtomicUsize = std::sync::atomic::AtomicUsize::new(0);
     let seq = TMP_SEQ.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
     let tmp = path.with_extension(format!("tmp.{}.{}", std::process::id(), seq));
-    std::fs::write(&tmp, data).map_err(|e| {
-        CliError::Auth(format!("Failed to write {}: {e}", tmp.display()))
-    })?;
+    let mut guard = TempFileGuard::new(tmp.clone());
+    std::fs::write(&tmp, data)
+        .map_err(|e| CliError::Auth(format!("Failed to write {}: {e}", tmp.display())))?;
     #[cfg(unix)]
     {
         use std::os::unix::fs::PermissionsExt;
         let perms = std::fs::Permissions::from_mode(0o600);
         let _ = std::fs::set_permissions(&tmp, perms);
     }
-    std::fs::rename(&tmp, path).map_err(|e| {
-        let _ = std::fs::remove_file(&tmp);
-        CliError::Auth(format!("Failed to rename {}: {e}", tmp.display()))
-    })
+    std::fs::rename(&tmp, path)
+        .map_err(|e| CliError::Auth(format!("Failed to rename {}: {e}", tmp.display())))?;
+    guard.disarm();
+    Ok(())
 }
 
 // ---------------------------------------------------------------------------
@@ -315,6 +348,56 @@ mod tests {
             .filter(|n| n.contains(".tmp"))
             .collect();
         assert!(leftovers.is_empty(), "temp files left behind: {leftovers:?}");
+    }
+
+    /// A failed write must not leave its temp file behind. Renaming a file onto
+    /// an existing directory fails on every platform, which drives the error
+    /// path without mocking the filesystem.
+    ///
+    /// The pre-`TempFileGuard` code already cleaned up on a `rename` error, so
+    /// this pins an invariant rather than catching a regression — see
+    /// `temp_file_guard_unlinks_unless_disarmed` for the guard's own coverage.
+    #[test]
+    fn atomic_write_cleans_up_temp_file_on_failure() {
+        let dir = tempfile::tempdir().unwrap();
+
+        // The target is a *directory*, so `rename` cannot replace it.
+        let target = dir.path().join("auth-keyring.json");
+        std::fs::create_dir(&target).unwrap();
+        std::fs::write(target.join("occupant"), b"x").unwrap();
+
+        let result = atomic_write(&target, br#"{"writer":0}"#);
+        assert!(result.is_err(), "expected rename onto a directory to fail");
+
+        let leftovers: Vec<String> = std::fs::read_dir(dir.path())
+            .unwrap()
+            .filter_map(|e| e.ok())
+            .map(|e| e.file_name().to_string_lossy().into_owned())
+            .filter(|n| n.contains(".tmp"))
+            .collect();
+        assert!(leftovers.is_empty(), "temp file leaked after a failed write: {leftovers:?}");
+    }
+
+    /// Pins [`TempFileGuard`]: armed drops unlink, disarmed drops don't. Drop
+    /// running on an armed guard is what covers early returns and unwinding
+    /// panics between `write` and `rename` — paths the old `rename`-only
+    /// cleanup missed. Deleting the guard or the `disarm()` call fails this.
+    #[test]
+    fn temp_file_guard_unlinks_unless_disarmed() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("auth-keyring.tmp.0.0");
+
+        std::fs::write(&path, b"x").unwrap();
+        drop(TempFileGuard::new(path.clone()));
+        assert!(!path.exists(), "armed guard must unlink on drop");
+
+        // The post-`rename` case: the file has been moved away, so the guard
+        // must not touch whatever now sits at that path.
+        std::fs::write(&path, b"x").unwrap();
+        let mut guard = TempFileGuard::new(path.clone());
+        guard.disarm();
+        drop(guard);
+        assert!(path.exists(), "disarmed guard must not unlink");
     }
 
     #[test]

--- a/seed/cli/cli-multi-spec-namespaced/no-custom-config/src/auth/oauth_common.rs
+++ b/seed/cli/cli-multi-spec-namespaced/no-custom-config/src/auth/oauth_common.rs
@@ -226,8 +226,29 @@ pub(crate) fn config_dir() -> Option<PathBuf> {
 
 /// Write `data` to `path` atomically: sibling temp file → owner-only
 /// permissions (0600 on Unix) → rename into place.
+///
+/// The temp file name is unique per writer — pid plus a process-local
+/// counter. Deriving it from the target alone meant every concurrent writer
+/// used the *same* sibling (`auth-keyring.tmp`): whichever one renamed first
+/// moved it away, and the rest failed with `ENOENT` from `rename`. That
+/// surfaced as intermittent `auth login --with-token` failures across a
+/// wire-test suite large enough to run many CLI processes at once, killing a
+/// different subset of cases on each run.
+///
+/// The pid covers the case that actually bit us (separate CLI processes); the
+/// counter covers two writers inside one process, and is what makes the
+/// behavior unit-testable without spawning subprocesses.
+///
+/// `rename` is still atomic for readers, which is what keeps a partially
+/// written credential file unobservable. This only fixes writer-vs-writer
+/// collisions on the temp path. `FileKeyringStore::set` remains a
+/// read-modify-write of the whole map with no lock, so simultaneous writers
+/// can still clobber one another's *entries*; making that safe needs file
+/// locking, which is a larger change.
 pub(crate) fn atomic_write(path: &Path, data: &[u8]) -> Result<(), CliError> {
-    let tmp = path.with_extension("tmp");
+    static TMP_SEQ: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+    let seq = TMP_SEQ.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+    let tmp = path.with_extension(format!("tmp.{}.{}", std::process::id(), seq));
     std::fs::write(&tmp, data).map_err(|e| {
         CliError::Auth(format!("Failed to write {}: {e}", tmp.display()))
     })?;
@@ -250,6 +271,51 @@ pub(crate) fn atomic_write(path: &Path, data: &[u8]) -> Result<(), CliError> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// Regression test for the temp-file collision that made
+    /// `auth login --with-token` fail intermittently: every writer derived the
+    /// same sibling path from the target, so the first `rename` moved it away
+    /// and the rest got `ENOENT`.
+    ///
+    /// Reverting `atomic_write` to a target-derived temp name fails this with
+    /// "Failed to rename ...: No such file or directory".
+    #[test]
+    fn atomic_write_tolerates_concurrent_writers() {
+        let dir = tempfile::tempdir().unwrap();
+        let target = dir.path().join("auth-keyring.json");
+
+        let results: Vec<Result<(), CliError>> = std::thread::scope(|scope| {
+            let handles: Vec<_> = (0..16)
+                .map(|i| {
+                    let target = target.clone();
+                    scope.spawn(move || atomic_write(&target, format!(r#"{{"writer":{i}}}"#).as_bytes()))
+                })
+                .collect();
+            handles.into_iter().map(|h| h.join().unwrap()).collect()
+        });
+
+        let failed: Vec<String> = results
+            .iter()
+            .filter_map(|r| r.as_ref().err().map(|e| e.to_string()))
+            .collect();
+        assert!(failed.is_empty(), "concurrent writers failed: {failed:?}");
+
+        // Last writer wins, but the file must always be one writer's complete
+        // payload — never a mix, and never absent.
+        let contents = std::fs::read_to_string(&target).unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(&contents)
+            .unwrap_or_else(|e| panic!("target is not valid JSON after concurrent writes: {e} in {contents:?}"));
+        assert!(parsed.get("writer").is_some(), "unexpected payload: {contents}");
+
+        // No temp files orphaned in the directory.
+        let leftovers: Vec<String> = std::fs::read_dir(dir.path())
+            .unwrap()
+            .filter_map(|e| e.ok())
+            .map(|e| e.file_name().to_string_lossy().into_owned())
+            .filter(|n| n.contains(".tmp"))
+            .collect();
+        assert!(leftovers.is_empty(), "temp files left behind: {leftovers:?}");
+    }
 
     #[test]
     fn token_bundle_roundtrip() {

--- a/seed/cli/cli-multi-spec-namespaced/with-split-type-crates/src/auth/oauth_common.rs
+++ b/seed/cli/cli-multi-spec-namespaced/with-split-type-crates/src/auth/oauth_common.rs
@@ -224,27 +224,6 @@ pub(crate) fn config_dir() -> Option<PathBuf> {
     }
 }
 
-/// Write `data` to `path` atomically: sibling temp file → owner-only
-/// permissions (0600 on Unix) → rename into place.
-///
-/// The temp file name is unique per writer — pid plus a process-local
-/// counter. Deriving it from the target alone meant every concurrent writer
-/// used the *same* sibling (`auth-keyring.tmp`): whichever one renamed first
-/// moved it away, and the rest failed with `ENOENT` from `rename`. That
-/// surfaced as intermittent `auth login --with-token` failures across a
-/// wire-test suite large enough to run many CLI processes at once, killing a
-/// different subset of cases on each run.
-///
-/// The pid covers the case that actually bit us (separate CLI processes); the
-/// counter covers two writers inside one process, and is what makes the
-/// behavior unit-testable without spawning subprocesses.
-///
-/// `rename` is still atomic for readers, which is what keeps a partially
-/// written credential file unobservable. This only fixes writer-vs-writer
-/// collisions on the temp path. `FileKeyringStore::set` remains a
-/// read-modify-write of the whole map with no lock, so simultaneous writers
-/// can still clobber one another's *entries*; making that safe needs file
-/// locking, which is a larger change.
 /// Unlinks a temp file on drop unless [`TempFileGuard::disarm`]ed. Covers
 /// every early return *and* a panic between creating the temp file and
 /// renaming it into place.
@@ -278,6 +257,30 @@ impl Drop for TempFileGuard {
     }
 }
 
+/// Write `data` to `path` atomically: sibling temp file → owner-only
+/// permissions (0600 on Unix) → rename into place.
+///
+/// The temp file name is unique per writer — pid plus a process-local
+/// counter. Deriving it from the target alone meant every concurrent writer
+/// used the *same* sibling (`auth-keyring.tmp`): whichever one renamed first
+/// moved it away, and the rest failed with `ENOENT` from `rename`. That
+/// surfaced as intermittent `auth login --with-token` failures across a
+/// wire-test suite large enough to run many CLI processes at once, killing a
+/// different subset of cases on each run.
+///
+/// The pid covers the case that actually bit us (separate CLI processes); the
+/// counter covers two writers inside one process, and is what makes the
+/// behavior unit-testable without spawning subprocesses.
+///
+/// A [`TempFileGuard`] unlinks the temp file if anything between creating it
+/// and renaming it fails, so unique names cannot accumulate as orphans.
+///
+/// `rename` is still atomic for readers, which is what keeps a partially
+/// written credential file unobservable. This only fixes writer-vs-writer
+/// collisions on the temp path. `FileKeyringStore::set` remains a
+/// read-modify-write of the whole map with no lock, so simultaneous writers
+/// can still clobber one another's *entries*; making that safe needs file
+/// locking, which is a larger change.
 pub(crate) fn atomic_write(path: &Path, data: &[u8]) -> Result<(), CliError> {
     static TMP_SEQ: std::sync::atomic::AtomicUsize = std::sync::atomic::AtomicUsize::new(0);
     let seq = TMP_SEQ.fetch_add(1, std::sync::atomic::Ordering::Relaxed);

--- a/seed/cli/cli-multi-spec-namespaced/with-split-type-crates/src/auth/oauth_common.rs
+++ b/seed/cli/cli-multi-spec-namespaced/with-split-type-crates/src/auth/oauth_common.rs
@@ -245,23 +245,56 @@ pub(crate) fn config_dir() -> Option<PathBuf> {
 /// read-modify-write of the whole map with no lock, so simultaneous writers
 /// can still clobber one another's *entries*; making that safe needs file
 /// locking, which is a larger change.
+/// Unlinks a temp file on drop unless [`TempFileGuard::disarm`]ed. Covers
+/// every early return *and* a panic between creating the temp file and
+/// renaming it into place.
+///
+/// This exists because the temp name is unique per writer. The old shared
+/// `auth-keyring.tmp` was self-limiting — a failed write left one stale file
+/// that the next write reused — whereas unique names would leak a distinct
+/// credential-bearing file on every failure, in a directory nothing prunes. A
+/// `SIGKILL` still leaks, since no in-process guard can cover that.
+struct TempFileGuard {
+    path: PathBuf,
+    armed: bool,
+}
+
+impl TempFileGuard {
+    fn new(path: PathBuf) -> Self {
+        Self { path, armed: true }
+    }
+
+    /// Relinquish the file — call once `rename` has moved it into place.
+    fn disarm(&mut self) {
+        self.armed = false;
+    }
+}
+
+impl Drop for TempFileGuard {
+    fn drop(&mut self) {
+        if self.armed {
+            let _ = std::fs::remove_file(&self.path);
+        }
+    }
+}
+
 pub(crate) fn atomic_write(path: &Path, data: &[u8]) -> Result<(), CliError> {
-    static TMP_SEQ: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+    static TMP_SEQ: std::sync::atomic::AtomicUsize = std::sync::atomic::AtomicUsize::new(0);
     let seq = TMP_SEQ.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
     let tmp = path.with_extension(format!("tmp.{}.{}", std::process::id(), seq));
-    std::fs::write(&tmp, data).map_err(|e| {
-        CliError::Auth(format!("Failed to write {}: {e}", tmp.display()))
-    })?;
+    let mut guard = TempFileGuard::new(tmp.clone());
+    std::fs::write(&tmp, data)
+        .map_err(|e| CliError::Auth(format!("Failed to write {}: {e}", tmp.display())))?;
     #[cfg(unix)]
     {
         use std::os::unix::fs::PermissionsExt;
         let perms = std::fs::Permissions::from_mode(0o600);
         let _ = std::fs::set_permissions(&tmp, perms);
     }
-    std::fs::rename(&tmp, path).map_err(|e| {
-        let _ = std::fs::remove_file(&tmp);
-        CliError::Auth(format!("Failed to rename {}: {e}", tmp.display()))
-    })
+    std::fs::rename(&tmp, path)
+        .map_err(|e| CliError::Auth(format!("Failed to rename {}: {e}", tmp.display())))?;
+    guard.disarm();
+    Ok(())
 }
 
 // ---------------------------------------------------------------------------
@@ -315,6 +348,56 @@ mod tests {
             .filter(|n| n.contains(".tmp"))
             .collect();
         assert!(leftovers.is_empty(), "temp files left behind: {leftovers:?}");
+    }
+
+    /// A failed write must not leave its temp file behind. Renaming a file onto
+    /// an existing directory fails on every platform, which drives the error
+    /// path without mocking the filesystem.
+    ///
+    /// The pre-`TempFileGuard` code already cleaned up on a `rename` error, so
+    /// this pins an invariant rather than catching a regression — see
+    /// `temp_file_guard_unlinks_unless_disarmed` for the guard's own coverage.
+    #[test]
+    fn atomic_write_cleans_up_temp_file_on_failure() {
+        let dir = tempfile::tempdir().unwrap();
+
+        // The target is a *directory*, so `rename` cannot replace it.
+        let target = dir.path().join("auth-keyring.json");
+        std::fs::create_dir(&target).unwrap();
+        std::fs::write(target.join("occupant"), b"x").unwrap();
+
+        let result = atomic_write(&target, br#"{"writer":0}"#);
+        assert!(result.is_err(), "expected rename onto a directory to fail");
+
+        let leftovers: Vec<String> = std::fs::read_dir(dir.path())
+            .unwrap()
+            .filter_map(|e| e.ok())
+            .map(|e| e.file_name().to_string_lossy().into_owned())
+            .filter(|n| n.contains(".tmp"))
+            .collect();
+        assert!(leftovers.is_empty(), "temp file leaked after a failed write: {leftovers:?}");
+    }
+
+    /// Pins [`TempFileGuard`]: armed drops unlink, disarmed drops don't. Drop
+    /// running on an armed guard is what covers early returns and unwinding
+    /// panics between `write` and `rename` — paths the old `rename`-only
+    /// cleanup missed. Deleting the guard or the `disarm()` call fails this.
+    #[test]
+    fn temp_file_guard_unlinks_unless_disarmed() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("auth-keyring.tmp.0.0");
+
+        std::fs::write(&path, b"x").unwrap();
+        drop(TempFileGuard::new(path.clone()));
+        assert!(!path.exists(), "armed guard must unlink on drop");
+
+        // The post-`rename` case: the file has been moved away, so the guard
+        // must not touch whatever now sits at that path.
+        std::fs::write(&path, b"x").unwrap();
+        let mut guard = TempFileGuard::new(path.clone());
+        guard.disarm();
+        drop(guard);
+        assert!(path.exists(), "disarmed guard must not unlink");
     }
 
     #[test]

--- a/seed/cli/cli-multi-spec-namespaced/with-split-type-crates/src/auth/oauth_common.rs
+++ b/seed/cli/cli-multi-spec-namespaced/with-split-type-crates/src/auth/oauth_common.rs
@@ -226,8 +226,29 @@ pub(crate) fn config_dir() -> Option<PathBuf> {
 
 /// Write `data` to `path` atomically: sibling temp file → owner-only
 /// permissions (0600 on Unix) → rename into place.
+///
+/// The temp file name is unique per writer — pid plus a process-local
+/// counter. Deriving it from the target alone meant every concurrent writer
+/// used the *same* sibling (`auth-keyring.tmp`): whichever one renamed first
+/// moved it away, and the rest failed with `ENOENT` from `rename`. That
+/// surfaced as intermittent `auth login --with-token` failures across a
+/// wire-test suite large enough to run many CLI processes at once, killing a
+/// different subset of cases on each run.
+///
+/// The pid covers the case that actually bit us (separate CLI processes); the
+/// counter covers two writers inside one process, and is what makes the
+/// behavior unit-testable without spawning subprocesses.
+///
+/// `rename` is still atomic for readers, which is what keeps a partially
+/// written credential file unobservable. This only fixes writer-vs-writer
+/// collisions on the temp path. `FileKeyringStore::set` remains a
+/// read-modify-write of the whole map with no lock, so simultaneous writers
+/// can still clobber one another's *entries*; making that safe needs file
+/// locking, which is a larger change.
 pub(crate) fn atomic_write(path: &Path, data: &[u8]) -> Result<(), CliError> {
-    let tmp = path.with_extension("tmp");
+    static TMP_SEQ: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+    let seq = TMP_SEQ.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+    let tmp = path.with_extension(format!("tmp.{}.{}", std::process::id(), seq));
     std::fs::write(&tmp, data).map_err(|e| {
         CliError::Auth(format!("Failed to write {}: {e}", tmp.display()))
     })?;
@@ -250,6 +271,51 @@ pub(crate) fn atomic_write(path: &Path, data: &[u8]) -> Result<(), CliError> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// Regression test for the temp-file collision that made
+    /// `auth login --with-token` fail intermittently: every writer derived the
+    /// same sibling path from the target, so the first `rename` moved it away
+    /// and the rest got `ENOENT`.
+    ///
+    /// Reverting `atomic_write` to a target-derived temp name fails this with
+    /// "Failed to rename ...: No such file or directory".
+    #[test]
+    fn atomic_write_tolerates_concurrent_writers() {
+        let dir = tempfile::tempdir().unwrap();
+        let target = dir.path().join("auth-keyring.json");
+
+        let results: Vec<Result<(), CliError>> = std::thread::scope(|scope| {
+            let handles: Vec<_> = (0..16)
+                .map(|i| {
+                    let target = target.clone();
+                    scope.spawn(move || atomic_write(&target, format!(r#"{{"writer":{i}}}"#).as_bytes()))
+                })
+                .collect();
+            handles.into_iter().map(|h| h.join().unwrap()).collect()
+        });
+
+        let failed: Vec<String> = results
+            .iter()
+            .filter_map(|r| r.as_ref().err().map(|e| e.to_string()))
+            .collect();
+        assert!(failed.is_empty(), "concurrent writers failed: {failed:?}");
+
+        // Last writer wins, but the file must always be one writer's complete
+        // payload — never a mix, and never absent.
+        let contents = std::fs::read_to_string(&target).unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(&contents)
+            .unwrap_or_else(|e| panic!("target is not valid JSON after concurrent writes: {e} in {contents:?}"));
+        assert!(parsed.get("writer").is_some(), "unexpected payload: {contents}");
+
+        // No temp files orphaned in the directory.
+        let leftovers: Vec<String> = std::fs::read_dir(dir.path())
+            .unwrap()
+            .filter_map(|e| e.ok())
+            .map(|e| e.file_name().to_string_lossy().into_owned())
+            .filter(|n| n.contains(".tmp"))
+            .collect();
+        assert!(leftovers.is_empty(), "temp files left behind: {leftovers:?}");
+    }
 
     #[test]
     fn token_bundle_roundtrip() {

--- a/seed/cli/cli-multi-spec-namespaced/with-wire-tests/src/auth/oauth_common.rs
+++ b/seed/cli/cli-multi-spec-namespaced/with-wire-tests/src/auth/oauth_common.rs
@@ -224,27 +224,6 @@ pub(crate) fn config_dir() -> Option<PathBuf> {
     }
 }
 
-/// Write `data` to `path` atomically: sibling temp file → owner-only
-/// permissions (0600 on Unix) → rename into place.
-///
-/// The temp file name is unique per writer — pid plus a process-local
-/// counter. Deriving it from the target alone meant every concurrent writer
-/// used the *same* sibling (`auth-keyring.tmp`): whichever one renamed first
-/// moved it away, and the rest failed with `ENOENT` from `rename`. That
-/// surfaced as intermittent `auth login --with-token` failures across a
-/// wire-test suite large enough to run many CLI processes at once, killing a
-/// different subset of cases on each run.
-///
-/// The pid covers the case that actually bit us (separate CLI processes); the
-/// counter covers two writers inside one process, and is what makes the
-/// behavior unit-testable without spawning subprocesses.
-///
-/// `rename` is still atomic for readers, which is what keeps a partially
-/// written credential file unobservable. This only fixes writer-vs-writer
-/// collisions on the temp path. `FileKeyringStore::set` remains a
-/// read-modify-write of the whole map with no lock, so simultaneous writers
-/// can still clobber one another's *entries*; making that safe needs file
-/// locking, which is a larger change.
 /// Unlinks a temp file on drop unless [`TempFileGuard::disarm`]ed. Covers
 /// every early return *and* a panic between creating the temp file and
 /// renaming it into place.
@@ -278,6 +257,30 @@ impl Drop for TempFileGuard {
     }
 }
 
+/// Write `data` to `path` atomically: sibling temp file → owner-only
+/// permissions (0600 on Unix) → rename into place.
+///
+/// The temp file name is unique per writer — pid plus a process-local
+/// counter. Deriving it from the target alone meant every concurrent writer
+/// used the *same* sibling (`auth-keyring.tmp`): whichever one renamed first
+/// moved it away, and the rest failed with `ENOENT` from `rename`. That
+/// surfaced as intermittent `auth login --with-token` failures across a
+/// wire-test suite large enough to run many CLI processes at once, killing a
+/// different subset of cases on each run.
+///
+/// The pid covers the case that actually bit us (separate CLI processes); the
+/// counter covers two writers inside one process, and is what makes the
+/// behavior unit-testable without spawning subprocesses.
+///
+/// A [`TempFileGuard`] unlinks the temp file if anything between creating it
+/// and renaming it fails, so unique names cannot accumulate as orphans.
+///
+/// `rename` is still atomic for readers, which is what keeps a partially
+/// written credential file unobservable. This only fixes writer-vs-writer
+/// collisions on the temp path. `FileKeyringStore::set` remains a
+/// read-modify-write of the whole map with no lock, so simultaneous writers
+/// can still clobber one another's *entries*; making that safe needs file
+/// locking, which is a larger change.
 pub(crate) fn atomic_write(path: &Path, data: &[u8]) -> Result<(), CliError> {
     static TMP_SEQ: std::sync::atomic::AtomicUsize = std::sync::atomic::AtomicUsize::new(0);
     let seq = TMP_SEQ.fetch_add(1, std::sync::atomic::Ordering::Relaxed);

--- a/seed/cli/cli-multi-spec-namespaced/with-wire-tests/src/auth/oauth_common.rs
+++ b/seed/cli/cli-multi-spec-namespaced/with-wire-tests/src/auth/oauth_common.rs
@@ -245,23 +245,56 @@ pub(crate) fn config_dir() -> Option<PathBuf> {
 /// read-modify-write of the whole map with no lock, so simultaneous writers
 /// can still clobber one another's *entries*; making that safe needs file
 /// locking, which is a larger change.
+/// Unlinks a temp file on drop unless [`TempFileGuard::disarm`]ed. Covers
+/// every early return *and* a panic between creating the temp file and
+/// renaming it into place.
+///
+/// This exists because the temp name is unique per writer. The old shared
+/// `auth-keyring.tmp` was self-limiting — a failed write left one stale file
+/// that the next write reused — whereas unique names would leak a distinct
+/// credential-bearing file on every failure, in a directory nothing prunes. A
+/// `SIGKILL` still leaks, since no in-process guard can cover that.
+struct TempFileGuard {
+    path: PathBuf,
+    armed: bool,
+}
+
+impl TempFileGuard {
+    fn new(path: PathBuf) -> Self {
+        Self { path, armed: true }
+    }
+
+    /// Relinquish the file — call once `rename` has moved it into place.
+    fn disarm(&mut self) {
+        self.armed = false;
+    }
+}
+
+impl Drop for TempFileGuard {
+    fn drop(&mut self) {
+        if self.armed {
+            let _ = std::fs::remove_file(&self.path);
+        }
+    }
+}
+
 pub(crate) fn atomic_write(path: &Path, data: &[u8]) -> Result<(), CliError> {
-    static TMP_SEQ: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+    static TMP_SEQ: std::sync::atomic::AtomicUsize = std::sync::atomic::AtomicUsize::new(0);
     let seq = TMP_SEQ.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
     let tmp = path.with_extension(format!("tmp.{}.{}", std::process::id(), seq));
-    std::fs::write(&tmp, data).map_err(|e| {
-        CliError::Auth(format!("Failed to write {}: {e}", tmp.display()))
-    })?;
+    let mut guard = TempFileGuard::new(tmp.clone());
+    std::fs::write(&tmp, data)
+        .map_err(|e| CliError::Auth(format!("Failed to write {}: {e}", tmp.display())))?;
     #[cfg(unix)]
     {
         use std::os::unix::fs::PermissionsExt;
         let perms = std::fs::Permissions::from_mode(0o600);
         let _ = std::fs::set_permissions(&tmp, perms);
     }
-    std::fs::rename(&tmp, path).map_err(|e| {
-        let _ = std::fs::remove_file(&tmp);
-        CliError::Auth(format!("Failed to rename {}: {e}", tmp.display()))
-    })
+    std::fs::rename(&tmp, path)
+        .map_err(|e| CliError::Auth(format!("Failed to rename {}: {e}", tmp.display())))?;
+    guard.disarm();
+    Ok(())
 }
 
 // ---------------------------------------------------------------------------
@@ -315,6 +348,56 @@ mod tests {
             .filter(|n| n.contains(".tmp"))
             .collect();
         assert!(leftovers.is_empty(), "temp files left behind: {leftovers:?}");
+    }
+
+    /// A failed write must not leave its temp file behind. Renaming a file onto
+    /// an existing directory fails on every platform, which drives the error
+    /// path without mocking the filesystem.
+    ///
+    /// The pre-`TempFileGuard` code already cleaned up on a `rename` error, so
+    /// this pins an invariant rather than catching a regression — see
+    /// `temp_file_guard_unlinks_unless_disarmed` for the guard's own coverage.
+    #[test]
+    fn atomic_write_cleans_up_temp_file_on_failure() {
+        let dir = tempfile::tempdir().unwrap();
+
+        // The target is a *directory*, so `rename` cannot replace it.
+        let target = dir.path().join("auth-keyring.json");
+        std::fs::create_dir(&target).unwrap();
+        std::fs::write(target.join("occupant"), b"x").unwrap();
+
+        let result = atomic_write(&target, br#"{"writer":0}"#);
+        assert!(result.is_err(), "expected rename onto a directory to fail");
+
+        let leftovers: Vec<String> = std::fs::read_dir(dir.path())
+            .unwrap()
+            .filter_map(|e| e.ok())
+            .map(|e| e.file_name().to_string_lossy().into_owned())
+            .filter(|n| n.contains(".tmp"))
+            .collect();
+        assert!(leftovers.is_empty(), "temp file leaked after a failed write: {leftovers:?}");
+    }
+
+    /// Pins [`TempFileGuard`]: armed drops unlink, disarmed drops don't. Drop
+    /// running on an armed guard is what covers early returns and unwinding
+    /// panics between `write` and `rename` — paths the old `rename`-only
+    /// cleanup missed. Deleting the guard or the `disarm()` call fails this.
+    #[test]
+    fn temp_file_guard_unlinks_unless_disarmed() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("auth-keyring.tmp.0.0");
+
+        std::fs::write(&path, b"x").unwrap();
+        drop(TempFileGuard::new(path.clone()));
+        assert!(!path.exists(), "armed guard must unlink on drop");
+
+        // The post-`rename` case: the file has been moved away, so the guard
+        // must not touch whatever now sits at that path.
+        std::fs::write(&path, b"x").unwrap();
+        let mut guard = TempFileGuard::new(path.clone());
+        guard.disarm();
+        drop(guard);
+        assert!(path.exists(), "disarmed guard must not unlink");
     }
 
     #[test]

--- a/seed/cli/cli-multi-spec-namespaced/with-wire-tests/src/auth/oauth_common.rs
+++ b/seed/cli/cli-multi-spec-namespaced/with-wire-tests/src/auth/oauth_common.rs
@@ -226,8 +226,29 @@ pub(crate) fn config_dir() -> Option<PathBuf> {
 
 /// Write `data` to `path` atomically: sibling temp file → owner-only
 /// permissions (0600 on Unix) → rename into place.
+///
+/// The temp file name is unique per writer — pid plus a process-local
+/// counter. Deriving it from the target alone meant every concurrent writer
+/// used the *same* sibling (`auth-keyring.tmp`): whichever one renamed first
+/// moved it away, and the rest failed with `ENOENT` from `rename`. That
+/// surfaced as intermittent `auth login --with-token` failures across a
+/// wire-test suite large enough to run many CLI processes at once, killing a
+/// different subset of cases on each run.
+///
+/// The pid covers the case that actually bit us (separate CLI processes); the
+/// counter covers two writers inside one process, and is what makes the
+/// behavior unit-testable without spawning subprocesses.
+///
+/// `rename` is still atomic for readers, which is what keeps a partially
+/// written credential file unobservable. This only fixes writer-vs-writer
+/// collisions on the temp path. `FileKeyringStore::set` remains a
+/// read-modify-write of the whole map with no lock, so simultaneous writers
+/// can still clobber one another's *entries*; making that safe needs file
+/// locking, which is a larger change.
 pub(crate) fn atomic_write(path: &Path, data: &[u8]) -> Result<(), CliError> {
-    let tmp = path.with_extension("tmp");
+    static TMP_SEQ: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+    let seq = TMP_SEQ.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+    let tmp = path.with_extension(format!("tmp.{}.{}", std::process::id(), seq));
     std::fs::write(&tmp, data).map_err(|e| {
         CliError::Auth(format!("Failed to write {}: {e}", tmp.display()))
     })?;
@@ -250,6 +271,51 @@ pub(crate) fn atomic_write(path: &Path, data: &[u8]) -> Result<(), CliError> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// Regression test for the temp-file collision that made
+    /// `auth login --with-token` fail intermittently: every writer derived the
+    /// same sibling path from the target, so the first `rename` moved it away
+    /// and the rest got `ENOENT`.
+    ///
+    /// Reverting `atomic_write` to a target-derived temp name fails this with
+    /// "Failed to rename ...: No such file or directory".
+    #[test]
+    fn atomic_write_tolerates_concurrent_writers() {
+        let dir = tempfile::tempdir().unwrap();
+        let target = dir.path().join("auth-keyring.json");
+
+        let results: Vec<Result<(), CliError>> = std::thread::scope(|scope| {
+            let handles: Vec<_> = (0..16)
+                .map(|i| {
+                    let target = target.clone();
+                    scope.spawn(move || atomic_write(&target, format!(r#"{{"writer":{i}}}"#).as_bytes()))
+                })
+                .collect();
+            handles.into_iter().map(|h| h.join().unwrap()).collect()
+        });
+
+        let failed: Vec<String> = results
+            .iter()
+            .filter_map(|r| r.as_ref().err().map(|e| e.to_string()))
+            .collect();
+        assert!(failed.is_empty(), "concurrent writers failed: {failed:?}");
+
+        // Last writer wins, but the file must always be one writer's complete
+        // payload — never a mix, and never absent.
+        let contents = std::fs::read_to_string(&target).unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(&contents)
+            .unwrap_or_else(|e| panic!("target is not valid JSON after concurrent writes: {e} in {contents:?}"));
+        assert!(parsed.get("writer").is_some(), "unexpected payload: {contents}");
+
+        // No temp files orphaned in the directory.
+        let leftovers: Vec<String> = std::fs::read_dir(dir.path())
+            .unwrap()
+            .filter_map(|e| e.ok())
+            .map(|e| e.file_name().to_string_lossy().into_owned())
+            .filter(|n| n.contains(".tmp"))
+            .collect();
+        assert!(leftovers.is_empty(), "temp files left behind: {leftovers:?}");
+    }
 
     #[test]
     fn token_bundle_roundtrip() {

--- a/seed/cli/cli-multi-spec/no-custom-config/src/auth/oauth_common.rs
+++ b/seed/cli/cli-multi-spec/no-custom-config/src/auth/oauth_common.rs
@@ -224,27 +224,6 @@ pub(crate) fn config_dir() -> Option<PathBuf> {
     }
 }
 
-/// Write `data` to `path` atomically: sibling temp file → owner-only
-/// permissions (0600 on Unix) → rename into place.
-///
-/// The temp file name is unique per writer — pid plus a process-local
-/// counter. Deriving it from the target alone meant every concurrent writer
-/// used the *same* sibling (`auth-keyring.tmp`): whichever one renamed first
-/// moved it away, and the rest failed with `ENOENT` from `rename`. That
-/// surfaced as intermittent `auth login --with-token` failures across a
-/// wire-test suite large enough to run many CLI processes at once, killing a
-/// different subset of cases on each run.
-///
-/// The pid covers the case that actually bit us (separate CLI processes); the
-/// counter covers two writers inside one process, and is what makes the
-/// behavior unit-testable without spawning subprocesses.
-///
-/// `rename` is still atomic for readers, which is what keeps a partially
-/// written credential file unobservable. This only fixes writer-vs-writer
-/// collisions on the temp path. `FileKeyringStore::set` remains a
-/// read-modify-write of the whole map with no lock, so simultaneous writers
-/// can still clobber one another's *entries*; making that safe needs file
-/// locking, which is a larger change.
 /// Unlinks a temp file on drop unless [`TempFileGuard::disarm`]ed. Covers
 /// every early return *and* a panic between creating the temp file and
 /// renaming it into place.
@@ -278,6 +257,30 @@ impl Drop for TempFileGuard {
     }
 }
 
+/// Write `data` to `path` atomically: sibling temp file → owner-only
+/// permissions (0600 on Unix) → rename into place.
+///
+/// The temp file name is unique per writer — pid plus a process-local
+/// counter. Deriving it from the target alone meant every concurrent writer
+/// used the *same* sibling (`auth-keyring.tmp`): whichever one renamed first
+/// moved it away, and the rest failed with `ENOENT` from `rename`. That
+/// surfaced as intermittent `auth login --with-token` failures across a
+/// wire-test suite large enough to run many CLI processes at once, killing a
+/// different subset of cases on each run.
+///
+/// The pid covers the case that actually bit us (separate CLI processes); the
+/// counter covers two writers inside one process, and is what makes the
+/// behavior unit-testable without spawning subprocesses.
+///
+/// A [`TempFileGuard`] unlinks the temp file if anything between creating it
+/// and renaming it fails, so unique names cannot accumulate as orphans.
+///
+/// `rename` is still atomic for readers, which is what keeps a partially
+/// written credential file unobservable. This only fixes writer-vs-writer
+/// collisions on the temp path. `FileKeyringStore::set` remains a
+/// read-modify-write of the whole map with no lock, so simultaneous writers
+/// can still clobber one another's *entries*; making that safe needs file
+/// locking, which is a larger change.
 pub(crate) fn atomic_write(path: &Path, data: &[u8]) -> Result<(), CliError> {
     static TMP_SEQ: std::sync::atomic::AtomicUsize = std::sync::atomic::AtomicUsize::new(0);
     let seq = TMP_SEQ.fetch_add(1, std::sync::atomic::Ordering::Relaxed);

--- a/seed/cli/cli-multi-spec/no-custom-config/src/auth/oauth_common.rs
+++ b/seed/cli/cli-multi-spec/no-custom-config/src/auth/oauth_common.rs
@@ -245,23 +245,56 @@ pub(crate) fn config_dir() -> Option<PathBuf> {
 /// read-modify-write of the whole map with no lock, so simultaneous writers
 /// can still clobber one another's *entries*; making that safe needs file
 /// locking, which is a larger change.
+/// Unlinks a temp file on drop unless [`TempFileGuard::disarm`]ed. Covers
+/// every early return *and* a panic between creating the temp file and
+/// renaming it into place.
+///
+/// This exists because the temp name is unique per writer. The old shared
+/// `auth-keyring.tmp` was self-limiting — a failed write left one stale file
+/// that the next write reused — whereas unique names would leak a distinct
+/// credential-bearing file on every failure, in a directory nothing prunes. A
+/// `SIGKILL` still leaks, since no in-process guard can cover that.
+struct TempFileGuard {
+    path: PathBuf,
+    armed: bool,
+}
+
+impl TempFileGuard {
+    fn new(path: PathBuf) -> Self {
+        Self { path, armed: true }
+    }
+
+    /// Relinquish the file — call once `rename` has moved it into place.
+    fn disarm(&mut self) {
+        self.armed = false;
+    }
+}
+
+impl Drop for TempFileGuard {
+    fn drop(&mut self) {
+        if self.armed {
+            let _ = std::fs::remove_file(&self.path);
+        }
+    }
+}
+
 pub(crate) fn atomic_write(path: &Path, data: &[u8]) -> Result<(), CliError> {
-    static TMP_SEQ: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+    static TMP_SEQ: std::sync::atomic::AtomicUsize = std::sync::atomic::AtomicUsize::new(0);
     let seq = TMP_SEQ.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
     let tmp = path.with_extension(format!("tmp.{}.{}", std::process::id(), seq));
-    std::fs::write(&tmp, data).map_err(|e| {
-        CliError::Auth(format!("Failed to write {}: {e}", tmp.display()))
-    })?;
+    let mut guard = TempFileGuard::new(tmp.clone());
+    std::fs::write(&tmp, data)
+        .map_err(|e| CliError::Auth(format!("Failed to write {}: {e}", tmp.display())))?;
     #[cfg(unix)]
     {
         use std::os::unix::fs::PermissionsExt;
         let perms = std::fs::Permissions::from_mode(0o600);
         let _ = std::fs::set_permissions(&tmp, perms);
     }
-    std::fs::rename(&tmp, path).map_err(|e| {
-        let _ = std::fs::remove_file(&tmp);
-        CliError::Auth(format!("Failed to rename {}: {e}", tmp.display()))
-    })
+    std::fs::rename(&tmp, path)
+        .map_err(|e| CliError::Auth(format!("Failed to rename {}: {e}", tmp.display())))?;
+    guard.disarm();
+    Ok(())
 }
 
 // ---------------------------------------------------------------------------
@@ -315,6 +348,56 @@ mod tests {
             .filter(|n| n.contains(".tmp"))
             .collect();
         assert!(leftovers.is_empty(), "temp files left behind: {leftovers:?}");
+    }
+
+    /// A failed write must not leave its temp file behind. Renaming a file onto
+    /// an existing directory fails on every platform, which drives the error
+    /// path without mocking the filesystem.
+    ///
+    /// The pre-`TempFileGuard` code already cleaned up on a `rename` error, so
+    /// this pins an invariant rather than catching a regression — see
+    /// `temp_file_guard_unlinks_unless_disarmed` for the guard's own coverage.
+    #[test]
+    fn atomic_write_cleans_up_temp_file_on_failure() {
+        let dir = tempfile::tempdir().unwrap();
+
+        // The target is a *directory*, so `rename` cannot replace it.
+        let target = dir.path().join("auth-keyring.json");
+        std::fs::create_dir(&target).unwrap();
+        std::fs::write(target.join("occupant"), b"x").unwrap();
+
+        let result = atomic_write(&target, br#"{"writer":0}"#);
+        assert!(result.is_err(), "expected rename onto a directory to fail");
+
+        let leftovers: Vec<String> = std::fs::read_dir(dir.path())
+            .unwrap()
+            .filter_map(|e| e.ok())
+            .map(|e| e.file_name().to_string_lossy().into_owned())
+            .filter(|n| n.contains(".tmp"))
+            .collect();
+        assert!(leftovers.is_empty(), "temp file leaked after a failed write: {leftovers:?}");
+    }
+
+    /// Pins [`TempFileGuard`]: armed drops unlink, disarmed drops don't. Drop
+    /// running on an armed guard is what covers early returns and unwinding
+    /// panics between `write` and `rename` — paths the old `rename`-only
+    /// cleanup missed. Deleting the guard or the `disarm()` call fails this.
+    #[test]
+    fn temp_file_guard_unlinks_unless_disarmed() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("auth-keyring.tmp.0.0");
+
+        std::fs::write(&path, b"x").unwrap();
+        drop(TempFileGuard::new(path.clone()));
+        assert!(!path.exists(), "armed guard must unlink on drop");
+
+        // The post-`rename` case: the file has been moved away, so the guard
+        // must not touch whatever now sits at that path.
+        std::fs::write(&path, b"x").unwrap();
+        let mut guard = TempFileGuard::new(path.clone());
+        guard.disarm();
+        drop(guard);
+        assert!(path.exists(), "disarmed guard must not unlink");
     }
 
     #[test]

--- a/seed/cli/cli-multi-spec/no-custom-config/src/auth/oauth_common.rs
+++ b/seed/cli/cli-multi-spec/no-custom-config/src/auth/oauth_common.rs
@@ -226,8 +226,29 @@ pub(crate) fn config_dir() -> Option<PathBuf> {
 
 /// Write `data` to `path` atomically: sibling temp file → owner-only
 /// permissions (0600 on Unix) → rename into place.
+///
+/// The temp file name is unique per writer — pid plus a process-local
+/// counter. Deriving it from the target alone meant every concurrent writer
+/// used the *same* sibling (`auth-keyring.tmp`): whichever one renamed first
+/// moved it away, and the rest failed with `ENOENT` from `rename`. That
+/// surfaced as intermittent `auth login --with-token` failures across a
+/// wire-test suite large enough to run many CLI processes at once, killing a
+/// different subset of cases on each run.
+///
+/// The pid covers the case that actually bit us (separate CLI processes); the
+/// counter covers two writers inside one process, and is what makes the
+/// behavior unit-testable without spawning subprocesses.
+///
+/// `rename` is still atomic for readers, which is what keeps a partially
+/// written credential file unobservable. This only fixes writer-vs-writer
+/// collisions on the temp path. `FileKeyringStore::set` remains a
+/// read-modify-write of the whole map with no lock, so simultaneous writers
+/// can still clobber one another's *entries*; making that safe needs file
+/// locking, which is a larger change.
 pub(crate) fn atomic_write(path: &Path, data: &[u8]) -> Result<(), CliError> {
-    let tmp = path.with_extension("tmp");
+    static TMP_SEQ: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+    let seq = TMP_SEQ.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+    let tmp = path.with_extension(format!("tmp.{}.{}", std::process::id(), seq));
     std::fs::write(&tmp, data).map_err(|e| {
         CliError::Auth(format!("Failed to write {}: {e}", tmp.display()))
     })?;
@@ -250,6 +271,51 @@ pub(crate) fn atomic_write(path: &Path, data: &[u8]) -> Result<(), CliError> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// Regression test for the temp-file collision that made
+    /// `auth login --with-token` fail intermittently: every writer derived the
+    /// same sibling path from the target, so the first `rename` moved it away
+    /// and the rest got `ENOENT`.
+    ///
+    /// Reverting `atomic_write` to a target-derived temp name fails this with
+    /// "Failed to rename ...: No such file or directory".
+    #[test]
+    fn atomic_write_tolerates_concurrent_writers() {
+        let dir = tempfile::tempdir().unwrap();
+        let target = dir.path().join("auth-keyring.json");
+
+        let results: Vec<Result<(), CliError>> = std::thread::scope(|scope| {
+            let handles: Vec<_> = (0..16)
+                .map(|i| {
+                    let target = target.clone();
+                    scope.spawn(move || atomic_write(&target, format!(r#"{{"writer":{i}}}"#).as_bytes()))
+                })
+                .collect();
+            handles.into_iter().map(|h| h.join().unwrap()).collect()
+        });
+
+        let failed: Vec<String> = results
+            .iter()
+            .filter_map(|r| r.as_ref().err().map(|e| e.to_string()))
+            .collect();
+        assert!(failed.is_empty(), "concurrent writers failed: {failed:?}");
+
+        // Last writer wins, but the file must always be one writer's complete
+        // payload — never a mix, and never absent.
+        let contents = std::fs::read_to_string(&target).unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(&contents)
+            .unwrap_or_else(|e| panic!("target is not valid JSON after concurrent writes: {e} in {contents:?}"));
+        assert!(parsed.get("writer").is_some(), "unexpected payload: {contents}");
+
+        // No temp files orphaned in the directory.
+        let leftovers: Vec<String> = std::fs::read_dir(dir.path())
+            .unwrap()
+            .filter_map(|e| e.ok())
+            .map(|e| e.file_name().to_string_lossy().into_owned())
+            .filter(|n| n.contains(".tmp"))
+            .collect();
+        assert!(leftovers.is_empty(), "temp files left behind: {leftovers:?}");
+    }
 
     #[test]
     fn token_bundle_roundtrip() {

--- a/seed/cli/cli-namespace-stutter/with-wire-tests/src/auth/oauth_common.rs
+++ b/seed/cli/cli-namespace-stutter/with-wire-tests/src/auth/oauth_common.rs
@@ -224,27 +224,6 @@ pub(crate) fn config_dir() -> Option<PathBuf> {
     }
 }
 
-/// Write `data` to `path` atomically: sibling temp file → owner-only
-/// permissions (0600 on Unix) → rename into place.
-///
-/// The temp file name is unique per writer — pid plus a process-local
-/// counter. Deriving it from the target alone meant every concurrent writer
-/// used the *same* sibling (`auth-keyring.tmp`): whichever one renamed first
-/// moved it away, and the rest failed with `ENOENT` from `rename`. That
-/// surfaced as intermittent `auth login --with-token` failures across a
-/// wire-test suite large enough to run many CLI processes at once, killing a
-/// different subset of cases on each run.
-///
-/// The pid covers the case that actually bit us (separate CLI processes); the
-/// counter covers two writers inside one process, and is what makes the
-/// behavior unit-testable without spawning subprocesses.
-///
-/// `rename` is still atomic for readers, which is what keeps a partially
-/// written credential file unobservable. This only fixes writer-vs-writer
-/// collisions on the temp path. `FileKeyringStore::set` remains a
-/// read-modify-write of the whole map with no lock, so simultaneous writers
-/// can still clobber one another's *entries*; making that safe needs file
-/// locking, which is a larger change.
 /// Unlinks a temp file on drop unless [`TempFileGuard::disarm`]ed. Covers
 /// every early return *and* a panic between creating the temp file and
 /// renaming it into place.
@@ -278,6 +257,30 @@ impl Drop for TempFileGuard {
     }
 }
 
+/// Write `data` to `path` atomically: sibling temp file → owner-only
+/// permissions (0600 on Unix) → rename into place.
+///
+/// The temp file name is unique per writer — pid plus a process-local
+/// counter. Deriving it from the target alone meant every concurrent writer
+/// used the *same* sibling (`auth-keyring.tmp`): whichever one renamed first
+/// moved it away, and the rest failed with `ENOENT` from `rename`. That
+/// surfaced as intermittent `auth login --with-token` failures across a
+/// wire-test suite large enough to run many CLI processes at once, killing a
+/// different subset of cases on each run.
+///
+/// The pid covers the case that actually bit us (separate CLI processes); the
+/// counter covers two writers inside one process, and is what makes the
+/// behavior unit-testable without spawning subprocesses.
+///
+/// A [`TempFileGuard`] unlinks the temp file if anything between creating it
+/// and renaming it fails, so unique names cannot accumulate as orphans.
+///
+/// `rename` is still atomic for readers, which is what keeps a partially
+/// written credential file unobservable. This only fixes writer-vs-writer
+/// collisions on the temp path. `FileKeyringStore::set` remains a
+/// read-modify-write of the whole map with no lock, so simultaneous writers
+/// can still clobber one another's *entries*; making that safe needs file
+/// locking, which is a larger change.
 pub(crate) fn atomic_write(path: &Path, data: &[u8]) -> Result<(), CliError> {
     static TMP_SEQ: std::sync::atomic::AtomicUsize = std::sync::atomic::AtomicUsize::new(0);
     let seq = TMP_SEQ.fetch_add(1, std::sync::atomic::Ordering::Relaxed);

--- a/seed/cli/cli-namespace-stutter/with-wire-tests/src/auth/oauth_common.rs
+++ b/seed/cli/cli-namespace-stutter/with-wire-tests/src/auth/oauth_common.rs
@@ -245,23 +245,56 @@ pub(crate) fn config_dir() -> Option<PathBuf> {
 /// read-modify-write of the whole map with no lock, so simultaneous writers
 /// can still clobber one another's *entries*; making that safe needs file
 /// locking, which is a larger change.
+/// Unlinks a temp file on drop unless [`TempFileGuard::disarm`]ed. Covers
+/// every early return *and* a panic between creating the temp file and
+/// renaming it into place.
+///
+/// This exists because the temp name is unique per writer. The old shared
+/// `auth-keyring.tmp` was self-limiting — a failed write left one stale file
+/// that the next write reused — whereas unique names would leak a distinct
+/// credential-bearing file on every failure, in a directory nothing prunes. A
+/// `SIGKILL` still leaks, since no in-process guard can cover that.
+struct TempFileGuard {
+    path: PathBuf,
+    armed: bool,
+}
+
+impl TempFileGuard {
+    fn new(path: PathBuf) -> Self {
+        Self { path, armed: true }
+    }
+
+    /// Relinquish the file — call once `rename` has moved it into place.
+    fn disarm(&mut self) {
+        self.armed = false;
+    }
+}
+
+impl Drop for TempFileGuard {
+    fn drop(&mut self) {
+        if self.armed {
+            let _ = std::fs::remove_file(&self.path);
+        }
+    }
+}
+
 pub(crate) fn atomic_write(path: &Path, data: &[u8]) -> Result<(), CliError> {
-    static TMP_SEQ: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+    static TMP_SEQ: std::sync::atomic::AtomicUsize = std::sync::atomic::AtomicUsize::new(0);
     let seq = TMP_SEQ.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
     let tmp = path.with_extension(format!("tmp.{}.{}", std::process::id(), seq));
-    std::fs::write(&tmp, data).map_err(|e| {
-        CliError::Auth(format!("Failed to write {}: {e}", tmp.display()))
-    })?;
+    let mut guard = TempFileGuard::new(tmp.clone());
+    std::fs::write(&tmp, data)
+        .map_err(|e| CliError::Auth(format!("Failed to write {}: {e}", tmp.display())))?;
     #[cfg(unix)]
     {
         use std::os::unix::fs::PermissionsExt;
         let perms = std::fs::Permissions::from_mode(0o600);
         let _ = std::fs::set_permissions(&tmp, perms);
     }
-    std::fs::rename(&tmp, path).map_err(|e| {
-        let _ = std::fs::remove_file(&tmp);
-        CliError::Auth(format!("Failed to rename {}: {e}", tmp.display()))
-    })
+    std::fs::rename(&tmp, path)
+        .map_err(|e| CliError::Auth(format!("Failed to rename {}: {e}", tmp.display())))?;
+    guard.disarm();
+    Ok(())
 }
 
 // ---------------------------------------------------------------------------
@@ -315,6 +348,56 @@ mod tests {
             .filter(|n| n.contains(".tmp"))
             .collect();
         assert!(leftovers.is_empty(), "temp files left behind: {leftovers:?}");
+    }
+
+    /// A failed write must not leave its temp file behind. Renaming a file onto
+    /// an existing directory fails on every platform, which drives the error
+    /// path without mocking the filesystem.
+    ///
+    /// The pre-`TempFileGuard` code already cleaned up on a `rename` error, so
+    /// this pins an invariant rather than catching a regression — see
+    /// `temp_file_guard_unlinks_unless_disarmed` for the guard's own coverage.
+    #[test]
+    fn atomic_write_cleans_up_temp_file_on_failure() {
+        let dir = tempfile::tempdir().unwrap();
+
+        // The target is a *directory*, so `rename` cannot replace it.
+        let target = dir.path().join("auth-keyring.json");
+        std::fs::create_dir(&target).unwrap();
+        std::fs::write(target.join("occupant"), b"x").unwrap();
+
+        let result = atomic_write(&target, br#"{"writer":0}"#);
+        assert!(result.is_err(), "expected rename onto a directory to fail");
+
+        let leftovers: Vec<String> = std::fs::read_dir(dir.path())
+            .unwrap()
+            .filter_map(|e| e.ok())
+            .map(|e| e.file_name().to_string_lossy().into_owned())
+            .filter(|n| n.contains(".tmp"))
+            .collect();
+        assert!(leftovers.is_empty(), "temp file leaked after a failed write: {leftovers:?}");
+    }
+
+    /// Pins [`TempFileGuard`]: armed drops unlink, disarmed drops don't. Drop
+    /// running on an armed guard is what covers early returns and unwinding
+    /// panics between `write` and `rename` — paths the old `rename`-only
+    /// cleanup missed. Deleting the guard or the `disarm()` call fails this.
+    #[test]
+    fn temp_file_guard_unlinks_unless_disarmed() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("auth-keyring.tmp.0.0");
+
+        std::fs::write(&path, b"x").unwrap();
+        drop(TempFileGuard::new(path.clone()));
+        assert!(!path.exists(), "armed guard must unlink on drop");
+
+        // The post-`rename` case: the file has been moved away, so the guard
+        // must not touch whatever now sits at that path.
+        std::fs::write(&path, b"x").unwrap();
+        let mut guard = TempFileGuard::new(path.clone());
+        guard.disarm();
+        drop(guard);
+        assert!(path.exists(), "disarmed guard must not unlink");
     }
 
     #[test]

--- a/seed/cli/cli-namespace-stutter/with-wire-tests/src/auth/oauth_common.rs
+++ b/seed/cli/cli-namespace-stutter/with-wire-tests/src/auth/oauth_common.rs
@@ -226,8 +226,29 @@ pub(crate) fn config_dir() -> Option<PathBuf> {
 
 /// Write `data` to `path` atomically: sibling temp file → owner-only
 /// permissions (0600 on Unix) → rename into place.
+///
+/// The temp file name is unique per writer — pid plus a process-local
+/// counter. Deriving it from the target alone meant every concurrent writer
+/// used the *same* sibling (`auth-keyring.tmp`): whichever one renamed first
+/// moved it away, and the rest failed with `ENOENT` from `rename`. That
+/// surfaced as intermittent `auth login --with-token` failures across a
+/// wire-test suite large enough to run many CLI processes at once, killing a
+/// different subset of cases on each run.
+///
+/// The pid covers the case that actually bit us (separate CLI processes); the
+/// counter covers two writers inside one process, and is what makes the
+/// behavior unit-testable without spawning subprocesses.
+///
+/// `rename` is still atomic for readers, which is what keeps a partially
+/// written credential file unobservable. This only fixes writer-vs-writer
+/// collisions on the temp path. `FileKeyringStore::set` remains a
+/// read-modify-write of the whole map with no lock, so simultaneous writers
+/// can still clobber one another's *entries*; making that safe needs file
+/// locking, which is a larger change.
 pub(crate) fn atomic_write(path: &Path, data: &[u8]) -> Result<(), CliError> {
-    let tmp = path.with_extension("tmp");
+    static TMP_SEQ: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+    let seq = TMP_SEQ.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+    let tmp = path.with_extension(format!("tmp.{}.{}", std::process::id(), seq));
     std::fs::write(&tmp, data).map_err(|e| {
         CliError::Auth(format!("Failed to write {}: {e}", tmp.display()))
     })?;
@@ -250,6 +271,51 @@ pub(crate) fn atomic_write(path: &Path, data: &[u8]) -> Result<(), CliError> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// Regression test for the temp-file collision that made
+    /// `auth login --with-token` fail intermittently: every writer derived the
+    /// same sibling path from the target, so the first `rename` moved it away
+    /// and the rest got `ENOENT`.
+    ///
+    /// Reverting `atomic_write` to a target-derived temp name fails this with
+    /// "Failed to rename ...: No such file or directory".
+    #[test]
+    fn atomic_write_tolerates_concurrent_writers() {
+        let dir = tempfile::tempdir().unwrap();
+        let target = dir.path().join("auth-keyring.json");
+
+        let results: Vec<Result<(), CliError>> = std::thread::scope(|scope| {
+            let handles: Vec<_> = (0..16)
+                .map(|i| {
+                    let target = target.clone();
+                    scope.spawn(move || atomic_write(&target, format!(r#"{{"writer":{i}}}"#).as_bytes()))
+                })
+                .collect();
+            handles.into_iter().map(|h| h.join().unwrap()).collect()
+        });
+
+        let failed: Vec<String> = results
+            .iter()
+            .filter_map(|r| r.as_ref().err().map(|e| e.to_string()))
+            .collect();
+        assert!(failed.is_empty(), "concurrent writers failed: {failed:?}");
+
+        // Last writer wins, but the file must always be one writer's complete
+        // payload — never a mix, and never absent.
+        let contents = std::fs::read_to_string(&target).unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(&contents)
+            .unwrap_or_else(|e| panic!("target is not valid JSON after concurrent writes: {e} in {contents:?}"));
+        assert!(parsed.get("writer").is_some(), "unexpected payload: {contents}");
+
+        // No temp files orphaned in the directory.
+        let leftovers: Vec<String> = std::fs::read_dir(dir.path())
+            .unwrap()
+            .filter_map(|e| e.ok())
+            .map(|e| e.file_name().to_string_lossy().into_owned())
+            .filter(|n| n.contains(".tmp"))
+            .collect();
+        assert!(leftovers.is_empty(), "temp files left behind: {leftovers:?}");
+    }
 
     #[test]
     fn token_bundle_roundtrip() {

--- a/seed/cli/cli-oauth-login-flow/with-wire-tests/src/auth/oauth_common.rs
+++ b/seed/cli/cli-oauth-login-flow/with-wire-tests/src/auth/oauth_common.rs
@@ -224,27 +224,6 @@ pub(crate) fn config_dir() -> Option<PathBuf> {
     }
 }
 
-/// Write `data` to `path` atomically: sibling temp file → owner-only
-/// permissions (0600 on Unix) → rename into place.
-///
-/// The temp file name is unique per writer — pid plus a process-local
-/// counter. Deriving it from the target alone meant every concurrent writer
-/// used the *same* sibling (`auth-keyring.tmp`): whichever one renamed first
-/// moved it away, and the rest failed with `ENOENT` from `rename`. That
-/// surfaced as intermittent `auth login --with-token` failures across a
-/// wire-test suite large enough to run many CLI processes at once, killing a
-/// different subset of cases on each run.
-///
-/// The pid covers the case that actually bit us (separate CLI processes); the
-/// counter covers two writers inside one process, and is what makes the
-/// behavior unit-testable without spawning subprocesses.
-///
-/// `rename` is still atomic for readers, which is what keeps a partially
-/// written credential file unobservable. This only fixes writer-vs-writer
-/// collisions on the temp path. `FileKeyringStore::set` remains a
-/// read-modify-write of the whole map with no lock, so simultaneous writers
-/// can still clobber one another's *entries*; making that safe needs file
-/// locking, which is a larger change.
 /// Unlinks a temp file on drop unless [`TempFileGuard::disarm`]ed. Covers
 /// every early return *and* a panic between creating the temp file and
 /// renaming it into place.
@@ -278,6 +257,30 @@ impl Drop for TempFileGuard {
     }
 }
 
+/// Write `data` to `path` atomically: sibling temp file → owner-only
+/// permissions (0600 on Unix) → rename into place.
+///
+/// The temp file name is unique per writer — pid plus a process-local
+/// counter. Deriving it from the target alone meant every concurrent writer
+/// used the *same* sibling (`auth-keyring.tmp`): whichever one renamed first
+/// moved it away, and the rest failed with `ENOENT` from `rename`. That
+/// surfaced as intermittent `auth login --with-token` failures across a
+/// wire-test suite large enough to run many CLI processes at once, killing a
+/// different subset of cases on each run.
+///
+/// The pid covers the case that actually bit us (separate CLI processes); the
+/// counter covers two writers inside one process, and is what makes the
+/// behavior unit-testable without spawning subprocesses.
+///
+/// A [`TempFileGuard`] unlinks the temp file if anything between creating it
+/// and renaming it fails, so unique names cannot accumulate as orphans.
+///
+/// `rename` is still atomic for readers, which is what keeps a partially
+/// written credential file unobservable. This only fixes writer-vs-writer
+/// collisions on the temp path. `FileKeyringStore::set` remains a
+/// read-modify-write of the whole map with no lock, so simultaneous writers
+/// can still clobber one another's *entries*; making that safe needs file
+/// locking, which is a larger change.
 pub(crate) fn atomic_write(path: &Path, data: &[u8]) -> Result<(), CliError> {
     static TMP_SEQ: std::sync::atomic::AtomicUsize = std::sync::atomic::AtomicUsize::new(0);
     let seq = TMP_SEQ.fetch_add(1, std::sync::atomic::Ordering::Relaxed);

--- a/seed/cli/cli-oauth-login-flow/with-wire-tests/src/auth/oauth_common.rs
+++ b/seed/cli/cli-oauth-login-flow/with-wire-tests/src/auth/oauth_common.rs
@@ -245,23 +245,56 @@ pub(crate) fn config_dir() -> Option<PathBuf> {
 /// read-modify-write of the whole map with no lock, so simultaneous writers
 /// can still clobber one another's *entries*; making that safe needs file
 /// locking, which is a larger change.
+/// Unlinks a temp file on drop unless [`TempFileGuard::disarm`]ed. Covers
+/// every early return *and* a panic between creating the temp file and
+/// renaming it into place.
+///
+/// This exists because the temp name is unique per writer. The old shared
+/// `auth-keyring.tmp` was self-limiting — a failed write left one stale file
+/// that the next write reused — whereas unique names would leak a distinct
+/// credential-bearing file on every failure, in a directory nothing prunes. A
+/// `SIGKILL` still leaks, since no in-process guard can cover that.
+struct TempFileGuard {
+    path: PathBuf,
+    armed: bool,
+}
+
+impl TempFileGuard {
+    fn new(path: PathBuf) -> Self {
+        Self { path, armed: true }
+    }
+
+    /// Relinquish the file — call once `rename` has moved it into place.
+    fn disarm(&mut self) {
+        self.armed = false;
+    }
+}
+
+impl Drop for TempFileGuard {
+    fn drop(&mut self) {
+        if self.armed {
+            let _ = std::fs::remove_file(&self.path);
+        }
+    }
+}
+
 pub(crate) fn atomic_write(path: &Path, data: &[u8]) -> Result<(), CliError> {
-    static TMP_SEQ: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+    static TMP_SEQ: std::sync::atomic::AtomicUsize = std::sync::atomic::AtomicUsize::new(0);
     let seq = TMP_SEQ.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
     let tmp = path.with_extension(format!("tmp.{}.{}", std::process::id(), seq));
-    std::fs::write(&tmp, data).map_err(|e| {
-        CliError::Auth(format!("Failed to write {}: {e}", tmp.display()))
-    })?;
+    let mut guard = TempFileGuard::new(tmp.clone());
+    std::fs::write(&tmp, data)
+        .map_err(|e| CliError::Auth(format!("Failed to write {}: {e}", tmp.display())))?;
     #[cfg(unix)]
     {
         use std::os::unix::fs::PermissionsExt;
         let perms = std::fs::Permissions::from_mode(0o600);
         let _ = std::fs::set_permissions(&tmp, perms);
     }
-    std::fs::rename(&tmp, path).map_err(|e| {
-        let _ = std::fs::remove_file(&tmp);
-        CliError::Auth(format!("Failed to rename {}: {e}", tmp.display()))
-    })
+    std::fs::rename(&tmp, path)
+        .map_err(|e| CliError::Auth(format!("Failed to rename {}: {e}", tmp.display())))?;
+    guard.disarm();
+    Ok(())
 }
 
 // ---------------------------------------------------------------------------
@@ -315,6 +348,56 @@ mod tests {
             .filter(|n| n.contains(".tmp"))
             .collect();
         assert!(leftovers.is_empty(), "temp files left behind: {leftovers:?}");
+    }
+
+    /// A failed write must not leave its temp file behind. Renaming a file onto
+    /// an existing directory fails on every platform, which drives the error
+    /// path without mocking the filesystem.
+    ///
+    /// The pre-`TempFileGuard` code already cleaned up on a `rename` error, so
+    /// this pins an invariant rather than catching a regression — see
+    /// `temp_file_guard_unlinks_unless_disarmed` for the guard's own coverage.
+    #[test]
+    fn atomic_write_cleans_up_temp_file_on_failure() {
+        let dir = tempfile::tempdir().unwrap();
+
+        // The target is a *directory*, so `rename` cannot replace it.
+        let target = dir.path().join("auth-keyring.json");
+        std::fs::create_dir(&target).unwrap();
+        std::fs::write(target.join("occupant"), b"x").unwrap();
+
+        let result = atomic_write(&target, br#"{"writer":0}"#);
+        assert!(result.is_err(), "expected rename onto a directory to fail");
+
+        let leftovers: Vec<String> = std::fs::read_dir(dir.path())
+            .unwrap()
+            .filter_map(|e| e.ok())
+            .map(|e| e.file_name().to_string_lossy().into_owned())
+            .filter(|n| n.contains(".tmp"))
+            .collect();
+        assert!(leftovers.is_empty(), "temp file leaked after a failed write: {leftovers:?}");
+    }
+
+    /// Pins [`TempFileGuard`]: armed drops unlink, disarmed drops don't. Drop
+    /// running on an armed guard is what covers early returns and unwinding
+    /// panics between `write` and `rename` — paths the old `rename`-only
+    /// cleanup missed. Deleting the guard or the `disarm()` call fails this.
+    #[test]
+    fn temp_file_guard_unlinks_unless_disarmed() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("auth-keyring.tmp.0.0");
+
+        std::fs::write(&path, b"x").unwrap();
+        drop(TempFileGuard::new(path.clone()));
+        assert!(!path.exists(), "armed guard must unlink on drop");
+
+        // The post-`rename` case: the file has been moved away, so the guard
+        // must not touch whatever now sits at that path.
+        std::fs::write(&path, b"x").unwrap();
+        let mut guard = TempFileGuard::new(path.clone());
+        guard.disarm();
+        drop(guard);
+        assert!(path.exists(), "disarmed guard must not unlink");
     }
 
     #[test]

--- a/seed/cli/cli-oauth-login-flow/with-wire-tests/src/auth/oauth_common.rs
+++ b/seed/cli/cli-oauth-login-flow/with-wire-tests/src/auth/oauth_common.rs
@@ -226,8 +226,29 @@ pub(crate) fn config_dir() -> Option<PathBuf> {
 
 /// Write `data` to `path` atomically: sibling temp file → owner-only
 /// permissions (0600 on Unix) → rename into place.
+///
+/// The temp file name is unique per writer — pid plus a process-local
+/// counter. Deriving it from the target alone meant every concurrent writer
+/// used the *same* sibling (`auth-keyring.tmp`): whichever one renamed first
+/// moved it away, and the rest failed with `ENOENT` from `rename`. That
+/// surfaced as intermittent `auth login --with-token` failures across a
+/// wire-test suite large enough to run many CLI processes at once, killing a
+/// different subset of cases on each run.
+///
+/// The pid covers the case that actually bit us (separate CLI processes); the
+/// counter covers two writers inside one process, and is what makes the
+/// behavior unit-testable without spawning subprocesses.
+///
+/// `rename` is still atomic for readers, which is what keeps a partially
+/// written credential file unobservable. This only fixes writer-vs-writer
+/// collisions on the temp path. `FileKeyringStore::set` remains a
+/// read-modify-write of the whole map with no lock, so simultaneous writers
+/// can still clobber one another's *entries*; making that safe needs file
+/// locking, which is a larger change.
 pub(crate) fn atomic_write(path: &Path, data: &[u8]) -> Result<(), CliError> {
-    let tmp = path.with_extension("tmp");
+    static TMP_SEQ: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+    let seq = TMP_SEQ.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+    let tmp = path.with_extension(format!("tmp.{}.{}", std::process::id(), seq));
     std::fs::write(&tmp, data).map_err(|e| {
         CliError::Auth(format!("Failed to write {}: {e}", tmp.display()))
     })?;
@@ -250,6 +271,51 @@ pub(crate) fn atomic_write(path: &Path, data: &[u8]) -> Result<(), CliError> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// Regression test for the temp-file collision that made
+    /// `auth login --with-token` fail intermittently: every writer derived the
+    /// same sibling path from the target, so the first `rename` moved it away
+    /// and the rest got `ENOENT`.
+    ///
+    /// Reverting `atomic_write` to a target-derived temp name fails this with
+    /// "Failed to rename ...: No such file or directory".
+    #[test]
+    fn atomic_write_tolerates_concurrent_writers() {
+        let dir = tempfile::tempdir().unwrap();
+        let target = dir.path().join("auth-keyring.json");
+
+        let results: Vec<Result<(), CliError>> = std::thread::scope(|scope| {
+            let handles: Vec<_> = (0..16)
+                .map(|i| {
+                    let target = target.clone();
+                    scope.spawn(move || atomic_write(&target, format!(r#"{{"writer":{i}}}"#).as_bytes()))
+                })
+                .collect();
+            handles.into_iter().map(|h| h.join().unwrap()).collect()
+        });
+
+        let failed: Vec<String> = results
+            .iter()
+            .filter_map(|r| r.as_ref().err().map(|e| e.to_string()))
+            .collect();
+        assert!(failed.is_empty(), "concurrent writers failed: {failed:?}");
+
+        // Last writer wins, but the file must always be one writer's complete
+        // payload — never a mix, and never absent.
+        let contents = std::fs::read_to_string(&target).unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(&contents)
+            .unwrap_or_else(|e| panic!("target is not valid JSON after concurrent writes: {e} in {contents:?}"));
+        assert!(parsed.get("writer").is_some(), "unexpected payload: {contents}");
+
+        // No temp files orphaned in the directory.
+        let leftovers: Vec<String> = std::fs::read_dir(dir.path())
+            .unwrap()
+            .filter_map(|e| e.ok())
+            .map(|e| e.file_name().to_string_lossy().into_owned())
+            .filter(|n| n.contains(".tmp"))
+            .collect();
+        assert!(leftovers.is_empty(), "temp files left behind: {leftovers:?}");
+    }
 
     #[test]
     fn token_bundle_roundtrip() {

--- a/seed/cli/cli-oauth/client-credentials/src/auth/oauth_common.rs
+++ b/seed/cli/cli-oauth/client-credentials/src/auth/oauth_common.rs
@@ -224,27 +224,6 @@ pub(crate) fn config_dir() -> Option<PathBuf> {
     }
 }
 
-/// Write `data` to `path` atomically: sibling temp file → owner-only
-/// permissions (0600 on Unix) → rename into place.
-///
-/// The temp file name is unique per writer — pid plus a process-local
-/// counter. Deriving it from the target alone meant every concurrent writer
-/// used the *same* sibling (`auth-keyring.tmp`): whichever one renamed first
-/// moved it away, and the rest failed with `ENOENT` from `rename`. That
-/// surfaced as intermittent `auth login --with-token` failures across a
-/// wire-test suite large enough to run many CLI processes at once, killing a
-/// different subset of cases on each run.
-///
-/// The pid covers the case that actually bit us (separate CLI processes); the
-/// counter covers two writers inside one process, and is what makes the
-/// behavior unit-testable without spawning subprocesses.
-///
-/// `rename` is still atomic for readers, which is what keeps a partially
-/// written credential file unobservable. This only fixes writer-vs-writer
-/// collisions on the temp path. `FileKeyringStore::set` remains a
-/// read-modify-write of the whole map with no lock, so simultaneous writers
-/// can still clobber one another's *entries*; making that safe needs file
-/// locking, which is a larger change.
 /// Unlinks a temp file on drop unless [`TempFileGuard::disarm`]ed. Covers
 /// every early return *and* a panic between creating the temp file and
 /// renaming it into place.
@@ -278,6 +257,30 @@ impl Drop for TempFileGuard {
     }
 }
 
+/// Write `data` to `path` atomically: sibling temp file → owner-only
+/// permissions (0600 on Unix) → rename into place.
+///
+/// The temp file name is unique per writer — pid plus a process-local
+/// counter. Deriving it from the target alone meant every concurrent writer
+/// used the *same* sibling (`auth-keyring.tmp`): whichever one renamed first
+/// moved it away, and the rest failed with `ENOENT` from `rename`. That
+/// surfaced as intermittent `auth login --with-token` failures across a
+/// wire-test suite large enough to run many CLI processes at once, killing a
+/// different subset of cases on each run.
+///
+/// The pid covers the case that actually bit us (separate CLI processes); the
+/// counter covers two writers inside one process, and is what makes the
+/// behavior unit-testable without spawning subprocesses.
+///
+/// A [`TempFileGuard`] unlinks the temp file if anything between creating it
+/// and renaming it fails, so unique names cannot accumulate as orphans.
+///
+/// `rename` is still atomic for readers, which is what keeps a partially
+/// written credential file unobservable. This only fixes writer-vs-writer
+/// collisions on the temp path. `FileKeyringStore::set` remains a
+/// read-modify-write of the whole map with no lock, so simultaneous writers
+/// can still clobber one another's *entries*; making that safe needs file
+/// locking, which is a larger change.
 pub(crate) fn atomic_write(path: &Path, data: &[u8]) -> Result<(), CliError> {
     static TMP_SEQ: std::sync::atomic::AtomicUsize = std::sync::atomic::AtomicUsize::new(0);
     let seq = TMP_SEQ.fetch_add(1, std::sync::atomic::Ordering::Relaxed);

--- a/seed/cli/cli-oauth/client-credentials/src/auth/oauth_common.rs
+++ b/seed/cli/cli-oauth/client-credentials/src/auth/oauth_common.rs
@@ -245,23 +245,56 @@ pub(crate) fn config_dir() -> Option<PathBuf> {
 /// read-modify-write of the whole map with no lock, so simultaneous writers
 /// can still clobber one another's *entries*; making that safe needs file
 /// locking, which is a larger change.
+/// Unlinks a temp file on drop unless [`TempFileGuard::disarm`]ed. Covers
+/// every early return *and* a panic between creating the temp file and
+/// renaming it into place.
+///
+/// This exists because the temp name is unique per writer. The old shared
+/// `auth-keyring.tmp` was self-limiting — a failed write left one stale file
+/// that the next write reused — whereas unique names would leak a distinct
+/// credential-bearing file on every failure, in a directory nothing prunes. A
+/// `SIGKILL` still leaks, since no in-process guard can cover that.
+struct TempFileGuard {
+    path: PathBuf,
+    armed: bool,
+}
+
+impl TempFileGuard {
+    fn new(path: PathBuf) -> Self {
+        Self { path, armed: true }
+    }
+
+    /// Relinquish the file — call once `rename` has moved it into place.
+    fn disarm(&mut self) {
+        self.armed = false;
+    }
+}
+
+impl Drop for TempFileGuard {
+    fn drop(&mut self) {
+        if self.armed {
+            let _ = std::fs::remove_file(&self.path);
+        }
+    }
+}
+
 pub(crate) fn atomic_write(path: &Path, data: &[u8]) -> Result<(), CliError> {
-    static TMP_SEQ: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+    static TMP_SEQ: std::sync::atomic::AtomicUsize = std::sync::atomic::AtomicUsize::new(0);
     let seq = TMP_SEQ.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
     let tmp = path.with_extension(format!("tmp.{}.{}", std::process::id(), seq));
-    std::fs::write(&tmp, data).map_err(|e| {
-        CliError::Auth(format!("Failed to write {}: {e}", tmp.display()))
-    })?;
+    let mut guard = TempFileGuard::new(tmp.clone());
+    std::fs::write(&tmp, data)
+        .map_err(|e| CliError::Auth(format!("Failed to write {}: {e}", tmp.display())))?;
     #[cfg(unix)]
     {
         use std::os::unix::fs::PermissionsExt;
         let perms = std::fs::Permissions::from_mode(0o600);
         let _ = std::fs::set_permissions(&tmp, perms);
     }
-    std::fs::rename(&tmp, path).map_err(|e| {
-        let _ = std::fs::remove_file(&tmp);
-        CliError::Auth(format!("Failed to rename {}: {e}", tmp.display()))
-    })
+    std::fs::rename(&tmp, path)
+        .map_err(|e| CliError::Auth(format!("Failed to rename {}: {e}", tmp.display())))?;
+    guard.disarm();
+    Ok(())
 }
 
 // ---------------------------------------------------------------------------
@@ -315,6 +348,56 @@ mod tests {
             .filter(|n| n.contains(".tmp"))
             .collect();
         assert!(leftovers.is_empty(), "temp files left behind: {leftovers:?}");
+    }
+
+    /// A failed write must not leave its temp file behind. Renaming a file onto
+    /// an existing directory fails on every platform, which drives the error
+    /// path without mocking the filesystem.
+    ///
+    /// The pre-`TempFileGuard` code already cleaned up on a `rename` error, so
+    /// this pins an invariant rather than catching a regression — see
+    /// `temp_file_guard_unlinks_unless_disarmed` for the guard's own coverage.
+    #[test]
+    fn atomic_write_cleans_up_temp_file_on_failure() {
+        let dir = tempfile::tempdir().unwrap();
+
+        // The target is a *directory*, so `rename` cannot replace it.
+        let target = dir.path().join("auth-keyring.json");
+        std::fs::create_dir(&target).unwrap();
+        std::fs::write(target.join("occupant"), b"x").unwrap();
+
+        let result = atomic_write(&target, br#"{"writer":0}"#);
+        assert!(result.is_err(), "expected rename onto a directory to fail");
+
+        let leftovers: Vec<String> = std::fs::read_dir(dir.path())
+            .unwrap()
+            .filter_map(|e| e.ok())
+            .map(|e| e.file_name().to_string_lossy().into_owned())
+            .filter(|n| n.contains(".tmp"))
+            .collect();
+        assert!(leftovers.is_empty(), "temp file leaked after a failed write: {leftovers:?}");
+    }
+
+    /// Pins [`TempFileGuard`]: armed drops unlink, disarmed drops don't. Drop
+    /// running on an armed guard is what covers early returns and unwinding
+    /// panics between `write` and `rename` — paths the old `rename`-only
+    /// cleanup missed. Deleting the guard or the `disarm()` call fails this.
+    #[test]
+    fn temp_file_guard_unlinks_unless_disarmed() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("auth-keyring.tmp.0.0");
+
+        std::fs::write(&path, b"x").unwrap();
+        drop(TempFileGuard::new(path.clone()));
+        assert!(!path.exists(), "armed guard must unlink on drop");
+
+        // The post-`rename` case: the file has been moved away, so the guard
+        // must not touch whatever now sits at that path.
+        std::fs::write(&path, b"x").unwrap();
+        let mut guard = TempFileGuard::new(path.clone());
+        guard.disarm();
+        drop(guard);
+        assert!(path.exists(), "disarmed guard must not unlink");
     }
 
     #[test]

--- a/seed/cli/cli-oauth/client-credentials/src/auth/oauth_common.rs
+++ b/seed/cli/cli-oauth/client-credentials/src/auth/oauth_common.rs
@@ -226,8 +226,29 @@ pub(crate) fn config_dir() -> Option<PathBuf> {
 
 /// Write `data` to `path` atomically: sibling temp file → owner-only
 /// permissions (0600 on Unix) → rename into place.
+///
+/// The temp file name is unique per writer — pid plus a process-local
+/// counter. Deriving it from the target alone meant every concurrent writer
+/// used the *same* sibling (`auth-keyring.tmp`): whichever one renamed first
+/// moved it away, and the rest failed with `ENOENT` from `rename`. That
+/// surfaced as intermittent `auth login --with-token` failures across a
+/// wire-test suite large enough to run many CLI processes at once, killing a
+/// different subset of cases on each run.
+///
+/// The pid covers the case that actually bit us (separate CLI processes); the
+/// counter covers two writers inside one process, and is what makes the
+/// behavior unit-testable without spawning subprocesses.
+///
+/// `rename` is still atomic for readers, which is what keeps a partially
+/// written credential file unobservable. This only fixes writer-vs-writer
+/// collisions on the temp path. `FileKeyringStore::set` remains a
+/// read-modify-write of the whole map with no lock, so simultaneous writers
+/// can still clobber one another's *entries*; making that safe needs file
+/// locking, which is a larger change.
 pub(crate) fn atomic_write(path: &Path, data: &[u8]) -> Result<(), CliError> {
-    let tmp = path.with_extension("tmp");
+    static TMP_SEQ: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+    let seq = TMP_SEQ.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+    let tmp = path.with_extension(format!("tmp.{}.{}", std::process::id(), seq));
     std::fs::write(&tmp, data).map_err(|e| {
         CliError::Auth(format!("Failed to write {}: {e}", tmp.display()))
     })?;
@@ -250,6 +271,51 @@ pub(crate) fn atomic_write(path: &Path, data: &[u8]) -> Result<(), CliError> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// Regression test for the temp-file collision that made
+    /// `auth login --with-token` fail intermittently: every writer derived the
+    /// same sibling path from the target, so the first `rename` moved it away
+    /// and the rest got `ENOENT`.
+    ///
+    /// Reverting `atomic_write` to a target-derived temp name fails this with
+    /// "Failed to rename ...: No such file or directory".
+    #[test]
+    fn atomic_write_tolerates_concurrent_writers() {
+        let dir = tempfile::tempdir().unwrap();
+        let target = dir.path().join("auth-keyring.json");
+
+        let results: Vec<Result<(), CliError>> = std::thread::scope(|scope| {
+            let handles: Vec<_> = (0..16)
+                .map(|i| {
+                    let target = target.clone();
+                    scope.spawn(move || atomic_write(&target, format!(r#"{{"writer":{i}}}"#).as_bytes()))
+                })
+                .collect();
+            handles.into_iter().map(|h| h.join().unwrap()).collect()
+        });
+
+        let failed: Vec<String> = results
+            .iter()
+            .filter_map(|r| r.as_ref().err().map(|e| e.to_string()))
+            .collect();
+        assert!(failed.is_empty(), "concurrent writers failed: {failed:?}");
+
+        // Last writer wins, but the file must always be one writer's complete
+        // payload — never a mix, and never absent.
+        let contents = std::fs::read_to_string(&target).unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(&contents)
+            .unwrap_or_else(|e| panic!("target is not valid JSON after concurrent writes: {e} in {contents:?}"));
+        assert!(parsed.get("writer").is_some(), "unexpected payload: {contents}");
+
+        // No temp files orphaned in the directory.
+        let leftovers: Vec<String> = std::fs::read_dir(dir.path())
+            .unwrap()
+            .filter_map(|e| e.ok())
+            .map(|e| e.file_name().to_string_lossy().into_owned())
+            .filter(|n| n.contains(".tmp"))
+            .collect();
+        assert!(leftovers.is_empty(), "temp files left behind: {leftovers:?}");
+    }
 
     #[test]
     fn token_bundle_roundtrip() {

--- a/seed/cli/cli-reserved-keywords/with-wire-tests/src/auth/oauth_common.rs
+++ b/seed/cli/cli-reserved-keywords/with-wire-tests/src/auth/oauth_common.rs
@@ -224,27 +224,6 @@ pub(crate) fn config_dir() -> Option<PathBuf> {
     }
 }
 
-/// Write `data` to `path` atomically: sibling temp file → owner-only
-/// permissions (0600 on Unix) → rename into place.
-///
-/// The temp file name is unique per writer — pid plus a process-local
-/// counter. Deriving it from the target alone meant every concurrent writer
-/// used the *same* sibling (`auth-keyring.tmp`): whichever one renamed first
-/// moved it away, and the rest failed with `ENOENT` from `rename`. That
-/// surfaced as intermittent `auth login --with-token` failures across a
-/// wire-test suite large enough to run many CLI processes at once, killing a
-/// different subset of cases on each run.
-///
-/// The pid covers the case that actually bit us (separate CLI processes); the
-/// counter covers two writers inside one process, and is what makes the
-/// behavior unit-testable without spawning subprocesses.
-///
-/// `rename` is still atomic for readers, which is what keeps a partially
-/// written credential file unobservable. This only fixes writer-vs-writer
-/// collisions on the temp path. `FileKeyringStore::set` remains a
-/// read-modify-write of the whole map with no lock, so simultaneous writers
-/// can still clobber one another's *entries*; making that safe needs file
-/// locking, which is a larger change.
 /// Unlinks a temp file on drop unless [`TempFileGuard::disarm`]ed. Covers
 /// every early return *and* a panic between creating the temp file and
 /// renaming it into place.
@@ -278,6 +257,30 @@ impl Drop for TempFileGuard {
     }
 }
 
+/// Write `data` to `path` atomically: sibling temp file → owner-only
+/// permissions (0600 on Unix) → rename into place.
+///
+/// The temp file name is unique per writer — pid plus a process-local
+/// counter. Deriving it from the target alone meant every concurrent writer
+/// used the *same* sibling (`auth-keyring.tmp`): whichever one renamed first
+/// moved it away, and the rest failed with `ENOENT` from `rename`. That
+/// surfaced as intermittent `auth login --with-token` failures across a
+/// wire-test suite large enough to run many CLI processes at once, killing a
+/// different subset of cases on each run.
+///
+/// The pid covers the case that actually bit us (separate CLI processes); the
+/// counter covers two writers inside one process, and is what makes the
+/// behavior unit-testable without spawning subprocesses.
+///
+/// A [`TempFileGuard`] unlinks the temp file if anything between creating it
+/// and renaming it fails, so unique names cannot accumulate as orphans.
+///
+/// `rename` is still atomic for readers, which is what keeps a partially
+/// written credential file unobservable. This only fixes writer-vs-writer
+/// collisions on the temp path. `FileKeyringStore::set` remains a
+/// read-modify-write of the whole map with no lock, so simultaneous writers
+/// can still clobber one another's *entries*; making that safe needs file
+/// locking, which is a larger change.
 pub(crate) fn atomic_write(path: &Path, data: &[u8]) -> Result<(), CliError> {
     static TMP_SEQ: std::sync::atomic::AtomicUsize = std::sync::atomic::AtomicUsize::new(0);
     let seq = TMP_SEQ.fetch_add(1, std::sync::atomic::Ordering::Relaxed);

--- a/seed/cli/cli-reserved-keywords/with-wire-tests/src/auth/oauth_common.rs
+++ b/seed/cli/cli-reserved-keywords/with-wire-tests/src/auth/oauth_common.rs
@@ -245,23 +245,56 @@ pub(crate) fn config_dir() -> Option<PathBuf> {
 /// read-modify-write of the whole map with no lock, so simultaneous writers
 /// can still clobber one another's *entries*; making that safe needs file
 /// locking, which is a larger change.
+/// Unlinks a temp file on drop unless [`TempFileGuard::disarm`]ed. Covers
+/// every early return *and* a panic between creating the temp file and
+/// renaming it into place.
+///
+/// This exists because the temp name is unique per writer. The old shared
+/// `auth-keyring.tmp` was self-limiting — a failed write left one stale file
+/// that the next write reused — whereas unique names would leak a distinct
+/// credential-bearing file on every failure, in a directory nothing prunes. A
+/// `SIGKILL` still leaks, since no in-process guard can cover that.
+struct TempFileGuard {
+    path: PathBuf,
+    armed: bool,
+}
+
+impl TempFileGuard {
+    fn new(path: PathBuf) -> Self {
+        Self { path, armed: true }
+    }
+
+    /// Relinquish the file — call once `rename` has moved it into place.
+    fn disarm(&mut self) {
+        self.armed = false;
+    }
+}
+
+impl Drop for TempFileGuard {
+    fn drop(&mut self) {
+        if self.armed {
+            let _ = std::fs::remove_file(&self.path);
+        }
+    }
+}
+
 pub(crate) fn atomic_write(path: &Path, data: &[u8]) -> Result<(), CliError> {
-    static TMP_SEQ: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+    static TMP_SEQ: std::sync::atomic::AtomicUsize = std::sync::atomic::AtomicUsize::new(0);
     let seq = TMP_SEQ.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
     let tmp = path.with_extension(format!("tmp.{}.{}", std::process::id(), seq));
-    std::fs::write(&tmp, data).map_err(|e| {
-        CliError::Auth(format!("Failed to write {}: {e}", tmp.display()))
-    })?;
+    let mut guard = TempFileGuard::new(tmp.clone());
+    std::fs::write(&tmp, data)
+        .map_err(|e| CliError::Auth(format!("Failed to write {}: {e}", tmp.display())))?;
     #[cfg(unix)]
     {
         use std::os::unix::fs::PermissionsExt;
         let perms = std::fs::Permissions::from_mode(0o600);
         let _ = std::fs::set_permissions(&tmp, perms);
     }
-    std::fs::rename(&tmp, path).map_err(|e| {
-        let _ = std::fs::remove_file(&tmp);
-        CliError::Auth(format!("Failed to rename {}: {e}", tmp.display()))
-    })
+    std::fs::rename(&tmp, path)
+        .map_err(|e| CliError::Auth(format!("Failed to rename {}: {e}", tmp.display())))?;
+    guard.disarm();
+    Ok(())
 }
 
 // ---------------------------------------------------------------------------
@@ -315,6 +348,56 @@ mod tests {
             .filter(|n| n.contains(".tmp"))
             .collect();
         assert!(leftovers.is_empty(), "temp files left behind: {leftovers:?}");
+    }
+
+    /// A failed write must not leave its temp file behind. Renaming a file onto
+    /// an existing directory fails on every platform, which drives the error
+    /// path without mocking the filesystem.
+    ///
+    /// The pre-`TempFileGuard` code already cleaned up on a `rename` error, so
+    /// this pins an invariant rather than catching a regression — see
+    /// `temp_file_guard_unlinks_unless_disarmed` for the guard's own coverage.
+    #[test]
+    fn atomic_write_cleans_up_temp_file_on_failure() {
+        let dir = tempfile::tempdir().unwrap();
+
+        // The target is a *directory*, so `rename` cannot replace it.
+        let target = dir.path().join("auth-keyring.json");
+        std::fs::create_dir(&target).unwrap();
+        std::fs::write(target.join("occupant"), b"x").unwrap();
+
+        let result = atomic_write(&target, br#"{"writer":0}"#);
+        assert!(result.is_err(), "expected rename onto a directory to fail");
+
+        let leftovers: Vec<String> = std::fs::read_dir(dir.path())
+            .unwrap()
+            .filter_map(|e| e.ok())
+            .map(|e| e.file_name().to_string_lossy().into_owned())
+            .filter(|n| n.contains(".tmp"))
+            .collect();
+        assert!(leftovers.is_empty(), "temp file leaked after a failed write: {leftovers:?}");
+    }
+
+    /// Pins [`TempFileGuard`]: armed drops unlink, disarmed drops don't. Drop
+    /// running on an armed guard is what covers early returns and unwinding
+    /// panics between `write` and `rename` — paths the old `rename`-only
+    /// cleanup missed. Deleting the guard or the `disarm()` call fails this.
+    #[test]
+    fn temp_file_guard_unlinks_unless_disarmed() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("auth-keyring.tmp.0.0");
+
+        std::fs::write(&path, b"x").unwrap();
+        drop(TempFileGuard::new(path.clone()));
+        assert!(!path.exists(), "armed guard must unlink on drop");
+
+        // The post-`rename` case: the file has been moved away, so the guard
+        // must not touch whatever now sits at that path.
+        std::fs::write(&path, b"x").unwrap();
+        let mut guard = TempFileGuard::new(path.clone());
+        guard.disarm();
+        drop(guard);
+        assert!(path.exists(), "disarmed guard must not unlink");
     }
 
     #[test]

--- a/seed/cli/cli-reserved-keywords/with-wire-tests/src/auth/oauth_common.rs
+++ b/seed/cli/cli-reserved-keywords/with-wire-tests/src/auth/oauth_common.rs
@@ -226,8 +226,29 @@ pub(crate) fn config_dir() -> Option<PathBuf> {
 
 /// Write `data` to `path` atomically: sibling temp file → owner-only
 /// permissions (0600 on Unix) → rename into place.
+///
+/// The temp file name is unique per writer — pid plus a process-local
+/// counter. Deriving it from the target alone meant every concurrent writer
+/// used the *same* sibling (`auth-keyring.tmp`): whichever one renamed first
+/// moved it away, and the rest failed with `ENOENT` from `rename`. That
+/// surfaced as intermittent `auth login --with-token` failures across a
+/// wire-test suite large enough to run many CLI processes at once, killing a
+/// different subset of cases on each run.
+///
+/// The pid covers the case that actually bit us (separate CLI processes); the
+/// counter covers two writers inside one process, and is what makes the
+/// behavior unit-testable without spawning subprocesses.
+///
+/// `rename` is still atomic for readers, which is what keeps a partially
+/// written credential file unobservable. This only fixes writer-vs-writer
+/// collisions on the temp path. `FileKeyringStore::set` remains a
+/// read-modify-write of the whole map with no lock, so simultaneous writers
+/// can still clobber one another's *entries*; making that safe needs file
+/// locking, which is a larger change.
 pub(crate) fn atomic_write(path: &Path, data: &[u8]) -> Result<(), CliError> {
-    let tmp = path.with_extension("tmp");
+    static TMP_SEQ: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+    let seq = TMP_SEQ.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+    let tmp = path.with_extension(format!("tmp.{}.{}", std::process::id(), seq));
     std::fs::write(&tmp, data).map_err(|e| {
         CliError::Auth(format!("Failed to write {}: {e}", tmp.display()))
     })?;
@@ -250,6 +271,51 @@ pub(crate) fn atomic_write(path: &Path, data: &[u8]) -> Result<(), CliError> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// Regression test for the temp-file collision that made
+    /// `auth login --with-token` fail intermittently: every writer derived the
+    /// same sibling path from the target, so the first `rename` moved it away
+    /// and the rest got `ENOENT`.
+    ///
+    /// Reverting `atomic_write` to a target-derived temp name fails this with
+    /// "Failed to rename ...: No such file or directory".
+    #[test]
+    fn atomic_write_tolerates_concurrent_writers() {
+        let dir = tempfile::tempdir().unwrap();
+        let target = dir.path().join("auth-keyring.json");
+
+        let results: Vec<Result<(), CliError>> = std::thread::scope(|scope| {
+            let handles: Vec<_> = (0..16)
+                .map(|i| {
+                    let target = target.clone();
+                    scope.spawn(move || atomic_write(&target, format!(r#"{{"writer":{i}}}"#).as_bytes()))
+                })
+                .collect();
+            handles.into_iter().map(|h| h.join().unwrap()).collect()
+        });
+
+        let failed: Vec<String> = results
+            .iter()
+            .filter_map(|r| r.as_ref().err().map(|e| e.to_string()))
+            .collect();
+        assert!(failed.is_empty(), "concurrent writers failed: {failed:?}");
+
+        // Last writer wins, but the file must always be one writer's complete
+        // payload — never a mix, and never absent.
+        let contents = std::fs::read_to_string(&target).unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(&contents)
+            .unwrap_or_else(|e| panic!("target is not valid JSON after concurrent writes: {e} in {contents:?}"));
+        assert!(parsed.get("writer").is_some(), "unexpected payload: {contents}");
+
+        // No temp files orphaned in the directory.
+        let leftovers: Vec<String> = std::fs::read_dir(dir.path())
+            .unwrap()
+            .filter_map(|e| e.ok())
+            .map(|e| e.file_name().to_string_lossy().into_owned())
+            .filter(|n| n.contains(".tmp"))
+            .collect();
+        assert!(leftovers.is_empty(), "temp files left behind: {leftovers:?}");
+    }
 
     #[test]
     fn token_bundle_roundtrip() {

--- a/seed/cli/cli-shared-types/with-split-type-crates/src/auth/oauth_common.rs
+++ b/seed/cli/cli-shared-types/with-split-type-crates/src/auth/oauth_common.rs
@@ -224,27 +224,6 @@ pub(crate) fn config_dir() -> Option<PathBuf> {
     }
 }
 
-/// Write `data` to `path` atomically: sibling temp file → owner-only
-/// permissions (0600 on Unix) → rename into place.
-///
-/// The temp file name is unique per writer — pid plus a process-local
-/// counter. Deriving it from the target alone meant every concurrent writer
-/// used the *same* sibling (`auth-keyring.tmp`): whichever one renamed first
-/// moved it away, and the rest failed with `ENOENT` from `rename`. That
-/// surfaced as intermittent `auth login --with-token` failures across a
-/// wire-test suite large enough to run many CLI processes at once, killing a
-/// different subset of cases on each run.
-///
-/// The pid covers the case that actually bit us (separate CLI processes); the
-/// counter covers two writers inside one process, and is what makes the
-/// behavior unit-testable without spawning subprocesses.
-///
-/// `rename` is still atomic for readers, which is what keeps a partially
-/// written credential file unobservable. This only fixes writer-vs-writer
-/// collisions on the temp path. `FileKeyringStore::set` remains a
-/// read-modify-write of the whole map with no lock, so simultaneous writers
-/// can still clobber one another's *entries*; making that safe needs file
-/// locking, which is a larger change.
 /// Unlinks a temp file on drop unless [`TempFileGuard::disarm`]ed. Covers
 /// every early return *and* a panic between creating the temp file and
 /// renaming it into place.
@@ -278,6 +257,30 @@ impl Drop for TempFileGuard {
     }
 }
 
+/// Write `data` to `path` atomically: sibling temp file → owner-only
+/// permissions (0600 on Unix) → rename into place.
+///
+/// The temp file name is unique per writer — pid plus a process-local
+/// counter. Deriving it from the target alone meant every concurrent writer
+/// used the *same* sibling (`auth-keyring.tmp`): whichever one renamed first
+/// moved it away, and the rest failed with `ENOENT` from `rename`. That
+/// surfaced as intermittent `auth login --with-token` failures across a
+/// wire-test suite large enough to run many CLI processes at once, killing a
+/// different subset of cases on each run.
+///
+/// The pid covers the case that actually bit us (separate CLI processes); the
+/// counter covers two writers inside one process, and is what makes the
+/// behavior unit-testable without spawning subprocesses.
+///
+/// A [`TempFileGuard`] unlinks the temp file if anything between creating it
+/// and renaming it fails, so unique names cannot accumulate as orphans.
+///
+/// `rename` is still atomic for readers, which is what keeps a partially
+/// written credential file unobservable. This only fixes writer-vs-writer
+/// collisions on the temp path. `FileKeyringStore::set` remains a
+/// read-modify-write of the whole map with no lock, so simultaneous writers
+/// can still clobber one another's *entries*; making that safe needs file
+/// locking, which is a larger change.
 pub(crate) fn atomic_write(path: &Path, data: &[u8]) -> Result<(), CliError> {
     static TMP_SEQ: std::sync::atomic::AtomicUsize = std::sync::atomic::AtomicUsize::new(0);
     let seq = TMP_SEQ.fetch_add(1, std::sync::atomic::Ordering::Relaxed);

--- a/seed/cli/cli-shared-types/with-split-type-crates/src/auth/oauth_common.rs
+++ b/seed/cli/cli-shared-types/with-split-type-crates/src/auth/oauth_common.rs
@@ -245,23 +245,56 @@ pub(crate) fn config_dir() -> Option<PathBuf> {
 /// read-modify-write of the whole map with no lock, so simultaneous writers
 /// can still clobber one another's *entries*; making that safe needs file
 /// locking, which is a larger change.
+/// Unlinks a temp file on drop unless [`TempFileGuard::disarm`]ed. Covers
+/// every early return *and* a panic between creating the temp file and
+/// renaming it into place.
+///
+/// This exists because the temp name is unique per writer. The old shared
+/// `auth-keyring.tmp` was self-limiting — a failed write left one stale file
+/// that the next write reused — whereas unique names would leak a distinct
+/// credential-bearing file on every failure, in a directory nothing prunes. A
+/// `SIGKILL` still leaks, since no in-process guard can cover that.
+struct TempFileGuard {
+    path: PathBuf,
+    armed: bool,
+}
+
+impl TempFileGuard {
+    fn new(path: PathBuf) -> Self {
+        Self { path, armed: true }
+    }
+
+    /// Relinquish the file — call once `rename` has moved it into place.
+    fn disarm(&mut self) {
+        self.armed = false;
+    }
+}
+
+impl Drop for TempFileGuard {
+    fn drop(&mut self) {
+        if self.armed {
+            let _ = std::fs::remove_file(&self.path);
+        }
+    }
+}
+
 pub(crate) fn atomic_write(path: &Path, data: &[u8]) -> Result<(), CliError> {
-    static TMP_SEQ: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+    static TMP_SEQ: std::sync::atomic::AtomicUsize = std::sync::atomic::AtomicUsize::new(0);
     let seq = TMP_SEQ.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
     let tmp = path.with_extension(format!("tmp.{}.{}", std::process::id(), seq));
-    std::fs::write(&tmp, data).map_err(|e| {
-        CliError::Auth(format!("Failed to write {}: {e}", tmp.display()))
-    })?;
+    let mut guard = TempFileGuard::new(tmp.clone());
+    std::fs::write(&tmp, data)
+        .map_err(|e| CliError::Auth(format!("Failed to write {}: {e}", tmp.display())))?;
     #[cfg(unix)]
     {
         use std::os::unix::fs::PermissionsExt;
         let perms = std::fs::Permissions::from_mode(0o600);
         let _ = std::fs::set_permissions(&tmp, perms);
     }
-    std::fs::rename(&tmp, path).map_err(|e| {
-        let _ = std::fs::remove_file(&tmp);
-        CliError::Auth(format!("Failed to rename {}: {e}", tmp.display()))
-    })
+    std::fs::rename(&tmp, path)
+        .map_err(|e| CliError::Auth(format!("Failed to rename {}: {e}", tmp.display())))?;
+    guard.disarm();
+    Ok(())
 }
 
 // ---------------------------------------------------------------------------
@@ -315,6 +348,56 @@ mod tests {
             .filter(|n| n.contains(".tmp"))
             .collect();
         assert!(leftovers.is_empty(), "temp files left behind: {leftovers:?}");
+    }
+
+    /// A failed write must not leave its temp file behind. Renaming a file onto
+    /// an existing directory fails on every platform, which drives the error
+    /// path without mocking the filesystem.
+    ///
+    /// The pre-`TempFileGuard` code already cleaned up on a `rename` error, so
+    /// this pins an invariant rather than catching a regression — see
+    /// `temp_file_guard_unlinks_unless_disarmed` for the guard's own coverage.
+    #[test]
+    fn atomic_write_cleans_up_temp_file_on_failure() {
+        let dir = tempfile::tempdir().unwrap();
+
+        // The target is a *directory*, so `rename` cannot replace it.
+        let target = dir.path().join("auth-keyring.json");
+        std::fs::create_dir(&target).unwrap();
+        std::fs::write(target.join("occupant"), b"x").unwrap();
+
+        let result = atomic_write(&target, br#"{"writer":0}"#);
+        assert!(result.is_err(), "expected rename onto a directory to fail");
+
+        let leftovers: Vec<String> = std::fs::read_dir(dir.path())
+            .unwrap()
+            .filter_map(|e| e.ok())
+            .map(|e| e.file_name().to_string_lossy().into_owned())
+            .filter(|n| n.contains(".tmp"))
+            .collect();
+        assert!(leftovers.is_empty(), "temp file leaked after a failed write: {leftovers:?}");
+    }
+
+    /// Pins [`TempFileGuard`]: armed drops unlink, disarmed drops don't. Drop
+    /// running on an armed guard is what covers early returns and unwinding
+    /// panics between `write` and `rename` — paths the old `rename`-only
+    /// cleanup missed. Deleting the guard or the `disarm()` call fails this.
+    #[test]
+    fn temp_file_guard_unlinks_unless_disarmed() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("auth-keyring.tmp.0.0");
+
+        std::fs::write(&path, b"x").unwrap();
+        drop(TempFileGuard::new(path.clone()));
+        assert!(!path.exists(), "armed guard must unlink on drop");
+
+        // The post-`rename` case: the file has been moved away, so the guard
+        // must not touch whatever now sits at that path.
+        std::fs::write(&path, b"x").unwrap();
+        let mut guard = TempFileGuard::new(path.clone());
+        guard.disarm();
+        drop(guard);
+        assert!(path.exists(), "disarmed guard must not unlink");
     }
 
     #[test]

--- a/seed/cli/cli-shared-types/with-split-type-crates/src/auth/oauth_common.rs
+++ b/seed/cli/cli-shared-types/with-split-type-crates/src/auth/oauth_common.rs
@@ -226,8 +226,29 @@ pub(crate) fn config_dir() -> Option<PathBuf> {
 
 /// Write `data` to `path` atomically: sibling temp file → owner-only
 /// permissions (0600 on Unix) → rename into place.
+///
+/// The temp file name is unique per writer — pid plus a process-local
+/// counter. Deriving it from the target alone meant every concurrent writer
+/// used the *same* sibling (`auth-keyring.tmp`): whichever one renamed first
+/// moved it away, and the rest failed with `ENOENT` from `rename`. That
+/// surfaced as intermittent `auth login --with-token` failures across a
+/// wire-test suite large enough to run many CLI processes at once, killing a
+/// different subset of cases on each run.
+///
+/// The pid covers the case that actually bit us (separate CLI processes); the
+/// counter covers two writers inside one process, and is what makes the
+/// behavior unit-testable without spawning subprocesses.
+///
+/// `rename` is still atomic for readers, which is what keeps a partially
+/// written credential file unobservable. This only fixes writer-vs-writer
+/// collisions on the temp path. `FileKeyringStore::set` remains a
+/// read-modify-write of the whole map with no lock, so simultaneous writers
+/// can still clobber one another's *entries*; making that safe needs file
+/// locking, which is a larger change.
 pub(crate) fn atomic_write(path: &Path, data: &[u8]) -> Result<(), CliError> {
-    let tmp = path.with_extension("tmp");
+    static TMP_SEQ: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+    let seq = TMP_SEQ.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+    let tmp = path.with_extension(format!("tmp.{}.{}", std::process::id(), seq));
     std::fs::write(&tmp, data).map_err(|e| {
         CliError::Auth(format!("Failed to write {}: {e}", tmp.display()))
     })?;
@@ -250,6 +271,51 @@ pub(crate) fn atomic_write(path: &Path, data: &[u8]) -> Result<(), CliError> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// Regression test for the temp-file collision that made
+    /// `auth login --with-token` fail intermittently: every writer derived the
+    /// same sibling path from the target, so the first `rename` moved it away
+    /// and the rest got `ENOENT`.
+    ///
+    /// Reverting `atomic_write` to a target-derived temp name fails this with
+    /// "Failed to rename ...: No such file or directory".
+    #[test]
+    fn atomic_write_tolerates_concurrent_writers() {
+        let dir = tempfile::tempdir().unwrap();
+        let target = dir.path().join("auth-keyring.json");
+
+        let results: Vec<Result<(), CliError>> = std::thread::scope(|scope| {
+            let handles: Vec<_> = (0..16)
+                .map(|i| {
+                    let target = target.clone();
+                    scope.spawn(move || atomic_write(&target, format!(r#"{{"writer":{i}}}"#).as_bytes()))
+                })
+                .collect();
+            handles.into_iter().map(|h| h.join().unwrap()).collect()
+        });
+
+        let failed: Vec<String> = results
+            .iter()
+            .filter_map(|r| r.as_ref().err().map(|e| e.to_string()))
+            .collect();
+        assert!(failed.is_empty(), "concurrent writers failed: {failed:?}");
+
+        // Last writer wins, but the file must always be one writer's complete
+        // payload — never a mix, and never absent.
+        let contents = std::fs::read_to_string(&target).unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(&contents)
+            .unwrap_or_else(|e| panic!("target is not valid JSON after concurrent writes: {e} in {contents:?}"));
+        assert!(parsed.get("writer").is_some(), "unexpected payload: {contents}");
+
+        // No temp files orphaned in the directory.
+        let leftovers: Vec<String> = std::fs::read_dir(dir.path())
+            .unwrap()
+            .filter_map(|e| e.ok())
+            .map(|e| e.file_name().to_string_lossy().into_owned())
+            .filter(|n| n.contains(".tmp"))
+            .collect();
+        assert!(leftovers.is_empty(), "temp files left behind: {leftovers:?}");
+    }
 
     #[test]
     fn token_bundle_roundtrip() {

--- a/seed/cli/discriminated-union-with-nested-oneof/src/auth/oauth_common.rs
+++ b/seed/cli/discriminated-union-with-nested-oneof/src/auth/oauth_common.rs
@@ -224,27 +224,6 @@ pub(crate) fn config_dir() -> Option<PathBuf> {
     }
 }
 
-/// Write `data` to `path` atomically: sibling temp file → owner-only
-/// permissions (0600 on Unix) → rename into place.
-///
-/// The temp file name is unique per writer — pid plus a process-local
-/// counter. Deriving it from the target alone meant every concurrent writer
-/// used the *same* sibling (`auth-keyring.tmp`): whichever one renamed first
-/// moved it away, and the rest failed with `ENOENT` from `rename`. That
-/// surfaced as intermittent `auth login --with-token` failures across a
-/// wire-test suite large enough to run many CLI processes at once, killing a
-/// different subset of cases on each run.
-///
-/// The pid covers the case that actually bit us (separate CLI processes); the
-/// counter covers two writers inside one process, and is what makes the
-/// behavior unit-testable without spawning subprocesses.
-///
-/// `rename` is still atomic for readers, which is what keeps a partially
-/// written credential file unobservable. This only fixes writer-vs-writer
-/// collisions on the temp path. `FileKeyringStore::set` remains a
-/// read-modify-write of the whole map with no lock, so simultaneous writers
-/// can still clobber one another's *entries*; making that safe needs file
-/// locking, which is a larger change.
 /// Unlinks a temp file on drop unless [`TempFileGuard::disarm`]ed. Covers
 /// every early return *and* a panic between creating the temp file and
 /// renaming it into place.
@@ -278,6 +257,30 @@ impl Drop for TempFileGuard {
     }
 }
 
+/// Write `data` to `path` atomically: sibling temp file → owner-only
+/// permissions (0600 on Unix) → rename into place.
+///
+/// The temp file name is unique per writer — pid plus a process-local
+/// counter. Deriving it from the target alone meant every concurrent writer
+/// used the *same* sibling (`auth-keyring.tmp`): whichever one renamed first
+/// moved it away, and the rest failed with `ENOENT` from `rename`. That
+/// surfaced as intermittent `auth login --with-token` failures across a
+/// wire-test suite large enough to run many CLI processes at once, killing a
+/// different subset of cases on each run.
+///
+/// The pid covers the case that actually bit us (separate CLI processes); the
+/// counter covers two writers inside one process, and is what makes the
+/// behavior unit-testable without spawning subprocesses.
+///
+/// A [`TempFileGuard`] unlinks the temp file if anything between creating it
+/// and renaming it fails, so unique names cannot accumulate as orphans.
+///
+/// `rename` is still atomic for readers, which is what keeps a partially
+/// written credential file unobservable. This only fixes writer-vs-writer
+/// collisions on the temp path. `FileKeyringStore::set` remains a
+/// read-modify-write of the whole map with no lock, so simultaneous writers
+/// can still clobber one another's *entries*; making that safe needs file
+/// locking, which is a larger change.
 pub(crate) fn atomic_write(path: &Path, data: &[u8]) -> Result<(), CliError> {
     static TMP_SEQ: std::sync::atomic::AtomicUsize = std::sync::atomic::AtomicUsize::new(0);
     let seq = TMP_SEQ.fetch_add(1, std::sync::atomic::Ordering::Relaxed);

--- a/seed/cli/discriminated-union-with-nested-oneof/src/auth/oauth_common.rs
+++ b/seed/cli/discriminated-union-with-nested-oneof/src/auth/oauth_common.rs
@@ -245,23 +245,56 @@ pub(crate) fn config_dir() -> Option<PathBuf> {
 /// read-modify-write of the whole map with no lock, so simultaneous writers
 /// can still clobber one another's *entries*; making that safe needs file
 /// locking, which is a larger change.
+/// Unlinks a temp file on drop unless [`TempFileGuard::disarm`]ed. Covers
+/// every early return *and* a panic between creating the temp file and
+/// renaming it into place.
+///
+/// This exists because the temp name is unique per writer. The old shared
+/// `auth-keyring.tmp` was self-limiting — a failed write left one stale file
+/// that the next write reused — whereas unique names would leak a distinct
+/// credential-bearing file on every failure, in a directory nothing prunes. A
+/// `SIGKILL` still leaks, since no in-process guard can cover that.
+struct TempFileGuard {
+    path: PathBuf,
+    armed: bool,
+}
+
+impl TempFileGuard {
+    fn new(path: PathBuf) -> Self {
+        Self { path, armed: true }
+    }
+
+    /// Relinquish the file — call once `rename` has moved it into place.
+    fn disarm(&mut self) {
+        self.armed = false;
+    }
+}
+
+impl Drop for TempFileGuard {
+    fn drop(&mut self) {
+        if self.armed {
+            let _ = std::fs::remove_file(&self.path);
+        }
+    }
+}
+
 pub(crate) fn atomic_write(path: &Path, data: &[u8]) -> Result<(), CliError> {
-    static TMP_SEQ: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+    static TMP_SEQ: std::sync::atomic::AtomicUsize = std::sync::atomic::AtomicUsize::new(0);
     let seq = TMP_SEQ.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
     let tmp = path.with_extension(format!("tmp.{}.{}", std::process::id(), seq));
-    std::fs::write(&tmp, data).map_err(|e| {
-        CliError::Auth(format!("Failed to write {}: {e}", tmp.display()))
-    })?;
+    let mut guard = TempFileGuard::new(tmp.clone());
+    std::fs::write(&tmp, data)
+        .map_err(|e| CliError::Auth(format!("Failed to write {}: {e}", tmp.display())))?;
     #[cfg(unix)]
     {
         use std::os::unix::fs::PermissionsExt;
         let perms = std::fs::Permissions::from_mode(0o600);
         let _ = std::fs::set_permissions(&tmp, perms);
     }
-    std::fs::rename(&tmp, path).map_err(|e| {
-        let _ = std::fs::remove_file(&tmp);
-        CliError::Auth(format!("Failed to rename {}: {e}", tmp.display()))
-    })
+    std::fs::rename(&tmp, path)
+        .map_err(|e| CliError::Auth(format!("Failed to rename {}: {e}", tmp.display())))?;
+    guard.disarm();
+    Ok(())
 }
 
 // ---------------------------------------------------------------------------
@@ -315,6 +348,56 @@ mod tests {
             .filter(|n| n.contains(".tmp"))
             .collect();
         assert!(leftovers.is_empty(), "temp files left behind: {leftovers:?}");
+    }
+
+    /// A failed write must not leave its temp file behind. Renaming a file onto
+    /// an existing directory fails on every platform, which drives the error
+    /// path without mocking the filesystem.
+    ///
+    /// The pre-`TempFileGuard` code already cleaned up on a `rename` error, so
+    /// this pins an invariant rather than catching a regression — see
+    /// `temp_file_guard_unlinks_unless_disarmed` for the guard's own coverage.
+    #[test]
+    fn atomic_write_cleans_up_temp_file_on_failure() {
+        let dir = tempfile::tempdir().unwrap();
+
+        // The target is a *directory*, so `rename` cannot replace it.
+        let target = dir.path().join("auth-keyring.json");
+        std::fs::create_dir(&target).unwrap();
+        std::fs::write(target.join("occupant"), b"x").unwrap();
+
+        let result = atomic_write(&target, br#"{"writer":0}"#);
+        assert!(result.is_err(), "expected rename onto a directory to fail");
+
+        let leftovers: Vec<String> = std::fs::read_dir(dir.path())
+            .unwrap()
+            .filter_map(|e| e.ok())
+            .map(|e| e.file_name().to_string_lossy().into_owned())
+            .filter(|n| n.contains(".tmp"))
+            .collect();
+        assert!(leftovers.is_empty(), "temp file leaked after a failed write: {leftovers:?}");
+    }
+
+    /// Pins [`TempFileGuard`]: armed drops unlink, disarmed drops don't. Drop
+    /// running on an armed guard is what covers early returns and unwinding
+    /// panics between `write` and `rename` — paths the old `rename`-only
+    /// cleanup missed. Deleting the guard or the `disarm()` call fails this.
+    #[test]
+    fn temp_file_guard_unlinks_unless_disarmed() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("auth-keyring.tmp.0.0");
+
+        std::fs::write(&path, b"x").unwrap();
+        drop(TempFileGuard::new(path.clone()));
+        assert!(!path.exists(), "armed guard must unlink on drop");
+
+        // The post-`rename` case: the file has been moved away, so the guard
+        // must not touch whatever now sits at that path.
+        std::fs::write(&path, b"x").unwrap();
+        let mut guard = TempFileGuard::new(path.clone());
+        guard.disarm();
+        drop(guard);
+        assert!(path.exists(), "disarmed guard must not unlink");
     }
 
     #[test]

--- a/seed/cli/discriminated-union-with-nested-oneof/src/auth/oauth_common.rs
+++ b/seed/cli/discriminated-union-with-nested-oneof/src/auth/oauth_common.rs
@@ -226,8 +226,29 @@ pub(crate) fn config_dir() -> Option<PathBuf> {
 
 /// Write `data` to `path` atomically: sibling temp file → owner-only
 /// permissions (0600 on Unix) → rename into place.
+///
+/// The temp file name is unique per writer — pid plus a process-local
+/// counter. Deriving it from the target alone meant every concurrent writer
+/// used the *same* sibling (`auth-keyring.tmp`): whichever one renamed first
+/// moved it away, and the rest failed with `ENOENT` from `rename`. That
+/// surfaced as intermittent `auth login --with-token` failures across a
+/// wire-test suite large enough to run many CLI processes at once, killing a
+/// different subset of cases on each run.
+///
+/// The pid covers the case that actually bit us (separate CLI processes); the
+/// counter covers two writers inside one process, and is what makes the
+/// behavior unit-testable without spawning subprocesses.
+///
+/// `rename` is still atomic for readers, which is what keeps a partially
+/// written credential file unobservable. This only fixes writer-vs-writer
+/// collisions on the temp path. `FileKeyringStore::set` remains a
+/// read-modify-write of the whole map with no lock, so simultaneous writers
+/// can still clobber one another's *entries*; making that safe needs file
+/// locking, which is a larger change.
 pub(crate) fn atomic_write(path: &Path, data: &[u8]) -> Result<(), CliError> {
-    let tmp = path.with_extension("tmp");
+    static TMP_SEQ: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+    let seq = TMP_SEQ.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+    let tmp = path.with_extension(format!("tmp.{}.{}", std::process::id(), seq));
     std::fs::write(&tmp, data).map_err(|e| {
         CliError::Auth(format!("Failed to write {}: {e}", tmp.display()))
     })?;
@@ -250,6 +271,51 @@ pub(crate) fn atomic_write(path: &Path, data: &[u8]) -> Result<(), CliError> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// Regression test for the temp-file collision that made
+    /// `auth login --with-token` fail intermittently: every writer derived the
+    /// same sibling path from the target, so the first `rename` moved it away
+    /// and the rest got `ENOENT`.
+    ///
+    /// Reverting `atomic_write` to a target-derived temp name fails this with
+    /// "Failed to rename ...: No such file or directory".
+    #[test]
+    fn atomic_write_tolerates_concurrent_writers() {
+        let dir = tempfile::tempdir().unwrap();
+        let target = dir.path().join("auth-keyring.json");
+
+        let results: Vec<Result<(), CliError>> = std::thread::scope(|scope| {
+            let handles: Vec<_> = (0..16)
+                .map(|i| {
+                    let target = target.clone();
+                    scope.spawn(move || atomic_write(&target, format!(r#"{{"writer":{i}}}"#).as_bytes()))
+                })
+                .collect();
+            handles.into_iter().map(|h| h.join().unwrap()).collect()
+        });
+
+        let failed: Vec<String> = results
+            .iter()
+            .filter_map(|r| r.as_ref().err().map(|e| e.to_string()))
+            .collect();
+        assert!(failed.is_empty(), "concurrent writers failed: {failed:?}");
+
+        // Last writer wins, but the file must always be one writer's complete
+        // payload — never a mix, and never absent.
+        let contents = std::fs::read_to_string(&target).unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(&contents)
+            .unwrap_or_else(|e| panic!("target is not valid JSON after concurrent writes: {e} in {contents:?}"));
+        assert!(parsed.get("writer").is_some(), "unexpected payload: {contents}");
+
+        // No temp files orphaned in the directory.
+        let leftovers: Vec<String> = std::fs::read_dir(dir.path())
+            .unwrap()
+            .filter_map(|e| e.ok())
+            .map(|e| e.file_name().to_string_lossy().into_owned())
+            .filter(|n| n.contains(".tmp"))
+            .collect();
+        assert!(leftovers.is_empty(), "temp files left behind: {leftovers:?}");
+    }
 
     #[test]
     fn token_bundle_roundtrip() {

--- a/seed/cli/file-upload-openapi/with-wire-tests/src/auth/oauth_common.rs
+++ b/seed/cli/file-upload-openapi/with-wire-tests/src/auth/oauth_common.rs
@@ -224,27 +224,6 @@ pub(crate) fn config_dir() -> Option<PathBuf> {
     }
 }
 
-/// Write `data` to `path` atomically: sibling temp file → owner-only
-/// permissions (0600 on Unix) → rename into place.
-///
-/// The temp file name is unique per writer — pid plus a process-local
-/// counter. Deriving it from the target alone meant every concurrent writer
-/// used the *same* sibling (`auth-keyring.tmp`): whichever one renamed first
-/// moved it away, and the rest failed with `ENOENT` from `rename`. That
-/// surfaced as intermittent `auth login --with-token` failures across a
-/// wire-test suite large enough to run many CLI processes at once, killing a
-/// different subset of cases on each run.
-///
-/// The pid covers the case that actually bit us (separate CLI processes); the
-/// counter covers two writers inside one process, and is what makes the
-/// behavior unit-testable without spawning subprocesses.
-///
-/// `rename` is still atomic for readers, which is what keeps a partially
-/// written credential file unobservable. This only fixes writer-vs-writer
-/// collisions on the temp path. `FileKeyringStore::set` remains a
-/// read-modify-write of the whole map with no lock, so simultaneous writers
-/// can still clobber one another's *entries*; making that safe needs file
-/// locking, which is a larger change.
 /// Unlinks a temp file on drop unless [`TempFileGuard::disarm`]ed. Covers
 /// every early return *and* a panic between creating the temp file and
 /// renaming it into place.
@@ -278,6 +257,30 @@ impl Drop for TempFileGuard {
     }
 }
 
+/// Write `data` to `path` atomically: sibling temp file → owner-only
+/// permissions (0600 on Unix) → rename into place.
+///
+/// The temp file name is unique per writer — pid plus a process-local
+/// counter. Deriving it from the target alone meant every concurrent writer
+/// used the *same* sibling (`auth-keyring.tmp`): whichever one renamed first
+/// moved it away, and the rest failed with `ENOENT` from `rename`. That
+/// surfaced as intermittent `auth login --with-token` failures across a
+/// wire-test suite large enough to run many CLI processes at once, killing a
+/// different subset of cases on each run.
+///
+/// The pid covers the case that actually bit us (separate CLI processes); the
+/// counter covers two writers inside one process, and is what makes the
+/// behavior unit-testable without spawning subprocesses.
+///
+/// A [`TempFileGuard`] unlinks the temp file if anything between creating it
+/// and renaming it fails, so unique names cannot accumulate as orphans.
+///
+/// `rename` is still atomic for readers, which is what keeps a partially
+/// written credential file unobservable. This only fixes writer-vs-writer
+/// collisions on the temp path. `FileKeyringStore::set` remains a
+/// read-modify-write of the whole map with no lock, so simultaneous writers
+/// can still clobber one another's *entries*; making that safe needs file
+/// locking, which is a larger change.
 pub(crate) fn atomic_write(path: &Path, data: &[u8]) -> Result<(), CliError> {
     static TMP_SEQ: std::sync::atomic::AtomicUsize = std::sync::atomic::AtomicUsize::new(0);
     let seq = TMP_SEQ.fetch_add(1, std::sync::atomic::Ordering::Relaxed);

--- a/seed/cli/file-upload-openapi/with-wire-tests/src/auth/oauth_common.rs
+++ b/seed/cli/file-upload-openapi/with-wire-tests/src/auth/oauth_common.rs
@@ -245,23 +245,56 @@ pub(crate) fn config_dir() -> Option<PathBuf> {
 /// read-modify-write of the whole map with no lock, so simultaneous writers
 /// can still clobber one another's *entries*; making that safe needs file
 /// locking, which is a larger change.
+/// Unlinks a temp file on drop unless [`TempFileGuard::disarm`]ed. Covers
+/// every early return *and* a panic between creating the temp file and
+/// renaming it into place.
+///
+/// This exists because the temp name is unique per writer. The old shared
+/// `auth-keyring.tmp` was self-limiting — a failed write left one stale file
+/// that the next write reused — whereas unique names would leak a distinct
+/// credential-bearing file on every failure, in a directory nothing prunes. A
+/// `SIGKILL` still leaks, since no in-process guard can cover that.
+struct TempFileGuard {
+    path: PathBuf,
+    armed: bool,
+}
+
+impl TempFileGuard {
+    fn new(path: PathBuf) -> Self {
+        Self { path, armed: true }
+    }
+
+    /// Relinquish the file — call once `rename` has moved it into place.
+    fn disarm(&mut self) {
+        self.armed = false;
+    }
+}
+
+impl Drop for TempFileGuard {
+    fn drop(&mut self) {
+        if self.armed {
+            let _ = std::fs::remove_file(&self.path);
+        }
+    }
+}
+
 pub(crate) fn atomic_write(path: &Path, data: &[u8]) -> Result<(), CliError> {
-    static TMP_SEQ: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+    static TMP_SEQ: std::sync::atomic::AtomicUsize = std::sync::atomic::AtomicUsize::new(0);
     let seq = TMP_SEQ.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
     let tmp = path.with_extension(format!("tmp.{}.{}", std::process::id(), seq));
-    std::fs::write(&tmp, data).map_err(|e| {
-        CliError::Auth(format!("Failed to write {}: {e}", tmp.display()))
-    })?;
+    let mut guard = TempFileGuard::new(tmp.clone());
+    std::fs::write(&tmp, data)
+        .map_err(|e| CliError::Auth(format!("Failed to write {}: {e}", tmp.display())))?;
     #[cfg(unix)]
     {
         use std::os::unix::fs::PermissionsExt;
         let perms = std::fs::Permissions::from_mode(0o600);
         let _ = std::fs::set_permissions(&tmp, perms);
     }
-    std::fs::rename(&tmp, path).map_err(|e| {
-        let _ = std::fs::remove_file(&tmp);
-        CliError::Auth(format!("Failed to rename {}: {e}", tmp.display()))
-    })
+    std::fs::rename(&tmp, path)
+        .map_err(|e| CliError::Auth(format!("Failed to rename {}: {e}", tmp.display())))?;
+    guard.disarm();
+    Ok(())
 }
 
 // ---------------------------------------------------------------------------
@@ -315,6 +348,56 @@ mod tests {
             .filter(|n| n.contains(".tmp"))
             .collect();
         assert!(leftovers.is_empty(), "temp files left behind: {leftovers:?}");
+    }
+
+    /// A failed write must not leave its temp file behind. Renaming a file onto
+    /// an existing directory fails on every platform, which drives the error
+    /// path without mocking the filesystem.
+    ///
+    /// The pre-`TempFileGuard` code already cleaned up on a `rename` error, so
+    /// this pins an invariant rather than catching a regression — see
+    /// `temp_file_guard_unlinks_unless_disarmed` for the guard's own coverage.
+    #[test]
+    fn atomic_write_cleans_up_temp_file_on_failure() {
+        let dir = tempfile::tempdir().unwrap();
+
+        // The target is a *directory*, so `rename` cannot replace it.
+        let target = dir.path().join("auth-keyring.json");
+        std::fs::create_dir(&target).unwrap();
+        std::fs::write(target.join("occupant"), b"x").unwrap();
+
+        let result = atomic_write(&target, br#"{"writer":0}"#);
+        assert!(result.is_err(), "expected rename onto a directory to fail");
+
+        let leftovers: Vec<String> = std::fs::read_dir(dir.path())
+            .unwrap()
+            .filter_map(|e| e.ok())
+            .map(|e| e.file_name().to_string_lossy().into_owned())
+            .filter(|n| n.contains(".tmp"))
+            .collect();
+        assert!(leftovers.is_empty(), "temp file leaked after a failed write: {leftovers:?}");
+    }
+
+    /// Pins [`TempFileGuard`]: armed drops unlink, disarmed drops don't. Drop
+    /// running on an armed guard is what covers early returns and unwinding
+    /// panics between `write` and `rename` — paths the old `rename`-only
+    /// cleanup missed. Deleting the guard or the `disarm()` call fails this.
+    #[test]
+    fn temp_file_guard_unlinks_unless_disarmed() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("auth-keyring.tmp.0.0");
+
+        std::fs::write(&path, b"x").unwrap();
+        drop(TempFileGuard::new(path.clone()));
+        assert!(!path.exists(), "armed guard must unlink on drop");
+
+        // The post-`rename` case: the file has been moved away, so the guard
+        // must not touch whatever now sits at that path.
+        std::fs::write(&path, b"x").unwrap();
+        let mut guard = TempFileGuard::new(path.clone());
+        guard.disarm();
+        drop(guard);
+        assert!(path.exists(), "disarmed guard must not unlink");
     }
 
     #[test]

--- a/seed/cli/file-upload-openapi/with-wire-tests/src/auth/oauth_common.rs
+++ b/seed/cli/file-upload-openapi/with-wire-tests/src/auth/oauth_common.rs
@@ -226,8 +226,29 @@ pub(crate) fn config_dir() -> Option<PathBuf> {
 
 /// Write `data` to `path` atomically: sibling temp file → owner-only
 /// permissions (0600 on Unix) → rename into place.
+///
+/// The temp file name is unique per writer — pid plus a process-local
+/// counter. Deriving it from the target alone meant every concurrent writer
+/// used the *same* sibling (`auth-keyring.tmp`): whichever one renamed first
+/// moved it away, and the rest failed with `ENOENT` from `rename`. That
+/// surfaced as intermittent `auth login --with-token` failures across a
+/// wire-test suite large enough to run many CLI processes at once, killing a
+/// different subset of cases on each run.
+///
+/// The pid covers the case that actually bit us (separate CLI processes); the
+/// counter covers two writers inside one process, and is what makes the
+/// behavior unit-testable without spawning subprocesses.
+///
+/// `rename` is still atomic for readers, which is what keeps a partially
+/// written credential file unobservable. This only fixes writer-vs-writer
+/// collisions on the temp path. `FileKeyringStore::set` remains a
+/// read-modify-write of the whole map with no lock, so simultaneous writers
+/// can still clobber one another's *entries*; making that safe needs file
+/// locking, which is a larger change.
 pub(crate) fn atomic_write(path: &Path, data: &[u8]) -> Result<(), CliError> {
-    let tmp = path.with_extension("tmp");
+    static TMP_SEQ: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+    let seq = TMP_SEQ.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+    let tmp = path.with_extension(format!("tmp.{}.{}", std::process::id(), seq));
     std::fs::write(&tmp, data).map_err(|e| {
         CliError::Auth(format!("Failed to write {}: {e}", tmp.display()))
     })?;
@@ -250,6 +271,51 @@ pub(crate) fn atomic_write(path: &Path, data: &[u8]) -> Result<(), CliError> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// Regression test for the temp-file collision that made
+    /// `auth login --with-token` fail intermittently: every writer derived the
+    /// same sibling path from the target, so the first `rename` moved it away
+    /// and the rest got `ENOENT`.
+    ///
+    /// Reverting `atomic_write` to a target-derived temp name fails this with
+    /// "Failed to rename ...: No such file or directory".
+    #[test]
+    fn atomic_write_tolerates_concurrent_writers() {
+        let dir = tempfile::tempdir().unwrap();
+        let target = dir.path().join("auth-keyring.json");
+
+        let results: Vec<Result<(), CliError>> = std::thread::scope(|scope| {
+            let handles: Vec<_> = (0..16)
+                .map(|i| {
+                    let target = target.clone();
+                    scope.spawn(move || atomic_write(&target, format!(r#"{{"writer":{i}}}"#).as_bytes()))
+                })
+                .collect();
+            handles.into_iter().map(|h| h.join().unwrap()).collect()
+        });
+
+        let failed: Vec<String> = results
+            .iter()
+            .filter_map(|r| r.as_ref().err().map(|e| e.to_string()))
+            .collect();
+        assert!(failed.is_empty(), "concurrent writers failed: {failed:?}");
+
+        // Last writer wins, but the file must always be one writer's complete
+        // payload — never a mix, and never absent.
+        let contents = std::fs::read_to_string(&target).unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(&contents)
+            .unwrap_or_else(|e| panic!("target is not valid JSON after concurrent writes: {e} in {contents:?}"));
+        assert!(parsed.get("writer").is_some(), "unexpected payload: {contents}");
+
+        // No temp files orphaned in the directory.
+        let leftovers: Vec<String> = std::fs::read_dir(dir.path())
+            .unwrap()
+            .filter_map(|e| e.ok())
+            .map(|e| e.file_name().to_string_lossy().into_owned())
+            .filter(|n| n.contains(".tmp"))
+            .collect();
+        assert!(leftovers.is_empty(), "temp files left behind: {leftovers:?}");
+    }
 
     #[test]
     fn token_bundle_roundtrip() {

--- a/seed/cli/imdb/src/auth/oauth_common.rs
+++ b/seed/cli/imdb/src/auth/oauth_common.rs
@@ -224,27 +224,6 @@ pub(crate) fn config_dir() -> Option<PathBuf> {
     }
 }
 
-/// Write `data` to `path` atomically: sibling temp file → owner-only
-/// permissions (0600 on Unix) → rename into place.
-///
-/// The temp file name is unique per writer — pid plus a process-local
-/// counter. Deriving it from the target alone meant every concurrent writer
-/// used the *same* sibling (`auth-keyring.tmp`): whichever one renamed first
-/// moved it away, and the rest failed with `ENOENT` from `rename`. That
-/// surfaced as intermittent `auth login --with-token` failures across a
-/// wire-test suite large enough to run many CLI processes at once, killing a
-/// different subset of cases on each run.
-///
-/// The pid covers the case that actually bit us (separate CLI processes); the
-/// counter covers two writers inside one process, and is what makes the
-/// behavior unit-testable without spawning subprocesses.
-///
-/// `rename` is still atomic for readers, which is what keeps a partially
-/// written credential file unobservable. This only fixes writer-vs-writer
-/// collisions on the temp path. `FileKeyringStore::set` remains a
-/// read-modify-write of the whole map with no lock, so simultaneous writers
-/// can still clobber one another's *entries*; making that safe needs file
-/// locking, which is a larger change.
 /// Unlinks a temp file on drop unless [`TempFileGuard::disarm`]ed. Covers
 /// every early return *and* a panic between creating the temp file and
 /// renaming it into place.
@@ -278,6 +257,30 @@ impl Drop for TempFileGuard {
     }
 }
 
+/// Write `data` to `path` atomically: sibling temp file → owner-only
+/// permissions (0600 on Unix) → rename into place.
+///
+/// The temp file name is unique per writer — pid plus a process-local
+/// counter. Deriving it from the target alone meant every concurrent writer
+/// used the *same* sibling (`auth-keyring.tmp`): whichever one renamed first
+/// moved it away, and the rest failed with `ENOENT` from `rename`. That
+/// surfaced as intermittent `auth login --with-token` failures across a
+/// wire-test suite large enough to run many CLI processes at once, killing a
+/// different subset of cases on each run.
+///
+/// The pid covers the case that actually bit us (separate CLI processes); the
+/// counter covers two writers inside one process, and is what makes the
+/// behavior unit-testable without spawning subprocesses.
+///
+/// A [`TempFileGuard`] unlinks the temp file if anything between creating it
+/// and renaming it fails, so unique names cannot accumulate as orphans.
+///
+/// `rename` is still atomic for readers, which is what keeps a partially
+/// written credential file unobservable. This only fixes writer-vs-writer
+/// collisions on the temp path. `FileKeyringStore::set` remains a
+/// read-modify-write of the whole map with no lock, so simultaneous writers
+/// can still clobber one another's *entries*; making that safe needs file
+/// locking, which is a larger change.
 pub(crate) fn atomic_write(path: &Path, data: &[u8]) -> Result<(), CliError> {
     static TMP_SEQ: std::sync::atomic::AtomicUsize = std::sync::atomic::AtomicUsize::new(0);
     let seq = TMP_SEQ.fetch_add(1, std::sync::atomic::Ordering::Relaxed);

--- a/seed/cli/imdb/src/auth/oauth_common.rs
+++ b/seed/cli/imdb/src/auth/oauth_common.rs
@@ -245,23 +245,56 @@ pub(crate) fn config_dir() -> Option<PathBuf> {
 /// read-modify-write of the whole map with no lock, so simultaneous writers
 /// can still clobber one another's *entries*; making that safe needs file
 /// locking, which is a larger change.
+/// Unlinks a temp file on drop unless [`TempFileGuard::disarm`]ed. Covers
+/// every early return *and* a panic between creating the temp file and
+/// renaming it into place.
+///
+/// This exists because the temp name is unique per writer. The old shared
+/// `auth-keyring.tmp` was self-limiting — a failed write left one stale file
+/// that the next write reused — whereas unique names would leak a distinct
+/// credential-bearing file on every failure, in a directory nothing prunes. A
+/// `SIGKILL` still leaks, since no in-process guard can cover that.
+struct TempFileGuard {
+    path: PathBuf,
+    armed: bool,
+}
+
+impl TempFileGuard {
+    fn new(path: PathBuf) -> Self {
+        Self { path, armed: true }
+    }
+
+    /// Relinquish the file — call once `rename` has moved it into place.
+    fn disarm(&mut self) {
+        self.armed = false;
+    }
+}
+
+impl Drop for TempFileGuard {
+    fn drop(&mut self) {
+        if self.armed {
+            let _ = std::fs::remove_file(&self.path);
+        }
+    }
+}
+
 pub(crate) fn atomic_write(path: &Path, data: &[u8]) -> Result<(), CliError> {
-    static TMP_SEQ: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+    static TMP_SEQ: std::sync::atomic::AtomicUsize = std::sync::atomic::AtomicUsize::new(0);
     let seq = TMP_SEQ.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
     let tmp = path.with_extension(format!("tmp.{}.{}", std::process::id(), seq));
-    std::fs::write(&tmp, data).map_err(|e| {
-        CliError::Auth(format!("Failed to write {}: {e}", tmp.display()))
-    })?;
+    let mut guard = TempFileGuard::new(tmp.clone());
+    std::fs::write(&tmp, data)
+        .map_err(|e| CliError::Auth(format!("Failed to write {}: {e}", tmp.display())))?;
     #[cfg(unix)]
     {
         use std::os::unix::fs::PermissionsExt;
         let perms = std::fs::Permissions::from_mode(0o600);
         let _ = std::fs::set_permissions(&tmp, perms);
     }
-    std::fs::rename(&tmp, path).map_err(|e| {
-        let _ = std::fs::remove_file(&tmp);
-        CliError::Auth(format!("Failed to rename {}: {e}", tmp.display()))
-    })
+    std::fs::rename(&tmp, path)
+        .map_err(|e| CliError::Auth(format!("Failed to rename {}: {e}", tmp.display())))?;
+    guard.disarm();
+    Ok(())
 }
 
 // ---------------------------------------------------------------------------
@@ -315,6 +348,56 @@ mod tests {
             .filter(|n| n.contains(".tmp"))
             .collect();
         assert!(leftovers.is_empty(), "temp files left behind: {leftovers:?}");
+    }
+
+    /// A failed write must not leave its temp file behind. Renaming a file onto
+    /// an existing directory fails on every platform, which drives the error
+    /// path without mocking the filesystem.
+    ///
+    /// The pre-`TempFileGuard` code already cleaned up on a `rename` error, so
+    /// this pins an invariant rather than catching a regression — see
+    /// `temp_file_guard_unlinks_unless_disarmed` for the guard's own coverage.
+    #[test]
+    fn atomic_write_cleans_up_temp_file_on_failure() {
+        let dir = tempfile::tempdir().unwrap();
+
+        // The target is a *directory*, so `rename` cannot replace it.
+        let target = dir.path().join("auth-keyring.json");
+        std::fs::create_dir(&target).unwrap();
+        std::fs::write(target.join("occupant"), b"x").unwrap();
+
+        let result = atomic_write(&target, br#"{"writer":0}"#);
+        assert!(result.is_err(), "expected rename onto a directory to fail");
+
+        let leftovers: Vec<String> = std::fs::read_dir(dir.path())
+            .unwrap()
+            .filter_map(|e| e.ok())
+            .map(|e| e.file_name().to_string_lossy().into_owned())
+            .filter(|n| n.contains(".tmp"))
+            .collect();
+        assert!(leftovers.is_empty(), "temp file leaked after a failed write: {leftovers:?}");
+    }
+
+    /// Pins [`TempFileGuard`]: armed drops unlink, disarmed drops don't. Drop
+    /// running on an armed guard is what covers early returns and unwinding
+    /// panics between `write` and `rename` — paths the old `rename`-only
+    /// cleanup missed. Deleting the guard or the `disarm()` call fails this.
+    #[test]
+    fn temp_file_guard_unlinks_unless_disarmed() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("auth-keyring.tmp.0.0");
+
+        std::fs::write(&path, b"x").unwrap();
+        drop(TempFileGuard::new(path.clone()));
+        assert!(!path.exists(), "armed guard must unlink on drop");
+
+        // The post-`rename` case: the file has been moved away, so the guard
+        // must not touch whatever now sits at that path.
+        std::fs::write(&path, b"x").unwrap();
+        let mut guard = TempFileGuard::new(path.clone());
+        guard.disarm();
+        drop(guard);
+        assert!(path.exists(), "disarmed guard must not unlink");
     }
 
     #[test]

--- a/seed/cli/imdb/src/auth/oauth_common.rs
+++ b/seed/cli/imdb/src/auth/oauth_common.rs
@@ -226,8 +226,29 @@ pub(crate) fn config_dir() -> Option<PathBuf> {
 
 /// Write `data` to `path` atomically: sibling temp file → owner-only
 /// permissions (0600 on Unix) → rename into place.
+///
+/// The temp file name is unique per writer — pid plus a process-local
+/// counter. Deriving it from the target alone meant every concurrent writer
+/// used the *same* sibling (`auth-keyring.tmp`): whichever one renamed first
+/// moved it away, and the rest failed with `ENOENT` from `rename`. That
+/// surfaced as intermittent `auth login --with-token` failures across a
+/// wire-test suite large enough to run many CLI processes at once, killing a
+/// different subset of cases on each run.
+///
+/// The pid covers the case that actually bit us (separate CLI processes); the
+/// counter covers two writers inside one process, and is what makes the
+/// behavior unit-testable without spawning subprocesses.
+///
+/// `rename` is still atomic for readers, which is what keeps a partially
+/// written credential file unobservable. This only fixes writer-vs-writer
+/// collisions on the temp path. `FileKeyringStore::set` remains a
+/// read-modify-write of the whole map with no lock, so simultaneous writers
+/// can still clobber one another's *entries*; making that safe needs file
+/// locking, which is a larger change.
 pub(crate) fn atomic_write(path: &Path, data: &[u8]) -> Result<(), CliError> {
-    let tmp = path.with_extension("tmp");
+    static TMP_SEQ: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+    let seq = TMP_SEQ.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+    let tmp = path.with_extension(format!("tmp.{}.{}", std::process::id(), seq));
     std::fs::write(&tmp, data).map_err(|e| {
         CliError::Auth(format!("Failed to write {}: {e}", tmp.display()))
     })?;
@@ -250,6 +271,51 @@ pub(crate) fn atomic_write(path: &Path, data: &[u8]) -> Result<(), CliError> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// Regression test for the temp-file collision that made
+    /// `auth login --with-token` fail intermittently: every writer derived the
+    /// same sibling path from the target, so the first `rename` moved it away
+    /// and the rest got `ENOENT`.
+    ///
+    /// Reverting `atomic_write` to a target-derived temp name fails this with
+    /// "Failed to rename ...: No such file or directory".
+    #[test]
+    fn atomic_write_tolerates_concurrent_writers() {
+        let dir = tempfile::tempdir().unwrap();
+        let target = dir.path().join("auth-keyring.json");
+
+        let results: Vec<Result<(), CliError>> = std::thread::scope(|scope| {
+            let handles: Vec<_> = (0..16)
+                .map(|i| {
+                    let target = target.clone();
+                    scope.spawn(move || atomic_write(&target, format!(r#"{{"writer":{i}}}"#).as_bytes()))
+                })
+                .collect();
+            handles.into_iter().map(|h| h.join().unwrap()).collect()
+        });
+
+        let failed: Vec<String> = results
+            .iter()
+            .filter_map(|r| r.as_ref().err().map(|e| e.to_string()))
+            .collect();
+        assert!(failed.is_empty(), "concurrent writers failed: {failed:?}");
+
+        // Last writer wins, but the file must always be one writer's complete
+        // payload — never a mix, and never absent.
+        let contents = std::fs::read_to_string(&target).unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(&contents)
+            .unwrap_or_else(|e| panic!("target is not valid JSON after concurrent writes: {e} in {contents:?}"));
+        assert!(parsed.get("writer").is_some(), "unexpected payload: {contents}");
+
+        // No temp files orphaned in the directory.
+        let leftovers: Vec<String> = std::fs::read_dir(dir.path())
+            .unwrap()
+            .filter_map(|e| e.ok())
+            .map(|e| e.file_name().to_string_lossy().into_owned())
+            .filter(|n| n.contains(".tmp"))
+            .collect();
+        assert!(leftovers.is_empty(), "temp files left behind: {leftovers:?}");
+    }
 
     #[test]
     fn token_bundle_roundtrip() {

--- a/seed/cli/inline-enum-type-name-override/src/auth/oauth_common.rs
+++ b/seed/cli/inline-enum-type-name-override/src/auth/oauth_common.rs
@@ -224,27 +224,6 @@ pub(crate) fn config_dir() -> Option<PathBuf> {
     }
 }
 
-/// Write `data` to `path` atomically: sibling temp file → owner-only
-/// permissions (0600 on Unix) → rename into place.
-///
-/// The temp file name is unique per writer — pid plus a process-local
-/// counter. Deriving it from the target alone meant every concurrent writer
-/// used the *same* sibling (`auth-keyring.tmp`): whichever one renamed first
-/// moved it away, and the rest failed with `ENOENT` from `rename`. That
-/// surfaced as intermittent `auth login --with-token` failures across a
-/// wire-test suite large enough to run many CLI processes at once, killing a
-/// different subset of cases on each run.
-///
-/// The pid covers the case that actually bit us (separate CLI processes); the
-/// counter covers two writers inside one process, and is what makes the
-/// behavior unit-testable without spawning subprocesses.
-///
-/// `rename` is still atomic for readers, which is what keeps a partially
-/// written credential file unobservable. This only fixes writer-vs-writer
-/// collisions on the temp path. `FileKeyringStore::set` remains a
-/// read-modify-write of the whole map with no lock, so simultaneous writers
-/// can still clobber one another's *entries*; making that safe needs file
-/// locking, which is a larger change.
 /// Unlinks a temp file on drop unless [`TempFileGuard::disarm`]ed. Covers
 /// every early return *and* a panic between creating the temp file and
 /// renaming it into place.
@@ -278,6 +257,30 @@ impl Drop for TempFileGuard {
     }
 }
 
+/// Write `data` to `path` atomically: sibling temp file → owner-only
+/// permissions (0600 on Unix) → rename into place.
+///
+/// The temp file name is unique per writer — pid plus a process-local
+/// counter. Deriving it from the target alone meant every concurrent writer
+/// used the *same* sibling (`auth-keyring.tmp`): whichever one renamed first
+/// moved it away, and the rest failed with `ENOENT` from `rename`. That
+/// surfaced as intermittent `auth login --with-token` failures across a
+/// wire-test suite large enough to run many CLI processes at once, killing a
+/// different subset of cases on each run.
+///
+/// The pid covers the case that actually bit us (separate CLI processes); the
+/// counter covers two writers inside one process, and is what makes the
+/// behavior unit-testable without spawning subprocesses.
+///
+/// A [`TempFileGuard`] unlinks the temp file if anything between creating it
+/// and renaming it fails, so unique names cannot accumulate as orphans.
+///
+/// `rename` is still atomic for readers, which is what keeps a partially
+/// written credential file unobservable. This only fixes writer-vs-writer
+/// collisions on the temp path. `FileKeyringStore::set` remains a
+/// read-modify-write of the whole map with no lock, so simultaneous writers
+/// can still clobber one another's *entries*; making that safe needs file
+/// locking, which is a larger change.
 pub(crate) fn atomic_write(path: &Path, data: &[u8]) -> Result<(), CliError> {
     static TMP_SEQ: std::sync::atomic::AtomicUsize = std::sync::atomic::AtomicUsize::new(0);
     let seq = TMP_SEQ.fetch_add(1, std::sync::atomic::Ordering::Relaxed);

--- a/seed/cli/inline-enum-type-name-override/src/auth/oauth_common.rs
+++ b/seed/cli/inline-enum-type-name-override/src/auth/oauth_common.rs
@@ -245,23 +245,56 @@ pub(crate) fn config_dir() -> Option<PathBuf> {
 /// read-modify-write of the whole map with no lock, so simultaneous writers
 /// can still clobber one another's *entries*; making that safe needs file
 /// locking, which is a larger change.
+/// Unlinks a temp file on drop unless [`TempFileGuard::disarm`]ed. Covers
+/// every early return *and* a panic between creating the temp file and
+/// renaming it into place.
+///
+/// This exists because the temp name is unique per writer. The old shared
+/// `auth-keyring.tmp` was self-limiting — a failed write left one stale file
+/// that the next write reused — whereas unique names would leak a distinct
+/// credential-bearing file on every failure, in a directory nothing prunes. A
+/// `SIGKILL` still leaks, since no in-process guard can cover that.
+struct TempFileGuard {
+    path: PathBuf,
+    armed: bool,
+}
+
+impl TempFileGuard {
+    fn new(path: PathBuf) -> Self {
+        Self { path, armed: true }
+    }
+
+    /// Relinquish the file — call once `rename` has moved it into place.
+    fn disarm(&mut self) {
+        self.armed = false;
+    }
+}
+
+impl Drop for TempFileGuard {
+    fn drop(&mut self) {
+        if self.armed {
+            let _ = std::fs::remove_file(&self.path);
+        }
+    }
+}
+
 pub(crate) fn atomic_write(path: &Path, data: &[u8]) -> Result<(), CliError> {
-    static TMP_SEQ: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+    static TMP_SEQ: std::sync::atomic::AtomicUsize = std::sync::atomic::AtomicUsize::new(0);
     let seq = TMP_SEQ.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
     let tmp = path.with_extension(format!("tmp.{}.{}", std::process::id(), seq));
-    std::fs::write(&tmp, data).map_err(|e| {
-        CliError::Auth(format!("Failed to write {}: {e}", tmp.display()))
-    })?;
+    let mut guard = TempFileGuard::new(tmp.clone());
+    std::fs::write(&tmp, data)
+        .map_err(|e| CliError::Auth(format!("Failed to write {}: {e}", tmp.display())))?;
     #[cfg(unix)]
     {
         use std::os::unix::fs::PermissionsExt;
         let perms = std::fs::Permissions::from_mode(0o600);
         let _ = std::fs::set_permissions(&tmp, perms);
     }
-    std::fs::rename(&tmp, path).map_err(|e| {
-        let _ = std::fs::remove_file(&tmp);
-        CliError::Auth(format!("Failed to rename {}: {e}", tmp.display()))
-    })
+    std::fs::rename(&tmp, path)
+        .map_err(|e| CliError::Auth(format!("Failed to rename {}: {e}", tmp.display())))?;
+    guard.disarm();
+    Ok(())
 }
 
 // ---------------------------------------------------------------------------
@@ -315,6 +348,56 @@ mod tests {
             .filter(|n| n.contains(".tmp"))
             .collect();
         assert!(leftovers.is_empty(), "temp files left behind: {leftovers:?}");
+    }
+
+    /// A failed write must not leave its temp file behind. Renaming a file onto
+    /// an existing directory fails on every platform, which drives the error
+    /// path without mocking the filesystem.
+    ///
+    /// The pre-`TempFileGuard` code already cleaned up on a `rename` error, so
+    /// this pins an invariant rather than catching a regression — see
+    /// `temp_file_guard_unlinks_unless_disarmed` for the guard's own coverage.
+    #[test]
+    fn atomic_write_cleans_up_temp_file_on_failure() {
+        let dir = tempfile::tempdir().unwrap();
+
+        // The target is a *directory*, so `rename` cannot replace it.
+        let target = dir.path().join("auth-keyring.json");
+        std::fs::create_dir(&target).unwrap();
+        std::fs::write(target.join("occupant"), b"x").unwrap();
+
+        let result = atomic_write(&target, br#"{"writer":0}"#);
+        assert!(result.is_err(), "expected rename onto a directory to fail");
+
+        let leftovers: Vec<String> = std::fs::read_dir(dir.path())
+            .unwrap()
+            .filter_map(|e| e.ok())
+            .map(|e| e.file_name().to_string_lossy().into_owned())
+            .filter(|n| n.contains(".tmp"))
+            .collect();
+        assert!(leftovers.is_empty(), "temp file leaked after a failed write: {leftovers:?}");
+    }
+
+    /// Pins [`TempFileGuard`]: armed drops unlink, disarmed drops don't. Drop
+    /// running on an armed guard is what covers early returns and unwinding
+    /// panics between `write` and `rename` — paths the old `rename`-only
+    /// cleanup missed. Deleting the guard or the `disarm()` call fails this.
+    #[test]
+    fn temp_file_guard_unlinks_unless_disarmed() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("auth-keyring.tmp.0.0");
+
+        std::fs::write(&path, b"x").unwrap();
+        drop(TempFileGuard::new(path.clone()));
+        assert!(!path.exists(), "armed guard must unlink on drop");
+
+        // The post-`rename` case: the file has been moved away, so the guard
+        // must not touch whatever now sits at that path.
+        std::fs::write(&path, b"x").unwrap();
+        let mut guard = TempFileGuard::new(path.clone());
+        guard.disarm();
+        drop(guard);
+        assert!(path.exists(), "disarmed guard must not unlink");
     }
 
     #[test]

--- a/seed/cli/inline-enum-type-name-override/src/auth/oauth_common.rs
+++ b/seed/cli/inline-enum-type-name-override/src/auth/oauth_common.rs
@@ -226,8 +226,29 @@ pub(crate) fn config_dir() -> Option<PathBuf> {
 
 /// Write `data` to `path` atomically: sibling temp file → owner-only
 /// permissions (0600 on Unix) → rename into place.
+///
+/// The temp file name is unique per writer — pid plus a process-local
+/// counter. Deriving it from the target alone meant every concurrent writer
+/// used the *same* sibling (`auth-keyring.tmp`): whichever one renamed first
+/// moved it away, and the rest failed with `ENOENT` from `rename`. That
+/// surfaced as intermittent `auth login --with-token` failures across a
+/// wire-test suite large enough to run many CLI processes at once, killing a
+/// different subset of cases on each run.
+///
+/// The pid covers the case that actually bit us (separate CLI processes); the
+/// counter covers two writers inside one process, and is what makes the
+/// behavior unit-testable without spawning subprocesses.
+///
+/// `rename` is still atomic for readers, which is what keeps a partially
+/// written credential file unobservable. This only fixes writer-vs-writer
+/// collisions on the temp path. `FileKeyringStore::set` remains a
+/// read-modify-write of the whole map with no lock, so simultaneous writers
+/// can still clobber one another's *entries*; making that safe needs file
+/// locking, which is a larger change.
 pub(crate) fn atomic_write(path: &Path, data: &[u8]) -> Result<(), CliError> {
-    let tmp = path.with_extension("tmp");
+    static TMP_SEQ: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+    let seq = TMP_SEQ.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+    let tmp = path.with_extension(format!("tmp.{}.{}", std::process::id(), seq));
     std::fs::write(&tmp, data).map_err(|e| {
         CliError::Auth(format!("Failed to write {}: {e}", tmp.display()))
     })?;
@@ -250,6 +271,51 @@ pub(crate) fn atomic_write(path: &Path, data: &[u8]) -> Result<(), CliError> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// Regression test for the temp-file collision that made
+    /// `auth login --with-token` fail intermittently: every writer derived the
+    /// same sibling path from the target, so the first `rename` moved it away
+    /// and the rest got `ENOENT`.
+    ///
+    /// Reverting `atomic_write` to a target-derived temp name fails this with
+    /// "Failed to rename ...: No such file or directory".
+    #[test]
+    fn atomic_write_tolerates_concurrent_writers() {
+        let dir = tempfile::tempdir().unwrap();
+        let target = dir.path().join("auth-keyring.json");
+
+        let results: Vec<Result<(), CliError>> = std::thread::scope(|scope| {
+            let handles: Vec<_> = (0..16)
+                .map(|i| {
+                    let target = target.clone();
+                    scope.spawn(move || atomic_write(&target, format!(r#"{{"writer":{i}}}"#).as_bytes()))
+                })
+                .collect();
+            handles.into_iter().map(|h| h.join().unwrap()).collect()
+        });
+
+        let failed: Vec<String> = results
+            .iter()
+            .filter_map(|r| r.as_ref().err().map(|e| e.to_string()))
+            .collect();
+        assert!(failed.is_empty(), "concurrent writers failed: {failed:?}");
+
+        // Last writer wins, but the file must always be one writer's complete
+        // payload — never a mix, and never absent.
+        let contents = std::fs::read_to_string(&target).unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(&contents)
+            .unwrap_or_else(|e| panic!("target is not valid JSON after concurrent writes: {e} in {contents:?}"));
+        assert!(parsed.get("writer").is_some(), "unexpected payload: {contents}");
+
+        // No temp files orphaned in the directory.
+        let leftovers: Vec<String> = std::fs::read_dir(dir.path())
+            .unwrap()
+            .filter_map(|e| e.ok())
+            .map(|e| e.file_name().to_string_lossy().into_owned())
+            .filter(|n| n.contains(".tmp"))
+            .collect();
+        assert!(leftovers.is_empty(), "temp files left behind: {leftovers:?}");
+    }
 
     #[test]
     fn token_bundle_roundtrip() {

--- a/seed/cli/multi-content-type-examples/src/auth/oauth_common.rs
+++ b/seed/cli/multi-content-type-examples/src/auth/oauth_common.rs
@@ -224,27 +224,6 @@ pub(crate) fn config_dir() -> Option<PathBuf> {
     }
 }
 
-/// Write `data` to `path` atomically: sibling temp file → owner-only
-/// permissions (0600 on Unix) → rename into place.
-///
-/// The temp file name is unique per writer — pid plus a process-local
-/// counter. Deriving it from the target alone meant every concurrent writer
-/// used the *same* sibling (`auth-keyring.tmp`): whichever one renamed first
-/// moved it away, and the rest failed with `ENOENT` from `rename`. That
-/// surfaced as intermittent `auth login --with-token` failures across a
-/// wire-test suite large enough to run many CLI processes at once, killing a
-/// different subset of cases on each run.
-///
-/// The pid covers the case that actually bit us (separate CLI processes); the
-/// counter covers two writers inside one process, and is what makes the
-/// behavior unit-testable without spawning subprocesses.
-///
-/// `rename` is still atomic for readers, which is what keeps a partially
-/// written credential file unobservable. This only fixes writer-vs-writer
-/// collisions on the temp path. `FileKeyringStore::set` remains a
-/// read-modify-write of the whole map with no lock, so simultaneous writers
-/// can still clobber one another's *entries*; making that safe needs file
-/// locking, which is a larger change.
 /// Unlinks a temp file on drop unless [`TempFileGuard::disarm`]ed. Covers
 /// every early return *and* a panic between creating the temp file and
 /// renaming it into place.
@@ -278,6 +257,30 @@ impl Drop for TempFileGuard {
     }
 }
 
+/// Write `data` to `path` atomically: sibling temp file → owner-only
+/// permissions (0600 on Unix) → rename into place.
+///
+/// The temp file name is unique per writer — pid plus a process-local
+/// counter. Deriving it from the target alone meant every concurrent writer
+/// used the *same* sibling (`auth-keyring.tmp`): whichever one renamed first
+/// moved it away, and the rest failed with `ENOENT` from `rename`. That
+/// surfaced as intermittent `auth login --with-token` failures across a
+/// wire-test suite large enough to run many CLI processes at once, killing a
+/// different subset of cases on each run.
+///
+/// The pid covers the case that actually bit us (separate CLI processes); the
+/// counter covers two writers inside one process, and is what makes the
+/// behavior unit-testable without spawning subprocesses.
+///
+/// A [`TempFileGuard`] unlinks the temp file if anything between creating it
+/// and renaming it fails, so unique names cannot accumulate as orphans.
+///
+/// `rename` is still atomic for readers, which is what keeps a partially
+/// written credential file unobservable. This only fixes writer-vs-writer
+/// collisions on the temp path. `FileKeyringStore::set` remains a
+/// read-modify-write of the whole map with no lock, so simultaneous writers
+/// can still clobber one another's *entries*; making that safe needs file
+/// locking, which is a larger change.
 pub(crate) fn atomic_write(path: &Path, data: &[u8]) -> Result<(), CliError> {
     static TMP_SEQ: std::sync::atomic::AtomicUsize = std::sync::atomic::AtomicUsize::new(0);
     let seq = TMP_SEQ.fetch_add(1, std::sync::atomic::Ordering::Relaxed);

--- a/seed/cli/multi-content-type-examples/src/auth/oauth_common.rs
+++ b/seed/cli/multi-content-type-examples/src/auth/oauth_common.rs
@@ -245,23 +245,56 @@ pub(crate) fn config_dir() -> Option<PathBuf> {
 /// read-modify-write of the whole map with no lock, so simultaneous writers
 /// can still clobber one another's *entries*; making that safe needs file
 /// locking, which is a larger change.
+/// Unlinks a temp file on drop unless [`TempFileGuard::disarm`]ed. Covers
+/// every early return *and* a panic between creating the temp file and
+/// renaming it into place.
+///
+/// This exists because the temp name is unique per writer. The old shared
+/// `auth-keyring.tmp` was self-limiting — a failed write left one stale file
+/// that the next write reused — whereas unique names would leak a distinct
+/// credential-bearing file on every failure, in a directory nothing prunes. A
+/// `SIGKILL` still leaks, since no in-process guard can cover that.
+struct TempFileGuard {
+    path: PathBuf,
+    armed: bool,
+}
+
+impl TempFileGuard {
+    fn new(path: PathBuf) -> Self {
+        Self { path, armed: true }
+    }
+
+    /// Relinquish the file — call once `rename` has moved it into place.
+    fn disarm(&mut self) {
+        self.armed = false;
+    }
+}
+
+impl Drop for TempFileGuard {
+    fn drop(&mut self) {
+        if self.armed {
+            let _ = std::fs::remove_file(&self.path);
+        }
+    }
+}
+
 pub(crate) fn atomic_write(path: &Path, data: &[u8]) -> Result<(), CliError> {
-    static TMP_SEQ: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+    static TMP_SEQ: std::sync::atomic::AtomicUsize = std::sync::atomic::AtomicUsize::new(0);
     let seq = TMP_SEQ.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
     let tmp = path.with_extension(format!("tmp.{}.{}", std::process::id(), seq));
-    std::fs::write(&tmp, data).map_err(|e| {
-        CliError::Auth(format!("Failed to write {}: {e}", tmp.display()))
-    })?;
+    let mut guard = TempFileGuard::new(tmp.clone());
+    std::fs::write(&tmp, data)
+        .map_err(|e| CliError::Auth(format!("Failed to write {}: {e}", tmp.display())))?;
     #[cfg(unix)]
     {
         use std::os::unix::fs::PermissionsExt;
         let perms = std::fs::Permissions::from_mode(0o600);
         let _ = std::fs::set_permissions(&tmp, perms);
     }
-    std::fs::rename(&tmp, path).map_err(|e| {
-        let _ = std::fs::remove_file(&tmp);
-        CliError::Auth(format!("Failed to rename {}: {e}", tmp.display()))
-    })
+    std::fs::rename(&tmp, path)
+        .map_err(|e| CliError::Auth(format!("Failed to rename {}: {e}", tmp.display())))?;
+    guard.disarm();
+    Ok(())
 }
 
 // ---------------------------------------------------------------------------
@@ -315,6 +348,56 @@ mod tests {
             .filter(|n| n.contains(".tmp"))
             .collect();
         assert!(leftovers.is_empty(), "temp files left behind: {leftovers:?}");
+    }
+
+    /// A failed write must not leave its temp file behind. Renaming a file onto
+    /// an existing directory fails on every platform, which drives the error
+    /// path without mocking the filesystem.
+    ///
+    /// The pre-`TempFileGuard` code already cleaned up on a `rename` error, so
+    /// this pins an invariant rather than catching a regression — see
+    /// `temp_file_guard_unlinks_unless_disarmed` for the guard's own coverage.
+    #[test]
+    fn atomic_write_cleans_up_temp_file_on_failure() {
+        let dir = tempfile::tempdir().unwrap();
+
+        // The target is a *directory*, so `rename` cannot replace it.
+        let target = dir.path().join("auth-keyring.json");
+        std::fs::create_dir(&target).unwrap();
+        std::fs::write(target.join("occupant"), b"x").unwrap();
+
+        let result = atomic_write(&target, br#"{"writer":0}"#);
+        assert!(result.is_err(), "expected rename onto a directory to fail");
+
+        let leftovers: Vec<String> = std::fs::read_dir(dir.path())
+            .unwrap()
+            .filter_map(|e| e.ok())
+            .map(|e| e.file_name().to_string_lossy().into_owned())
+            .filter(|n| n.contains(".tmp"))
+            .collect();
+        assert!(leftovers.is_empty(), "temp file leaked after a failed write: {leftovers:?}");
+    }
+
+    /// Pins [`TempFileGuard`]: armed drops unlink, disarmed drops don't. Drop
+    /// running on an armed guard is what covers early returns and unwinding
+    /// panics between `write` and `rename` — paths the old `rename`-only
+    /// cleanup missed. Deleting the guard or the `disarm()` call fails this.
+    #[test]
+    fn temp_file_guard_unlinks_unless_disarmed() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("auth-keyring.tmp.0.0");
+
+        std::fs::write(&path, b"x").unwrap();
+        drop(TempFileGuard::new(path.clone()));
+        assert!(!path.exists(), "armed guard must unlink on drop");
+
+        // The post-`rename` case: the file has been moved away, so the guard
+        // must not touch whatever now sits at that path.
+        std::fs::write(&path, b"x").unwrap();
+        let mut guard = TempFileGuard::new(path.clone());
+        guard.disarm();
+        drop(guard);
+        assert!(path.exists(), "disarmed guard must not unlink");
     }
 
     #[test]

--- a/seed/cli/multi-content-type-examples/src/auth/oauth_common.rs
+++ b/seed/cli/multi-content-type-examples/src/auth/oauth_common.rs
@@ -226,8 +226,29 @@ pub(crate) fn config_dir() -> Option<PathBuf> {
 
 /// Write `data` to `path` atomically: sibling temp file → owner-only
 /// permissions (0600 on Unix) → rename into place.
+///
+/// The temp file name is unique per writer — pid plus a process-local
+/// counter. Deriving it from the target alone meant every concurrent writer
+/// used the *same* sibling (`auth-keyring.tmp`): whichever one renamed first
+/// moved it away, and the rest failed with `ENOENT` from `rename`. That
+/// surfaced as intermittent `auth login --with-token` failures across a
+/// wire-test suite large enough to run many CLI processes at once, killing a
+/// different subset of cases on each run.
+///
+/// The pid covers the case that actually bit us (separate CLI processes); the
+/// counter covers two writers inside one process, and is what makes the
+/// behavior unit-testable without spawning subprocesses.
+///
+/// `rename` is still atomic for readers, which is what keeps a partially
+/// written credential file unobservable. This only fixes writer-vs-writer
+/// collisions on the temp path. `FileKeyringStore::set` remains a
+/// read-modify-write of the whole map with no lock, so simultaneous writers
+/// can still clobber one another's *entries*; making that safe needs file
+/// locking, which is a larger change.
 pub(crate) fn atomic_write(path: &Path, data: &[u8]) -> Result<(), CliError> {
-    let tmp = path.with_extension("tmp");
+    static TMP_SEQ: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+    let seq = TMP_SEQ.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+    let tmp = path.with_extension(format!("tmp.{}.{}", std::process::id(), seq));
     std::fs::write(&tmp, data).map_err(|e| {
         CliError::Auth(format!("Failed to write {}: {e}", tmp.display()))
     })?;
@@ -250,6 +271,51 @@ pub(crate) fn atomic_write(path: &Path, data: &[u8]) -> Result<(), CliError> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// Regression test for the temp-file collision that made
+    /// `auth login --with-token` fail intermittently: every writer derived the
+    /// same sibling path from the target, so the first `rename` moved it away
+    /// and the rest got `ENOENT`.
+    ///
+    /// Reverting `atomic_write` to a target-derived temp name fails this with
+    /// "Failed to rename ...: No such file or directory".
+    #[test]
+    fn atomic_write_tolerates_concurrent_writers() {
+        let dir = tempfile::tempdir().unwrap();
+        let target = dir.path().join("auth-keyring.json");
+
+        let results: Vec<Result<(), CliError>> = std::thread::scope(|scope| {
+            let handles: Vec<_> = (0..16)
+                .map(|i| {
+                    let target = target.clone();
+                    scope.spawn(move || atomic_write(&target, format!(r#"{{"writer":{i}}}"#).as_bytes()))
+                })
+                .collect();
+            handles.into_iter().map(|h| h.join().unwrap()).collect()
+        });
+
+        let failed: Vec<String> = results
+            .iter()
+            .filter_map(|r| r.as_ref().err().map(|e| e.to_string()))
+            .collect();
+        assert!(failed.is_empty(), "concurrent writers failed: {failed:?}");
+
+        // Last writer wins, but the file must always be one writer's complete
+        // payload — never a mix, and never absent.
+        let contents = std::fs::read_to_string(&target).unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(&contents)
+            .unwrap_or_else(|e| panic!("target is not valid JSON after concurrent writes: {e} in {contents:?}"));
+        assert!(parsed.get("writer").is_some(), "unexpected payload: {contents}");
+
+        // No temp files orphaned in the directory.
+        let leftovers: Vec<String> = std::fs::read_dir(dir.path())
+            .unwrap()
+            .filter_map(|e| e.ok())
+            .map(|e| e.file_name().to_string_lossy().into_owned())
+            .filter(|n| n.contains(".tmp"))
+            .collect();
+        assert!(leftovers.is_empty(), "temp files left behind: {leftovers:?}");
+    }
 
     #[test]
     fn token_bundle_roundtrip() {

--- a/seed/cli/multi-url-environment-reference/src/auth/oauth_common.rs
+++ b/seed/cli/multi-url-environment-reference/src/auth/oauth_common.rs
@@ -224,27 +224,6 @@ pub(crate) fn config_dir() -> Option<PathBuf> {
     }
 }
 
-/// Write `data` to `path` atomically: sibling temp file → owner-only
-/// permissions (0600 on Unix) → rename into place.
-///
-/// The temp file name is unique per writer — pid plus a process-local
-/// counter. Deriving it from the target alone meant every concurrent writer
-/// used the *same* sibling (`auth-keyring.tmp`): whichever one renamed first
-/// moved it away, and the rest failed with `ENOENT` from `rename`. That
-/// surfaced as intermittent `auth login --with-token` failures across a
-/// wire-test suite large enough to run many CLI processes at once, killing a
-/// different subset of cases on each run.
-///
-/// The pid covers the case that actually bit us (separate CLI processes); the
-/// counter covers two writers inside one process, and is what makes the
-/// behavior unit-testable without spawning subprocesses.
-///
-/// `rename` is still atomic for readers, which is what keeps a partially
-/// written credential file unobservable. This only fixes writer-vs-writer
-/// collisions on the temp path. `FileKeyringStore::set` remains a
-/// read-modify-write of the whole map with no lock, so simultaneous writers
-/// can still clobber one another's *entries*; making that safe needs file
-/// locking, which is a larger change.
 /// Unlinks a temp file on drop unless [`TempFileGuard::disarm`]ed. Covers
 /// every early return *and* a panic between creating the temp file and
 /// renaming it into place.
@@ -278,6 +257,30 @@ impl Drop for TempFileGuard {
     }
 }
 
+/// Write `data` to `path` atomically: sibling temp file → owner-only
+/// permissions (0600 on Unix) → rename into place.
+///
+/// The temp file name is unique per writer — pid plus a process-local
+/// counter. Deriving it from the target alone meant every concurrent writer
+/// used the *same* sibling (`auth-keyring.tmp`): whichever one renamed first
+/// moved it away, and the rest failed with `ENOENT` from `rename`. That
+/// surfaced as intermittent `auth login --with-token` failures across a
+/// wire-test suite large enough to run many CLI processes at once, killing a
+/// different subset of cases on each run.
+///
+/// The pid covers the case that actually bit us (separate CLI processes); the
+/// counter covers two writers inside one process, and is what makes the
+/// behavior unit-testable without spawning subprocesses.
+///
+/// A [`TempFileGuard`] unlinks the temp file if anything between creating it
+/// and renaming it fails, so unique names cannot accumulate as orphans.
+///
+/// `rename` is still atomic for readers, which is what keeps a partially
+/// written credential file unobservable. This only fixes writer-vs-writer
+/// collisions on the temp path. `FileKeyringStore::set` remains a
+/// read-modify-write of the whole map with no lock, so simultaneous writers
+/// can still clobber one another's *entries*; making that safe needs file
+/// locking, which is a larger change.
 pub(crate) fn atomic_write(path: &Path, data: &[u8]) -> Result<(), CliError> {
     static TMP_SEQ: std::sync::atomic::AtomicUsize = std::sync::atomic::AtomicUsize::new(0);
     let seq = TMP_SEQ.fetch_add(1, std::sync::atomic::Ordering::Relaxed);

--- a/seed/cli/multi-url-environment-reference/src/auth/oauth_common.rs
+++ b/seed/cli/multi-url-environment-reference/src/auth/oauth_common.rs
@@ -245,23 +245,56 @@ pub(crate) fn config_dir() -> Option<PathBuf> {
 /// read-modify-write of the whole map with no lock, so simultaneous writers
 /// can still clobber one another's *entries*; making that safe needs file
 /// locking, which is a larger change.
+/// Unlinks a temp file on drop unless [`TempFileGuard::disarm`]ed. Covers
+/// every early return *and* a panic between creating the temp file and
+/// renaming it into place.
+///
+/// This exists because the temp name is unique per writer. The old shared
+/// `auth-keyring.tmp` was self-limiting — a failed write left one stale file
+/// that the next write reused — whereas unique names would leak a distinct
+/// credential-bearing file on every failure, in a directory nothing prunes. A
+/// `SIGKILL` still leaks, since no in-process guard can cover that.
+struct TempFileGuard {
+    path: PathBuf,
+    armed: bool,
+}
+
+impl TempFileGuard {
+    fn new(path: PathBuf) -> Self {
+        Self { path, armed: true }
+    }
+
+    /// Relinquish the file — call once `rename` has moved it into place.
+    fn disarm(&mut self) {
+        self.armed = false;
+    }
+}
+
+impl Drop for TempFileGuard {
+    fn drop(&mut self) {
+        if self.armed {
+            let _ = std::fs::remove_file(&self.path);
+        }
+    }
+}
+
 pub(crate) fn atomic_write(path: &Path, data: &[u8]) -> Result<(), CliError> {
-    static TMP_SEQ: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+    static TMP_SEQ: std::sync::atomic::AtomicUsize = std::sync::atomic::AtomicUsize::new(0);
     let seq = TMP_SEQ.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
     let tmp = path.with_extension(format!("tmp.{}.{}", std::process::id(), seq));
-    std::fs::write(&tmp, data).map_err(|e| {
-        CliError::Auth(format!("Failed to write {}: {e}", tmp.display()))
-    })?;
+    let mut guard = TempFileGuard::new(tmp.clone());
+    std::fs::write(&tmp, data)
+        .map_err(|e| CliError::Auth(format!("Failed to write {}: {e}", tmp.display())))?;
     #[cfg(unix)]
     {
         use std::os::unix::fs::PermissionsExt;
         let perms = std::fs::Permissions::from_mode(0o600);
         let _ = std::fs::set_permissions(&tmp, perms);
     }
-    std::fs::rename(&tmp, path).map_err(|e| {
-        let _ = std::fs::remove_file(&tmp);
-        CliError::Auth(format!("Failed to rename {}: {e}", tmp.display()))
-    })
+    std::fs::rename(&tmp, path)
+        .map_err(|e| CliError::Auth(format!("Failed to rename {}: {e}", tmp.display())))?;
+    guard.disarm();
+    Ok(())
 }
 
 // ---------------------------------------------------------------------------
@@ -315,6 +348,56 @@ mod tests {
             .filter(|n| n.contains(".tmp"))
             .collect();
         assert!(leftovers.is_empty(), "temp files left behind: {leftovers:?}");
+    }
+
+    /// A failed write must not leave its temp file behind. Renaming a file onto
+    /// an existing directory fails on every platform, which drives the error
+    /// path without mocking the filesystem.
+    ///
+    /// The pre-`TempFileGuard` code already cleaned up on a `rename` error, so
+    /// this pins an invariant rather than catching a regression — see
+    /// `temp_file_guard_unlinks_unless_disarmed` for the guard's own coverage.
+    #[test]
+    fn atomic_write_cleans_up_temp_file_on_failure() {
+        let dir = tempfile::tempdir().unwrap();
+
+        // The target is a *directory*, so `rename` cannot replace it.
+        let target = dir.path().join("auth-keyring.json");
+        std::fs::create_dir(&target).unwrap();
+        std::fs::write(target.join("occupant"), b"x").unwrap();
+
+        let result = atomic_write(&target, br#"{"writer":0}"#);
+        assert!(result.is_err(), "expected rename onto a directory to fail");
+
+        let leftovers: Vec<String> = std::fs::read_dir(dir.path())
+            .unwrap()
+            .filter_map(|e| e.ok())
+            .map(|e| e.file_name().to_string_lossy().into_owned())
+            .filter(|n| n.contains(".tmp"))
+            .collect();
+        assert!(leftovers.is_empty(), "temp file leaked after a failed write: {leftovers:?}");
+    }
+
+    /// Pins [`TempFileGuard`]: armed drops unlink, disarmed drops don't. Drop
+    /// running on an armed guard is what covers early returns and unwinding
+    /// panics between `write` and `rename` — paths the old `rename`-only
+    /// cleanup missed. Deleting the guard or the `disarm()` call fails this.
+    #[test]
+    fn temp_file_guard_unlinks_unless_disarmed() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("auth-keyring.tmp.0.0");
+
+        std::fs::write(&path, b"x").unwrap();
+        drop(TempFileGuard::new(path.clone()));
+        assert!(!path.exists(), "armed guard must unlink on drop");
+
+        // The post-`rename` case: the file has been moved away, so the guard
+        // must not touch whatever now sits at that path.
+        std::fs::write(&path, b"x").unwrap();
+        let mut guard = TempFileGuard::new(path.clone());
+        guard.disarm();
+        drop(guard);
+        assert!(path.exists(), "disarmed guard must not unlink");
     }
 
     #[test]

--- a/seed/cli/multi-url-environment-reference/src/auth/oauth_common.rs
+++ b/seed/cli/multi-url-environment-reference/src/auth/oauth_common.rs
@@ -226,8 +226,29 @@ pub(crate) fn config_dir() -> Option<PathBuf> {
 
 /// Write `data` to `path` atomically: sibling temp file → owner-only
 /// permissions (0600 on Unix) → rename into place.
+///
+/// The temp file name is unique per writer — pid plus a process-local
+/// counter. Deriving it from the target alone meant every concurrent writer
+/// used the *same* sibling (`auth-keyring.tmp`): whichever one renamed first
+/// moved it away, and the rest failed with `ENOENT` from `rename`. That
+/// surfaced as intermittent `auth login --with-token` failures across a
+/// wire-test suite large enough to run many CLI processes at once, killing a
+/// different subset of cases on each run.
+///
+/// The pid covers the case that actually bit us (separate CLI processes); the
+/// counter covers two writers inside one process, and is what makes the
+/// behavior unit-testable without spawning subprocesses.
+///
+/// `rename` is still atomic for readers, which is what keeps a partially
+/// written credential file unobservable. This only fixes writer-vs-writer
+/// collisions on the temp path. `FileKeyringStore::set` remains a
+/// read-modify-write of the whole map with no lock, so simultaneous writers
+/// can still clobber one another's *entries*; making that safe needs file
+/// locking, which is a larger change.
 pub(crate) fn atomic_write(path: &Path, data: &[u8]) -> Result<(), CliError> {
-    let tmp = path.with_extension("tmp");
+    static TMP_SEQ: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+    let seq = TMP_SEQ.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+    let tmp = path.with_extension(format!("tmp.{}.{}", std::process::id(), seq));
     std::fs::write(&tmp, data).map_err(|e| {
         CliError::Auth(format!("Failed to write {}: {e}", tmp.display()))
     })?;
@@ -250,6 +271,51 @@ pub(crate) fn atomic_write(path: &Path, data: &[u8]) -> Result<(), CliError> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// Regression test for the temp-file collision that made
+    /// `auth login --with-token` fail intermittently: every writer derived the
+    /// same sibling path from the target, so the first `rename` moved it away
+    /// and the rest got `ENOENT`.
+    ///
+    /// Reverting `atomic_write` to a target-derived temp name fails this with
+    /// "Failed to rename ...: No such file or directory".
+    #[test]
+    fn atomic_write_tolerates_concurrent_writers() {
+        let dir = tempfile::tempdir().unwrap();
+        let target = dir.path().join("auth-keyring.json");
+
+        let results: Vec<Result<(), CliError>> = std::thread::scope(|scope| {
+            let handles: Vec<_> = (0..16)
+                .map(|i| {
+                    let target = target.clone();
+                    scope.spawn(move || atomic_write(&target, format!(r#"{{"writer":{i}}}"#).as_bytes()))
+                })
+                .collect();
+            handles.into_iter().map(|h| h.join().unwrap()).collect()
+        });
+
+        let failed: Vec<String> = results
+            .iter()
+            .filter_map(|r| r.as_ref().err().map(|e| e.to_string()))
+            .collect();
+        assert!(failed.is_empty(), "concurrent writers failed: {failed:?}");
+
+        // Last writer wins, but the file must always be one writer's complete
+        // payload — never a mix, and never absent.
+        let contents = std::fs::read_to_string(&target).unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(&contents)
+            .unwrap_or_else(|e| panic!("target is not valid JSON after concurrent writes: {e} in {contents:?}"));
+        assert!(parsed.get("writer").is_some(), "unexpected payload: {contents}");
+
+        // No temp files orphaned in the directory.
+        let leftovers: Vec<String> = std::fs::read_dir(dir.path())
+            .unwrap()
+            .filter_map(|e| e.ok())
+            .map(|e| e.file_name().to_string_lossy().into_owned())
+            .filter(|n| n.contains(".tmp"))
+            .collect();
+        assert!(leftovers.is_empty(), "temp files left behind: {leftovers:?}");
+    }
 
     #[test]
     fn token_bundle_roundtrip() {

--- a/seed/cli/no-content-response/src/auth/oauth_common.rs
+++ b/seed/cli/no-content-response/src/auth/oauth_common.rs
@@ -224,27 +224,6 @@ pub(crate) fn config_dir() -> Option<PathBuf> {
     }
 }
 
-/// Write `data` to `path` atomically: sibling temp file → owner-only
-/// permissions (0600 on Unix) → rename into place.
-///
-/// The temp file name is unique per writer — pid plus a process-local
-/// counter. Deriving it from the target alone meant every concurrent writer
-/// used the *same* sibling (`auth-keyring.tmp`): whichever one renamed first
-/// moved it away, and the rest failed with `ENOENT` from `rename`. That
-/// surfaced as intermittent `auth login --with-token` failures across a
-/// wire-test suite large enough to run many CLI processes at once, killing a
-/// different subset of cases on each run.
-///
-/// The pid covers the case that actually bit us (separate CLI processes); the
-/// counter covers two writers inside one process, and is what makes the
-/// behavior unit-testable without spawning subprocesses.
-///
-/// `rename` is still atomic for readers, which is what keeps a partially
-/// written credential file unobservable. This only fixes writer-vs-writer
-/// collisions on the temp path. `FileKeyringStore::set` remains a
-/// read-modify-write of the whole map with no lock, so simultaneous writers
-/// can still clobber one another's *entries*; making that safe needs file
-/// locking, which is a larger change.
 /// Unlinks a temp file on drop unless [`TempFileGuard::disarm`]ed. Covers
 /// every early return *and* a panic between creating the temp file and
 /// renaming it into place.
@@ -278,6 +257,30 @@ impl Drop for TempFileGuard {
     }
 }
 
+/// Write `data` to `path` atomically: sibling temp file → owner-only
+/// permissions (0600 on Unix) → rename into place.
+///
+/// The temp file name is unique per writer — pid plus a process-local
+/// counter. Deriving it from the target alone meant every concurrent writer
+/// used the *same* sibling (`auth-keyring.tmp`): whichever one renamed first
+/// moved it away, and the rest failed with `ENOENT` from `rename`. That
+/// surfaced as intermittent `auth login --with-token` failures across a
+/// wire-test suite large enough to run many CLI processes at once, killing a
+/// different subset of cases on each run.
+///
+/// The pid covers the case that actually bit us (separate CLI processes); the
+/// counter covers two writers inside one process, and is what makes the
+/// behavior unit-testable without spawning subprocesses.
+///
+/// A [`TempFileGuard`] unlinks the temp file if anything between creating it
+/// and renaming it fails, so unique names cannot accumulate as orphans.
+///
+/// `rename` is still atomic for readers, which is what keeps a partially
+/// written credential file unobservable. This only fixes writer-vs-writer
+/// collisions on the temp path. `FileKeyringStore::set` remains a
+/// read-modify-write of the whole map with no lock, so simultaneous writers
+/// can still clobber one another's *entries*; making that safe needs file
+/// locking, which is a larger change.
 pub(crate) fn atomic_write(path: &Path, data: &[u8]) -> Result<(), CliError> {
     static TMP_SEQ: std::sync::atomic::AtomicUsize = std::sync::atomic::AtomicUsize::new(0);
     let seq = TMP_SEQ.fetch_add(1, std::sync::atomic::Ordering::Relaxed);

--- a/seed/cli/no-content-response/src/auth/oauth_common.rs
+++ b/seed/cli/no-content-response/src/auth/oauth_common.rs
@@ -245,23 +245,56 @@ pub(crate) fn config_dir() -> Option<PathBuf> {
 /// read-modify-write of the whole map with no lock, so simultaneous writers
 /// can still clobber one another's *entries*; making that safe needs file
 /// locking, which is a larger change.
+/// Unlinks a temp file on drop unless [`TempFileGuard::disarm`]ed. Covers
+/// every early return *and* a panic between creating the temp file and
+/// renaming it into place.
+///
+/// This exists because the temp name is unique per writer. The old shared
+/// `auth-keyring.tmp` was self-limiting — a failed write left one stale file
+/// that the next write reused — whereas unique names would leak a distinct
+/// credential-bearing file on every failure, in a directory nothing prunes. A
+/// `SIGKILL` still leaks, since no in-process guard can cover that.
+struct TempFileGuard {
+    path: PathBuf,
+    armed: bool,
+}
+
+impl TempFileGuard {
+    fn new(path: PathBuf) -> Self {
+        Self { path, armed: true }
+    }
+
+    /// Relinquish the file — call once `rename` has moved it into place.
+    fn disarm(&mut self) {
+        self.armed = false;
+    }
+}
+
+impl Drop for TempFileGuard {
+    fn drop(&mut self) {
+        if self.armed {
+            let _ = std::fs::remove_file(&self.path);
+        }
+    }
+}
+
 pub(crate) fn atomic_write(path: &Path, data: &[u8]) -> Result<(), CliError> {
-    static TMP_SEQ: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+    static TMP_SEQ: std::sync::atomic::AtomicUsize = std::sync::atomic::AtomicUsize::new(0);
     let seq = TMP_SEQ.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
     let tmp = path.with_extension(format!("tmp.{}.{}", std::process::id(), seq));
-    std::fs::write(&tmp, data).map_err(|e| {
-        CliError::Auth(format!("Failed to write {}: {e}", tmp.display()))
-    })?;
+    let mut guard = TempFileGuard::new(tmp.clone());
+    std::fs::write(&tmp, data)
+        .map_err(|e| CliError::Auth(format!("Failed to write {}: {e}", tmp.display())))?;
     #[cfg(unix)]
     {
         use std::os::unix::fs::PermissionsExt;
         let perms = std::fs::Permissions::from_mode(0o600);
         let _ = std::fs::set_permissions(&tmp, perms);
     }
-    std::fs::rename(&tmp, path).map_err(|e| {
-        let _ = std::fs::remove_file(&tmp);
-        CliError::Auth(format!("Failed to rename {}: {e}", tmp.display()))
-    })
+    std::fs::rename(&tmp, path)
+        .map_err(|e| CliError::Auth(format!("Failed to rename {}: {e}", tmp.display())))?;
+    guard.disarm();
+    Ok(())
 }
 
 // ---------------------------------------------------------------------------
@@ -315,6 +348,56 @@ mod tests {
             .filter(|n| n.contains(".tmp"))
             .collect();
         assert!(leftovers.is_empty(), "temp files left behind: {leftovers:?}");
+    }
+
+    /// A failed write must not leave its temp file behind. Renaming a file onto
+    /// an existing directory fails on every platform, which drives the error
+    /// path without mocking the filesystem.
+    ///
+    /// The pre-`TempFileGuard` code already cleaned up on a `rename` error, so
+    /// this pins an invariant rather than catching a regression — see
+    /// `temp_file_guard_unlinks_unless_disarmed` for the guard's own coverage.
+    #[test]
+    fn atomic_write_cleans_up_temp_file_on_failure() {
+        let dir = tempfile::tempdir().unwrap();
+
+        // The target is a *directory*, so `rename` cannot replace it.
+        let target = dir.path().join("auth-keyring.json");
+        std::fs::create_dir(&target).unwrap();
+        std::fs::write(target.join("occupant"), b"x").unwrap();
+
+        let result = atomic_write(&target, br#"{"writer":0}"#);
+        assert!(result.is_err(), "expected rename onto a directory to fail");
+
+        let leftovers: Vec<String> = std::fs::read_dir(dir.path())
+            .unwrap()
+            .filter_map(|e| e.ok())
+            .map(|e| e.file_name().to_string_lossy().into_owned())
+            .filter(|n| n.contains(".tmp"))
+            .collect();
+        assert!(leftovers.is_empty(), "temp file leaked after a failed write: {leftovers:?}");
+    }
+
+    /// Pins [`TempFileGuard`]: armed drops unlink, disarmed drops don't. Drop
+    /// running on an armed guard is what covers early returns and unwinding
+    /// panics between `write` and `rename` — paths the old `rename`-only
+    /// cleanup missed. Deleting the guard or the `disarm()` call fails this.
+    #[test]
+    fn temp_file_guard_unlinks_unless_disarmed() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("auth-keyring.tmp.0.0");
+
+        std::fs::write(&path, b"x").unwrap();
+        drop(TempFileGuard::new(path.clone()));
+        assert!(!path.exists(), "armed guard must unlink on drop");
+
+        // The post-`rename` case: the file has been moved away, so the guard
+        // must not touch whatever now sits at that path.
+        std::fs::write(&path, b"x").unwrap();
+        let mut guard = TempFileGuard::new(path.clone());
+        guard.disarm();
+        drop(guard);
+        assert!(path.exists(), "disarmed guard must not unlink");
     }
 
     #[test]

--- a/seed/cli/no-content-response/src/auth/oauth_common.rs
+++ b/seed/cli/no-content-response/src/auth/oauth_common.rs
@@ -226,8 +226,29 @@ pub(crate) fn config_dir() -> Option<PathBuf> {
 
 /// Write `data` to `path` atomically: sibling temp file → owner-only
 /// permissions (0600 on Unix) → rename into place.
+///
+/// The temp file name is unique per writer — pid plus a process-local
+/// counter. Deriving it from the target alone meant every concurrent writer
+/// used the *same* sibling (`auth-keyring.tmp`): whichever one renamed first
+/// moved it away, and the rest failed with `ENOENT` from `rename`. That
+/// surfaced as intermittent `auth login --with-token` failures across a
+/// wire-test suite large enough to run many CLI processes at once, killing a
+/// different subset of cases on each run.
+///
+/// The pid covers the case that actually bit us (separate CLI processes); the
+/// counter covers two writers inside one process, and is what makes the
+/// behavior unit-testable without spawning subprocesses.
+///
+/// `rename` is still atomic for readers, which is what keeps a partially
+/// written credential file unobservable. This only fixes writer-vs-writer
+/// collisions on the temp path. `FileKeyringStore::set` remains a
+/// read-modify-write of the whole map with no lock, so simultaneous writers
+/// can still clobber one another's *entries*; making that safe needs file
+/// locking, which is a larger change.
 pub(crate) fn atomic_write(path: &Path, data: &[u8]) -> Result<(), CliError> {
-    let tmp = path.with_extension("tmp");
+    static TMP_SEQ: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+    let seq = TMP_SEQ.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+    let tmp = path.with_extension(format!("tmp.{}.{}", std::process::id(), seq));
     std::fs::write(&tmp, data).map_err(|e| {
         CliError::Auth(format!("Failed to write {}: {e}", tmp.display()))
     })?;
@@ -250,6 +271,51 @@ pub(crate) fn atomic_write(path: &Path, data: &[u8]) -> Result<(), CliError> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// Regression test for the temp-file collision that made
+    /// `auth login --with-token` fail intermittently: every writer derived the
+    /// same sibling path from the target, so the first `rename` moved it away
+    /// and the rest got `ENOENT`.
+    ///
+    /// Reverting `atomic_write` to a target-derived temp name fails this with
+    /// "Failed to rename ...: No such file or directory".
+    #[test]
+    fn atomic_write_tolerates_concurrent_writers() {
+        let dir = tempfile::tempdir().unwrap();
+        let target = dir.path().join("auth-keyring.json");
+
+        let results: Vec<Result<(), CliError>> = std::thread::scope(|scope| {
+            let handles: Vec<_> = (0..16)
+                .map(|i| {
+                    let target = target.clone();
+                    scope.spawn(move || atomic_write(&target, format!(r#"{{"writer":{i}}}"#).as_bytes()))
+                })
+                .collect();
+            handles.into_iter().map(|h| h.join().unwrap()).collect()
+        });
+
+        let failed: Vec<String> = results
+            .iter()
+            .filter_map(|r| r.as_ref().err().map(|e| e.to_string()))
+            .collect();
+        assert!(failed.is_empty(), "concurrent writers failed: {failed:?}");
+
+        // Last writer wins, but the file must always be one writer's complete
+        // payload — never a mix, and never absent.
+        let contents = std::fs::read_to_string(&target).unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(&contents)
+            .unwrap_or_else(|e| panic!("target is not valid JSON after concurrent writes: {e} in {contents:?}"));
+        assert!(parsed.get("writer").is_some(), "unexpected payload: {contents}");
+
+        // No temp files orphaned in the directory.
+        let leftovers: Vec<String> = std::fs::read_dir(dir.path())
+            .unwrap()
+            .filter_map(|e| e.ok())
+            .map(|e| e.file_name().to_string_lossy().into_owned())
+            .filter(|n| n.contains(".tmp"))
+            .collect();
+        assert!(leftovers.is_empty(), "temp files left behind: {leftovers:?}");
+    }
 
     #[test]
     fn token_bundle_roundtrip() {

--- a/seed/cli/null-type/src/auth/oauth_common.rs
+++ b/seed/cli/null-type/src/auth/oauth_common.rs
@@ -224,27 +224,6 @@ pub(crate) fn config_dir() -> Option<PathBuf> {
     }
 }
 
-/// Write `data` to `path` atomically: sibling temp file → owner-only
-/// permissions (0600 on Unix) → rename into place.
-///
-/// The temp file name is unique per writer — pid plus a process-local
-/// counter. Deriving it from the target alone meant every concurrent writer
-/// used the *same* sibling (`auth-keyring.tmp`): whichever one renamed first
-/// moved it away, and the rest failed with `ENOENT` from `rename`. That
-/// surfaced as intermittent `auth login --with-token` failures across a
-/// wire-test suite large enough to run many CLI processes at once, killing a
-/// different subset of cases on each run.
-///
-/// The pid covers the case that actually bit us (separate CLI processes); the
-/// counter covers two writers inside one process, and is what makes the
-/// behavior unit-testable without spawning subprocesses.
-///
-/// `rename` is still atomic for readers, which is what keeps a partially
-/// written credential file unobservable. This only fixes writer-vs-writer
-/// collisions on the temp path. `FileKeyringStore::set` remains a
-/// read-modify-write of the whole map with no lock, so simultaneous writers
-/// can still clobber one another's *entries*; making that safe needs file
-/// locking, which is a larger change.
 /// Unlinks a temp file on drop unless [`TempFileGuard::disarm`]ed. Covers
 /// every early return *and* a panic between creating the temp file and
 /// renaming it into place.
@@ -278,6 +257,30 @@ impl Drop for TempFileGuard {
     }
 }
 
+/// Write `data` to `path` atomically: sibling temp file → owner-only
+/// permissions (0600 on Unix) → rename into place.
+///
+/// The temp file name is unique per writer — pid plus a process-local
+/// counter. Deriving it from the target alone meant every concurrent writer
+/// used the *same* sibling (`auth-keyring.tmp`): whichever one renamed first
+/// moved it away, and the rest failed with `ENOENT` from `rename`. That
+/// surfaced as intermittent `auth login --with-token` failures across a
+/// wire-test suite large enough to run many CLI processes at once, killing a
+/// different subset of cases on each run.
+///
+/// The pid covers the case that actually bit us (separate CLI processes); the
+/// counter covers two writers inside one process, and is what makes the
+/// behavior unit-testable without spawning subprocesses.
+///
+/// A [`TempFileGuard`] unlinks the temp file if anything between creating it
+/// and renaming it fails, so unique names cannot accumulate as orphans.
+///
+/// `rename` is still atomic for readers, which is what keeps a partially
+/// written credential file unobservable. This only fixes writer-vs-writer
+/// collisions on the temp path. `FileKeyringStore::set` remains a
+/// read-modify-write of the whole map with no lock, so simultaneous writers
+/// can still clobber one another's *entries*; making that safe needs file
+/// locking, which is a larger change.
 pub(crate) fn atomic_write(path: &Path, data: &[u8]) -> Result<(), CliError> {
     static TMP_SEQ: std::sync::atomic::AtomicUsize = std::sync::atomic::AtomicUsize::new(0);
     let seq = TMP_SEQ.fetch_add(1, std::sync::atomic::Ordering::Relaxed);

--- a/seed/cli/null-type/src/auth/oauth_common.rs
+++ b/seed/cli/null-type/src/auth/oauth_common.rs
@@ -245,23 +245,56 @@ pub(crate) fn config_dir() -> Option<PathBuf> {
 /// read-modify-write of the whole map with no lock, so simultaneous writers
 /// can still clobber one another's *entries*; making that safe needs file
 /// locking, which is a larger change.
+/// Unlinks a temp file on drop unless [`TempFileGuard::disarm`]ed. Covers
+/// every early return *and* a panic between creating the temp file and
+/// renaming it into place.
+///
+/// This exists because the temp name is unique per writer. The old shared
+/// `auth-keyring.tmp` was self-limiting — a failed write left one stale file
+/// that the next write reused — whereas unique names would leak a distinct
+/// credential-bearing file on every failure, in a directory nothing prunes. A
+/// `SIGKILL` still leaks, since no in-process guard can cover that.
+struct TempFileGuard {
+    path: PathBuf,
+    armed: bool,
+}
+
+impl TempFileGuard {
+    fn new(path: PathBuf) -> Self {
+        Self { path, armed: true }
+    }
+
+    /// Relinquish the file — call once `rename` has moved it into place.
+    fn disarm(&mut self) {
+        self.armed = false;
+    }
+}
+
+impl Drop for TempFileGuard {
+    fn drop(&mut self) {
+        if self.armed {
+            let _ = std::fs::remove_file(&self.path);
+        }
+    }
+}
+
 pub(crate) fn atomic_write(path: &Path, data: &[u8]) -> Result<(), CliError> {
-    static TMP_SEQ: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+    static TMP_SEQ: std::sync::atomic::AtomicUsize = std::sync::atomic::AtomicUsize::new(0);
     let seq = TMP_SEQ.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
     let tmp = path.with_extension(format!("tmp.{}.{}", std::process::id(), seq));
-    std::fs::write(&tmp, data).map_err(|e| {
-        CliError::Auth(format!("Failed to write {}: {e}", tmp.display()))
-    })?;
+    let mut guard = TempFileGuard::new(tmp.clone());
+    std::fs::write(&tmp, data)
+        .map_err(|e| CliError::Auth(format!("Failed to write {}: {e}", tmp.display())))?;
     #[cfg(unix)]
     {
         use std::os::unix::fs::PermissionsExt;
         let perms = std::fs::Permissions::from_mode(0o600);
         let _ = std::fs::set_permissions(&tmp, perms);
     }
-    std::fs::rename(&tmp, path).map_err(|e| {
-        let _ = std::fs::remove_file(&tmp);
-        CliError::Auth(format!("Failed to rename {}: {e}", tmp.display()))
-    })
+    std::fs::rename(&tmp, path)
+        .map_err(|e| CliError::Auth(format!("Failed to rename {}: {e}", tmp.display())))?;
+    guard.disarm();
+    Ok(())
 }
 
 // ---------------------------------------------------------------------------
@@ -315,6 +348,56 @@ mod tests {
             .filter(|n| n.contains(".tmp"))
             .collect();
         assert!(leftovers.is_empty(), "temp files left behind: {leftovers:?}");
+    }
+
+    /// A failed write must not leave its temp file behind. Renaming a file onto
+    /// an existing directory fails on every platform, which drives the error
+    /// path without mocking the filesystem.
+    ///
+    /// The pre-`TempFileGuard` code already cleaned up on a `rename` error, so
+    /// this pins an invariant rather than catching a regression — see
+    /// `temp_file_guard_unlinks_unless_disarmed` for the guard's own coverage.
+    #[test]
+    fn atomic_write_cleans_up_temp_file_on_failure() {
+        let dir = tempfile::tempdir().unwrap();
+
+        // The target is a *directory*, so `rename` cannot replace it.
+        let target = dir.path().join("auth-keyring.json");
+        std::fs::create_dir(&target).unwrap();
+        std::fs::write(target.join("occupant"), b"x").unwrap();
+
+        let result = atomic_write(&target, br#"{"writer":0}"#);
+        assert!(result.is_err(), "expected rename onto a directory to fail");
+
+        let leftovers: Vec<String> = std::fs::read_dir(dir.path())
+            .unwrap()
+            .filter_map(|e| e.ok())
+            .map(|e| e.file_name().to_string_lossy().into_owned())
+            .filter(|n| n.contains(".tmp"))
+            .collect();
+        assert!(leftovers.is_empty(), "temp file leaked after a failed write: {leftovers:?}");
+    }
+
+    /// Pins [`TempFileGuard`]: armed drops unlink, disarmed drops don't. Drop
+    /// running on an armed guard is what covers early returns and unwinding
+    /// panics between `write` and `rename` — paths the old `rename`-only
+    /// cleanup missed. Deleting the guard or the `disarm()` call fails this.
+    #[test]
+    fn temp_file_guard_unlinks_unless_disarmed() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("auth-keyring.tmp.0.0");
+
+        std::fs::write(&path, b"x").unwrap();
+        drop(TempFileGuard::new(path.clone()));
+        assert!(!path.exists(), "armed guard must unlink on drop");
+
+        // The post-`rename` case: the file has been moved away, so the guard
+        // must not touch whatever now sits at that path.
+        std::fs::write(&path, b"x").unwrap();
+        let mut guard = TempFileGuard::new(path.clone());
+        guard.disarm();
+        drop(guard);
+        assert!(path.exists(), "disarmed guard must not unlink");
     }
 
     #[test]

--- a/seed/cli/null-type/src/auth/oauth_common.rs
+++ b/seed/cli/null-type/src/auth/oauth_common.rs
@@ -226,8 +226,29 @@ pub(crate) fn config_dir() -> Option<PathBuf> {
 
 /// Write `data` to `path` atomically: sibling temp file → owner-only
 /// permissions (0600 on Unix) → rename into place.
+///
+/// The temp file name is unique per writer — pid plus a process-local
+/// counter. Deriving it from the target alone meant every concurrent writer
+/// used the *same* sibling (`auth-keyring.tmp`): whichever one renamed first
+/// moved it away, and the rest failed with `ENOENT` from `rename`. That
+/// surfaced as intermittent `auth login --with-token` failures across a
+/// wire-test suite large enough to run many CLI processes at once, killing a
+/// different subset of cases on each run.
+///
+/// The pid covers the case that actually bit us (separate CLI processes); the
+/// counter covers two writers inside one process, and is what makes the
+/// behavior unit-testable without spawning subprocesses.
+///
+/// `rename` is still atomic for readers, which is what keeps a partially
+/// written credential file unobservable. This only fixes writer-vs-writer
+/// collisions on the temp path. `FileKeyringStore::set` remains a
+/// read-modify-write of the whole map with no lock, so simultaneous writers
+/// can still clobber one another's *entries*; making that safe needs file
+/// locking, which is a larger change.
 pub(crate) fn atomic_write(path: &Path, data: &[u8]) -> Result<(), CliError> {
-    let tmp = path.with_extension("tmp");
+    static TMP_SEQ: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+    let seq = TMP_SEQ.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+    let tmp = path.with_extension(format!("tmp.{}.{}", std::process::id(), seq));
     std::fs::write(&tmp, data).map_err(|e| {
         CliError::Auth(format!("Failed to write {}: {e}", tmp.display()))
     })?;
@@ -250,6 +271,51 @@ pub(crate) fn atomic_write(path: &Path, data: &[u8]) -> Result<(), CliError> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// Regression test for the temp-file collision that made
+    /// `auth login --with-token` fail intermittently: every writer derived the
+    /// same sibling path from the target, so the first `rename` moved it away
+    /// and the rest got `ENOENT`.
+    ///
+    /// Reverting `atomic_write` to a target-derived temp name fails this with
+    /// "Failed to rename ...: No such file or directory".
+    #[test]
+    fn atomic_write_tolerates_concurrent_writers() {
+        let dir = tempfile::tempdir().unwrap();
+        let target = dir.path().join("auth-keyring.json");
+
+        let results: Vec<Result<(), CliError>> = std::thread::scope(|scope| {
+            let handles: Vec<_> = (0..16)
+                .map(|i| {
+                    let target = target.clone();
+                    scope.spawn(move || atomic_write(&target, format!(r#"{{"writer":{i}}}"#).as_bytes()))
+                })
+                .collect();
+            handles.into_iter().map(|h| h.join().unwrap()).collect()
+        });
+
+        let failed: Vec<String> = results
+            .iter()
+            .filter_map(|r| r.as_ref().err().map(|e| e.to_string()))
+            .collect();
+        assert!(failed.is_empty(), "concurrent writers failed: {failed:?}");
+
+        // Last writer wins, but the file must always be one writer's complete
+        // payload — never a mix, and never absent.
+        let contents = std::fs::read_to_string(&target).unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(&contents)
+            .unwrap_or_else(|e| panic!("target is not valid JSON after concurrent writes: {e} in {contents:?}"));
+        assert!(parsed.get("writer").is_some(), "unexpected payload: {contents}");
+
+        // No temp files orphaned in the directory.
+        let leftovers: Vec<String> = std::fs::read_dir(dir.path())
+            .unwrap()
+            .filter_map(|e| e.ok())
+            .map(|e| e.file_name().to_string_lossy().into_owned())
+            .filter(|n| n.contains(".tmp"))
+            .collect();
+        assert!(leftovers.is_empty(), "temp files left behind: {leftovers:?}");
+    }
 
     #[test]
     fn token_bundle_roundtrip() {

--- a/seed/cli/nullable-allof-extends/src/auth/oauth_common.rs
+++ b/seed/cli/nullable-allof-extends/src/auth/oauth_common.rs
@@ -224,27 +224,6 @@ pub(crate) fn config_dir() -> Option<PathBuf> {
     }
 }
 
-/// Write `data` to `path` atomically: sibling temp file → owner-only
-/// permissions (0600 on Unix) → rename into place.
-///
-/// The temp file name is unique per writer — pid plus a process-local
-/// counter. Deriving it from the target alone meant every concurrent writer
-/// used the *same* sibling (`auth-keyring.tmp`): whichever one renamed first
-/// moved it away, and the rest failed with `ENOENT` from `rename`. That
-/// surfaced as intermittent `auth login --with-token` failures across a
-/// wire-test suite large enough to run many CLI processes at once, killing a
-/// different subset of cases on each run.
-///
-/// The pid covers the case that actually bit us (separate CLI processes); the
-/// counter covers two writers inside one process, and is what makes the
-/// behavior unit-testable without spawning subprocesses.
-///
-/// `rename` is still atomic for readers, which is what keeps a partially
-/// written credential file unobservable. This only fixes writer-vs-writer
-/// collisions on the temp path. `FileKeyringStore::set` remains a
-/// read-modify-write of the whole map with no lock, so simultaneous writers
-/// can still clobber one another's *entries*; making that safe needs file
-/// locking, which is a larger change.
 /// Unlinks a temp file on drop unless [`TempFileGuard::disarm`]ed. Covers
 /// every early return *and* a panic between creating the temp file and
 /// renaming it into place.
@@ -278,6 +257,30 @@ impl Drop for TempFileGuard {
     }
 }
 
+/// Write `data` to `path` atomically: sibling temp file → owner-only
+/// permissions (0600 on Unix) → rename into place.
+///
+/// The temp file name is unique per writer — pid plus a process-local
+/// counter. Deriving it from the target alone meant every concurrent writer
+/// used the *same* sibling (`auth-keyring.tmp`): whichever one renamed first
+/// moved it away, and the rest failed with `ENOENT` from `rename`. That
+/// surfaced as intermittent `auth login --with-token` failures across a
+/// wire-test suite large enough to run many CLI processes at once, killing a
+/// different subset of cases on each run.
+///
+/// The pid covers the case that actually bit us (separate CLI processes); the
+/// counter covers two writers inside one process, and is what makes the
+/// behavior unit-testable without spawning subprocesses.
+///
+/// A [`TempFileGuard`] unlinks the temp file if anything between creating it
+/// and renaming it fails, so unique names cannot accumulate as orphans.
+///
+/// `rename` is still atomic for readers, which is what keeps a partially
+/// written credential file unobservable. This only fixes writer-vs-writer
+/// collisions on the temp path. `FileKeyringStore::set` remains a
+/// read-modify-write of the whole map with no lock, so simultaneous writers
+/// can still clobber one another's *entries*; making that safe needs file
+/// locking, which is a larger change.
 pub(crate) fn atomic_write(path: &Path, data: &[u8]) -> Result<(), CliError> {
     static TMP_SEQ: std::sync::atomic::AtomicUsize = std::sync::atomic::AtomicUsize::new(0);
     let seq = TMP_SEQ.fetch_add(1, std::sync::atomic::Ordering::Relaxed);

--- a/seed/cli/nullable-allof-extends/src/auth/oauth_common.rs
+++ b/seed/cli/nullable-allof-extends/src/auth/oauth_common.rs
@@ -245,23 +245,56 @@ pub(crate) fn config_dir() -> Option<PathBuf> {
 /// read-modify-write of the whole map with no lock, so simultaneous writers
 /// can still clobber one another's *entries*; making that safe needs file
 /// locking, which is a larger change.
+/// Unlinks a temp file on drop unless [`TempFileGuard::disarm`]ed. Covers
+/// every early return *and* a panic between creating the temp file and
+/// renaming it into place.
+///
+/// This exists because the temp name is unique per writer. The old shared
+/// `auth-keyring.tmp` was self-limiting — a failed write left one stale file
+/// that the next write reused — whereas unique names would leak a distinct
+/// credential-bearing file on every failure, in a directory nothing prunes. A
+/// `SIGKILL` still leaks, since no in-process guard can cover that.
+struct TempFileGuard {
+    path: PathBuf,
+    armed: bool,
+}
+
+impl TempFileGuard {
+    fn new(path: PathBuf) -> Self {
+        Self { path, armed: true }
+    }
+
+    /// Relinquish the file — call once `rename` has moved it into place.
+    fn disarm(&mut self) {
+        self.armed = false;
+    }
+}
+
+impl Drop for TempFileGuard {
+    fn drop(&mut self) {
+        if self.armed {
+            let _ = std::fs::remove_file(&self.path);
+        }
+    }
+}
+
 pub(crate) fn atomic_write(path: &Path, data: &[u8]) -> Result<(), CliError> {
-    static TMP_SEQ: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+    static TMP_SEQ: std::sync::atomic::AtomicUsize = std::sync::atomic::AtomicUsize::new(0);
     let seq = TMP_SEQ.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
     let tmp = path.with_extension(format!("tmp.{}.{}", std::process::id(), seq));
-    std::fs::write(&tmp, data).map_err(|e| {
-        CliError::Auth(format!("Failed to write {}: {e}", tmp.display()))
-    })?;
+    let mut guard = TempFileGuard::new(tmp.clone());
+    std::fs::write(&tmp, data)
+        .map_err(|e| CliError::Auth(format!("Failed to write {}: {e}", tmp.display())))?;
     #[cfg(unix)]
     {
         use std::os::unix::fs::PermissionsExt;
         let perms = std::fs::Permissions::from_mode(0o600);
         let _ = std::fs::set_permissions(&tmp, perms);
     }
-    std::fs::rename(&tmp, path).map_err(|e| {
-        let _ = std::fs::remove_file(&tmp);
-        CliError::Auth(format!("Failed to rename {}: {e}", tmp.display()))
-    })
+    std::fs::rename(&tmp, path)
+        .map_err(|e| CliError::Auth(format!("Failed to rename {}: {e}", tmp.display())))?;
+    guard.disarm();
+    Ok(())
 }
 
 // ---------------------------------------------------------------------------
@@ -315,6 +348,56 @@ mod tests {
             .filter(|n| n.contains(".tmp"))
             .collect();
         assert!(leftovers.is_empty(), "temp files left behind: {leftovers:?}");
+    }
+
+    /// A failed write must not leave its temp file behind. Renaming a file onto
+    /// an existing directory fails on every platform, which drives the error
+    /// path without mocking the filesystem.
+    ///
+    /// The pre-`TempFileGuard` code already cleaned up on a `rename` error, so
+    /// this pins an invariant rather than catching a regression — see
+    /// `temp_file_guard_unlinks_unless_disarmed` for the guard's own coverage.
+    #[test]
+    fn atomic_write_cleans_up_temp_file_on_failure() {
+        let dir = tempfile::tempdir().unwrap();
+
+        // The target is a *directory*, so `rename` cannot replace it.
+        let target = dir.path().join("auth-keyring.json");
+        std::fs::create_dir(&target).unwrap();
+        std::fs::write(target.join("occupant"), b"x").unwrap();
+
+        let result = atomic_write(&target, br#"{"writer":0}"#);
+        assert!(result.is_err(), "expected rename onto a directory to fail");
+
+        let leftovers: Vec<String> = std::fs::read_dir(dir.path())
+            .unwrap()
+            .filter_map(|e| e.ok())
+            .map(|e| e.file_name().to_string_lossy().into_owned())
+            .filter(|n| n.contains(".tmp"))
+            .collect();
+        assert!(leftovers.is_empty(), "temp file leaked after a failed write: {leftovers:?}");
+    }
+
+    /// Pins [`TempFileGuard`]: armed drops unlink, disarmed drops don't. Drop
+    /// running on an armed guard is what covers early returns and unwinding
+    /// panics between `write` and `rename` — paths the old `rename`-only
+    /// cleanup missed. Deleting the guard or the `disarm()` call fails this.
+    #[test]
+    fn temp_file_guard_unlinks_unless_disarmed() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("auth-keyring.tmp.0.0");
+
+        std::fs::write(&path, b"x").unwrap();
+        drop(TempFileGuard::new(path.clone()));
+        assert!(!path.exists(), "armed guard must unlink on drop");
+
+        // The post-`rename` case: the file has been moved away, so the guard
+        // must not touch whatever now sits at that path.
+        std::fs::write(&path, b"x").unwrap();
+        let mut guard = TempFileGuard::new(path.clone());
+        guard.disarm();
+        drop(guard);
+        assert!(path.exists(), "disarmed guard must not unlink");
     }
 
     #[test]

--- a/seed/cli/nullable-allof-extends/src/auth/oauth_common.rs
+++ b/seed/cli/nullable-allof-extends/src/auth/oauth_common.rs
@@ -226,8 +226,29 @@ pub(crate) fn config_dir() -> Option<PathBuf> {
 
 /// Write `data` to `path` atomically: sibling temp file → owner-only
 /// permissions (0600 on Unix) → rename into place.
+///
+/// The temp file name is unique per writer — pid plus a process-local
+/// counter. Deriving it from the target alone meant every concurrent writer
+/// used the *same* sibling (`auth-keyring.tmp`): whichever one renamed first
+/// moved it away, and the rest failed with `ENOENT` from `rename`. That
+/// surfaced as intermittent `auth login --with-token` failures across a
+/// wire-test suite large enough to run many CLI processes at once, killing a
+/// different subset of cases on each run.
+///
+/// The pid covers the case that actually bit us (separate CLI processes); the
+/// counter covers two writers inside one process, and is what makes the
+/// behavior unit-testable without spawning subprocesses.
+///
+/// `rename` is still atomic for readers, which is what keeps a partially
+/// written credential file unobservable. This only fixes writer-vs-writer
+/// collisions on the temp path. `FileKeyringStore::set` remains a
+/// read-modify-write of the whole map with no lock, so simultaneous writers
+/// can still clobber one another's *entries*; making that safe needs file
+/// locking, which is a larger change.
 pub(crate) fn atomic_write(path: &Path, data: &[u8]) -> Result<(), CliError> {
-    let tmp = path.with_extension("tmp");
+    static TMP_SEQ: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+    let seq = TMP_SEQ.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+    let tmp = path.with_extension(format!("tmp.{}.{}", std::process::id(), seq));
     std::fs::write(&tmp, data).map_err(|e| {
         CliError::Auth(format!("Failed to write {}: {e}", tmp.display()))
     })?;
@@ -250,6 +271,51 @@ pub(crate) fn atomic_write(path: &Path, data: &[u8]) -> Result<(), CliError> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// Regression test for the temp-file collision that made
+    /// `auth login --with-token` fail intermittently: every writer derived the
+    /// same sibling path from the target, so the first `rename` moved it away
+    /// and the rest got `ENOENT`.
+    ///
+    /// Reverting `atomic_write` to a target-derived temp name fails this with
+    /// "Failed to rename ...: No such file or directory".
+    #[test]
+    fn atomic_write_tolerates_concurrent_writers() {
+        let dir = tempfile::tempdir().unwrap();
+        let target = dir.path().join("auth-keyring.json");
+
+        let results: Vec<Result<(), CliError>> = std::thread::scope(|scope| {
+            let handles: Vec<_> = (0..16)
+                .map(|i| {
+                    let target = target.clone();
+                    scope.spawn(move || atomic_write(&target, format!(r#"{{"writer":{i}}}"#).as_bytes()))
+                })
+                .collect();
+            handles.into_iter().map(|h| h.join().unwrap()).collect()
+        });
+
+        let failed: Vec<String> = results
+            .iter()
+            .filter_map(|r| r.as_ref().err().map(|e| e.to_string()))
+            .collect();
+        assert!(failed.is_empty(), "concurrent writers failed: {failed:?}");
+
+        // Last writer wins, but the file must always be one writer's complete
+        // payload — never a mix, and never absent.
+        let contents = std::fs::read_to_string(&target).unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(&contents)
+            .unwrap_or_else(|e| panic!("target is not valid JSON after concurrent writes: {e} in {contents:?}"));
+        assert!(parsed.get("writer").is_some(), "unexpected payload: {contents}");
+
+        // No temp files orphaned in the directory.
+        let leftovers: Vec<String> = std::fs::read_dir(dir.path())
+            .unwrap()
+            .filter_map(|e| e.ok())
+            .map(|e| e.file_name().to_string_lossy().into_owned())
+            .filter(|n| n.contains(".tmp"))
+            .collect();
+        assert!(leftovers.is_empty(), "temp files left behind: {leftovers:?}");
+    }
 
     #[test]
     fn token_bundle_roundtrip() {

--- a/seed/cli/nullable-request-body/src/auth/oauth_common.rs
+++ b/seed/cli/nullable-request-body/src/auth/oauth_common.rs
@@ -224,27 +224,6 @@ pub(crate) fn config_dir() -> Option<PathBuf> {
     }
 }
 
-/// Write `data` to `path` atomically: sibling temp file → owner-only
-/// permissions (0600 on Unix) → rename into place.
-///
-/// The temp file name is unique per writer — pid plus a process-local
-/// counter. Deriving it from the target alone meant every concurrent writer
-/// used the *same* sibling (`auth-keyring.tmp`): whichever one renamed first
-/// moved it away, and the rest failed with `ENOENT` from `rename`. That
-/// surfaced as intermittent `auth login --with-token` failures across a
-/// wire-test suite large enough to run many CLI processes at once, killing a
-/// different subset of cases on each run.
-///
-/// The pid covers the case that actually bit us (separate CLI processes); the
-/// counter covers two writers inside one process, and is what makes the
-/// behavior unit-testable without spawning subprocesses.
-///
-/// `rename` is still atomic for readers, which is what keeps a partially
-/// written credential file unobservable. This only fixes writer-vs-writer
-/// collisions on the temp path. `FileKeyringStore::set` remains a
-/// read-modify-write of the whole map with no lock, so simultaneous writers
-/// can still clobber one another's *entries*; making that safe needs file
-/// locking, which is a larger change.
 /// Unlinks a temp file on drop unless [`TempFileGuard::disarm`]ed. Covers
 /// every early return *and* a panic between creating the temp file and
 /// renaming it into place.
@@ -278,6 +257,30 @@ impl Drop for TempFileGuard {
     }
 }
 
+/// Write `data` to `path` atomically: sibling temp file → owner-only
+/// permissions (0600 on Unix) → rename into place.
+///
+/// The temp file name is unique per writer — pid plus a process-local
+/// counter. Deriving it from the target alone meant every concurrent writer
+/// used the *same* sibling (`auth-keyring.tmp`): whichever one renamed first
+/// moved it away, and the rest failed with `ENOENT` from `rename`. That
+/// surfaced as intermittent `auth login --with-token` failures across a
+/// wire-test suite large enough to run many CLI processes at once, killing a
+/// different subset of cases on each run.
+///
+/// The pid covers the case that actually bit us (separate CLI processes); the
+/// counter covers two writers inside one process, and is what makes the
+/// behavior unit-testable without spawning subprocesses.
+///
+/// A [`TempFileGuard`] unlinks the temp file if anything between creating it
+/// and renaming it fails, so unique names cannot accumulate as orphans.
+///
+/// `rename` is still atomic for readers, which is what keeps a partially
+/// written credential file unobservable. This only fixes writer-vs-writer
+/// collisions on the temp path. `FileKeyringStore::set` remains a
+/// read-modify-write of the whole map with no lock, so simultaneous writers
+/// can still clobber one another's *entries*; making that safe needs file
+/// locking, which is a larger change.
 pub(crate) fn atomic_write(path: &Path, data: &[u8]) -> Result<(), CliError> {
     static TMP_SEQ: std::sync::atomic::AtomicUsize = std::sync::atomic::AtomicUsize::new(0);
     let seq = TMP_SEQ.fetch_add(1, std::sync::atomic::Ordering::Relaxed);

--- a/seed/cli/nullable-request-body/src/auth/oauth_common.rs
+++ b/seed/cli/nullable-request-body/src/auth/oauth_common.rs
@@ -245,23 +245,56 @@ pub(crate) fn config_dir() -> Option<PathBuf> {
 /// read-modify-write of the whole map with no lock, so simultaneous writers
 /// can still clobber one another's *entries*; making that safe needs file
 /// locking, which is a larger change.
+/// Unlinks a temp file on drop unless [`TempFileGuard::disarm`]ed. Covers
+/// every early return *and* a panic between creating the temp file and
+/// renaming it into place.
+///
+/// This exists because the temp name is unique per writer. The old shared
+/// `auth-keyring.tmp` was self-limiting — a failed write left one stale file
+/// that the next write reused — whereas unique names would leak a distinct
+/// credential-bearing file on every failure, in a directory nothing prunes. A
+/// `SIGKILL` still leaks, since no in-process guard can cover that.
+struct TempFileGuard {
+    path: PathBuf,
+    armed: bool,
+}
+
+impl TempFileGuard {
+    fn new(path: PathBuf) -> Self {
+        Self { path, armed: true }
+    }
+
+    /// Relinquish the file — call once `rename` has moved it into place.
+    fn disarm(&mut self) {
+        self.armed = false;
+    }
+}
+
+impl Drop for TempFileGuard {
+    fn drop(&mut self) {
+        if self.armed {
+            let _ = std::fs::remove_file(&self.path);
+        }
+    }
+}
+
 pub(crate) fn atomic_write(path: &Path, data: &[u8]) -> Result<(), CliError> {
-    static TMP_SEQ: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+    static TMP_SEQ: std::sync::atomic::AtomicUsize = std::sync::atomic::AtomicUsize::new(0);
     let seq = TMP_SEQ.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
     let tmp = path.with_extension(format!("tmp.{}.{}", std::process::id(), seq));
-    std::fs::write(&tmp, data).map_err(|e| {
-        CliError::Auth(format!("Failed to write {}: {e}", tmp.display()))
-    })?;
+    let mut guard = TempFileGuard::new(tmp.clone());
+    std::fs::write(&tmp, data)
+        .map_err(|e| CliError::Auth(format!("Failed to write {}: {e}", tmp.display())))?;
     #[cfg(unix)]
     {
         use std::os::unix::fs::PermissionsExt;
         let perms = std::fs::Permissions::from_mode(0o600);
         let _ = std::fs::set_permissions(&tmp, perms);
     }
-    std::fs::rename(&tmp, path).map_err(|e| {
-        let _ = std::fs::remove_file(&tmp);
-        CliError::Auth(format!("Failed to rename {}: {e}", tmp.display()))
-    })
+    std::fs::rename(&tmp, path)
+        .map_err(|e| CliError::Auth(format!("Failed to rename {}: {e}", tmp.display())))?;
+    guard.disarm();
+    Ok(())
 }
 
 // ---------------------------------------------------------------------------
@@ -315,6 +348,56 @@ mod tests {
             .filter(|n| n.contains(".tmp"))
             .collect();
         assert!(leftovers.is_empty(), "temp files left behind: {leftovers:?}");
+    }
+
+    /// A failed write must not leave its temp file behind. Renaming a file onto
+    /// an existing directory fails on every platform, which drives the error
+    /// path without mocking the filesystem.
+    ///
+    /// The pre-`TempFileGuard` code already cleaned up on a `rename` error, so
+    /// this pins an invariant rather than catching a regression — see
+    /// `temp_file_guard_unlinks_unless_disarmed` for the guard's own coverage.
+    #[test]
+    fn atomic_write_cleans_up_temp_file_on_failure() {
+        let dir = tempfile::tempdir().unwrap();
+
+        // The target is a *directory*, so `rename` cannot replace it.
+        let target = dir.path().join("auth-keyring.json");
+        std::fs::create_dir(&target).unwrap();
+        std::fs::write(target.join("occupant"), b"x").unwrap();
+
+        let result = atomic_write(&target, br#"{"writer":0}"#);
+        assert!(result.is_err(), "expected rename onto a directory to fail");
+
+        let leftovers: Vec<String> = std::fs::read_dir(dir.path())
+            .unwrap()
+            .filter_map(|e| e.ok())
+            .map(|e| e.file_name().to_string_lossy().into_owned())
+            .filter(|n| n.contains(".tmp"))
+            .collect();
+        assert!(leftovers.is_empty(), "temp file leaked after a failed write: {leftovers:?}");
+    }
+
+    /// Pins [`TempFileGuard`]: armed drops unlink, disarmed drops don't. Drop
+    /// running on an armed guard is what covers early returns and unwinding
+    /// panics between `write` and `rename` — paths the old `rename`-only
+    /// cleanup missed. Deleting the guard or the `disarm()` call fails this.
+    #[test]
+    fn temp_file_guard_unlinks_unless_disarmed() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("auth-keyring.tmp.0.0");
+
+        std::fs::write(&path, b"x").unwrap();
+        drop(TempFileGuard::new(path.clone()));
+        assert!(!path.exists(), "armed guard must unlink on drop");
+
+        // The post-`rename` case: the file has been moved away, so the guard
+        // must not touch whatever now sits at that path.
+        std::fs::write(&path, b"x").unwrap();
+        let mut guard = TempFileGuard::new(path.clone());
+        guard.disarm();
+        drop(guard);
+        assert!(path.exists(), "disarmed guard must not unlink");
     }
 
     #[test]

--- a/seed/cli/nullable-request-body/src/auth/oauth_common.rs
+++ b/seed/cli/nullable-request-body/src/auth/oauth_common.rs
@@ -226,8 +226,29 @@ pub(crate) fn config_dir() -> Option<PathBuf> {
 
 /// Write `data` to `path` atomically: sibling temp file → owner-only
 /// permissions (0600 on Unix) → rename into place.
+///
+/// The temp file name is unique per writer — pid plus a process-local
+/// counter. Deriving it from the target alone meant every concurrent writer
+/// used the *same* sibling (`auth-keyring.tmp`): whichever one renamed first
+/// moved it away, and the rest failed with `ENOENT` from `rename`. That
+/// surfaced as intermittent `auth login --with-token` failures across a
+/// wire-test suite large enough to run many CLI processes at once, killing a
+/// different subset of cases on each run.
+///
+/// The pid covers the case that actually bit us (separate CLI processes); the
+/// counter covers two writers inside one process, and is what makes the
+/// behavior unit-testable without spawning subprocesses.
+///
+/// `rename` is still atomic for readers, which is what keeps a partially
+/// written credential file unobservable. This only fixes writer-vs-writer
+/// collisions on the temp path. `FileKeyringStore::set` remains a
+/// read-modify-write of the whole map with no lock, so simultaneous writers
+/// can still clobber one another's *entries*; making that safe needs file
+/// locking, which is a larger change.
 pub(crate) fn atomic_write(path: &Path, data: &[u8]) -> Result<(), CliError> {
-    let tmp = path.with_extension("tmp");
+    static TMP_SEQ: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+    let seq = TMP_SEQ.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+    let tmp = path.with_extension(format!("tmp.{}.{}", std::process::id(), seq));
     std::fs::write(&tmp, data).map_err(|e| {
         CliError::Auth(format!("Failed to write {}: {e}", tmp.display()))
     })?;
@@ -250,6 +271,51 @@ pub(crate) fn atomic_write(path: &Path, data: &[u8]) -> Result<(), CliError> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// Regression test for the temp-file collision that made
+    /// `auth login --with-token` fail intermittently: every writer derived the
+    /// same sibling path from the target, so the first `rename` moved it away
+    /// and the rest got `ENOENT`.
+    ///
+    /// Reverting `atomic_write` to a target-derived temp name fails this with
+    /// "Failed to rename ...: No such file or directory".
+    #[test]
+    fn atomic_write_tolerates_concurrent_writers() {
+        let dir = tempfile::tempdir().unwrap();
+        let target = dir.path().join("auth-keyring.json");
+
+        let results: Vec<Result<(), CliError>> = std::thread::scope(|scope| {
+            let handles: Vec<_> = (0..16)
+                .map(|i| {
+                    let target = target.clone();
+                    scope.spawn(move || atomic_write(&target, format!(r#"{{"writer":{i}}}"#).as_bytes()))
+                })
+                .collect();
+            handles.into_iter().map(|h| h.join().unwrap()).collect()
+        });
+
+        let failed: Vec<String> = results
+            .iter()
+            .filter_map(|r| r.as_ref().err().map(|e| e.to_string()))
+            .collect();
+        assert!(failed.is_empty(), "concurrent writers failed: {failed:?}");
+
+        // Last writer wins, but the file must always be one writer's complete
+        // payload — never a mix, and never absent.
+        let contents = std::fs::read_to_string(&target).unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(&contents)
+            .unwrap_or_else(|e| panic!("target is not valid JSON after concurrent writes: {e} in {contents:?}"));
+        assert!(parsed.get("writer").is_some(), "unexpected payload: {contents}");
+
+        // No temp files orphaned in the directory.
+        let leftovers: Vec<String> = std::fs::read_dir(dir.path())
+            .unwrap()
+            .filter_map(|e| e.ok())
+            .map(|e| e.file_name().to_string_lossy().into_owned())
+            .filter(|n| n.contains(".tmp"))
+            .collect();
+        assert!(leftovers.is_empty(), "temp files left behind: {leftovers:?}");
+    }
 
     #[test]
     fn token_bundle_roundtrip() {

--- a/seed/cli/oauth-client-credentials-openapi/with-wire-tests/src/auth/oauth_common.rs
+++ b/seed/cli/oauth-client-credentials-openapi/with-wire-tests/src/auth/oauth_common.rs
@@ -224,27 +224,6 @@ pub(crate) fn config_dir() -> Option<PathBuf> {
     }
 }
 
-/// Write `data` to `path` atomically: sibling temp file → owner-only
-/// permissions (0600 on Unix) → rename into place.
-///
-/// The temp file name is unique per writer — pid plus a process-local
-/// counter. Deriving it from the target alone meant every concurrent writer
-/// used the *same* sibling (`auth-keyring.tmp`): whichever one renamed first
-/// moved it away, and the rest failed with `ENOENT` from `rename`. That
-/// surfaced as intermittent `auth login --with-token` failures across a
-/// wire-test suite large enough to run many CLI processes at once, killing a
-/// different subset of cases on each run.
-///
-/// The pid covers the case that actually bit us (separate CLI processes); the
-/// counter covers two writers inside one process, and is what makes the
-/// behavior unit-testable without spawning subprocesses.
-///
-/// `rename` is still atomic for readers, which is what keeps a partially
-/// written credential file unobservable. This only fixes writer-vs-writer
-/// collisions on the temp path. `FileKeyringStore::set` remains a
-/// read-modify-write of the whole map with no lock, so simultaneous writers
-/// can still clobber one another's *entries*; making that safe needs file
-/// locking, which is a larger change.
 /// Unlinks a temp file on drop unless [`TempFileGuard::disarm`]ed. Covers
 /// every early return *and* a panic between creating the temp file and
 /// renaming it into place.
@@ -278,6 +257,30 @@ impl Drop for TempFileGuard {
     }
 }
 
+/// Write `data` to `path` atomically: sibling temp file → owner-only
+/// permissions (0600 on Unix) → rename into place.
+///
+/// The temp file name is unique per writer — pid plus a process-local
+/// counter. Deriving it from the target alone meant every concurrent writer
+/// used the *same* sibling (`auth-keyring.tmp`): whichever one renamed first
+/// moved it away, and the rest failed with `ENOENT` from `rename`. That
+/// surfaced as intermittent `auth login --with-token` failures across a
+/// wire-test suite large enough to run many CLI processes at once, killing a
+/// different subset of cases on each run.
+///
+/// The pid covers the case that actually bit us (separate CLI processes); the
+/// counter covers two writers inside one process, and is what makes the
+/// behavior unit-testable without spawning subprocesses.
+///
+/// A [`TempFileGuard`] unlinks the temp file if anything between creating it
+/// and renaming it fails, so unique names cannot accumulate as orphans.
+///
+/// `rename` is still atomic for readers, which is what keeps a partially
+/// written credential file unobservable. This only fixes writer-vs-writer
+/// collisions on the temp path. `FileKeyringStore::set` remains a
+/// read-modify-write of the whole map with no lock, so simultaneous writers
+/// can still clobber one another's *entries*; making that safe needs file
+/// locking, which is a larger change.
 pub(crate) fn atomic_write(path: &Path, data: &[u8]) -> Result<(), CliError> {
     static TMP_SEQ: std::sync::atomic::AtomicUsize = std::sync::atomic::AtomicUsize::new(0);
     let seq = TMP_SEQ.fetch_add(1, std::sync::atomic::Ordering::Relaxed);

--- a/seed/cli/oauth-client-credentials-openapi/with-wire-tests/src/auth/oauth_common.rs
+++ b/seed/cli/oauth-client-credentials-openapi/with-wire-tests/src/auth/oauth_common.rs
@@ -245,23 +245,56 @@ pub(crate) fn config_dir() -> Option<PathBuf> {
 /// read-modify-write of the whole map with no lock, so simultaneous writers
 /// can still clobber one another's *entries*; making that safe needs file
 /// locking, which is a larger change.
+/// Unlinks a temp file on drop unless [`TempFileGuard::disarm`]ed. Covers
+/// every early return *and* a panic between creating the temp file and
+/// renaming it into place.
+///
+/// This exists because the temp name is unique per writer. The old shared
+/// `auth-keyring.tmp` was self-limiting — a failed write left one stale file
+/// that the next write reused — whereas unique names would leak a distinct
+/// credential-bearing file on every failure, in a directory nothing prunes. A
+/// `SIGKILL` still leaks, since no in-process guard can cover that.
+struct TempFileGuard {
+    path: PathBuf,
+    armed: bool,
+}
+
+impl TempFileGuard {
+    fn new(path: PathBuf) -> Self {
+        Self { path, armed: true }
+    }
+
+    /// Relinquish the file — call once `rename` has moved it into place.
+    fn disarm(&mut self) {
+        self.armed = false;
+    }
+}
+
+impl Drop for TempFileGuard {
+    fn drop(&mut self) {
+        if self.armed {
+            let _ = std::fs::remove_file(&self.path);
+        }
+    }
+}
+
 pub(crate) fn atomic_write(path: &Path, data: &[u8]) -> Result<(), CliError> {
-    static TMP_SEQ: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+    static TMP_SEQ: std::sync::atomic::AtomicUsize = std::sync::atomic::AtomicUsize::new(0);
     let seq = TMP_SEQ.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
     let tmp = path.with_extension(format!("tmp.{}.{}", std::process::id(), seq));
-    std::fs::write(&tmp, data).map_err(|e| {
-        CliError::Auth(format!("Failed to write {}: {e}", tmp.display()))
-    })?;
+    let mut guard = TempFileGuard::new(tmp.clone());
+    std::fs::write(&tmp, data)
+        .map_err(|e| CliError::Auth(format!("Failed to write {}: {e}", tmp.display())))?;
     #[cfg(unix)]
     {
         use std::os::unix::fs::PermissionsExt;
         let perms = std::fs::Permissions::from_mode(0o600);
         let _ = std::fs::set_permissions(&tmp, perms);
     }
-    std::fs::rename(&tmp, path).map_err(|e| {
-        let _ = std::fs::remove_file(&tmp);
-        CliError::Auth(format!("Failed to rename {}: {e}", tmp.display()))
-    })
+    std::fs::rename(&tmp, path)
+        .map_err(|e| CliError::Auth(format!("Failed to rename {}: {e}", tmp.display())))?;
+    guard.disarm();
+    Ok(())
 }
 
 // ---------------------------------------------------------------------------
@@ -315,6 +348,56 @@ mod tests {
             .filter(|n| n.contains(".tmp"))
             .collect();
         assert!(leftovers.is_empty(), "temp files left behind: {leftovers:?}");
+    }
+
+    /// A failed write must not leave its temp file behind. Renaming a file onto
+    /// an existing directory fails on every platform, which drives the error
+    /// path without mocking the filesystem.
+    ///
+    /// The pre-`TempFileGuard` code already cleaned up on a `rename` error, so
+    /// this pins an invariant rather than catching a regression — see
+    /// `temp_file_guard_unlinks_unless_disarmed` for the guard's own coverage.
+    #[test]
+    fn atomic_write_cleans_up_temp_file_on_failure() {
+        let dir = tempfile::tempdir().unwrap();
+
+        // The target is a *directory*, so `rename` cannot replace it.
+        let target = dir.path().join("auth-keyring.json");
+        std::fs::create_dir(&target).unwrap();
+        std::fs::write(target.join("occupant"), b"x").unwrap();
+
+        let result = atomic_write(&target, br#"{"writer":0}"#);
+        assert!(result.is_err(), "expected rename onto a directory to fail");
+
+        let leftovers: Vec<String> = std::fs::read_dir(dir.path())
+            .unwrap()
+            .filter_map(|e| e.ok())
+            .map(|e| e.file_name().to_string_lossy().into_owned())
+            .filter(|n| n.contains(".tmp"))
+            .collect();
+        assert!(leftovers.is_empty(), "temp file leaked after a failed write: {leftovers:?}");
+    }
+
+    /// Pins [`TempFileGuard`]: armed drops unlink, disarmed drops don't. Drop
+    /// running on an armed guard is what covers early returns and unwinding
+    /// panics between `write` and `rename` — paths the old `rename`-only
+    /// cleanup missed. Deleting the guard or the `disarm()` call fails this.
+    #[test]
+    fn temp_file_guard_unlinks_unless_disarmed() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("auth-keyring.tmp.0.0");
+
+        std::fs::write(&path, b"x").unwrap();
+        drop(TempFileGuard::new(path.clone()));
+        assert!(!path.exists(), "armed guard must unlink on drop");
+
+        // The post-`rename` case: the file has been moved away, so the guard
+        // must not touch whatever now sits at that path.
+        std::fs::write(&path, b"x").unwrap();
+        let mut guard = TempFileGuard::new(path.clone());
+        guard.disarm();
+        drop(guard);
+        assert!(path.exists(), "disarmed guard must not unlink");
     }
 
     #[test]

--- a/seed/cli/oauth-client-credentials-openapi/with-wire-tests/src/auth/oauth_common.rs
+++ b/seed/cli/oauth-client-credentials-openapi/with-wire-tests/src/auth/oauth_common.rs
@@ -226,8 +226,29 @@ pub(crate) fn config_dir() -> Option<PathBuf> {
 
 /// Write `data` to `path` atomically: sibling temp file → owner-only
 /// permissions (0600 on Unix) → rename into place.
+///
+/// The temp file name is unique per writer — pid plus a process-local
+/// counter. Deriving it from the target alone meant every concurrent writer
+/// used the *same* sibling (`auth-keyring.tmp`): whichever one renamed first
+/// moved it away, and the rest failed with `ENOENT` from `rename`. That
+/// surfaced as intermittent `auth login --with-token` failures across a
+/// wire-test suite large enough to run many CLI processes at once, killing a
+/// different subset of cases on each run.
+///
+/// The pid covers the case that actually bit us (separate CLI processes); the
+/// counter covers two writers inside one process, and is what makes the
+/// behavior unit-testable without spawning subprocesses.
+///
+/// `rename` is still atomic for readers, which is what keeps a partially
+/// written credential file unobservable. This only fixes writer-vs-writer
+/// collisions on the temp path. `FileKeyringStore::set` remains a
+/// read-modify-write of the whole map with no lock, so simultaneous writers
+/// can still clobber one another's *entries*; making that safe needs file
+/// locking, which is a larger change.
 pub(crate) fn atomic_write(path: &Path, data: &[u8]) -> Result<(), CliError> {
-    let tmp = path.with_extension("tmp");
+    static TMP_SEQ: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+    let seq = TMP_SEQ.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+    let tmp = path.with_extension(format!("tmp.{}.{}", std::process::id(), seq));
     std::fs::write(&tmp, data).map_err(|e| {
         CliError::Auth(format!("Failed to write {}: {e}", tmp.display()))
     })?;
@@ -250,6 +271,51 @@ pub(crate) fn atomic_write(path: &Path, data: &[u8]) -> Result<(), CliError> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// Regression test for the temp-file collision that made
+    /// `auth login --with-token` fail intermittently: every writer derived the
+    /// same sibling path from the target, so the first `rename` moved it away
+    /// and the rest got `ENOENT`.
+    ///
+    /// Reverting `atomic_write` to a target-derived temp name fails this with
+    /// "Failed to rename ...: No such file or directory".
+    #[test]
+    fn atomic_write_tolerates_concurrent_writers() {
+        let dir = tempfile::tempdir().unwrap();
+        let target = dir.path().join("auth-keyring.json");
+
+        let results: Vec<Result<(), CliError>> = std::thread::scope(|scope| {
+            let handles: Vec<_> = (0..16)
+                .map(|i| {
+                    let target = target.clone();
+                    scope.spawn(move || atomic_write(&target, format!(r#"{{"writer":{i}}}"#).as_bytes()))
+                })
+                .collect();
+            handles.into_iter().map(|h| h.join().unwrap()).collect()
+        });
+
+        let failed: Vec<String> = results
+            .iter()
+            .filter_map(|r| r.as_ref().err().map(|e| e.to_string()))
+            .collect();
+        assert!(failed.is_empty(), "concurrent writers failed: {failed:?}");
+
+        // Last writer wins, but the file must always be one writer's complete
+        // payload — never a mix, and never absent.
+        let contents = std::fs::read_to_string(&target).unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(&contents)
+            .unwrap_or_else(|e| panic!("target is not valid JSON after concurrent writes: {e} in {contents:?}"));
+        assert!(parsed.get("writer").is_some(), "unexpected payload: {contents}");
+
+        // No temp files orphaned in the directory.
+        let leftovers: Vec<String> = std::fs::read_dir(dir.path())
+            .unwrap()
+            .filter_map(|e| e.ok())
+            .map(|e| e.file_name().to_string_lossy().into_owned())
+            .filter(|n| n.contains(".tmp"))
+            .collect();
+        assert!(leftovers.is_empty(), "temp files left behind: {leftovers:?}");
+    }
 
     #[test]
     fn token_bundle_roundtrip() {

--- a/seed/cli/openapi-path-param-body-collision/with-wire-tests/src/auth/oauth_common.rs
+++ b/seed/cli/openapi-path-param-body-collision/with-wire-tests/src/auth/oauth_common.rs
@@ -224,27 +224,6 @@ pub(crate) fn config_dir() -> Option<PathBuf> {
     }
 }
 
-/// Write `data` to `path` atomically: sibling temp file → owner-only
-/// permissions (0600 on Unix) → rename into place.
-///
-/// The temp file name is unique per writer — pid plus a process-local
-/// counter. Deriving it from the target alone meant every concurrent writer
-/// used the *same* sibling (`auth-keyring.tmp`): whichever one renamed first
-/// moved it away, and the rest failed with `ENOENT` from `rename`. That
-/// surfaced as intermittent `auth login --with-token` failures across a
-/// wire-test suite large enough to run many CLI processes at once, killing a
-/// different subset of cases on each run.
-///
-/// The pid covers the case that actually bit us (separate CLI processes); the
-/// counter covers two writers inside one process, and is what makes the
-/// behavior unit-testable without spawning subprocesses.
-///
-/// `rename` is still atomic for readers, which is what keeps a partially
-/// written credential file unobservable. This only fixes writer-vs-writer
-/// collisions on the temp path. `FileKeyringStore::set` remains a
-/// read-modify-write of the whole map with no lock, so simultaneous writers
-/// can still clobber one another's *entries*; making that safe needs file
-/// locking, which is a larger change.
 /// Unlinks a temp file on drop unless [`TempFileGuard::disarm`]ed. Covers
 /// every early return *and* a panic between creating the temp file and
 /// renaming it into place.
@@ -278,6 +257,30 @@ impl Drop for TempFileGuard {
     }
 }
 
+/// Write `data` to `path` atomically: sibling temp file → owner-only
+/// permissions (0600 on Unix) → rename into place.
+///
+/// The temp file name is unique per writer — pid plus a process-local
+/// counter. Deriving it from the target alone meant every concurrent writer
+/// used the *same* sibling (`auth-keyring.tmp`): whichever one renamed first
+/// moved it away, and the rest failed with `ENOENT` from `rename`. That
+/// surfaced as intermittent `auth login --with-token` failures across a
+/// wire-test suite large enough to run many CLI processes at once, killing a
+/// different subset of cases on each run.
+///
+/// The pid covers the case that actually bit us (separate CLI processes); the
+/// counter covers two writers inside one process, and is what makes the
+/// behavior unit-testable without spawning subprocesses.
+///
+/// A [`TempFileGuard`] unlinks the temp file if anything between creating it
+/// and renaming it fails, so unique names cannot accumulate as orphans.
+///
+/// `rename` is still atomic for readers, which is what keeps a partially
+/// written credential file unobservable. This only fixes writer-vs-writer
+/// collisions on the temp path. `FileKeyringStore::set` remains a
+/// read-modify-write of the whole map with no lock, so simultaneous writers
+/// can still clobber one another's *entries*; making that safe needs file
+/// locking, which is a larger change.
 pub(crate) fn atomic_write(path: &Path, data: &[u8]) -> Result<(), CliError> {
     static TMP_SEQ: std::sync::atomic::AtomicUsize = std::sync::atomic::AtomicUsize::new(0);
     let seq = TMP_SEQ.fetch_add(1, std::sync::atomic::Ordering::Relaxed);

--- a/seed/cli/openapi-path-param-body-collision/with-wire-tests/src/auth/oauth_common.rs
+++ b/seed/cli/openapi-path-param-body-collision/with-wire-tests/src/auth/oauth_common.rs
@@ -245,23 +245,56 @@ pub(crate) fn config_dir() -> Option<PathBuf> {
 /// read-modify-write of the whole map with no lock, so simultaneous writers
 /// can still clobber one another's *entries*; making that safe needs file
 /// locking, which is a larger change.
+/// Unlinks a temp file on drop unless [`TempFileGuard::disarm`]ed. Covers
+/// every early return *and* a panic between creating the temp file and
+/// renaming it into place.
+///
+/// This exists because the temp name is unique per writer. The old shared
+/// `auth-keyring.tmp` was self-limiting — a failed write left one stale file
+/// that the next write reused — whereas unique names would leak a distinct
+/// credential-bearing file on every failure, in a directory nothing prunes. A
+/// `SIGKILL` still leaks, since no in-process guard can cover that.
+struct TempFileGuard {
+    path: PathBuf,
+    armed: bool,
+}
+
+impl TempFileGuard {
+    fn new(path: PathBuf) -> Self {
+        Self { path, armed: true }
+    }
+
+    /// Relinquish the file — call once `rename` has moved it into place.
+    fn disarm(&mut self) {
+        self.armed = false;
+    }
+}
+
+impl Drop for TempFileGuard {
+    fn drop(&mut self) {
+        if self.armed {
+            let _ = std::fs::remove_file(&self.path);
+        }
+    }
+}
+
 pub(crate) fn atomic_write(path: &Path, data: &[u8]) -> Result<(), CliError> {
-    static TMP_SEQ: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+    static TMP_SEQ: std::sync::atomic::AtomicUsize = std::sync::atomic::AtomicUsize::new(0);
     let seq = TMP_SEQ.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
     let tmp = path.with_extension(format!("tmp.{}.{}", std::process::id(), seq));
-    std::fs::write(&tmp, data).map_err(|e| {
-        CliError::Auth(format!("Failed to write {}: {e}", tmp.display()))
-    })?;
+    let mut guard = TempFileGuard::new(tmp.clone());
+    std::fs::write(&tmp, data)
+        .map_err(|e| CliError::Auth(format!("Failed to write {}: {e}", tmp.display())))?;
     #[cfg(unix)]
     {
         use std::os::unix::fs::PermissionsExt;
         let perms = std::fs::Permissions::from_mode(0o600);
         let _ = std::fs::set_permissions(&tmp, perms);
     }
-    std::fs::rename(&tmp, path).map_err(|e| {
-        let _ = std::fs::remove_file(&tmp);
-        CliError::Auth(format!("Failed to rename {}: {e}", tmp.display()))
-    })
+    std::fs::rename(&tmp, path)
+        .map_err(|e| CliError::Auth(format!("Failed to rename {}: {e}", tmp.display())))?;
+    guard.disarm();
+    Ok(())
 }
 
 // ---------------------------------------------------------------------------
@@ -315,6 +348,56 @@ mod tests {
             .filter(|n| n.contains(".tmp"))
             .collect();
         assert!(leftovers.is_empty(), "temp files left behind: {leftovers:?}");
+    }
+
+    /// A failed write must not leave its temp file behind. Renaming a file onto
+    /// an existing directory fails on every platform, which drives the error
+    /// path without mocking the filesystem.
+    ///
+    /// The pre-`TempFileGuard` code already cleaned up on a `rename` error, so
+    /// this pins an invariant rather than catching a regression — see
+    /// `temp_file_guard_unlinks_unless_disarmed` for the guard's own coverage.
+    #[test]
+    fn atomic_write_cleans_up_temp_file_on_failure() {
+        let dir = tempfile::tempdir().unwrap();
+
+        // The target is a *directory*, so `rename` cannot replace it.
+        let target = dir.path().join("auth-keyring.json");
+        std::fs::create_dir(&target).unwrap();
+        std::fs::write(target.join("occupant"), b"x").unwrap();
+
+        let result = atomic_write(&target, br#"{"writer":0}"#);
+        assert!(result.is_err(), "expected rename onto a directory to fail");
+
+        let leftovers: Vec<String> = std::fs::read_dir(dir.path())
+            .unwrap()
+            .filter_map(|e| e.ok())
+            .map(|e| e.file_name().to_string_lossy().into_owned())
+            .filter(|n| n.contains(".tmp"))
+            .collect();
+        assert!(leftovers.is_empty(), "temp file leaked after a failed write: {leftovers:?}");
+    }
+
+    /// Pins [`TempFileGuard`]: armed drops unlink, disarmed drops don't. Drop
+    /// running on an armed guard is what covers early returns and unwinding
+    /// panics between `write` and `rename` — paths the old `rename`-only
+    /// cleanup missed. Deleting the guard or the `disarm()` call fails this.
+    #[test]
+    fn temp_file_guard_unlinks_unless_disarmed() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("auth-keyring.tmp.0.0");
+
+        std::fs::write(&path, b"x").unwrap();
+        drop(TempFileGuard::new(path.clone()));
+        assert!(!path.exists(), "armed guard must unlink on drop");
+
+        // The post-`rename` case: the file has been moved away, so the guard
+        // must not touch whatever now sits at that path.
+        std::fs::write(&path, b"x").unwrap();
+        let mut guard = TempFileGuard::new(path.clone());
+        guard.disarm();
+        drop(guard);
+        assert!(path.exists(), "disarmed guard must not unlink");
     }
 
     #[test]

--- a/seed/cli/openapi-path-param-body-collision/with-wire-tests/src/auth/oauth_common.rs
+++ b/seed/cli/openapi-path-param-body-collision/with-wire-tests/src/auth/oauth_common.rs
@@ -226,8 +226,29 @@ pub(crate) fn config_dir() -> Option<PathBuf> {
 
 /// Write `data` to `path` atomically: sibling temp file → owner-only
 /// permissions (0600 on Unix) → rename into place.
+///
+/// The temp file name is unique per writer — pid plus a process-local
+/// counter. Deriving it from the target alone meant every concurrent writer
+/// used the *same* sibling (`auth-keyring.tmp`): whichever one renamed first
+/// moved it away, and the rest failed with `ENOENT` from `rename`. That
+/// surfaced as intermittent `auth login --with-token` failures across a
+/// wire-test suite large enough to run many CLI processes at once, killing a
+/// different subset of cases on each run.
+///
+/// The pid covers the case that actually bit us (separate CLI processes); the
+/// counter covers two writers inside one process, and is what makes the
+/// behavior unit-testable without spawning subprocesses.
+///
+/// `rename` is still atomic for readers, which is what keeps a partially
+/// written credential file unobservable. This only fixes writer-vs-writer
+/// collisions on the temp path. `FileKeyringStore::set` remains a
+/// read-modify-write of the whole map with no lock, so simultaneous writers
+/// can still clobber one another's *entries*; making that safe needs file
+/// locking, which is a larger change.
 pub(crate) fn atomic_write(path: &Path, data: &[u8]) -> Result<(), CliError> {
-    let tmp = path.with_extension("tmp");
+    static TMP_SEQ: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+    let seq = TMP_SEQ.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+    let tmp = path.with_extension(format!("tmp.{}.{}", std::process::id(), seq));
     std::fs::write(&tmp, data).map_err(|e| {
         CliError::Auth(format!("Failed to write {}: {e}", tmp.display()))
     })?;
@@ -250,6 +271,51 @@ pub(crate) fn atomic_write(path: &Path, data: &[u8]) -> Result<(), CliError> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// Regression test for the temp-file collision that made
+    /// `auth login --with-token` fail intermittently: every writer derived the
+    /// same sibling path from the target, so the first `rename` moved it away
+    /// and the rest got `ENOENT`.
+    ///
+    /// Reverting `atomic_write` to a target-derived temp name fails this with
+    /// "Failed to rename ...: No such file or directory".
+    #[test]
+    fn atomic_write_tolerates_concurrent_writers() {
+        let dir = tempfile::tempdir().unwrap();
+        let target = dir.path().join("auth-keyring.json");
+
+        let results: Vec<Result<(), CliError>> = std::thread::scope(|scope| {
+            let handles: Vec<_> = (0..16)
+                .map(|i| {
+                    let target = target.clone();
+                    scope.spawn(move || atomic_write(&target, format!(r#"{{"writer":{i}}}"#).as_bytes()))
+                })
+                .collect();
+            handles.into_iter().map(|h| h.join().unwrap()).collect()
+        });
+
+        let failed: Vec<String> = results
+            .iter()
+            .filter_map(|r| r.as_ref().err().map(|e| e.to_string()))
+            .collect();
+        assert!(failed.is_empty(), "concurrent writers failed: {failed:?}");
+
+        // Last writer wins, but the file must always be one writer's complete
+        // payload — never a mix, and never absent.
+        let contents = std::fs::read_to_string(&target).unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(&contents)
+            .unwrap_or_else(|e| panic!("target is not valid JSON after concurrent writes: {e} in {contents:?}"));
+        assert!(parsed.get("writer").is_some(), "unexpected payload: {contents}");
+
+        // No temp files orphaned in the directory.
+        let leftovers: Vec<String> = std::fs::read_dir(dir.path())
+            .unwrap()
+            .filter_map(|e| e.ok())
+            .map(|e| e.file_name().to_string_lossy().into_owned())
+            .filter(|n| n.contains(".tmp"))
+            .collect();
+        assert!(leftovers.is_empty(), "temp files left behind: {leftovers:?}");
+    }
 
     #[test]
     fn token_bundle_roundtrip() {

--- a/seed/cli/openapi-request-body-ref/src/auth/oauth_common.rs
+++ b/seed/cli/openapi-request-body-ref/src/auth/oauth_common.rs
@@ -224,27 +224,6 @@ pub(crate) fn config_dir() -> Option<PathBuf> {
     }
 }
 
-/// Write `data` to `path` atomically: sibling temp file → owner-only
-/// permissions (0600 on Unix) → rename into place.
-///
-/// The temp file name is unique per writer — pid plus a process-local
-/// counter. Deriving it from the target alone meant every concurrent writer
-/// used the *same* sibling (`auth-keyring.tmp`): whichever one renamed first
-/// moved it away, and the rest failed with `ENOENT` from `rename`. That
-/// surfaced as intermittent `auth login --with-token` failures across a
-/// wire-test suite large enough to run many CLI processes at once, killing a
-/// different subset of cases on each run.
-///
-/// The pid covers the case that actually bit us (separate CLI processes); the
-/// counter covers two writers inside one process, and is what makes the
-/// behavior unit-testable without spawning subprocesses.
-///
-/// `rename` is still atomic for readers, which is what keeps a partially
-/// written credential file unobservable. This only fixes writer-vs-writer
-/// collisions on the temp path. `FileKeyringStore::set` remains a
-/// read-modify-write of the whole map with no lock, so simultaneous writers
-/// can still clobber one another's *entries*; making that safe needs file
-/// locking, which is a larger change.
 /// Unlinks a temp file on drop unless [`TempFileGuard::disarm`]ed. Covers
 /// every early return *and* a panic between creating the temp file and
 /// renaming it into place.
@@ -278,6 +257,30 @@ impl Drop for TempFileGuard {
     }
 }
 
+/// Write `data` to `path` atomically: sibling temp file → owner-only
+/// permissions (0600 on Unix) → rename into place.
+///
+/// The temp file name is unique per writer — pid plus a process-local
+/// counter. Deriving it from the target alone meant every concurrent writer
+/// used the *same* sibling (`auth-keyring.tmp`): whichever one renamed first
+/// moved it away, and the rest failed with `ENOENT` from `rename`. That
+/// surfaced as intermittent `auth login --with-token` failures across a
+/// wire-test suite large enough to run many CLI processes at once, killing a
+/// different subset of cases on each run.
+///
+/// The pid covers the case that actually bit us (separate CLI processes); the
+/// counter covers two writers inside one process, and is what makes the
+/// behavior unit-testable without spawning subprocesses.
+///
+/// A [`TempFileGuard`] unlinks the temp file if anything between creating it
+/// and renaming it fails, so unique names cannot accumulate as orphans.
+///
+/// `rename` is still atomic for readers, which is what keeps a partially
+/// written credential file unobservable. This only fixes writer-vs-writer
+/// collisions on the temp path. `FileKeyringStore::set` remains a
+/// read-modify-write of the whole map with no lock, so simultaneous writers
+/// can still clobber one another's *entries*; making that safe needs file
+/// locking, which is a larger change.
 pub(crate) fn atomic_write(path: &Path, data: &[u8]) -> Result<(), CliError> {
     static TMP_SEQ: std::sync::atomic::AtomicUsize = std::sync::atomic::AtomicUsize::new(0);
     let seq = TMP_SEQ.fetch_add(1, std::sync::atomic::Ordering::Relaxed);

--- a/seed/cli/openapi-request-body-ref/src/auth/oauth_common.rs
+++ b/seed/cli/openapi-request-body-ref/src/auth/oauth_common.rs
@@ -245,23 +245,56 @@ pub(crate) fn config_dir() -> Option<PathBuf> {
 /// read-modify-write of the whole map with no lock, so simultaneous writers
 /// can still clobber one another's *entries*; making that safe needs file
 /// locking, which is a larger change.
+/// Unlinks a temp file on drop unless [`TempFileGuard::disarm`]ed. Covers
+/// every early return *and* a panic between creating the temp file and
+/// renaming it into place.
+///
+/// This exists because the temp name is unique per writer. The old shared
+/// `auth-keyring.tmp` was self-limiting — a failed write left one stale file
+/// that the next write reused — whereas unique names would leak a distinct
+/// credential-bearing file on every failure, in a directory nothing prunes. A
+/// `SIGKILL` still leaks, since no in-process guard can cover that.
+struct TempFileGuard {
+    path: PathBuf,
+    armed: bool,
+}
+
+impl TempFileGuard {
+    fn new(path: PathBuf) -> Self {
+        Self { path, armed: true }
+    }
+
+    /// Relinquish the file — call once `rename` has moved it into place.
+    fn disarm(&mut self) {
+        self.armed = false;
+    }
+}
+
+impl Drop for TempFileGuard {
+    fn drop(&mut self) {
+        if self.armed {
+            let _ = std::fs::remove_file(&self.path);
+        }
+    }
+}
+
 pub(crate) fn atomic_write(path: &Path, data: &[u8]) -> Result<(), CliError> {
-    static TMP_SEQ: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+    static TMP_SEQ: std::sync::atomic::AtomicUsize = std::sync::atomic::AtomicUsize::new(0);
     let seq = TMP_SEQ.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
     let tmp = path.with_extension(format!("tmp.{}.{}", std::process::id(), seq));
-    std::fs::write(&tmp, data).map_err(|e| {
-        CliError::Auth(format!("Failed to write {}: {e}", tmp.display()))
-    })?;
+    let mut guard = TempFileGuard::new(tmp.clone());
+    std::fs::write(&tmp, data)
+        .map_err(|e| CliError::Auth(format!("Failed to write {}: {e}", tmp.display())))?;
     #[cfg(unix)]
     {
         use std::os::unix::fs::PermissionsExt;
         let perms = std::fs::Permissions::from_mode(0o600);
         let _ = std::fs::set_permissions(&tmp, perms);
     }
-    std::fs::rename(&tmp, path).map_err(|e| {
-        let _ = std::fs::remove_file(&tmp);
-        CliError::Auth(format!("Failed to rename {}: {e}", tmp.display()))
-    })
+    std::fs::rename(&tmp, path)
+        .map_err(|e| CliError::Auth(format!("Failed to rename {}: {e}", tmp.display())))?;
+    guard.disarm();
+    Ok(())
 }
 
 // ---------------------------------------------------------------------------
@@ -315,6 +348,56 @@ mod tests {
             .filter(|n| n.contains(".tmp"))
             .collect();
         assert!(leftovers.is_empty(), "temp files left behind: {leftovers:?}");
+    }
+
+    /// A failed write must not leave its temp file behind. Renaming a file onto
+    /// an existing directory fails on every platform, which drives the error
+    /// path without mocking the filesystem.
+    ///
+    /// The pre-`TempFileGuard` code already cleaned up on a `rename` error, so
+    /// this pins an invariant rather than catching a regression — see
+    /// `temp_file_guard_unlinks_unless_disarmed` for the guard's own coverage.
+    #[test]
+    fn atomic_write_cleans_up_temp_file_on_failure() {
+        let dir = tempfile::tempdir().unwrap();
+
+        // The target is a *directory*, so `rename` cannot replace it.
+        let target = dir.path().join("auth-keyring.json");
+        std::fs::create_dir(&target).unwrap();
+        std::fs::write(target.join("occupant"), b"x").unwrap();
+
+        let result = atomic_write(&target, br#"{"writer":0}"#);
+        assert!(result.is_err(), "expected rename onto a directory to fail");
+
+        let leftovers: Vec<String> = std::fs::read_dir(dir.path())
+            .unwrap()
+            .filter_map(|e| e.ok())
+            .map(|e| e.file_name().to_string_lossy().into_owned())
+            .filter(|n| n.contains(".tmp"))
+            .collect();
+        assert!(leftovers.is_empty(), "temp file leaked after a failed write: {leftovers:?}");
+    }
+
+    /// Pins [`TempFileGuard`]: armed drops unlink, disarmed drops don't. Drop
+    /// running on an armed guard is what covers early returns and unwinding
+    /// panics between `write` and `rename` — paths the old `rename`-only
+    /// cleanup missed. Deleting the guard or the `disarm()` call fails this.
+    #[test]
+    fn temp_file_guard_unlinks_unless_disarmed() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("auth-keyring.tmp.0.0");
+
+        std::fs::write(&path, b"x").unwrap();
+        drop(TempFileGuard::new(path.clone()));
+        assert!(!path.exists(), "armed guard must unlink on drop");
+
+        // The post-`rename` case: the file has been moved away, so the guard
+        // must not touch whatever now sits at that path.
+        std::fs::write(&path, b"x").unwrap();
+        let mut guard = TempFileGuard::new(path.clone());
+        guard.disarm();
+        drop(guard);
+        assert!(path.exists(), "disarmed guard must not unlink");
     }
 
     #[test]

--- a/seed/cli/openapi-request-body-ref/src/auth/oauth_common.rs
+++ b/seed/cli/openapi-request-body-ref/src/auth/oauth_common.rs
@@ -226,8 +226,29 @@ pub(crate) fn config_dir() -> Option<PathBuf> {
 
 /// Write `data` to `path` atomically: sibling temp file → owner-only
 /// permissions (0600 on Unix) → rename into place.
+///
+/// The temp file name is unique per writer — pid plus a process-local
+/// counter. Deriving it from the target alone meant every concurrent writer
+/// used the *same* sibling (`auth-keyring.tmp`): whichever one renamed first
+/// moved it away, and the rest failed with `ENOENT` from `rename`. That
+/// surfaced as intermittent `auth login --with-token` failures across a
+/// wire-test suite large enough to run many CLI processes at once, killing a
+/// different subset of cases on each run.
+///
+/// The pid covers the case that actually bit us (separate CLI processes); the
+/// counter covers two writers inside one process, and is what makes the
+/// behavior unit-testable without spawning subprocesses.
+///
+/// `rename` is still atomic for readers, which is what keeps a partially
+/// written credential file unobservable. This only fixes writer-vs-writer
+/// collisions on the temp path. `FileKeyringStore::set` remains a
+/// read-modify-write of the whole map with no lock, so simultaneous writers
+/// can still clobber one another's *entries*; making that safe needs file
+/// locking, which is a larger change.
 pub(crate) fn atomic_write(path: &Path, data: &[u8]) -> Result<(), CliError> {
-    let tmp = path.with_extension("tmp");
+    static TMP_SEQ: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+    let seq = TMP_SEQ.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+    let tmp = path.with_extension(format!("tmp.{}.{}", std::process::id(), seq));
     std::fs::write(&tmp, data).map_err(|e| {
         CliError::Auth(format!("Failed to write {}: {e}", tmp.display()))
     })?;
@@ -250,6 +271,51 @@ pub(crate) fn atomic_write(path: &Path, data: &[u8]) -> Result<(), CliError> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// Regression test for the temp-file collision that made
+    /// `auth login --with-token` fail intermittently: every writer derived the
+    /// same sibling path from the target, so the first `rename` moved it away
+    /// and the rest got `ENOENT`.
+    ///
+    /// Reverting `atomic_write` to a target-derived temp name fails this with
+    /// "Failed to rename ...: No such file or directory".
+    #[test]
+    fn atomic_write_tolerates_concurrent_writers() {
+        let dir = tempfile::tempdir().unwrap();
+        let target = dir.path().join("auth-keyring.json");
+
+        let results: Vec<Result<(), CliError>> = std::thread::scope(|scope| {
+            let handles: Vec<_> = (0..16)
+                .map(|i| {
+                    let target = target.clone();
+                    scope.spawn(move || atomic_write(&target, format!(r#"{{"writer":{i}}}"#).as_bytes()))
+                })
+                .collect();
+            handles.into_iter().map(|h| h.join().unwrap()).collect()
+        });
+
+        let failed: Vec<String> = results
+            .iter()
+            .filter_map(|r| r.as_ref().err().map(|e| e.to_string()))
+            .collect();
+        assert!(failed.is_empty(), "concurrent writers failed: {failed:?}");
+
+        // Last writer wins, but the file must always be one writer's complete
+        // payload — never a mix, and never absent.
+        let contents = std::fs::read_to_string(&target).unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(&contents)
+            .unwrap_or_else(|e| panic!("target is not valid JSON after concurrent writes: {e} in {contents:?}"));
+        assert!(parsed.get("writer").is_some(), "unexpected payload: {contents}");
+
+        // No temp files orphaned in the directory.
+        let leftovers: Vec<String> = std::fs::read_dir(dir.path())
+            .unwrap()
+            .filter_map(|e| e.ok())
+            .map(|e| e.file_name().to_string_lossy().into_owned())
+            .filter(|n| n.contains(".tmp"))
+            .collect();
+        assert!(leftovers.is_empty(), "temp files left behind: {leftovers:?}");
+    }
 
     #[test]
     fn token_bundle_roundtrip() {

--- a/seed/cli/openapi-subtitle/src/auth/oauth_common.rs
+++ b/seed/cli/openapi-subtitle/src/auth/oauth_common.rs
@@ -224,27 +224,6 @@ pub(crate) fn config_dir() -> Option<PathBuf> {
     }
 }
 
-/// Write `data` to `path` atomically: sibling temp file → owner-only
-/// permissions (0600 on Unix) → rename into place.
-///
-/// The temp file name is unique per writer — pid plus a process-local
-/// counter. Deriving it from the target alone meant every concurrent writer
-/// used the *same* sibling (`auth-keyring.tmp`): whichever one renamed first
-/// moved it away, and the rest failed with `ENOENT` from `rename`. That
-/// surfaced as intermittent `auth login --with-token` failures across a
-/// wire-test suite large enough to run many CLI processes at once, killing a
-/// different subset of cases on each run.
-///
-/// The pid covers the case that actually bit us (separate CLI processes); the
-/// counter covers two writers inside one process, and is what makes the
-/// behavior unit-testable without spawning subprocesses.
-///
-/// `rename` is still atomic for readers, which is what keeps a partially
-/// written credential file unobservable. This only fixes writer-vs-writer
-/// collisions on the temp path. `FileKeyringStore::set` remains a
-/// read-modify-write of the whole map with no lock, so simultaneous writers
-/// can still clobber one another's *entries*; making that safe needs file
-/// locking, which is a larger change.
 /// Unlinks a temp file on drop unless [`TempFileGuard::disarm`]ed. Covers
 /// every early return *and* a panic between creating the temp file and
 /// renaming it into place.
@@ -278,6 +257,30 @@ impl Drop for TempFileGuard {
     }
 }
 
+/// Write `data` to `path` atomically: sibling temp file → owner-only
+/// permissions (0600 on Unix) → rename into place.
+///
+/// The temp file name is unique per writer — pid plus a process-local
+/// counter. Deriving it from the target alone meant every concurrent writer
+/// used the *same* sibling (`auth-keyring.tmp`): whichever one renamed first
+/// moved it away, and the rest failed with `ENOENT` from `rename`. That
+/// surfaced as intermittent `auth login --with-token` failures across a
+/// wire-test suite large enough to run many CLI processes at once, killing a
+/// different subset of cases on each run.
+///
+/// The pid covers the case that actually bit us (separate CLI processes); the
+/// counter covers two writers inside one process, and is what makes the
+/// behavior unit-testable without spawning subprocesses.
+///
+/// A [`TempFileGuard`] unlinks the temp file if anything between creating it
+/// and renaming it fails, so unique names cannot accumulate as orphans.
+///
+/// `rename` is still atomic for readers, which is what keeps a partially
+/// written credential file unobservable. This only fixes writer-vs-writer
+/// collisions on the temp path. `FileKeyringStore::set` remains a
+/// read-modify-write of the whole map with no lock, so simultaneous writers
+/// can still clobber one another's *entries*; making that safe needs file
+/// locking, which is a larger change.
 pub(crate) fn atomic_write(path: &Path, data: &[u8]) -> Result<(), CliError> {
     static TMP_SEQ: std::sync::atomic::AtomicUsize = std::sync::atomic::AtomicUsize::new(0);
     let seq = TMP_SEQ.fetch_add(1, std::sync::atomic::Ordering::Relaxed);

--- a/seed/cli/openapi-subtitle/src/auth/oauth_common.rs
+++ b/seed/cli/openapi-subtitle/src/auth/oauth_common.rs
@@ -245,23 +245,56 @@ pub(crate) fn config_dir() -> Option<PathBuf> {
 /// read-modify-write of the whole map with no lock, so simultaneous writers
 /// can still clobber one another's *entries*; making that safe needs file
 /// locking, which is a larger change.
+/// Unlinks a temp file on drop unless [`TempFileGuard::disarm`]ed. Covers
+/// every early return *and* a panic between creating the temp file and
+/// renaming it into place.
+///
+/// This exists because the temp name is unique per writer. The old shared
+/// `auth-keyring.tmp` was self-limiting — a failed write left one stale file
+/// that the next write reused — whereas unique names would leak a distinct
+/// credential-bearing file on every failure, in a directory nothing prunes. A
+/// `SIGKILL` still leaks, since no in-process guard can cover that.
+struct TempFileGuard {
+    path: PathBuf,
+    armed: bool,
+}
+
+impl TempFileGuard {
+    fn new(path: PathBuf) -> Self {
+        Self { path, armed: true }
+    }
+
+    /// Relinquish the file — call once `rename` has moved it into place.
+    fn disarm(&mut self) {
+        self.armed = false;
+    }
+}
+
+impl Drop for TempFileGuard {
+    fn drop(&mut self) {
+        if self.armed {
+            let _ = std::fs::remove_file(&self.path);
+        }
+    }
+}
+
 pub(crate) fn atomic_write(path: &Path, data: &[u8]) -> Result<(), CliError> {
-    static TMP_SEQ: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+    static TMP_SEQ: std::sync::atomic::AtomicUsize = std::sync::atomic::AtomicUsize::new(0);
     let seq = TMP_SEQ.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
     let tmp = path.with_extension(format!("tmp.{}.{}", std::process::id(), seq));
-    std::fs::write(&tmp, data).map_err(|e| {
-        CliError::Auth(format!("Failed to write {}: {e}", tmp.display()))
-    })?;
+    let mut guard = TempFileGuard::new(tmp.clone());
+    std::fs::write(&tmp, data)
+        .map_err(|e| CliError::Auth(format!("Failed to write {}: {e}", tmp.display())))?;
     #[cfg(unix)]
     {
         use std::os::unix::fs::PermissionsExt;
         let perms = std::fs::Permissions::from_mode(0o600);
         let _ = std::fs::set_permissions(&tmp, perms);
     }
-    std::fs::rename(&tmp, path).map_err(|e| {
-        let _ = std::fs::remove_file(&tmp);
-        CliError::Auth(format!("Failed to rename {}: {e}", tmp.display()))
-    })
+    std::fs::rename(&tmp, path)
+        .map_err(|e| CliError::Auth(format!("Failed to rename {}: {e}", tmp.display())))?;
+    guard.disarm();
+    Ok(())
 }
 
 // ---------------------------------------------------------------------------
@@ -315,6 +348,56 @@ mod tests {
             .filter(|n| n.contains(".tmp"))
             .collect();
         assert!(leftovers.is_empty(), "temp files left behind: {leftovers:?}");
+    }
+
+    /// A failed write must not leave its temp file behind. Renaming a file onto
+    /// an existing directory fails on every platform, which drives the error
+    /// path without mocking the filesystem.
+    ///
+    /// The pre-`TempFileGuard` code already cleaned up on a `rename` error, so
+    /// this pins an invariant rather than catching a regression — see
+    /// `temp_file_guard_unlinks_unless_disarmed` for the guard's own coverage.
+    #[test]
+    fn atomic_write_cleans_up_temp_file_on_failure() {
+        let dir = tempfile::tempdir().unwrap();
+
+        // The target is a *directory*, so `rename` cannot replace it.
+        let target = dir.path().join("auth-keyring.json");
+        std::fs::create_dir(&target).unwrap();
+        std::fs::write(target.join("occupant"), b"x").unwrap();
+
+        let result = atomic_write(&target, br#"{"writer":0}"#);
+        assert!(result.is_err(), "expected rename onto a directory to fail");
+
+        let leftovers: Vec<String> = std::fs::read_dir(dir.path())
+            .unwrap()
+            .filter_map(|e| e.ok())
+            .map(|e| e.file_name().to_string_lossy().into_owned())
+            .filter(|n| n.contains(".tmp"))
+            .collect();
+        assert!(leftovers.is_empty(), "temp file leaked after a failed write: {leftovers:?}");
+    }
+
+    /// Pins [`TempFileGuard`]: armed drops unlink, disarmed drops don't. Drop
+    /// running on an armed guard is what covers early returns and unwinding
+    /// panics between `write` and `rename` — paths the old `rename`-only
+    /// cleanup missed. Deleting the guard or the `disarm()` call fails this.
+    #[test]
+    fn temp_file_guard_unlinks_unless_disarmed() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("auth-keyring.tmp.0.0");
+
+        std::fs::write(&path, b"x").unwrap();
+        drop(TempFileGuard::new(path.clone()));
+        assert!(!path.exists(), "armed guard must unlink on drop");
+
+        // The post-`rename` case: the file has been moved away, so the guard
+        // must not touch whatever now sits at that path.
+        std::fs::write(&path, b"x").unwrap();
+        let mut guard = TempFileGuard::new(path.clone());
+        guard.disarm();
+        drop(guard);
+        assert!(path.exists(), "disarmed guard must not unlink");
     }
 
     #[test]

--- a/seed/cli/openapi-subtitle/src/auth/oauth_common.rs
+++ b/seed/cli/openapi-subtitle/src/auth/oauth_common.rs
@@ -226,8 +226,29 @@ pub(crate) fn config_dir() -> Option<PathBuf> {
 
 /// Write `data` to `path` atomically: sibling temp file → owner-only
 /// permissions (0600 on Unix) → rename into place.
+///
+/// The temp file name is unique per writer — pid plus a process-local
+/// counter. Deriving it from the target alone meant every concurrent writer
+/// used the *same* sibling (`auth-keyring.tmp`): whichever one renamed first
+/// moved it away, and the rest failed with `ENOENT` from `rename`. That
+/// surfaced as intermittent `auth login --with-token` failures across a
+/// wire-test suite large enough to run many CLI processes at once, killing a
+/// different subset of cases on each run.
+///
+/// The pid covers the case that actually bit us (separate CLI processes); the
+/// counter covers two writers inside one process, and is what makes the
+/// behavior unit-testable without spawning subprocesses.
+///
+/// `rename` is still atomic for readers, which is what keeps a partially
+/// written credential file unobservable. This only fixes writer-vs-writer
+/// collisions on the temp path. `FileKeyringStore::set` remains a
+/// read-modify-write of the whole map with no lock, so simultaneous writers
+/// can still clobber one another's *entries*; making that safe needs file
+/// locking, which is a larger change.
 pub(crate) fn atomic_write(path: &Path, data: &[u8]) -> Result<(), CliError> {
-    let tmp = path.with_extension("tmp");
+    static TMP_SEQ: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+    let seq = TMP_SEQ.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+    let tmp = path.with_extension(format!("tmp.{}.{}", std::process::id(), seq));
     std::fs::write(&tmp, data).map_err(|e| {
         CliError::Auth(format!("Failed to write {}: {e}", tmp.display()))
     })?;
@@ -250,6 +271,51 @@ pub(crate) fn atomic_write(path: &Path, data: &[u8]) -> Result<(), CliError> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// Regression test for the temp-file collision that made
+    /// `auth login --with-token` fail intermittently: every writer derived the
+    /// same sibling path from the target, so the first `rename` moved it away
+    /// and the rest got `ENOENT`.
+    ///
+    /// Reverting `atomic_write` to a target-derived temp name fails this with
+    /// "Failed to rename ...: No such file or directory".
+    #[test]
+    fn atomic_write_tolerates_concurrent_writers() {
+        let dir = tempfile::tempdir().unwrap();
+        let target = dir.path().join("auth-keyring.json");
+
+        let results: Vec<Result<(), CliError>> = std::thread::scope(|scope| {
+            let handles: Vec<_> = (0..16)
+                .map(|i| {
+                    let target = target.clone();
+                    scope.spawn(move || atomic_write(&target, format!(r#"{{"writer":{i}}}"#).as_bytes()))
+                })
+                .collect();
+            handles.into_iter().map(|h| h.join().unwrap()).collect()
+        });
+
+        let failed: Vec<String> = results
+            .iter()
+            .filter_map(|r| r.as_ref().err().map(|e| e.to_string()))
+            .collect();
+        assert!(failed.is_empty(), "concurrent writers failed: {failed:?}");
+
+        // Last writer wins, but the file must always be one writer's complete
+        // payload — never a mix, and never absent.
+        let contents = std::fs::read_to_string(&target).unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(&contents)
+            .unwrap_or_else(|e| panic!("target is not valid JSON after concurrent writes: {e} in {contents:?}"));
+        assert!(parsed.get("writer").is_some(), "unexpected payload: {contents}");
+
+        // No temp files orphaned in the directory.
+        let leftovers: Vec<String> = std::fs::read_dir(dir.path())
+            .unwrap()
+            .filter_map(|e| e.ok())
+            .map(|e| e.file_name().to_string_lossy().into_owned())
+            .filter(|n| n.contains(".tmp"))
+            .collect();
+        assert!(leftovers.is_empty(), "temp files left behind: {leftovers:?}");
+    }
 
     #[test]
     fn token_bundle_roundtrip() {

--- a/seed/cli/query-param-name-conflict/src/auth/oauth_common.rs
+++ b/seed/cli/query-param-name-conflict/src/auth/oauth_common.rs
@@ -224,27 +224,6 @@ pub(crate) fn config_dir() -> Option<PathBuf> {
     }
 }
 
-/// Write `data` to `path` atomically: sibling temp file → owner-only
-/// permissions (0600 on Unix) → rename into place.
-///
-/// The temp file name is unique per writer — pid plus a process-local
-/// counter. Deriving it from the target alone meant every concurrent writer
-/// used the *same* sibling (`auth-keyring.tmp`): whichever one renamed first
-/// moved it away, and the rest failed with `ENOENT` from `rename`. That
-/// surfaced as intermittent `auth login --with-token` failures across a
-/// wire-test suite large enough to run many CLI processes at once, killing a
-/// different subset of cases on each run.
-///
-/// The pid covers the case that actually bit us (separate CLI processes); the
-/// counter covers two writers inside one process, and is what makes the
-/// behavior unit-testable without spawning subprocesses.
-///
-/// `rename` is still atomic for readers, which is what keeps a partially
-/// written credential file unobservable. This only fixes writer-vs-writer
-/// collisions on the temp path. `FileKeyringStore::set` remains a
-/// read-modify-write of the whole map with no lock, so simultaneous writers
-/// can still clobber one another's *entries*; making that safe needs file
-/// locking, which is a larger change.
 /// Unlinks a temp file on drop unless [`TempFileGuard::disarm`]ed. Covers
 /// every early return *and* a panic between creating the temp file and
 /// renaming it into place.
@@ -278,6 +257,30 @@ impl Drop for TempFileGuard {
     }
 }
 
+/// Write `data` to `path` atomically: sibling temp file → owner-only
+/// permissions (0600 on Unix) → rename into place.
+///
+/// The temp file name is unique per writer — pid plus a process-local
+/// counter. Deriving it from the target alone meant every concurrent writer
+/// used the *same* sibling (`auth-keyring.tmp`): whichever one renamed first
+/// moved it away, and the rest failed with `ENOENT` from `rename`. That
+/// surfaced as intermittent `auth login --with-token` failures across a
+/// wire-test suite large enough to run many CLI processes at once, killing a
+/// different subset of cases on each run.
+///
+/// The pid covers the case that actually bit us (separate CLI processes); the
+/// counter covers two writers inside one process, and is what makes the
+/// behavior unit-testable without spawning subprocesses.
+///
+/// A [`TempFileGuard`] unlinks the temp file if anything between creating it
+/// and renaming it fails, so unique names cannot accumulate as orphans.
+///
+/// `rename` is still atomic for readers, which is what keeps a partially
+/// written credential file unobservable. This only fixes writer-vs-writer
+/// collisions on the temp path. `FileKeyringStore::set` remains a
+/// read-modify-write of the whole map with no lock, so simultaneous writers
+/// can still clobber one another's *entries*; making that safe needs file
+/// locking, which is a larger change.
 pub(crate) fn atomic_write(path: &Path, data: &[u8]) -> Result<(), CliError> {
     static TMP_SEQ: std::sync::atomic::AtomicUsize = std::sync::atomic::AtomicUsize::new(0);
     let seq = TMP_SEQ.fetch_add(1, std::sync::atomic::Ordering::Relaxed);

--- a/seed/cli/query-param-name-conflict/src/auth/oauth_common.rs
+++ b/seed/cli/query-param-name-conflict/src/auth/oauth_common.rs
@@ -245,23 +245,56 @@ pub(crate) fn config_dir() -> Option<PathBuf> {
 /// read-modify-write of the whole map with no lock, so simultaneous writers
 /// can still clobber one another's *entries*; making that safe needs file
 /// locking, which is a larger change.
+/// Unlinks a temp file on drop unless [`TempFileGuard::disarm`]ed. Covers
+/// every early return *and* a panic between creating the temp file and
+/// renaming it into place.
+///
+/// This exists because the temp name is unique per writer. The old shared
+/// `auth-keyring.tmp` was self-limiting — a failed write left one stale file
+/// that the next write reused — whereas unique names would leak a distinct
+/// credential-bearing file on every failure, in a directory nothing prunes. A
+/// `SIGKILL` still leaks, since no in-process guard can cover that.
+struct TempFileGuard {
+    path: PathBuf,
+    armed: bool,
+}
+
+impl TempFileGuard {
+    fn new(path: PathBuf) -> Self {
+        Self { path, armed: true }
+    }
+
+    /// Relinquish the file — call once `rename` has moved it into place.
+    fn disarm(&mut self) {
+        self.armed = false;
+    }
+}
+
+impl Drop for TempFileGuard {
+    fn drop(&mut self) {
+        if self.armed {
+            let _ = std::fs::remove_file(&self.path);
+        }
+    }
+}
+
 pub(crate) fn atomic_write(path: &Path, data: &[u8]) -> Result<(), CliError> {
-    static TMP_SEQ: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+    static TMP_SEQ: std::sync::atomic::AtomicUsize = std::sync::atomic::AtomicUsize::new(0);
     let seq = TMP_SEQ.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
     let tmp = path.with_extension(format!("tmp.{}.{}", std::process::id(), seq));
-    std::fs::write(&tmp, data).map_err(|e| {
-        CliError::Auth(format!("Failed to write {}: {e}", tmp.display()))
-    })?;
+    let mut guard = TempFileGuard::new(tmp.clone());
+    std::fs::write(&tmp, data)
+        .map_err(|e| CliError::Auth(format!("Failed to write {}: {e}", tmp.display())))?;
     #[cfg(unix)]
     {
         use std::os::unix::fs::PermissionsExt;
         let perms = std::fs::Permissions::from_mode(0o600);
         let _ = std::fs::set_permissions(&tmp, perms);
     }
-    std::fs::rename(&tmp, path).map_err(|e| {
-        let _ = std::fs::remove_file(&tmp);
-        CliError::Auth(format!("Failed to rename {}: {e}", tmp.display()))
-    })
+    std::fs::rename(&tmp, path)
+        .map_err(|e| CliError::Auth(format!("Failed to rename {}: {e}", tmp.display())))?;
+    guard.disarm();
+    Ok(())
 }
 
 // ---------------------------------------------------------------------------
@@ -315,6 +348,56 @@ mod tests {
             .filter(|n| n.contains(".tmp"))
             .collect();
         assert!(leftovers.is_empty(), "temp files left behind: {leftovers:?}");
+    }
+
+    /// A failed write must not leave its temp file behind. Renaming a file onto
+    /// an existing directory fails on every platform, which drives the error
+    /// path without mocking the filesystem.
+    ///
+    /// The pre-`TempFileGuard` code already cleaned up on a `rename` error, so
+    /// this pins an invariant rather than catching a regression — see
+    /// `temp_file_guard_unlinks_unless_disarmed` for the guard's own coverage.
+    #[test]
+    fn atomic_write_cleans_up_temp_file_on_failure() {
+        let dir = tempfile::tempdir().unwrap();
+
+        // The target is a *directory*, so `rename` cannot replace it.
+        let target = dir.path().join("auth-keyring.json");
+        std::fs::create_dir(&target).unwrap();
+        std::fs::write(target.join("occupant"), b"x").unwrap();
+
+        let result = atomic_write(&target, br#"{"writer":0}"#);
+        assert!(result.is_err(), "expected rename onto a directory to fail");
+
+        let leftovers: Vec<String> = std::fs::read_dir(dir.path())
+            .unwrap()
+            .filter_map(|e| e.ok())
+            .map(|e| e.file_name().to_string_lossy().into_owned())
+            .filter(|n| n.contains(".tmp"))
+            .collect();
+        assert!(leftovers.is_empty(), "temp file leaked after a failed write: {leftovers:?}");
+    }
+
+    /// Pins [`TempFileGuard`]: armed drops unlink, disarmed drops don't. Drop
+    /// running on an armed guard is what covers early returns and unwinding
+    /// panics between `write` and `rename` — paths the old `rename`-only
+    /// cleanup missed. Deleting the guard or the `disarm()` call fails this.
+    #[test]
+    fn temp_file_guard_unlinks_unless_disarmed() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("auth-keyring.tmp.0.0");
+
+        std::fs::write(&path, b"x").unwrap();
+        drop(TempFileGuard::new(path.clone()));
+        assert!(!path.exists(), "armed guard must unlink on drop");
+
+        // The post-`rename` case: the file has been moved away, so the guard
+        // must not touch whatever now sits at that path.
+        std::fs::write(&path, b"x").unwrap();
+        let mut guard = TempFileGuard::new(path.clone());
+        guard.disarm();
+        drop(guard);
+        assert!(path.exists(), "disarmed guard must not unlink");
     }
 
     #[test]

--- a/seed/cli/query-param-name-conflict/src/auth/oauth_common.rs
+++ b/seed/cli/query-param-name-conflict/src/auth/oauth_common.rs
@@ -226,8 +226,29 @@ pub(crate) fn config_dir() -> Option<PathBuf> {
 
 /// Write `data` to `path` atomically: sibling temp file → owner-only
 /// permissions (0600 on Unix) → rename into place.
+///
+/// The temp file name is unique per writer — pid plus a process-local
+/// counter. Deriving it from the target alone meant every concurrent writer
+/// used the *same* sibling (`auth-keyring.tmp`): whichever one renamed first
+/// moved it away, and the rest failed with `ENOENT` from `rename`. That
+/// surfaced as intermittent `auth login --with-token` failures across a
+/// wire-test suite large enough to run many CLI processes at once, killing a
+/// different subset of cases on each run.
+///
+/// The pid covers the case that actually bit us (separate CLI processes); the
+/// counter covers two writers inside one process, and is what makes the
+/// behavior unit-testable without spawning subprocesses.
+///
+/// `rename` is still atomic for readers, which is what keeps a partially
+/// written credential file unobservable. This only fixes writer-vs-writer
+/// collisions on the temp path. `FileKeyringStore::set` remains a
+/// read-modify-write of the whole map with no lock, so simultaneous writers
+/// can still clobber one another's *entries*; making that safe needs file
+/// locking, which is a larger change.
 pub(crate) fn atomic_write(path: &Path, data: &[u8]) -> Result<(), CliError> {
-    let tmp = path.with_extension("tmp");
+    static TMP_SEQ: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+    let seq = TMP_SEQ.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+    let tmp = path.with_extension(format!("tmp.{}.{}", std::process::id(), seq));
     std::fs::write(&tmp, data).map_err(|e| {
         CliError::Auth(format!("Failed to write {}: {e}", tmp.display()))
     })?;
@@ -250,6 +271,51 @@ pub(crate) fn atomic_write(path: &Path, data: &[u8]) -> Result<(), CliError> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// Regression test for the temp-file collision that made
+    /// `auth login --with-token` fail intermittently: every writer derived the
+    /// same sibling path from the target, so the first `rename` moved it away
+    /// and the rest got `ENOENT`.
+    ///
+    /// Reverting `atomic_write` to a target-derived temp name fails this with
+    /// "Failed to rename ...: No such file or directory".
+    #[test]
+    fn atomic_write_tolerates_concurrent_writers() {
+        let dir = tempfile::tempdir().unwrap();
+        let target = dir.path().join("auth-keyring.json");
+
+        let results: Vec<Result<(), CliError>> = std::thread::scope(|scope| {
+            let handles: Vec<_> = (0..16)
+                .map(|i| {
+                    let target = target.clone();
+                    scope.spawn(move || atomic_write(&target, format!(r#"{{"writer":{i}}}"#).as_bytes()))
+                })
+                .collect();
+            handles.into_iter().map(|h| h.join().unwrap()).collect()
+        });
+
+        let failed: Vec<String> = results
+            .iter()
+            .filter_map(|r| r.as_ref().err().map(|e| e.to_string()))
+            .collect();
+        assert!(failed.is_empty(), "concurrent writers failed: {failed:?}");
+
+        // Last writer wins, but the file must always be one writer's complete
+        // payload — never a mix, and never absent.
+        let contents = std::fs::read_to_string(&target).unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(&contents)
+            .unwrap_or_else(|e| panic!("target is not valid JSON after concurrent writes: {e} in {contents:?}"));
+        assert!(parsed.get("writer").is_some(), "unexpected payload: {contents}");
+
+        // No temp files orphaned in the directory.
+        let leftovers: Vec<String> = std::fs::read_dir(dir.path())
+            .unwrap()
+            .filter_map(|e| e.ok())
+            .map(|e| e.file_name().to_string_lossy().into_owned())
+            .filter(|n| n.contains(".tmp"))
+            .collect();
+        assert!(leftovers.is_empty(), "temp files left behind: {leftovers:?}");
+    }
 
     #[test]
     fn token_bundle_roundtrip() {

--- a/seed/cli/query-parameters-openapi-as-objects/src/auth/oauth_common.rs
+++ b/seed/cli/query-parameters-openapi-as-objects/src/auth/oauth_common.rs
@@ -224,27 +224,6 @@ pub(crate) fn config_dir() -> Option<PathBuf> {
     }
 }
 
-/// Write `data` to `path` atomically: sibling temp file → owner-only
-/// permissions (0600 on Unix) → rename into place.
-///
-/// The temp file name is unique per writer — pid plus a process-local
-/// counter. Deriving it from the target alone meant every concurrent writer
-/// used the *same* sibling (`auth-keyring.tmp`): whichever one renamed first
-/// moved it away, and the rest failed with `ENOENT` from `rename`. That
-/// surfaced as intermittent `auth login --with-token` failures across a
-/// wire-test suite large enough to run many CLI processes at once, killing a
-/// different subset of cases on each run.
-///
-/// The pid covers the case that actually bit us (separate CLI processes); the
-/// counter covers two writers inside one process, and is what makes the
-/// behavior unit-testable without spawning subprocesses.
-///
-/// `rename` is still atomic for readers, which is what keeps a partially
-/// written credential file unobservable. This only fixes writer-vs-writer
-/// collisions on the temp path. `FileKeyringStore::set` remains a
-/// read-modify-write of the whole map with no lock, so simultaneous writers
-/// can still clobber one another's *entries*; making that safe needs file
-/// locking, which is a larger change.
 /// Unlinks a temp file on drop unless [`TempFileGuard::disarm`]ed. Covers
 /// every early return *and* a panic between creating the temp file and
 /// renaming it into place.
@@ -278,6 +257,30 @@ impl Drop for TempFileGuard {
     }
 }
 
+/// Write `data` to `path` atomically: sibling temp file → owner-only
+/// permissions (0600 on Unix) → rename into place.
+///
+/// The temp file name is unique per writer — pid plus a process-local
+/// counter. Deriving it from the target alone meant every concurrent writer
+/// used the *same* sibling (`auth-keyring.tmp`): whichever one renamed first
+/// moved it away, and the rest failed with `ENOENT` from `rename`. That
+/// surfaced as intermittent `auth login --with-token` failures across a
+/// wire-test suite large enough to run many CLI processes at once, killing a
+/// different subset of cases on each run.
+///
+/// The pid covers the case that actually bit us (separate CLI processes); the
+/// counter covers two writers inside one process, and is what makes the
+/// behavior unit-testable without spawning subprocesses.
+///
+/// A [`TempFileGuard`] unlinks the temp file if anything between creating it
+/// and renaming it fails, so unique names cannot accumulate as orphans.
+///
+/// `rename` is still atomic for readers, which is what keeps a partially
+/// written credential file unobservable. This only fixes writer-vs-writer
+/// collisions on the temp path. `FileKeyringStore::set` remains a
+/// read-modify-write of the whole map with no lock, so simultaneous writers
+/// can still clobber one another's *entries*; making that safe needs file
+/// locking, which is a larger change.
 pub(crate) fn atomic_write(path: &Path, data: &[u8]) -> Result<(), CliError> {
     static TMP_SEQ: std::sync::atomic::AtomicUsize = std::sync::atomic::AtomicUsize::new(0);
     let seq = TMP_SEQ.fetch_add(1, std::sync::atomic::Ordering::Relaxed);

--- a/seed/cli/query-parameters-openapi-as-objects/src/auth/oauth_common.rs
+++ b/seed/cli/query-parameters-openapi-as-objects/src/auth/oauth_common.rs
@@ -245,23 +245,56 @@ pub(crate) fn config_dir() -> Option<PathBuf> {
 /// read-modify-write of the whole map with no lock, so simultaneous writers
 /// can still clobber one another's *entries*; making that safe needs file
 /// locking, which is a larger change.
+/// Unlinks a temp file on drop unless [`TempFileGuard::disarm`]ed. Covers
+/// every early return *and* a panic between creating the temp file and
+/// renaming it into place.
+///
+/// This exists because the temp name is unique per writer. The old shared
+/// `auth-keyring.tmp` was self-limiting — a failed write left one stale file
+/// that the next write reused — whereas unique names would leak a distinct
+/// credential-bearing file on every failure, in a directory nothing prunes. A
+/// `SIGKILL` still leaks, since no in-process guard can cover that.
+struct TempFileGuard {
+    path: PathBuf,
+    armed: bool,
+}
+
+impl TempFileGuard {
+    fn new(path: PathBuf) -> Self {
+        Self { path, armed: true }
+    }
+
+    /// Relinquish the file — call once `rename` has moved it into place.
+    fn disarm(&mut self) {
+        self.armed = false;
+    }
+}
+
+impl Drop for TempFileGuard {
+    fn drop(&mut self) {
+        if self.armed {
+            let _ = std::fs::remove_file(&self.path);
+        }
+    }
+}
+
 pub(crate) fn atomic_write(path: &Path, data: &[u8]) -> Result<(), CliError> {
-    static TMP_SEQ: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+    static TMP_SEQ: std::sync::atomic::AtomicUsize = std::sync::atomic::AtomicUsize::new(0);
     let seq = TMP_SEQ.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
     let tmp = path.with_extension(format!("tmp.{}.{}", std::process::id(), seq));
-    std::fs::write(&tmp, data).map_err(|e| {
-        CliError::Auth(format!("Failed to write {}: {e}", tmp.display()))
-    })?;
+    let mut guard = TempFileGuard::new(tmp.clone());
+    std::fs::write(&tmp, data)
+        .map_err(|e| CliError::Auth(format!("Failed to write {}: {e}", tmp.display())))?;
     #[cfg(unix)]
     {
         use std::os::unix::fs::PermissionsExt;
         let perms = std::fs::Permissions::from_mode(0o600);
         let _ = std::fs::set_permissions(&tmp, perms);
     }
-    std::fs::rename(&tmp, path).map_err(|e| {
-        let _ = std::fs::remove_file(&tmp);
-        CliError::Auth(format!("Failed to rename {}: {e}", tmp.display()))
-    })
+    std::fs::rename(&tmp, path)
+        .map_err(|e| CliError::Auth(format!("Failed to rename {}: {e}", tmp.display())))?;
+    guard.disarm();
+    Ok(())
 }
 
 // ---------------------------------------------------------------------------
@@ -315,6 +348,56 @@ mod tests {
             .filter(|n| n.contains(".tmp"))
             .collect();
         assert!(leftovers.is_empty(), "temp files left behind: {leftovers:?}");
+    }
+
+    /// A failed write must not leave its temp file behind. Renaming a file onto
+    /// an existing directory fails on every platform, which drives the error
+    /// path without mocking the filesystem.
+    ///
+    /// The pre-`TempFileGuard` code already cleaned up on a `rename` error, so
+    /// this pins an invariant rather than catching a regression — see
+    /// `temp_file_guard_unlinks_unless_disarmed` for the guard's own coverage.
+    #[test]
+    fn atomic_write_cleans_up_temp_file_on_failure() {
+        let dir = tempfile::tempdir().unwrap();
+
+        // The target is a *directory*, so `rename` cannot replace it.
+        let target = dir.path().join("auth-keyring.json");
+        std::fs::create_dir(&target).unwrap();
+        std::fs::write(target.join("occupant"), b"x").unwrap();
+
+        let result = atomic_write(&target, br#"{"writer":0}"#);
+        assert!(result.is_err(), "expected rename onto a directory to fail");
+
+        let leftovers: Vec<String> = std::fs::read_dir(dir.path())
+            .unwrap()
+            .filter_map(|e| e.ok())
+            .map(|e| e.file_name().to_string_lossy().into_owned())
+            .filter(|n| n.contains(".tmp"))
+            .collect();
+        assert!(leftovers.is_empty(), "temp file leaked after a failed write: {leftovers:?}");
+    }
+
+    /// Pins [`TempFileGuard`]: armed drops unlink, disarmed drops don't. Drop
+    /// running on an armed guard is what covers early returns and unwinding
+    /// panics between `write` and `rename` — paths the old `rename`-only
+    /// cleanup missed. Deleting the guard or the `disarm()` call fails this.
+    #[test]
+    fn temp_file_guard_unlinks_unless_disarmed() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("auth-keyring.tmp.0.0");
+
+        std::fs::write(&path, b"x").unwrap();
+        drop(TempFileGuard::new(path.clone()));
+        assert!(!path.exists(), "armed guard must unlink on drop");
+
+        // The post-`rename` case: the file has been moved away, so the guard
+        // must not touch whatever now sits at that path.
+        std::fs::write(&path, b"x").unwrap();
+        let mut guard = TempFileGuard::new(path.clone());
+        guard.disarm();
+        drop(guard);
+        assert!(path.exists(), "disarmed guard must not unlink");
     }
 
     #[test]

--- a/seed/cli/query-parameters-openapi-as-objects/src/auth/oauth_common.rs
+++ b/seed/cli/query-parameters-openapi-as-objects/src/auth/oauth_common.rs
@@ -226,8 +226,29 @@ pub(crate) fn config_dir() -> Option<PathBuf> {
 
 /// Write `data` to `path` atomically: sibling temp file → owner-only
 /// permissions (0600 on Unix) → rename into place.
+///
+/// The temp file name is unique per writer — pid plus a process-local
+/// counter. Deriving it from the target alone meant every concurrent writer
+/// used the *same* sibling (`auth-keyring.tmp`): whichever one renamed first
+/// moved it away, and the rest failed with `ENOENT` from `rename`. That
+/// surfaced as intermittent `auth login --with-token` failures across a
+/// wire-test suite large enough to run many CLI processes at once, killing a
+/// different subset of cases on each run.
+///
+/// The pid covers the case that actually bit us (separate CLI processes); the
+/// counter covers two writers inside one process, and is what makes the
+/// behavior unit-testable without spawning subprocesses.
+///
+/// `rename` is still atomic for readers, which is what keeps a partially
+/// written credential file unobservable. This only fixes writer-vs-writer
+/// collisions on the temp path. `FileKeyringStore::set` remains a
+/// read-modify-write of the whole map with no lock, so simultaneous writers
+/// can still clobber one another's *entries*; making that safe needs file
+/// locking, which is a larger change.
 pub(crate) fn atomic_write(path: &Path, data: &[u8]) -> Result<(), CliError> {
-    let tmp = path.with_extension("tmp");
+    static TMP_SEQ: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+    let seq = TMP_SEQ.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+    let tmp = path.with_extension(format!("tmp.{}.{}", std::process::id(), seq));
     std::fs::write(&tmp, data).map_err(|e| {
         CliError::Auth(format!("Failed to write {}: {e}", tmp.display()))
     })?;
@@ -250,6 +271,51 @@ pub(crate) fn atomic_write(path: &Path, data: &[u8]) -> Result<(), CliError> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// Regression test for the temp-file collision that made
+    /// `auth login --with-token` fail intermittently: every writer derived the
+    /// same sibling path from the target, so the first `rename` moved it away
+    /// and the rest got `ENOENT`.
+    ///
+    /// Reverting `atomic_write` to a target-derived temp name fails this with
+    /// "Failed to rename ...: No such file or directory".
+    #[test]
+    fn atomic_write_tolerates_concurrent_writers() {
+        let dir = tempfile::tempdir().unwrap();
+        let target = dir.path().join("auth-keyring.json");
+
+        let results: Vec<Result<(), CliError>> = std::thread::scope(|scope| {
+            let handles: Vec<_> = (0..16)
+                .map(|i| {
+                    let target = target.clone();
+                    scope.spawn(move || atomic_write(&target, format!(r#"{{"writer":{i}}}"#).as_bytes()))
+                })
+                .collect();
+            handles.into_iter().map(|h| h.join().unwrap()).collect()
+        });
+
+        let failed: Vec<String> = results
+            .iter()
+            .filter_map(|r| r.as_ref().err().map(|e| e.to_string()))
+            .collect();
+        assert!(failed.is_empty(), "concurrent writers failed: {failed:?}");
+
+        // Last writer wins, but the file must always be one writer's complete
+        // payload — never a mix, and never absent.
+        let contents = std::fs::read_to_string(&target).unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(&contents)
+            .unwrap_or_else(|e| panic!("target is not valid JSON after concurrent writes: {e} in {contents:?}"));
+        assert!(parsed.get("writer").is_some(), "unexpected payload: {contents}");
+
+        // No temp files orphaned in the directory.
+        let leftovers: Vec<String> = std::fs::read_dir(dir.path())
+            .unwrap()
+            .filter_map(|e| e.ok())
+            .map(|e| e.file_name().to_string_lossy().into_owned())
+            .filter(|n| n.contains(".tmp"))
+            .collect();
+        assert!(leftovers.is_empty(), "temp files left behind: {leftovers:?}");
+    }
 
     #[test]
     fn token_bundle_roundtrip() {

--- a/seed/cli/query-parameters-openapi/github-distribution/src/auth/oauth_common.rs
+++ b/seed/cli/query-parameters-openapi/github-distribution/src/auth/oauth_common.rs
@@ -224,27 +224,6 @@ pub(crate) fn config_dir() -> Option<PathBuf> {
     }
 }
 
-/// Write `data` to `path` atomically: sibling temp file → owner-only
-/// permissions (0600 on Unix) → rename into place.
-///
-/// The temp file name is unique per writer — pid plus a process-local
-/// counter. Deriving it from the target alone meant every concurrent writer
-/// used the *same* sibling (`auth-keyring.tmp`): whichever one renamed first
-/// moved it away, and the rest failed with `ENOENT` from `rename`. That
-/// surfaced as intermittent `auth login --with-token` failures across a
-/// wire-test suite large enough to run many CLI processes at once, killing a
-/// different subset of cases on each run.
-///
-/// The pid covers the case that actually bit us (separate CLI processes); the
-/// counter covers two writers inside one process, and is what makes the
-/// behavior unit-testable without spawning subprocesses.
-///
-/// `rename` is still atomic for readers, which is what keeps a partially
-/// written credential file unobservable. This only fixes writer-vs-writer
-/// collisions on the temp path. `FileKeyringStore::set` remains a
-/// read-modify-write of the whole map with no lock, so simultaneous writers
-/// can still clobber one another's *entries*; making that safe needs file
-/// locking, which is a larger change.
 /// Unlinks a temp file on drop unless [`TempFileGuard::disarm`]ed. Covers
 /// every early return *and* a panic between creating the temp file and
 /// renaming it into place.
@@ -278,6 +257,30 @@ impl Drop for TempFileGuard {
     }
 }
 
+/// Write `data` to `path` atomically: sibling temp file → owner-only
+/// permissions (0600 on Unix) → rename into place.
+///
+/// The temp file name is unique per writer — pid plus a process-local
+/// counter. Deriving it from the target alone meant every concurrent writer
+/// used the *same* sibling (`auth-keyring.tmp`): whichever one renamed first
+/// moved it away, and the rest failed with `ENOENT` from `rename`. That
+/// surfaced as intermittent `auth login --with-token` failures across a
+/// wire-test suite large enough to run many CLI processes at once, killing a
+/// different subset of cases on each run.
+///
+/// The pid covers the case that actually bit us (separate CLI processes); the
+/// counter covers two writers inside one process, and is what makes the
+/// behavior unit-testable without spawning subprocesses.
+///
+/// A [`TempFileGuard`] unlinks the temp file if anything between creating it
+/// and renaming it fails, so unique names cannot accumulate as orphans.
+///
+/// `rename` is still atomic for readers, which is what keeps a partially
+/// written credential file unobservable. This only fixes writer-vs-writer
+/// collisions on the temp path. `FileKeyringStore::set` remains a
+/// read-modify-write of the whole map with no lock, so simultaneous writers
+/// can still clobber one another's *entries*; making that safe needs file
+/// locking, which is a larger change.
 pub(crate) fn atomic_write(path: &Path, data: &[u8]) -> Result<(), CliError> {
     static TMP_SEQ: std::sync::atomic::AtomicUsize = std::sync::atomic::AtomicUsize::new(0);
     let seq = TMP_SEQ.fetch_add(1, std::sync::atomic::Ordering::Relaxed);

--- a/seed/cli/query-parameters-openapi/github-distribution/src/auth/oauth_common.rs
+++ b/seed/cli/query-parameters-openapi/github-distribution/src/auth/oauth_common.rs
@@ -245,23 +245,56 @@ pub(crate) fn config_dir() -> Option<PathBuf> {
 /// read-modify-write of the whole map with no lock, so simultaneous writers
 /// can still clobber one another's *entries*; making that safe needs file
 /// locking, which is a larger change.
+/// Unlinks a temp file on drop unless [`TempFileGuard::disarm`]ed. Covers
+/// every early return *and* a panic between creating the temp file and
+/// renaming it into place.
+///
+/// This exists because the temp name is unique per writer. The old shared
+/// `auth-keyring.tmp` was self-limiting — a failed write left one stale file
+/// that the next write reused — whereas unique names would leak a distinct
+/// credential-bearing file on every failure, in a directory nothing prunes. A
+/// `SIGKILL` still leaks, since no in-process guard can cover that.
+struct TempFileGuard {
+    path: PathBuf,
+    armed: bool,
+}
+
+impl TempFileGuard {
+    fn new(path: PathBuf) -> Self {
+        Self { path, armed: true }
+    }
+
+    /// Relinquish the file — call once `rename` has moved it into place.
+    fn disarm(&mut self) {
+        self.armed = false;
+    }
+}
+
+impl Drop for TempFileGuard {
+    fn drop(&mut self) {
+        if self.armed {
+            let _ = std::fs::remove_file(&self.path);
+        }
+    }
+}
+
 pub(crate) fn atomic_write(path: &Path, data: &[u8]) -> Result<(), CliError> {
-    static TMP_SEQ: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+    static TMP_SEQ: std::sync::atomic::AtomicUsize = std::sync::atomic::AtomicUsize::new(0);
     let seq = TMP_SEQ.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
     let tmp = path.with_extension(format!("tmp.{}.{}", std::process::id(), seq));
-    std::fs::write(&tmp, data).map_err(|e| {
-        CliError::Auth(format!("Failed to write {}: {e}", tmp.display()))
-    })?;
+    let mut guard = TempFileGuard::new(tmp.clone());
+    std::fs::write(&tmp, data)
+        .map_err(|e| CliError::Auth(format!("Failed to write {}: {e}", tmp.display())))?;
     #[cfg(unix)]
     {
         use std::os::unix::fs::PermissionsExt;
         let perms = std::fs::Permissions::from_mode(0o600);
         let _ = std::fs::set_permissions(&tmp, perms);
     }
-    std::fs::rename(&tmp, path).map_err(|e| {
-        let _ = std::fs::remove_file(&tmp);
-        CliError::Auth(format!("Failed to rename {}: {e}", tmp.display()))
-    })
+    std::fs::rename(&tmp, path)
+        .map_err(|e| CliError::Auth(format!("Failed to rename {}: {e}", tmp.display())))?;
+    guard.disarm();
+    Ok(())
 }
 
 // ---------------------------------------------------------------------------
@@ -315,6 +348,56 @@ mod tests {
             .filter(|n| n.contains(".tmp"))
             .collect();
         assert!(leftovers.is_empty(), "temp files left behind: {leftovers:?}");
+    }
+
+    /// A failed write must not leave its temp file behind. Renaming a file onto
+    /// an existing directory fails on every platform, which drives the error
+    /// path without mocking the filesystem.
+    ///
+    /// The pre-`TempFileGuard` code already cleaned up on a `rename` error, so
+    /// this pins an invariant rather than catching a regression — see
+    /// `temp_file_guard_unlinks_unless_disarmed` for the guard's own coverage.
+    #[test]
+    fn atomic_write_cleans_up_temp_file_on_failure() {
+        let dir = tempfile::tempdir().unwrap();
+
+        // The target is a *directory*, so `rename` cannot replace it.
+        let target = dir.path().join("auth-keyring.json");
+        std::fs::create_dir(&target).unwrap();
+        std::fs::write(target.join("occupant"), b"x").unwrap();
+
+        let result = atomic_write(&target, br#"{"writer":0}"#);
+        assert!(result.is_err(), "expected rename onto a directory to fail");
+
+        let leftovers: Vec<String> = std::fs::read_dir(dir.path())
+            .unwrap()
+            .filter_map(|e| e.ok())
+            .map(|e| e.file_name().to_string_lossy().into_owned())
+            .filter(|n| n.contains(".tmp"))
+            .collect();
+        assert!(leftovers.is_empty(), "temp file leaked after a failed write: {leftovers:?}");
+    }
+
+    /// Pins [`TempFileGuard`]: armed drops unlink, disarmed drops don't. Drop
+    /// running on an armed guard is what covers early returns and unwinding
+    /// panics between `write` and `rename` — paths the old `rename`-only
+    /// cleanup missed. Deleting the guard or the `disarm()` call fails this.
+    #[test]
+    fn temp_file_guard_unlinks_unless_disarmed() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("auth-keyring.tmp.0.0");
+
+        std::fs::write(&path, b"x").unwrap();
+        drop(TempFileGuard::new(path.clone()));
+        assert!(!path.exists(), "armed guard must unlink on drop");
+
+        // The post-`rename` case: the file has been moved away, so the guard
+        // must not touch whatever now sits at that path.
+        std::fs::write(&path, b"x").unwrap();
+        let mut guard = TempFileGuard::new(path.clone());
+        guard.disarm();
+        drop(guard);
+        assert!(path.exists(), "disarmed guard must not unlink");
     }
 
     #[test]

--- a/seed/cli/query-parameters-openapi/github-distribution/src/auth/oauth_common.rs
+++ b/seed/cli/query-parameters-openapi/github-distribution/src/auth/oauth_common.rs
@@ -226,8 +226,29 @@ pub(crate) fn config_dir() -> Option<PathBuf> {
 
 /// Write `data` to `path` atomically: sibling temp file → owner-only
 /// permissions (0600 on Unix) → rename into place.
+///
+/// The temp file name is unique per writer — pid plus a process-local
+/// counter. Deriving it from the target alone meant every concurrent writer
+/// used the *same* sibling (`auth-keyring.tmp`): whichever one renamed first
+/// moved it away, and the rest failed with `ENOENT` from `rename`. That
+/// surfaced as intermittent `auth login --with-token` failures across a
+/// wire-test suite large enough to run many CLI processes at once, killing a
+/// different subset of cases on each run.
+///
+/// The pid covers the case that actually bit us (separate CLI processes); the
+/// counter covers two writers inside one process, and is what makes the
+/// behavior unit-testable without spawning subprocesses.
+///
+/// `rename` is still atomic for readers, which is what keeps a partially
+/// written credential file unobservable. This only fixes writer-vs-writer
+/// collisions on the temp path. `FileKeyringStore::set` remains a
+/// read-modify-write of the whole map with no lock, so simultaneous writers
+/// can still clobber one another's *entries*; making that safe needs file
+/// locking, which is a larger change.
 pub(crate) fn atomic_write(path: &Path, data: &[u8]) -> Result<(), CliError> {
-    let tmp = path.with_extension("tmp");
+    static TMP_SEQ: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+    let seq = TMP_SEQ.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+    let tmp = path.with_extension(format!("tmp.{}.{}", std::process::id(), seq));
     std::fs::write(&tmp, data).map_err(|e| {
         CliError::Auth(format!("Failed to write {}: {e}", tmp.display()))
     })?;
@@ -250,6 +271,51 @@ pub(crate) fn atomic_write(path: &Path, data: &[u8]) -> Result<(), CliError> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// Regression test for the temp-file collision that made
+    /// `auth login --with-token` fail intermittently: every writer derived the
+    /// same sibling path from the target, so the first `rename` moved it away
+    /// and the rest got `ENOENT`.
+    ///
+    /// Reverting `atomic_write` to a target-derived temp name fails this with
+    /// "Failed to rename ...: No such file or directory".
+    #[test]
+    fn atomic_write_tolerates_concurrent_writers() {
+        let dir = tempfile::tempdir().unwrap();
+        let target = dir.path().join("auth-keyring.json");
+
+        let results: Vec<Result<(), CliError>> = std::thread::scope(|scope| {
+            let handles: Vec<_> = (0..16)
+                .map(|i| {
+                    let target = target.clone();
+                    scope.spawn(move || atomic_write(&target, format!(r#"{{"writer":{i}}}"#).as_bytes()))
+                })
+                .collect();
+            handles.into_iter().map(|h| h.join().unwrap()).collect()
+        });
+
+        let failed: Vec<String> = results
+            .iter()
+            .filter_map(|r| r.as_ref().err().map(|e| e.to_string()))
+            .collect();
+        assert!(failed.is_empty(), "concurrent writers failed: {failed:?}");
+
+        // Last writer wins, but the file must always be one writer's complete
+        // payload — never a mix, and never absent.
+        let contents = std::fs::read_to_string(&target).unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(&contents)
+            .unwrap_or_else(|e| panic!("target is not valid JSON after concurrent writes: {e} in {contents:?}"));
+        assert!(parsed.get("writer").is_some(), "unexpected payload: {contents}");
+
+        // No temp files orphaned in the directory.
+        let leftovers: Vec<String> = std::fs::read_dir(dir.path())
+            .unwrap()
+            .filter_map(|e| e.ok())
+            .map(|e| e.file_name().to_string_lossy().into_owned())
+            .filter(|n| n.contains(".tmp"))
+            .collect();
+        assert!(leftovers.is_empty(), "temp files left behind: {leftovers:?}");
+    }
 
     #[test]
     fn token_bundle_roundtrip() {

--- a/seed/cli/query-parameters-openapi/github-no-publish/src/auth/oauth_common.rs
+++ b/seed/cli/query-parameters-openapi/github-no-publish/src/auth/oauth_common.rs
@@ -224,27 +224,6 @@ pub(crate) fn config_dir() -> Option<PathBuf> {
     }
 }
 
-/// Write `data` to `path` atomically: sibling temp file → owner-only
-/// permissions (0600 on Unix) → rename into place.
-///
-/// The temp file name is unique per writer — pid plus a process-local
-/// counter. Deriving it from the target alone meant every concurrent writer
-/// used the *same* sibling (`auth-keyring.tmp`): whichever one renamed first
-/// moved it away, and the rest failed with `ENOENT` from `rename`. That
-/// surfaced as intermittent `auth login --with-token` failures across a
-/// wire-test suite large enough to run many CLI processes at once, killing a
-/// different subset of cases on each run.
-///
-/// The pid covers the case that actually bit us (separate CLI processes); the
-/// counter covers two writers inside one process, and is what makes the
-/// behavior unit-testable without spawning subprocesses.
-///
-/// `rename` is still atomic for readers, which is what keeps a partially
-/// written credential file unobservable. This only fixes writer-vs-writer
-/// collisions on the temp path. `FileKeyringStore::set` remains a
-/// read-modify-write of the whole map with no lock, so simultaneous writers
-/// can still clobber one another's *entries*; making that safe needs file
-/// locking, which is a larger change.
 /// Unlinks a temp file on drop unless [`TempFileGuard::disarm`]ed. Covers
 /// every early return *and* a panic between creating the temp file and
 /// renaming it into place.
@@ -278,6 +257,30 @@ impl Drop for TempFileGuard {
     }
 }
 
+/// Write `data` to `path` atomically: sibling temp file → owner-only
+/// permissions (0600 on Unix) → rename into place.
+///
+/// The temp file name is unique per writer — pid plus a process-local
+/// counter. Deriving it from the target alone meant every concurrent writer
+/// used the *same* sibling (`auth-keyring.tmp`): whichever one renamed first
+/// moved it away, and the rest failed with `ENOENT` from `rename`. That
+/// surfaced as intermittent `auth login --with-token` failures across a
+/// wire-test suite large enough to run many CLI processes at once, killing a
+/// different subset of cases on each run.
+///
+/// The pid covers the case that actually bit us (separate CLI processes); the
+/// counter covers two writers inside one process, and is what makes the
+/// behavior unit-testable without spawning subprocesses.
+///
+/// A [`TempFileGuard`] unlinks the temp file if anything between creating it
+/// and renaming it fails, so unique names cannot accumulate as orphans.
+///
+/// `rename` is still atomic for readers, which is what keeps a partially
+/// written credential file unobservable. This only fixes writer-vs-writer
+/// collisions on the temp path. `FileKeyringStore::set` remains a
+/// read-modify-write of the whole map with no lock, so simultaneous writers
+/// can still clobber one another's *entries*; making that safe needs file
+/// locking, which is a larger change.
 pub(crate) fn atomic_write(path: &Path, data: &[u8]) -> Result<(), CliError> {
     static TMP_SEQ: std::sync::atomic::AtomicUsize = std::sync::atomic::AtomicUsize::new(0);
     let seq = TMP_SEQ.fetch_add(1, std::sync::atomic::Ordering::Relaxed);

--- a/seed/cli/query-parameters-openapi/github-no-publish/src/auth/oauth_common.rs
+++ b/seed/cli/query-parameters-openapi/github-no-publish/src/auth/oauth_common.rs
@@ -245,23 +245,56 @@ pub(crate) fn config_dir() -> Option<PathBuf> {
 /// read-modify-write of the whole map with no lock, so simultaneous writers
 /// can still clobber one another's *entries*; making that safe needs file
 /// locking, which is a larger change.
+/// Unlinks a temp file on drop unless [`TempFileGuard::disarm`]ed. Covers
+/// every early return *and* a panic between creating the temp file and
+/// renaming it into place.
+///
+/// This exists because the temp name is unique per writer. The old shared
+/// `auth-keyring.tmp` was self-limiting — a failed write left one stale file
+/// that the next write reused — whereas unique names would leak a distinct
+/// credential-bearing file on every failure, in a directory nothing prunes. A
+/// `SIGKILL` still leaks, since no in-process guard can cover that.
+struct TempFileGuard {
+    path: PathBuf,
+    armed: bool,
+}
+
+impl TempFileGuard {
+    fn new(path: PathBuf) -> Self {
+        Self { path, armed: true }
+    }
+
+    /// Relinquish the file — call once `rename` has moved it into place.
+    fn disarm(&mut self) {
+        self.armed = false;
+    }
+}
+
+impl Drop for TempFileGuard {
+    fn drop(&mut self) {
+        if self.armed {
+            let _ = std::fs::remove_file(&self.path);
+        }
+    }
+}
+
 pub(crate) fn atomic_write(path: &Path, data: &[u8]) -> Result<(), CliError> {
-    static TMP_SEQ: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+    static TMP_SEQ: std::sync::atomic::AtomicUsize = std::sync::atomic::AtomicUsize::new(0);
     let seq = TMP_SEQ.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
     let tmp = path.with_extension(format!("tmp.{}.{}", std::process::id(), seq));
-    std::fs::write(&tmp, data).map_err(|e| {
-        CliError::Auth(format!("Failed to write {}: {e}", tmp.display()))
-    })?;
+    let mut guard = TempFileGuard::new(tmp.clone());
+    std::fs::write(&tmp, data)
+        .map_err(|e| CliError::Auth(format!("Failed to write {}: {e}", tmp.display())))?;
     #[cfg(unix)]
     {
         use std::os::unix::fs::PermissionsExt;
         let perms = std::fs::Permissions::from_mode(0o600);
         let _ = std::fs::set_permissions(&tmp, perms);
     }
-    std::fs::rename(&tmp, path).map_err(|e| {
-        let _ = std::fs::remove_file(&tmp);
-        CliError::Auth(format!("Failed to rename {}: {e}", tmp.display()))
-    })
+    std::fs::rename(&tmp, path)
+        .map_err(|e| CliError::Auth(format!("Failed to rename {}: {e}", tmp.display())))?;
+    guard.disarm();
+    Ok(())
 }
 
 // ---------------------------------------------------------------------------
@@ -315,6 +348,56 @@ mod tests {
             .filter(|n| n.contains(".tmp"))
             .collect();
         assert!(leftovers.is_empty(), "temp files left behind: {leftovers:?}");
+    }
+
+    /// A failed write must not leave its temp file behind. Renaming a file onto
+    /// an existing directory fails on every platform, which drives the error
+    /// path without mocking the filesystem.
+    ///
+    /// The pre-`TempFileGuard` code already cleaned up on a `rename` error, so
+    /// this pins an invariant rather than catching a regression — see
+    /// `temp_file_guard_unlinks_unless_disarmed` for the guard's own coverage.
+    #[test]
+    fn atomic_write_cleans_up_temp_file_on_failure() {
+        let dir = tempfile::tempdir().unwrap();
+
+        // The target is a *directory*, so `rename` cannot replace it.
+        let target = dir.path().join("auth-keyring.json");
+        std::fs::create_dir(&target).unwrap();
+        std::fs::write(target.join("occupant"), b"x").unwrap();
+
+        let result = atomic_write(&target, br#"{"writer":0}"#);
+        assert!(result.is_err(), "expected rename onto a directory to fail");
+
+        let leftovers: Vec<String> = std::fs::read_dir(dir.path())
+            .unwrap()
+            .filter_map(|e| e.ok())
+            .map(|e| e.file_name().to_string_lossy().into_owned())
+            .filter(|n| n.contains(".tmp"))
+            .collect();
+        assert!(leftovers.is_empty(), "temp file leaked after a failed write: {leftovers:?}");
+    }
+
+    /// Pins [`TempFileGuard`]: armed drops unlink, disarmed drops don't. Drop
+    /// running on an armed guard is what covers early returns and unwinding
+    /// panics between `write` and `rename` — paths the old `rename`-only
+    /// cleanup missed. Deleting the guard or the `disarm()` call fails this.
+    #[test]
+    fn temp_file_guard_unlinks_unless_disarmed() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("auth-keyring.tmp.0.0");
+
+        std::fs::write(&path, b"x").unwrap();
+        drop(TempFileGuard::new(path.clone()));
+        assert!(!path.exists(), "armed guard must unlink on drop");
+
+        // The post-`rename` case: the file has been moved away, so the guard
+        // must not touch whatever now sits at that path.
+        std::fs::write(&path, b"x").unwrap();
+        let mut guard = TempFileGuard::new(path.clone());
+        guard.disarm();
+        drop(guard);
+        assert!(path.exists(), "disarmed guard must not unlink");
     }
 
     #[test]

--- a/seed/cli/query-parameters-openapi/github-no-publish/src/auth/oauth_common.rs
+++ b/seed/cli/query-parameters-openapi/github-no-publish/src/auth/oauth_common.rs
@@ -226,8 +226,29 @@ pub(crate) fn config_dir() -> Option<PathBuf> {
 
 /// Write `data` to `path` atomically: sibling temp file → owner-only
 /// permissions (0600 on Unix) → rename into place.
+///
+/// The temp file name is unique per writer — pid plus a process-local
+/// counter. Deriving it from the target alone meant every concurrent writer
+/// used the *same* sibling (`auth-keyring.tmp`): whichever one renamed first
+/// moved it away, and the rest failed with `ENOENT` from `rename`. That
+/// surfaced as intermittent `auth login --with-token` failures across a
+/// wire-test suite large enough to run many CLI processes at once, killing a
+/// different subset of cases on each run.
+///
+/// The pid covers the case that actually bit us (separate CLI processes); the
+/// counter covers two writers inside one process, and is what makes the
+/// behavior unit-testable without spawning subprocesses.
+///
+/// `rename` is still atomic for readers, which is what keeps a partially
+/// written credential file unobservable. This only fixes writer-vs-writer
+/// collisions on the temp path. `FileKeyringStore::set` remains a
+/// read-modify-write of the whole map with no lock, so simultaneous writers
+/// can still clobber one another's *entries*; making that safe needs file
+/// locking, which is a larger change.
 pub(crate) fn atomic_write(path: &Path, data: &[u8]) -> Result<(), CliError> {
-    let tmp = path.with_extension("tmp");
+    static TMP_SEQ: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+    let seq = TMP_SEQ.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+    let tmp = path.with_extension(format!("tmp.{}.{}", std::process::id(), seq));
     std::fs::write(&tmp, data).map_err(|e| {
         CliError::Auth(format!("Failed to write {}: {e}", tmp.display()))
     })?;
@@ -250,6 +271,51 @@ pub(crate) fn atomic_write(path: &Path, data: &[u8]) -> Result<(), CliError> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// Regression test for the temp-file collision that made
+    /// `auth login --with-token` fail intermittently: every writer derived the
+    /// same sibling path from the target, so the first `rename` moved it away
+    /// and the rest got `ENOENT`.
+    ///
+    /// Reverting `atomic_write` to a target-derived temp name fails this with
+    /// "Failed to rename ...: No such file or directory".
+    #[test]
+    fn atomic_write_tolerates_concurrent_writers() {
+        let dir = tempfile::tempdir().unwrap();
+        let target = dir.path().join("auth-keyring.json");
+
+        let results: Vec<Result<(), CliError>> = std::thread::scope(|scope| {
+            let handles: Vec<_> = (0..16)
+                .map(|i| {
+                    let target = target.clone();
+                    scope.spawn(move || atomic_write(&target, format!(r#"{{"writer":{i}}}"#).as_bytes()))
+                })
+                .collect();
+            handles.into_iter().map(|h| h.join().unwrap()).collect()
+        });
+
+        let failed: Vec<String> = results
+            .iter()
+            .filter_map(|r| r.as_ref().err().map(|e| e.to_string()))
+            .collect();
+        assert!(failed.is_empty(), "concurrent writers failed: {failed:?}");
+
+        // Last writer wins, but the file must always be one writer's complete
+        // payload — never a mix, and never absent.
+        let contents = std::fs::read_to_string(&target).unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(&contents)
+            .unwrap_or_else(|e| panic!("target is not valid JSON after concurrent writes: {e} in {contents:?}"));
+        assert!(parsed.get("writer").is_some(), "unexpected payload: {contents}");
+
+        // No temp files orphaned in the directory.
+        let leftovers: Vec<String> = std::fs::read_dir(dir.path())
+            .unwrap()
+            .filter_map(|e| e.ok())
+            .map(|e| e.file_name().to_string_lossy().into_owned())
+            .filter(|n| n.contains(".tmp"))
+            .collect();
+        assert!(leftovers.is_empty(), "temp files left behind: {leftovers:?}");
+    }
 
     #[test]
     fn token_bundle_roundtrip() {

--- a/seed/cli/query-parameters-openapi/github-npm/src/auth/oauth_common.rs
+++ b/seed/cli/query-parameters-openapi/github-npm/src/auth/oauth_common.rs
@@ -224,27 +224,6 @@ pub(crate) fn config_dir() -> Option<PathBuf> {
     }
 }
 
-/// Write `data` to `path` atomically: sibling temp file → owner-only
-/// permissions (0600 on Unix) → rename into place.
-///
-/// The temp file name is unique per writer — pid plus a process-local
-/// counter. Deriving it from the target alone meant every concurrent writer
-/// used the *same* sibling (`auth-keyring.tmp`): whichever one renamed first
-/// moved it away, and the rest failed with `ENOENT` from `rename`. That
-/// surfaced as intermittent `auth login --with-token` failures across a
-/// wire-test suite large enough to run many CLI processes at once, killing a
-/// different subset of cases on each run.
-///
-/// The pid covers the case that actually bit us (separate CLI processes); the
-/// counter covers two writers inside one process, and is what makes the
-/// behavior unit-testable without spawning subprocesses.
-///
-/// `rename` is still atomic for readers, which is what keeps a partially
-/// written credential file unobservable. This only fixes writer-vs-writer
-/// collisions on the temp path. `FileKeyringStore::set` remains a
-/// read-modify-write of the whole map with no lock, so simultaneous writers
-/// can still clobber one another's *entries*; making that safe needs file
-/// locking, which is a larger change.
 /// Unlinks a temp file on drop unless [`TempFileGuard::disarm`]ed. Covers
 /// every early return *and* a panic between creating the temp file and
 /// renaming it into place.
@@ -278,6 +257,30 @@ impl Drop for TempFileGuard {
     }
 }
 
+/// Write `data` to `path` atomically: sibling temp file → owner-only
+/// permissions (0600 on Unix) → rename into place.
+///
+/// The temp file name is unique per writer — pid plus a process-local
+/// counter. Deriving it from the target alone meant every concurrent writer
+/// used the *same* sibling (`auth-keyring.tmp`): whichever one renamed first
+/// moved it away, and the rest failed with `ENOENT` from `rename`. That
+/// surfaced as intermittent `auth login --with-token` failures across a
+/// wire-test suite large enough to run many CLI processes at once, killing a
+/// different subset of cases on each run.
+///
+/// The pid covers the case that actually bit us (separate CLI processes); the
+/// counter covers two writers inside one process, and is what makes the
+/// behavior unit-testable without spawning subprocesses.
+///
+/// A [`TempFileGuard`] unlinks the temp file if anything between creating it
+/// and renaming it fails, so unique names cannot accumulate as orphans.
+///
+/// `rename` is still atomic for readers, which is what keeps a partially
+/// written credential file unobservable. This only fixes writer-vs-writer
+/// collisions on the temp path. `FileKeyringStore::set` remains a
+/// read-modify-write of the whole map with no lock, so simultaneous writers
+/// can still clobber one another's *entries*; making that safe needs file
+/// locking, which is a larger change.
 pub(crate) fn atomic_write(path: &Path, data: &[u8]) -> Result<(), CliError> {
     static TMP_SEQ: std::sync::atomic::AtomicUsize = std::sync::atomic::AtomicUsize::new(0);
     let seq = TMP_SEQ.fetch_add(1, std::sync::atomic::Ordering::Relaxed);

--- a/seed/cli/query-parameters-openapi/github-npm/src/auth/oauth_common.rs
+++ b/seed/cli/query-parameters-openapi/github-npm/src/auth/oauth_common.rs
@@ -245,23 +245,56 @@ pub(crate) fn config_dir() -> Option<PathBuf> {
 /// read-modify-write of the whole map with no lock, so simultaneous writers
 /// can still clobber one another's *entries*; making that safe needs file
 /// locking, which is a larger change.
+/// Unlinks a temp file on drop unless [`TempFileGuard::disarm`]ed. Covers
+/// every early return *and* a panic between creating the temp file and
+/// renaming it into place.
+///
+/// This exists because the temp name is unique per writer. The old shared
+/// `auth-keyring.tmp` was self-limiting — a failed write left one stale file
+/// that the next write reused — whereas unique names would leak a distinct
+/// credential-bearing file on every failure, in a directory nothing prunes. A
+/// `SIGKILL` still leaks, since no in-process guard can cover that.
+struct TempFileGuard {
+    path: PathBuf,
+    armed: bool,
+}
+
+impl TempFileGuard {
+    fn new(path: PathBuf) -> Self {
+        Self { path, armed: true }
+    }
+
+    /// Relinquish the file — call once `rename` has moved it into place.
+    fn disarm(&mut self) {
+        self.armed = false;
+    }
+}
+
+impl Drop for TempFileGuard {
+    fn drop(&mut self) {
+        if self.armed {
+            let _ = std::fs::remove_file(&self.path);
+        }
+    }
+}
+
 pub(crate) fn atomic_write(path: &Path, data: &[u8]) -> Result<(), CliError> {
-    static TMP_SEQ: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+    static TMP_SEQ: std::sync::atomic::AtomicUsize = std::sync::atomic::AtomicUsize::new(0);
     let seq = TMP_SEQ.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
     let tmp = path.with_extension(format!("tmp.{}.{}", std::process::id(), seq));
-    std::fs::write(&tmp, data).map_err(|e| {
-        CliError::Auth(format!("Failed to write {}: {e}", tmp.display()))
-    })?;
+    let mut guard = TempFileGuard::new(tmp.clone());
+    std::fs::write(&tmp, data)
+        .map_err(|e| CliError::Auth(format!("Failed to write {}: {e}", tmp.display())))?;
     #[cfg(unix)]
     {
         use std::os::unix::fs::PermissionsExt;
         let perms = std::fs::Permissions::from_mode(0o600);
         let _ = std::fs::set_permissions(&tmp, perms);
     }
-    std::fs::rename(&tmp, path).map_err(|e| {
-        let _ = std::fs::remove_file(&tmp);
-        CliError::Auth(format!("Failed to rename {}: {e}", tmp.display()))
-    })
+    std::fs::rename(&tmp, path)
+        .map_err(|e| CliError::Auth(format!("Failed to rename {}: {e}", tmp.display())))?;
+    guard.disarm();
+    Ok(())
 }
 
 // ---------------------------------------------------------------------------
@@ -315,6 +348,56 @@ mod tests {
             .filter(|n| n.contains(".tmp"))
             .collect();
         assert!(leftovers.is_empty(), "temp files left behind: {leftovers:?}");
+    }
+
+    /// A failed write must not leave its temp file behind. Renaming a file onto
+    /// an existing directory fails on every platform, which drives the error
+    /// path without mocking the filesystem.
+    ///
+    /// The pre-`TempFileGuard` code already cleaned up on a `rename` error, so
+    /// this pins an invariant rather than catching a regression — see
+    /// `temp_file_guard_unlinks_unless_disarmed` for the guard's own coverage.
+    #[test]
+    fn atomic_write_cleans_up_temp_file_on_failure() {
+        let dir = tempfile::tempdir().unwrap();
+
+        // The target is a *directory*, so `rename` cannot replace it.
+        let target = dir.path().join("auth-keyring.json");
+        std::fs::create_dir(&target).unwrap();
+        std::fs::write(target.join("occupant"), b"x").unwrap();
+
+        let result = atomic_write(&target, br#"{"writer":0}"#);
+        assert!(result.is_err(), "expected rename onto a directory to fail");
+
+        let leftovers: Vec<String> = std::fs::read_dir(dir.path())
+            .unwrap()
+            .filter_map(|e| e.ok())
+            .map(|e| e.file_name().to_string_lossy().into_owned())
+            .filter(|n| n.contains(".tmp"))
+            .collect();
+        assert!(leftovers.is_empty(), "temp file leaked after a failed write: {leftovers:?}");
+    }
+
+    /// Pins [`TempFileGuard`]: armed drops unlink, disarmed drops don't. Drop
+    /// running on an armed guard is what covers early returns and unwinding
+    /// panics between `write` and `rename` — paths the old `rename`-only
+    /// cleanup missed. Deleting the guard or the `disarm()` call fails this.
+    #[test]
+    fn temp_file_guard_unlinks_unless_disarmed() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("auth-keyring.tmp.0.0");
+
+        std::fs::write(&path, b"x").unwrap();
+        drop(TempFileGuard::new(path.clone()));
+        assert!(!path.exists(), "armed guard must unlink on drop");
+
+        // The post-`rename` case: the file has been moved away, so the guard
+        // must not touch whatever now sits at that path.
+        std::fs::write(&path, b"x").unwrap();
+        let mut guard = TempFileGuard::new(path.clone());
+        guard.disarm();
+        drop(guard);
+        assert!(path.exists(), "disarmed guard must not unlink");
     }
 
     #[test]

--- a/seed/cli/query-parameters-openapi/github-npm/src/auth/oauth_common.rs
+++ b/seed/cli/query-parameters-openapi/github-npm/src/auth/oauth_common.rs
@@ -226,8 +226,29 @@ pub(crate) fn config_dir() -> Option<PathBuf> {
 
 /// Write `data` to `path` atomically: sibling temp file → owner-only
 /// permissions (0600 on Unix) → rename into place.
+///
+/// The temp file name is unique per writer — pid plus a process-local
+/// counter. Deriving it from the target alone meant every concurrent writer
+/// used the *same* sibling (`auth-keyring.tmp`): whichever one renamed first
+/// moved it away, and the rest failed with `ENOENT` from `rename`. That
+/// surfaced as intermittent `auth login --with-token` failures across a
+/// wire-test suite large enough to run many CLI processes at once, killing a
+/// different subset of cases on each run.
+///
+/// The pid covers the case that actually bit us (separate CLI processes); the
+/// counter covers two writers inside one process, and is what makes the
+/// behavior unit-testable without spawning subprocesses.
+///
+/// `rename` is still atomic for readers, which is what keeps a partially
+/// written credential file unobservable. This only fixes writer-vs-writer
+/// collisions on the temp path. `FileKeyringStore::set` remains a
+/// read-modify-write of the whole map with no lock, so simultaneous writers
+/// can still clobber one another's *entries*; making that safe needs file
+/// locking, which is a larger change.
 pub(crate) fn atomic_write(path: &Path, data: &[u8]) -> Result<(), CliError> {
-    let tmp = path.with_extension("tmp");
+    static TMP_SEQ: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+    let seq = TMP_SEQ.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+    let tmp = path.with_extension(format!("tmp.{}.{}", std::process::id(), seq));
     std::fs::write(&tmp, data).map_err(|e| {
         CliError::Auth(format!("Failed to write {}: {e}", tmp.display()))
     })?;
@@ -250,6 +271,51 @@ pub(crate) fn atomic_write(path: &Path, data: &[u8]) -> Result<(), CliError> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// Regression test for the temp-file collision that made
+    /// `auth login --with-token` fail intermittently: every writer derived the
+    /// same sibling path from the target, so the first `rename` moved it away
+    /// and the rest got `ENOENT`.
+    ///
+    /// Reverting `atomic_write` to a target-derived temp name fails this with
+    /// "Failed to rename ...: No such file or directory".
+    #[test]
+    fn atomic_write_tolerates_concurrent_writers() {
+        let dir = tempfile::tempdir().unwrap();
+        let target = dir.path().join("auth-keyring.json");
+
+        let results: Vec<Result<(), CliError>> = std::thread::scope(|scope| {
+            let handles: Vec<_> = (0..16)
+                .map(|i| {
+                    let target = target.clone();
+                    scope.spawn(move || atomic_write(&target, format!(r#"{{"writer":{i}}}"#).as_bytes()))
+                })
+                .collect();
+            handles.into_iter().map(|h| h.join().unwrap()).collect()
+        });
+
+        let failed: Vec<String> = results
+            .iter()
+            .filter_map(|r| r.as_ref().err().map(|e| e.to_string()))
+            .collect();
+        assert!(failed.is_empty(), "concurrent writers failed: {failed:?}");
+
+        // Last writer wins, but the file must always be one writer's complete
+        // payload — never a mix, and never absent.
+        let contents = std::fs::read_to_string(&target).unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(&contents)
+            .unwrap_or_else(|e| panic!("target is not valid JSON after concurrent writes: {e} in {contents:?}"));
+        assert!(parsed.get("writer").is_some(), "unexpected payload: {contents}");
+
+        // No temp files orphaned in the directory.
+        let leftovers: Vec<String> = std::fs::read_dir(dir.path())
+            .unwrap()
+            .filter_map(|e| e.ok())
+            .map(|e| e.file_name().to_string_lossy().into_owned())
+            .filter(|n| n.contains(".tmp"))
+            .collect();
+        assert!(leftovers.is_empty(), "temp files left behind: {leftovers:?}");
+    }
 
     #[test]
     fn token_bundle_roundtrip() {

--- a/seed/cli/query-parameters-openapi/no-custom-config/src/auth/oauth_common.rs
+++ b/seed/cli/query-parameters-openapi/no-custom-config/src/auth/oauth_common.rs
@@ -224,27 +224,6 @@ pub(crate) fn config_dir() -> Option<PathBuf> {
     }
 }
 
-/// Write `data` to `path` atomically: sibling temp file → owner-only
-/// permissions (0600 on Unix) → rename into place.
-///
-/// The temp file name is unique per writer — pid plus a process-local
-/// counter. Deriving it from the target alone meant every concurrent writer
-/// used the *same* sibling (`auth-keyring.tmp`): whichever one renamed first
-/// moved it away, and the rest failed with `ENOENT` from `rename`. That
-/// surfaced as intermittent `auth login --with-token` failures across a
-/// wire-test suite large enough to run many CLI processes at once, killing a
-/// different subset of cases on each run.
-///
-/// The pid covers the case that actually bit us (separate CLI processes); the
-/// counter covers two writers inside one process, and is what makes the
-/// behavior unit-testable without spawning subprocesses.
-///
-/// `rename` is still atomic for readers, which is what keeps a partially
-/// written credential file unobservable. This only fixes writer-vs-writer
-/// collisions on the temp path. `FileKeyringStore::set` remains a
-/// read-modify-write of the whole map with no lock, so simultaneous writers
-/// can still clobber one another's *entries*; making that safe needs file
-/// locking, which is a larger change.
 /// Unlinks a temp file on drop unless [`TempFileGuard::disarm`]ed. Covers
 /// every early return *and* a panic between creating the temp file and
 /// renaming it into place.
@@ -278,6 +257,30 @@ impl Drop for TempFileGuard {
     }
 }
 
+/// Write `data` to `path` atomically: sibling temp file → owner-only
+/// permissions (0600 on Unix) → rename into place.
+///
+/// The temp file name is unique per writer — pid plus a process-local
+/// counter. Deriving it from the target alone meant every concurrent writer
+/// used the *same* sibling (`auth-keyring.tmp`): whichever one renamed first
+/// moved it away, and the rest failed with `ENOENT` from `rename`. That
+/// surfaced as intermittent `auth login --with-token` failures across a
+/// wire-test suite large enough to run many CLI processes at once, killing a
+/// different subset of cases on each run.
+///
+/// The pid covers the case that actually bit us (separate CLI processes); the
+/// counter covers two writers inside one process, and is what makes the
+/// behavior unit-testable without spawning subprocesses.
+///
+/// A [`TempFileGuard`] unlinks the temp file if anything between creating it
+/// and renaming it fails, so unique names cannot accumulate as orphans.
+///
+/// `rename` is still atomic for readers, which is what keeps a partially
+/// written credential file unobservable. This only fixes writer-vs-writer
+/// collisions on the temp path. `FileKeyringStore::set` remains a
+/// read-modify-write of the whole map with no lock, so simultaneous writers
+/// can still clobber one another's *entries*; making that safe needs file
+/// locking, which is a larger change.
 pub(crate) fn atomic_write(path: &Path, data: &[u8]) -> Result<(), CliError> {
     static TMP_SEQ: std::sync::atomic::AtomicUsize = std::sync::atomic::AtomicUsize::new(0);
     let seq = TMP_SEQ.fetch_add(1, std::sync::atomic::Ordering::Relaxed);

--- a/seed/cli/query-parameters-openapi/no-custom-config/src/auth/oauth_common.rs
+++ b/seed/cli/query-parameters-openapi/no-custom-config/src/auth/oauth_common.rs
@@ -245,23 +245,56 @@ pub(crate) fn config_dir() -> Option<PathBuf> {
 /// read-modify-write of the whole map with no lock, so simultaneous writers
 /// can still clobber one another's *entries*; making that safe needs file
 /// locking, which is a larger change.
+/// Unlinks a temp file on drop unless [`TempFileGuard::disarm`]ed. Covers
+/// every early return *and* a panic between creating the temp file and
+/// renaming it into place.
+///
+/// This exists because the temp name is unique per writer. The old shared
+/// `auth-keyring.tmp` was self-limiting — a failed write left one stale file
+/// that the next write reused — whereas unique names would leak a distinct
+/// credential-bearing file on every failure, in a directory nothing prunes. A
+/// `SIGKILL` still leaks, since no in-process guard can cover that.
+struct TempFileGuard {
+    path: PathBuf,
+    armed: bool,
+}
+
+impl TempFileGuard {
+    fn new(path: PathBuf) -> Self {
+        Self { path, armed: true }
+    }
+
+    /// Relinquish the file — call once `rename` has moved it into place.
+    fn disarm(&mut self) {
+        self.armed = false;
+    }
+}
+
+impl Drop for TempFileGuard {
+    fn drop(&mut self) {
+        if self.armed {
+            let _ = std::fs::remove_file(&self.path);
+        }
+    }
+}
+
 pub(crate) fn atomic_write(path: &Path, data: &[u8]) -> Result<(), CliError> {
-    static TMP_SEQ: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+    static TMP_SEQ: std::sync::atomic::AtomicUsize = std::sync::atomic::AtomicUsize::new(0);
     let seq = TMP_SEQ.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
     let tmp = path.with_extension(format!("tmp.{}.{}", std::process::id(), seq));
-    std::fs::write(&tmp, data).map_err(|e| {
-        CliError::Auth(format!("Failed to write {}: {e}", tmp.display()))
-    })?;
+    let mut guard = TempFileGuard::new(tmp.clone());
+    std::fs::write(&tmp, data)
+        .map_err(|e| CliError::Auth(format!("Failed to write {}: {e}", tmp.display())))?;
     #[cfg(unix)]
     {
         use std::os::unix::fs::PermissionsExt;
         let perms = std::fs::Permissions::from_mode(0o600);
         let _ = std::fs::set_permissions(&tmp, perms);
     }
-    std::fs::rename(&tmp, path).map_err(|e| {
-        let _ = std::fs::remove_file(&tmp);
-        CliError::Auth(format!("Failed to rename {}: {e}", tmp.display()))
-    })
+    std::fs::rename(&tmp, path)
+        .map_err(|e| CliError::Auth(format!("Failed to rename {}: {e}", tmp.display())))?;
+    guard.disarm();
+    Ok(())
 }
 
 // ---------------------------------------------------------------------------
@@ -315,6 +348,56 @@ mod tests {
             .filter(|n| n.contains(".tmp"))
             .collect();
         assert!(leftovers.is_empty(), "temp files left behind: {leftovers:?}");
+    }
+
+    /// A failed write must not leave its temp file behind. Renaming a file onto
+    /// an existing directory fails on every platform, which drives the error
+    /// path without mocking the filesystem.
+    ///
+    /// The pre-`TempFileGuard` code already cleaned up on a `rename` error, so
+    /// this pins an invariant rather than catching a regression — see
+    /// `temp_file_guard_unlinks_unless_disarmed` for the guard's own coverage.
+    #[test]
+    fn atomic_write_cleans_up_temp_file_on_failure() {
+        let dir = tempfile::tempdir().unwrap();
+
+        // The target is a *directory*, so `rename` cannot replace it.
+        let target = dir.path().join("auth-keyring.json");
+        std::fs::create_dir(&target).unwrap();
+        std::fs::write(target.join("occupant"), b"x").unwrap();
+
+        let result = atomic_write(&target, br#"{"writer":0}"#);
+        assert!(result.is_err(), "expected rename onto a directory to fail");
+
+        let leftovers: Vec<String> = std::fs::read_dir(dir.path())
+            .unwrap()
+            .filter_map(|e| e.ok())
+            .map(|e| e.file_name().to_string_lossy().into_owned())
+            .filter(|n| n.contains(".tmp"))
+            .collect();
+        assert!(leftovers.is_empty(), "temp file leaked after a failed write: {leftovers:?}");
+    }
+
+    /// Pins [`TempFileGuard`]: armed drops unlink, disarmed drops don't. Drop
+    /// running on an armed guard is what covers early returns and unwinding
+    /// panics between `write` and `rename` — paths the old `rename`-only
+    /// cleanup missed. Deleting the guard or the `disarm()` call fails this.
+    #[test]
+    fn temp_file_guard_unlinks_unless_disarmed() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("auth-keyring.tmp.0.0");
+
+        std::fs::write(&path, b"x").unwrap();
+        drop(TempFileGuard::new(path.clone()));
+        assert!(!path.exists(), "armed guard must unlink on drop");
+
+        // The post-`rename` case: the file has been moved away, so the guard
+        // must not touch whatever now sits at that path.
+        std::fs::write(&path, b"x").unwrap();
+        let mut guard = TempFileGuard::new(path.clone());
+        guard.disarm();
+        drop(guard);
+        assert!(path.exists(), "disarmed guard must not unlink");
     }
 
     #[test]

--- a/seed/cli/query-parameters-openapi/no-custom-config/src/auth/oauth_common.rs
+++ b/seed/cli/query-parameters-openapi/no-custom-config/src/auth/oauth_common.rs
@@ -226,8 +226,29 @@ pub(crate) fn config_dir() -> Option<PathBuf> {
 
 /// Write `data` to `path` atomically: sibling temp file → owner-only
 /// permissions (0600 on Unix) → rename into place.
+///
+/// The temp file name is unique per writer — pid plus a process-local
+/// counter. Deriving it from the target alone meant every concurrent writer
+/// used the *same* sibling (`auth-keyring.tmp`): whichever one renamed first
+/// moved it away, and the rest failed with `ENOENT` from `rename`. That
+/// surfaced as intermittent `auth login --with-token` failures across a
+/// wire-test suite large enough to run many CLI processes at once, killing a
+/// different subset of cases on each run.
+///
+/// The pid covers the case that actually bit us (separate CLI processes); the
+/// counter covers two writers inside one process, and is what makes the
+/// behavior unit-testable without spawning subprocesses.
+///
+/// `rename` is still atomic for readers, which is what keeps a partially
+/// written credential file unobservable. This only fixes writer-vs-writer
+/// collisions on the temp path. `FileKeyringStore::set` remains a
+/// read-modify-write of the whole map with no lock, so simultaneous writers
+/// can still clobber one another's *entries*; making that safe needs file
+/// locking, which is a larger change.
 pub(crate) fn atomic_write(path: &Path, data: &[u8]) -> Result<(), CliError> {
-    let tmp = path.with_extension("tmp");
+    static TMP_SEQ: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+    let seq = TMP_SEQ.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+    let tmp = path.with_extension(format!("tmp.{}.{}", std::process::id(), seq));
     std::fs::write(&tmp, data).map_err(|e| {
         CliError::Auth(format!("Failed to write {}: {e}", tmp.display()))
     })?;
@@ -250,6 +271,51 @@ pub(crate) fn atomic_write(path: &Path, data: &[u8]) -> Result<(), CliError> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// Regression test for the temp-file collision that made
+    /// `auth login --with-token` fail intermittently: every writer derived the
+    /// same sibling path from the target, so the first `rename` moved it away
+    /// and the rest got `ENOENT`.
+    ///
+    /// Reverting `atomic_write` to a target-derived temp name fails this with
+    /// "Failed to rename ...: No such file or directory".
+    #[test]
+    fn atomic_write_tolerates_concurrent_writers() {
+        let dir = tempfile::tempdir().unwrap();
+        let target = dir.path().join("auth-keyring.json");
+
+        let results: Vec<Result<(), CliError>> = std::thread::scope(|scope| {
+            let handles: Vec<_> = (0..16)
+                .map(|i| {
+                    let target = target.clone();
+                    scope.spawn(move || atomic_write(&target, format!(r#"{{"writer":{i}}}"#).as_bytes()))
+                })
+                .collect();
+            handles.into_iter().map(|h| h.join().unwrap()).collect()
+        });
+
+        let failed: Vec<String> = results
+            .iter()
+            .filter_map(|r| r.as_ref().err().map(|e| e.to_string()))
+            .collect();
+        assert!(failed.is_empty(), "concurrent writers failed: {failed:?}");
+
+        // Last writer wins, but the file must always be one writer's complete
+        // payload — never a mix, and never absent.
+        let contents = std::fs::read_to_string(&target).unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(&contents)
+            .unwrap_or_else(|e| panic!("target is not valid JSON after concurrent writes: {e} in {contents:?}"));
+        assert!(parsed.get("writer").is_some(), "unexpected payload: {contents}");
+
+        // No temp files orphaned in the directory.
+        let leftovers: Vec<String> = std::fs::read_dir(dir.path())
+            .unwrap()
+            .filter_map(|e| e.ok())
+            .map(|e| e.file_name().to_string_lossy().into_owned())
+            .filter(|n| n.contains(".tmp"))
+            .collect();
+        assert!(leftovers.is_empty(), "temp files left behind: {leftovers:?}");
+    }
 
     #[test]
     fn token_bundle_roundtrip() {

--- a/seed/cli/query-parameters-openapi/with-split-type-crates/src/auth/oauth_common.rs
+++ b/seed/cli/query-parameters-openapi/with-split-type-crates/src/auth/oauth_common.rs
@@ -224,27 +224,6 @@ pub(crate) fn config_dir() -> Option<PathBuf> {
     }
 }
 
-/// Write `data` to `path` atomically: sibling temp file → owner-only
-/// permissions (0600 on Unix) → rename into place.
-///
-/// The temp file name is unique per writer — pid plus a process-local
-/// counter. Deriving it from the target alone meant every concurrent writer
-/// used the *same* sibling (`auth-keyring.tmp`): whichever one renamed first
-/// moved it away, and the rest failed with `ENOENT` from `rename`. That
-/// surfaced as intermittent `auth login --with-token` failures across a
-/// wire-test suite large enough to run many CLI processes at once, killing a
-/// different subset of cases on each run.
-///
-/// The pid covers the case that actually bit us (separate CLI processes); the
-/// counter covers two writers inside one process, and is what makes the
-/// behavior unit-testable without spawning subprocesses.
-///
-/// `rename` is still atomic for readers, which is what keeps a partially
-/// written credential file unobservable. This only fixes writer-vs-writer
-/// collisions on the temp path. `FileKeyringStore::set` remains a
-/// read-modify-write of the whole map with no lock, so simultaneous writers
-/// can still clobber one another's *entries*; making that safe needs file
-/// locking, which is a larger change.
 /// Unlinks a temp file on drop unless [`TempFileGuard::disarm`]ed. Covers
 /// every early return *and* a panic between creating the temp file and
 /// renaming it into place.
@@ -278,6 +257,30 @@ impl Drop for TempFileGuard {
     }
 }
 
+/// Write `data` to `path` atomically: sibling temp file → owner-only
+/// permissions (0600 on Unix) → rename into place.
+///
+/// The temp file name is unique per writer — pid plus a process-local
+/// counter. Deriving it from the target alone meant every concurrent writer
+/// used the *same* sibling (`auth-keyring.tmp`): whichever one renamed first
+/// moved it away, and the rest failed with `ENOENT` from `rename`. That
+/// surfaced as intermittent `auth login --with-token` failures across a
+/// wire-test suite large enough to run many CLI processes at once, killing a
+/// different subset of cases on each run.
+///
+/// The pid covers the case that actually bit us (separate CLI processes); the
+/// counter covers two writers inside one process, and is what makes the
+/// behavior unit-testable without spawning subprocesses.
+///
+/// A [`TempFileGuard`] unlinks the temp file if anything between creating it
+/// and renaming it fails, so unique names cannot accumulate as orphans.
+///
+/// `rename` is still atomic for readers, which is what keeps a partially
+/// written credential file unobservable. This only fixes writer-vs-writer
+/// collisions on the temp path. `FileKeyringStore::set` remains a
+/// read-modify-write of the whole map with no lock, so simultaneous writers
+/// can still clobber one another's *entries*; making that safe needs file
+/// locking, which is a larger change.
 pub(crate) fn atomic_write(path: &Path, data: &[u8]) -> Result<(), CliError> {
     static TMP_SEQ: std::sync::atomic::AtomicUsize = std::sync::atomic::AtomicUsize::new(0);
     let seq = TMP_SEQ.fetch_add(1, std::sync::atomic::Ordering::Relaxed);

--- a/seed/cli/query-parameters-openapi/with-split-type-crates/src/auth/oauth_common.rs
+++ b/seed/cli/query-parameters-openapi/with-split-type-crates/src/auth/oauth_common.rs
@@ -245,23 +245,56 @@ pub(crate) fn config_dir() -> Option<PathBuf> {
 /// read-modify-write of the whole map with no lock, so simultaneous writers
 /// can still clobber one another's *entries*; making that safe needs file
 /// locking, which is a larger change.
+/// Unlinks a temp file on drop unless [`TempFileGuard::disarm`]ed. Covers
+/// every early return *and* a panic between creating the temp file and
+/// renaming it into place.
+///
+/// This exists because the temp name is unique per writer. The old shared
+/// `auth-keyring.tmp` was self-limiting — a failed write left one stale file
+/// that the next write reused — whereas unique names would leak a distinct
+/// credential-bearing file on every failure, in a directory nothing prunes. A
+/// `SIGKILL` still leaks, since no in-process guard can cover that.
+struct TempFileGuard {
+    path: PathBuf,
+    armed: bool,
+}
+
+impl TempFileGuard {
+    fn new(path: PathBuf) -> Self {
+        Self { path, armed: true }
+    }
+
+    /// Relinquish the file — call once `rename` has moved it into place.
+    fn disarm(&mut self) {
+        self.armed = false;
+    }
+}
+
+impl Drop for TempFileGuard {
+    fn drop(&mut self) {
+        if self.armed {
+            let _ = std::fs::remove_file(&self.path);
+        }
+    }
+}
+
 pub(crate) fn atomic_write(path: &Path, data: &[u8]) -> Result<(), CliError> {
-    static TMP_SEQ: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+    static TMP_SEQ: std::sync::atomic::AtomicUsize = std::sync::atomic::AtomicUsize::new(0);
     let seq = TMP_SEQ.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
     let tmp = path.with_extension(format!("tmp.{}.{}", std::process::id(), seq));
-    std::fs::write(&tmp, data).map_err(|e| {
-        CliError::Auth(format!("Failed to write {}: {e}", tmp.display()))
-    })?;
+    let mut guard = TempFileGuard::new(tmp.clone());
+    std::fs::write(&tmp, data)
+        .map_err(|e| CliError::Auth(format!("Failed to write {}: {e}", tmp.display())))?;
     #[cfg(unix)]
     {
         use std::os::unix::fs::PermissionsExt;
         let perms = std::fs::Permissions::from_mode(0o600);
         let _ = std::fs::set_permissions(&tmp, perms);
     }
-    std::fs::rename(&tmp, path).map_err(|e| {
-        let _ = std::fs::remove_file(&tmp);
-        CliError::Auth(format!("Failed to rename {}: {e}", tmp.display()))
-    })
+    std::fs::rename(&tmp, path)
+        .map_err(|e| CliError::Auth(format!("Failed to rename {}: {e}", tmp.display())))?;
+    guard.disarm();
+    Ok(())
 }
 
 // ---------------------------------------------------------------------------
@@ -315,6 +348,56 @@ mod tests {
             .filter(|n| n.contains(".tmp"))
             .collect();
         assert!(leftovers.is_empty(), "temp files left behind: {leftovers:?}");
+    }
+
+    /// A failed write must not leave its temp file behind. Renaming a file onto
+    /// an existing directory fails on every platform, which drives the error
+    /// path without mocking the filesystem.
+    ///
+    /// The pre-`TempFileGuard` code already cleaned up on a `rename` error, so
+    /// this pins an invariant rather than catching a regression — see
+    /// `temp_file_guard_unlinks_unless_disarmed` for the guard's own coverage.
+    #[test]
+    fn atomic_write_cleans_up_temp_file_on_failure() {
+        let dir = tempfile::tempdir().unwrap();
+
+        // The target is a *directory*, so `rename` cannot replace it.
+        let target = dir.path().join("auth-keyring.json");
+        std::fs::create_dir(&target).unwrap();
+        std::fs::write(target.join("occupant"), b"x").unwrap();
+
+        let result = atomic_write(&target, br#"{"writer":0}"#);
+        assert!(result.is_err(), "expected rename onto a directory to fail");
+
+        let leftovers: Vec<String> = std::fs::read_dir(dir.path())
+            .unwrap()
+            .filter_map(|e| e.ok())
+            .map(|e| e.file_name().to_string_lossy().into_owned())
+            .filter(|n| n.contains(".tmp"))
+            .collect();
+        assert!(leftovers.is_empty(), "temp file leaked after a failed write: {leftovers:?}");
+    }
+
+    /// Pins [`TempFileGuard`]: armed drops unlink, disarmed drops don't. Drop
+    /// running on an armed guard is what covers early returns and unwinding
+    /// panics between `write` and `rename` — paths the old `rename`-only
+    /// cleanup missed. Deleting the guard or the `disarm()` call fails this.
+    #[test]
+    fn temp_file_guard_unlinks_unless_disarmed() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("auth-keyring.tmp.0.0");
+
+        std::fs::write(&path, b"x").unwrap();
+        drop(TempFileGuard::new(path.clone()));
+        assert!(!path.exists(), "armed guard must unlink on drop");
+
+        // The post-`rename` case: the file has been moved away, so the guard
+        // must not touch whatever now sits at that path.
+        std::fs::write(&path, b"x").unwrap();
+        let mut guard = TempFileGuard::new(path.clone());
+        guard.disarm();
+        drop(guard);
+        assert!(path.exists(), "disarmed guard must not unlink");
     }
 
     #[test]

--- a/seed/cli/query-parameters-openapi/with-split-type-crates/src/auth/oauth_common.rs
+++ b/seed/cli/query-parameters-openapi/with-split-type-crates/src/auth/oauth_common.rs
@@ -226,8 +226,29 @@ pub(crate) fn config_dir() -> Option<PathBuf> {
 
 /// Write `data` to `path` atomically: sibling temp file → owner-only
 /// permissions (0600 on Unix) → rename into place.
+///
+/// The temp file name is unique per writer — pid plus a process-local
+/// counter. Deriving it from the target alone meant every concurrent writer
+/// used the *same* sibling (`auth-keyring.tmp`): whichever one renamed first
+/// moved it away, and the rest failed with `ENOENT` from `rename`. That
+/// surfaced as intermittent `auth login --with-token` failures across a
+/// wire-test suite large enough to run many CLI processes at once, killing a
+/// different subset of cases on each run.
+///
+/// The pid covers the case that actually bit us (separate CLI processes); the
+/// counter covers two writers inside one process, and is what makes the
+/// behavior unit-testable without spawning subprocesses.
+///
+/// `rename` is still atomic for readers, which is what keeps a partially
+/// written credential file unobservable. This only fixes writer-vs-writer
+/// collisions on the temp path. `FileKeyringStore::set` remains a
+/// read-modify-write of the whole map with no lock, so simultaneous writers
+/// can still clobber one another's *entries*; making that safe needs file
+/// locking, which is a larger change.
 pub(crate) fn atomic_write(path: &Path, data: &[u8]) -> Result<(), CliError> {
-    let tmp = path.with_extension("tmp");
+    static TMP_SEQ: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+    let seq = TMP_SEQ.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+    let tmp = path.with_extension(format!("tmp.{}.{}", std::process::id(), seq));
     std::fs::write(&tmp, data).map_err(|e| {
         CliError::Auth(format!("Failed to write {}: {e}", tmp.display()))
     })?;
@@ -250,6 +271,51 @@ pub(crate) fn atomic_write(path: &Path, data: &[u8]) -> Result<(), CliError> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// Regression test for the temp-file collision that made
+    /// `auth login --with-token` fail intermittently: every writer derived the
+    /// same sibling path from the target, so the first `rename` moved it away
+    /// and the rest got `ENOENT`.
+    ///
+    /// Reverting `atomic_write` to a target-derived temp name fails this with
+    /// "Failed to rename ...: No such file or directory".
+    #[test]
+    fn atomic_write_tolerates_concurrent_writers() {
+        let dir = tempfile::tempdir().unwrap();
+        let target = dir.path().join("auth-keyring.json");
+
+        let results: Vec<Result<(), CliError>> = std::thread::scope(|scope| {
+            let handles: Vec<_> = (0..16)
+                .map(|i| {
+                    let target = target.clone();
+                    scope.spawn(move || atomic_write(&target, format!(r#"{{"writer":{i}}}"#).as_bytes()))
+                })
+                .collect();
+            handles.into_iter().map(|h| h.join().unwrap()).collect()
+        });
+
+        let failed: Vec<String> = results
+            .iter()
+            .filter_map(|r| r.as_ref().err().map(|e| e.to_string()))
+            .collect();
+        assert!(failed.is_empty(), "concurrent writers failed: {failed:?}");
+
+        // Last writer wins, but the file must always be one writer's complete
+        // payload — never a mix, and never absent.
+        let contents = std::fs::read_to_string(&target).unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(&contents)
+            .unwrap_or_else(|e| panic!("target is not valid JSON after concurrent writes: {e} in {contents:?}"));
+        assert!(parsed.get("writer").is_some(), "unexpected payload: {contents}");
+
+        // No temp files orphaned in the directory.
+        let leftovers: Vec<String> = std::fs::read_dir(dir.path())
+            .unwrap()
+            .filter_map(|e| e.ok())
+            .map(|e| e.file_name().to_string_lossy().into_owned())
+            .filter(|n| n.contains(".tmp"))
+            .collect();
+        assert!(leftovers.is_empty(), "temp files left behind: {leftovers:?}");
+    }
 
     #[test]
     fn token_bundle_roundtrip() {

--- a/seed/cli/query-parameters-openapi/with-wire-tests/src/auth/oauth_common.rs
+++ b/seed/cli/query-parameters-openapi/with-wire-tests/src/auth/oauth_common.rs
@@ -224,27 +224,6 @@ pub(crate) fn config_dir() -> Option<PathBuf> {
     }
 }
 
-/// Write `data` to `path` atomically: sibling temp file → owner-only
-/// permissions (0600 on Unix) → rename into place.
-///
-/// The temp file name is unique per writer — pid plus a process-local
-/// counter. Deriving it from the target alone meant every concurrent writer
-/// used the *same* sibling (`auth-keyring.tmp`): whichever one renamed first
-/// moved it away, and the rest failed with `ENOENT` from `rename`. That
-/// surfaced as intermittent `auth login --with-token` failures across a
-/// wire-test suite large enough to run many CLI processes at once, killing a
-/// different subset of cases on each run.
-///
-/// The pid covers the case that actually bit us (separate CLI processes); the
-/// counter covers two writers inside one process, and is what makes the
-/// behavior unit-testable without spawning subprocesses.
-///
-/// `rename` is still atomic for readers, which is what keeps a partially
-/// written credential file unobservable. This only fixes writer-vs-writer
-/// collisions on the temp path. `FileKeyringStore::set` remains a
-/// read-modify-write of the whole map with no lock, so simultaneous writers
-/// can still clobber one another's *entries*; making that safe needs file
-/// locking, which is a larger change.
 /// Unlinks a temp file on drop unless [`TempFileGuard::disarm`]ed. Covers
 /// every early return *and* a panic between creating the temp file and
 /// renaming it into place.
@@ -278,6 +257,30 @@ impl Drop for TempFileGuard {
     }
 }
 
+/// Write `data` to `path` atomically: sibling temp file → owner-only
+/// permissions (0600 on Unix) → rename into place.
+///
+/// The temp file name is unique per writer — pid plus a process-local
+/// counter. Deriving it from the target alone meant every concurrent writer
+/// used the *same* sibling (`auth-keyring.tmp`): whichever one renamed first
+/// moved it away, and the rest failed with `ENOENT` from `rename`. That
+/// surfaced as intermittent `auth login --with-token` failures across a
+/// wire-test suite large enough to run many CLI processes at once, killing a
+/// different subset of cases on each run.
+///
+/// The pid covers the case that actually bit us (separate CLI processes); the
+/// counter covers two writers inside one process, and is what makes the
+/// behavior unit-testable without spawning subprocesses.
+///
+/// A [`TempFileGuard`] unlinks the temp file if anything between creating it
+/// and renaming it fails, so unique names cannot accumulate as orphans.
+///
+/// `rename` is still atomic for readers, which is what keeps a partially
+/// written credential file unobservable. This only fixes writer-vs-writer
+/// collisions on the temp path. `FileKeyringStore::set` remains a
+/// read-modify-write of the whole map with no lock, so simultaneous writers
+/// can still clobber one another's *entries*; making that safe needs file
+/// locking, which is a larger change.
 pub(crate) fn atomic_write(path: &Path, data: &[u8]) -> Result<(), CliError> {
     static TMP_SEQ: std::sync::atomic::AtomicUsize = std::sync::atomic::AtomicUsize::new(0);
     let seq = TMP_SEQ.fetch_add(1, std::sync::atomic::Ordering::Relaxed);

--- a/seed/cli/query-parameters-openapi/with-wire-tests/src/auth/oauth_common.rs
+++ b/seed/cli/query-parameters-openapi/with-wire-tests/src/auth/oauth_common.rs
@@ -245,23 +245,56 @@ pub(crate) fn config_dir() -> Option<PathBuf> {
 /// read-modify-write of the whole map with no lock, so simultaneous writers
 /// can still clobber one another's *entries*; making that safe needs file
 /// locking, which is a larger change.
+/// Unlinks a temp file on drop unless [`TempFileGuard::disarm`]ed. Covers
+/// every early return *and* a panic between creating the temp file and
+/// renaming it into place.
+///
+/// This exists because the temp name is unique per writer. The old shared
+/// `auth-keyring.tmp` was self-limiting — a failed write left one stale file
+/// that the next write reused — whereas unique names would leak a distinct
+/// credential-bearing file on every failure, in a directory nothing prunes. A
+/// `SIGKILL` still leaks, since no in-process guard can cover that.
+struct TempFileGuard {
+    path: PathBuf,
+    armed: bool,
+}
+
+impl TempFileGuard {
+    fn new(path: PathBuf) -> Self {
+        Self { path, armed: true }
+    }
+
+    /// Relinquish the file — call once `rename` has moved it into place.
+    fn disarm(&mut self) {
+        self.armed = false;
+    }
+}
+
+impl Drop for TempFileGuard {
+    fn drop(&mut self) {
+        if self.armed {
+            let _ = std::fs::remove_file(&self.path);
+        }
+    }
+}
+
 pub(crate) fn atomic_write(path: &Path, data: &[u8]) -> Result<(), CliError> {
-    static TMP_SEQ: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+    static TMP_SEQ: std::sync::atomic::AtomicUsize = std::sync::atomic::AtomicUsize::new(0);
     let seq = TMP_SEQ.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
     let tmp = path.with_extension(format!("tmp.{}.{}", std::process::id(), seq));
-    std::fs::write(&tmp, data).map_err(|e| {
-        CliError::Auth(format!("Failed to write {}: {e}", tmp.display()))
-    })?;
+    let mut guard = TempFileGuard::new(tmp.clone());
+    std::fs::write(&tmp, data)
+        .map_err(|e| CliError::Auth(format!("Failed to write {}: {e}", tmp.display())))?;
     #[cfg(unix)]
     {
         use std::os::unix::fs::PermissionsExt;
         let perms = std::fs::Permissions::from_mode(0o600);
         let _ = std::fs::set_permissions(&tmp, perms);
     }
-    std::fs::rename(&tmp, path).map_err(|e| {
-        let _ = std::fs::remove_file(&tmp);
-        CliError::Auth(format!("Failed to rename {}: {e}", tmp.display()))
-    })
+    std::fs::rename(&tmp, path)
+        .map_err(|e| CliError::Auth(format!("Failed to rename {}: {e}", tmp.display())))?;
+    guard.disarm();
+    Ok(())
 }
 
 // ---------------------------------------------------------------------------
@@ -315,6 +348,56 @@ mod tests {
             .filter(|n| n.contains(".tmp"))
             .collect();
         assert!(leftovers.is_empty(), "temp files left behind: {leftovers:?}");
+    }
+
+    /// A failed write must not leave its temp file behind. Renaming a file onto
+    /// an existing directory fails on every platform, which drives the error
+    /// path without mocking the filesystem.
+    ///
+    /// The pre-`TempFileGuard` code already cleaned up on a `rename` error, so
+    /// this pins an invariant rather than catching a regression — see
+    /// `temp_file_guard_unlinks_unless_disarmed` for the guard's own coverage.
+    #[test]
+    fn atomic_write_cleans_up_temp_file_on_failure() {
+        let dir = tempfile::tempdir().unwrap();
+
+        // The target is a *directory*, so `rename` cannot replace it.
+        let target = dir.path().join("auth-keyring.json");
+        std::fs::create_dir(&target).unwrap();
+        std::fs::write(target.join("occupant"), b"x").unwrap();
+
+        let result = atomic_write(&target, br#"{"writer":0}"#);
+        assert!(result.is_err(), "expected rename onto a directory to fail");
+
+        let leftovers: Vec<String> = std::fs::read_dir(dir.path())
+            .unwrap()
+            .filter_map(|e| e.ok())
+            .map(|e| e.file_name().to_string_lossy().into_owned())
+            .filter(|n| n.contains(".tmp"))
+            .collect();
+        assert!(leftovers.is_empty(), "temp file leaked after a failed write: {leftovers:?}");
+    }
+
+    /// Pins [`TempFileGuard`]: armed drops unlink, disarmed drops don't. Drop
+    /// running on an armed guard is what covers early returns and unwinding
+    /// panics between `write` and `rename` — paths the old `rename`-only
+    /// cleanup missed. Deleting the guard or the `disarm()` call fails this.
+    #[test]
+    fn temp_file_guard_unlinks_unless_disarmed() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("auth-keyring.tmp.0.0");
+
+        std::fs::write(&path, b"x").unwrap();
+        drop(TempFileGuard::new(path.clone()));
+        assert!(!path.exists(), "armed guard must unlink on drop");
+
+        // The post-`rename` case: the file has been moved away, so the guard
+        // must not touch whatever now sits at that path.
+        std::fs::write(&path, b"x").unwrap();
+        let mut guard = TempFileGuard::new(path.clone());
+        guard.disarm();
+        drop(guard);
+        assert!(path.exists(), "disarmed guard must not unlink");
     }
 
     #[test]

--- a/seed/cli/query-parameters-openapi/with-wire-tests/src/auth/oauth_common.rs
+++ b/seed/cli/query-parameters-openapi/with-wire-tests/src/auth/oauth_common.rs
@@ -226,8 +226,29 @@ pub(crate) fn config_dir() -> Option<PathBuf> {
 
 /// Write `data` to `path` atomically: sibling temp file → owner-only
 /// permissions (0600 on Unix) → rename into place.
+///
+/// The temp file name is unique per writer — pid plus a process-local
+/// counter. Deriving it from the target alone meant every concurrent writer
+/// used the *same* sibling (`auth-keyring.tmp`): whichever one renamed first
+/// moved it away, and the rest failed with `ENOENT` from `rename`. That
+/// surfaced as intermittent `auth login --with-token` failures across a
+/// wire-test suite large enough to run many CLI processes at once, killing a
+/// different subset of cases on each run.
+///
+/// The pid covers the case that actually bit us (separate CLI processes); the
+/// counter covers two writers inside one process, and is what makes the
+/// behavior unit-testable without spawning subprocesses.
+///
+/// `rename` is still atomic for readers, which is what keeps a partially
+/// written credential file unobservable. This only fixes writer-vs-writer
+/// collisions on the temp path. `FileKeyringStore::set` remains a
+/// read-modify-write of the whole map with no lock, so simultaneous writers
+/// can still clobber one another's *entries*; making that safe needs file
+/// locking, which is a larger change.
 pub(crate) fn atomic_write(path: &Path, data: &[u8]) -> Result<(), CliError> {
-    let tmp = path.with_extension("tmp");
+    static TMP_SEQ: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+    let seq = TMP_SEQ.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+    let tmp = path.with_extension(format!("tmp.{}.{}", std::process::id(), seq));
     std::fs::write(&tmp, data).map_err(|e| {
         CliError::Auth(format!("Failed to write {}: {e}", tmp.display()))
     })?;
@@ -250,6 +271,51 @@ pub(crate) fn atomic_write(path: &Path, data: &[u8]) -> Result<(), CliError> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// Regression test for the temp-file collision that made
+    /// `auth login --with-token` fail intermittently: every writer derived the
+    /// same sibling path from the target, so the first `rename` moved it away
+    /// and the rest got `ENOENT`.
+    ///
+    /// Reverting `atomic_write` to a target-derived temp name fails this with
+    /// "Failed to rename ...: No such file or directory".
+    #[test]
+    fn atomic_write_tolerates_concurrent_writers() {
+        let dir = tempfile::tempdir().unwrap();
+        let target = dir.path().join("auth-keyring.json");
+
+        let results: Vec<Result<(), CliError>> = std::thread::scope(|scope| {
+            let handles: Vec<_> = (0..16)
+                .map(|i| {
+                    let target = target.clone();
+                    scope.spawn(move || atomic_write(&target, format!(r#"{{"writer":{i}}}"#).as_bytes()))
+                })
+                .collect();
+            handles.into_iter().map(|h| h.join().unwrap()).collect()
+        });
+
+        let failed: Vec<String> = results
+            .iter()
+            .filter_map(|r| r.as_ref().err().map(|e| e.to_string()))
+            .collect();
+        assert!(failed.is_empty(), "concurrent writers failed: {failed:?}");
+
+        // Last writer wins, but the file must always be one writer's complete
+        // payload — never a mix, and never absent.
+        let contents = std::fs::read_to_string(&target).unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(&contents)
+            .unwrap_or_else(|e| panic!("target is not valid JSON after concurrent writes: {e} in {contents:?}"));
+        assert!(parsed.get("writer").is_some(), "unexpected payload: {contents}");
+
+        // No temp files orphaned in the directory.
+        let leftovers: Vec<String> = std::fs::read_dir(dir.path())
+            .unwrap()
+            .filter_map(|e| e.ok())
+            .map(|e| e.file_name().to_string_lossy().into_owned())
+            .filter(|n| n.contains(".tmp"))
+            .collect();
+        assert!(leftovers.is_empty(), "temp files left behind: {leftovers:?}");
+    }
 
     #[test]
     fn token_bundle_roundtrip() {

--- a/seed/cli/respect-optional-request-body/src/auth/oauth_common.rs
+++ b/seed/cli/respect-optional-request-body/src/auth/oauth_common.rs
@@ -224,27 +224,6 @@ pub(crate) fn config_dir() -> Option<PathBuf> {
     }
 }
 
-/// Write `data` to `path` atomically: sibling temp file → owner-only
-/// permissions (0600 on Unix) → rename into place.
-///
-/// The temp file name is unique per writer — pid plus a process-local
-/// counter. Deriving it from the target alone meant every concurrent writer
-/// used the *same* sibling (`auth-keyring.tmp`): whichever one renamed first
-/// moved it away, and the rest failed with `ENOENT` from `rename`. That
-/// surfaced as intermittent `auth login --with-token` failures across a
-/// wire-test suite large enough to run many CLI processes at once, killing a
-/// different subset of cases on each run.
-///
-/// The pid covers the case that actually bit us (separate CLI processes); the
-/// counter covers two writers inside one process, and is what makes the
-/// behavior unit-testable without spawning subprocesses.
-///
-/// `rename` is still atomic for readers, which is what keeps a partially
-/// written credential file unobservable. This only fixes writer-vs-writer
-/// collisions on the temp path. `FileKeyringStore::set` remains a
-/// read-modify-write of the whole map with no lock, so simultaneous writers
-/// can still clobber one another's *entries*; making that safe needs file
-/// locking, which is a larger change.
 /// Unlinks a temp file on drop unless [`TempFileGuard::disarm`]ed. Covers
 /// every early return *and* a panic between creating the temp file and
 /// renaming it into place.
@@ -278,6 +257,30 @@ impl Drop for TempFileGuard {
     }
 }
 
+/// Write `data` to `path` atomically: sibling temp file → owner-only
+/// permissions (0600 on Unix) → rename into place.
+///
+/// The temp file name is unique per writer — pid plus a process-local
+/// counter. Deriving it from the target alone meant every concurrent writer
+/// used the *same* sibling (`auth-keyring.tmp`): whichever one renamed first
+/// moved it away, and the rest failed with `ENOENT` from `rename`. That
+/// surfaced as intermittent `auth login --with-token` failures across a
+/// wire-test suite large enough to run many CLI processes at once, killing a
+/// different subset of cases on each run.
+///
+/// The pid covers the case that actually bit us (separate CLI processes); the
+/// counter covers two writers inside one process, and is what makes the
+/// behavior unit-testable without spawning subprocesses.
+///
+/// A [`TempFileGuard`] unlinks the temp file if anything between creating it
+/// and renaming it fails, so unique names cannot accumulate as orphans.
+///
+/// `rename` is still atomic for readers, which is what keeps a partially
+/// written credential file unobservable. This only fixes writer-vs-writer
+/// collisions on the temp path. `FileKeyringStore::set` remains a
+/// read-modify-write of the whole map with no lock, so simultaneous writers
+/// can still clobber one another's *entries*; making that safe needs file
+/// locking, which is a larger change.
 pub(crate) fn atomic_write(path: &Path, data: &[u8]) -> Result<(), CliError> {
     static TMP_SEQ: std::sync::atomic::AtomicUsize = std::sync::atomic::AtomicUsize::new(0);
     let seq = TMP_SEQ.fetch_add(1, std::sync::atomic::Ordering::Relaxed);

--- a/seed/cli/respect-optional-request-body/src/auth/oauth_common.rs
+++ b/seed/cli/respect-optional-request-body/src/auth/oauth_common.rs
@@ -245,23 +245,56 @@ pub(crate) fn config_dir() -> Option<PathBuf> {
 /// read-modify-write of the whole map with no lock, so simultaneous writers
 /// can still clobber one another's *entries*; making that safe needs file
 /// locking, which is a larger change.
+/// Unlinks a temp file on drop unless [`TempFileGuard::disarm`]ed. Covers
+/// every early return *and* a panic between creating the temp file and
+/// renaming it into place.
+///
+/// This exists because the temp name is unique per writer. The old shared
+/// `auth-keyring.tmp` was self-limiting — a failed write left one stale file
+/// that the next write reused — whereas unique names would leak a distinct
+/// credential-bearing file on every failure, in a directory nothing prunes. A
+/// `SIGKILL` still leaks, since no in-process guard can cover that.
+struct TempFileGuard {
+    path: PathBuf,
+    armed: bool,
+}
+
+impl TempFileGuard {
+    fn new(path: PathBuf) -> Self {
+        Self { path, armed: true }
+    }
+
+    /// Relinquish the file — call once `rename` has moved it into place.
+    fn disarm(&mut self) {
+        self.armed = false;
+    }
+}
+
+impl Drop for TempFileGuard {
+    fn drop(&mut self) {
+        if self.armed {
+            let _ = std::fs::remove_file(&self.path);
+        }
+    }
+}
+
 pub(crate) fn atomic_write(path: &Path, data: &[u8]) -> Result<(), CliError> {
-    static TMP_SEQ: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+    static TMP_SEQ: std::sync::atomic::AtomicUsize = std::sync::atomic::AtomicUsize::new(0);
     let seq = TMP_SEQ.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
     let tmp = path.with_extension(format!("tmp.{}.{}", std::process::id(), seq));
-    std::fs::write(&tmp, data).map_err(|e| {
-        CliError::Auth(format!("Failed to write {}: {e}", tmp.display()))
-    })?;
+    let mut guard = TempFileGuard::new(tmp.clone());
+    std::fs::write(&tmp, data)
+        .map_err(|e| CliError::Auth(format!("Failed to write {}: {e}", tmp.display())))?;
     #[cfg(unix)]
     {
         use std::os::unix::fs::PermissionsExt;
         let perms = std::fs::Permissions::from_mode(0o600);
         let _ = std::fs::set_permissions(&tmp, perms);
     }
-    std::fs::rename(&tmp, path).map_err(|e| {
-        let _ = std::fs::remove_file(&tmp);
-        CliError::Auth(format!("Failed to rename {}: {e}", tmp.display()))
-    })
+    std::fs::rename(&tmp, path)
+        .map_err(|e| CliError::Auth(format!("Failed to rename {}: {e}", tmp.display())))?;
+    guard.disarm();
+    Ok(())
 }
 
 // ---------------------------------------------------------------------------
@@ -315,6 +348,56 @@ mod tests {
             .filter(|n| n.contains(".tmp"))
             .collect();
         assert!(leftovers.is_empty(), "temp files left behind: {leftovers:?}");
+    }
+
+    /// A failed write must not leave its temp file behind. Renaming a file onto
+    /// an existing directory fails on every platform, which drives the error
+    /// path without mocking the filesystem.
+    ///
+    /// The pre-`TempFileGuard` code already cleaned up on a `rename` error, so
+    /// this pins an invariant rather than catching a regression — see
+    /// `temp_file_guard_unlinks_unless_disarmed` for the guard's own coverage.
+    #[test]
+    fn atomic_write_cleans_up_temp_file_on_failure() {
+        let dir = tempfile::tempdir().unwrap();
+
+        // The target is a *directory*, so `rename` cannot replace it.
+        let target = dir.path().join("auth-keyring.json");
+        std::fs::create_dir(&target).unwrap();
+        std::fs::write(target.join("occupant"), b"x").unwrap();
+
+        let result = atomic_write(&target, br#"{"writer":0}"#);
+        assert!(result.is_err(), "expected rename onto a directory to fail");
+
+        let leftovers: Vec<String> = std::fs::read_dir(dir.path())
+            .unwrap()
+            .filter_map(|e| e.ok())
+            .map(|e| e.file_name().to_string_lossy().into_owned())
+            .filter(|n| n.contains(".tmp"))
+            .collect();
+        assert!(leftovers.is_empty(), "temp file leaked after a failed write: {leftovers:?}");
+    }
+
+    /// Pins [`TempFileGuard`]: armed drops unlink, disarmed drops don't. Drop
+    /// running on an armed guard is what covers early returns and unwinding
+    /// panics between `write` and `rename` — paths the old `rename`-only
+    /// cleanup missed. Deleting the guard or the `disarm()` call fails this.
+    #[test]
+    fn temp_file_guard_unlinks_unless_disarmed() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("auth-keyring.tmp.0.0");
+
+        std::fs::write(&path, b"x").unwrap();
+        drop(TempFileGuard::new(path.clone()));
+        assert!(!path.exists(), "armed guard must unlink on drop");
+
+        // The post-`rename` case: the file has been moved away, so the guard
+        // must not touch whatever now sits at that path.
+        std::fs::write(&path, b"x").unwrap();
+        let mut guard = TempFileGuard::new(path.clone());
+        guard.disarm();
+        drop(guard);
+        assert!(path.exists(), "disarmed guard must not unlink");
     }
 
     #[test]

--- a/seed/cli/respect-optional-request-body/src/auth/oauth_common.rs
+++ b/seed/cli/respect-optional-request-body/src/auth/oauth_common.rs
@@ -226,8 +226,29 @@ pub(crate) fn config_dir() -> Option<PathBuf> {
 
 /// Write `data` to `path` atomically: sibling temp file → owner-only
 /// permissions (0600 on Unix) → rename into place.
+///
+/// The temp file name is unique per writer — pid plus a process-local
+/// counter. Deriving it from the target alone meant every concurrent writer
+/// used the *same* sibling (`auth-keyring.tmp`): whichever one renamed first
+/// moved it away, and the rest failed with `ENOENT` from `rename`. That
+/// surfaced as intermittent `auth login --with-token` failures across a
+/// wire-test suite large enough to run many CLI processes at once, killing a
+/// different subset of cases on each run.
+///
+/// The pid covers the case that actually bit us (separate CLI processes); the
+/// counter covers two writers inside one process, and is what makes the
+/// behavior unit-testable without spawning subprocesses.
+///
+/// `rename` is still atomic for readers, which is what keeps a partially
+/// written credential file unobservable. This only fixes writer-vs-writer
+/// collisions on the temp path. `FileKeyringStore::set` remains a
+/// read-modify-write of the whole map with no lock, so simultaneous writers
+/// can still clobber one another's *entries*; making that safe needs file
+/// locking, which is a larger change.
 pub(crate) fn atomic_write(path: &Path, data: &[u8]) -> Result<(), CliError> {
-    let tmp = path.with_extension("tmp");
+    static TMP_SEQ: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+    let seq = TMP_SEQ.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+    let tmp = path.with_extension(format!("tmp.{}.{}", std::process::id(), seq));
     std::fs::write(&tmp, data).map_err(|e| {
         CliError::Auth(format!("Failed to write {}: {e}", tmp.display()))
     })?;
@@ -250,6 +271,51 @@ pub(crate) fn atomic_write(path: &Path, data: &[u8]) -> Result<(), CliError> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// Regression test for the temp-file collision that made
+    /// `auth login --with-token` fail intermittently: every writer derived the
+    /// same sibling path from the target, so the first `rename` moved it away
+    /// and the rest got `ENOENT`.
+    ///
+    /// Reverting `atomic_write` to a target-derived temp name fails this with
+    /// "Failed to rename ...: No such file or directory".
+    #[test]
+    fn atomic_write_tolerates_concurrent_writers() {
+        let dir = tempfile::tempdir().unwrap();
+        let target = dir.path().join("auth-keyring.json");
+
+        let results: Vec<Result<(), CliError>> = std::thread::scope(|scope| {
+            let handles: Vec<_> = (0..16)
+                .map(|i| {
+                    let target = target.clone();
+                    scope.spawn(move || atomic_write(&target, format!(r#"{{"writer":{i}}}"#).as_bytes()))
+                })
+                .collect();
+            handles.into_iter().map(|h| h.join().unwrap()).collect()
+        });
+
+        let failed: Vec<String> = results
+            .iter()
+            .filter_map(|r| r.as_ref().err().map(|e| e.to_string()))
+            .collect();
+        assert!(failed.is_empty(), "concurrent writers failed: {failed:?}");
+
+        // Last writer wins, but the file must always be one writer's complete
+        // payload — never a mix, and never absent.
+        let contents = std::fs::read_to_string(&target).unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(&contents)
+            .unwrap_or_else(|e| panic!("target is not valid JSON after concurrent writes: {e} in {contents:?}"));
+        assert!(parsed.get("writer").is_some(), "unexpected payload: {contents}");
+
+        // No temp files orphaned in the directory.
+        let leftovers: Vec<String> = std::fs::read_dir(dir.path())
+            .unwrap()
+            .filter_map(|e| e.ok())
+            .map(|e| e.file_name().to_string_lossy().into_owned())
+            .filter(|n| n.contains(".tmp"))
+            .collect();
+        assert!(leftovers.is_empty(), "temp files left behind: {leftovers:?}");
+    }
 
     #[test]
     fn token_bundle_roundtrip() {

--- a/seed/cli/schemaless-request-body-examples/src/auth/oauth_common.rs
+++ b/seed/cli/schemaless-request-body-examples/src/auth/oauth_common.rs
@@ -224,27 +224,6 @@ pub(crate) fn config_dir() -> Option<PathBuf> {
     }
 }
 
-/// Write `data` to `path` atomically: sibling temp file → owner-only
-/// permissions (0600 on Unix) → rename into place.
-///
-/// The temp file name is unique per writer — pid plus a process-local
-/// counter. Deriving it from the target alone meant every concurrent writer
-/// used the *same* sibling (`auth-keyring.tmp`): whichever one renamed first
-/// moved it away, and the rest failed with `ENOENT` from `rename`. That
-/// surfaced as intermittent `auth login --with-token` failures across a
-/// wire-test suite large enough to run many CLI processes at once, killing a
-/// different subset of cases on each run.
-///
-/// The pid covers the case that actually bit us (separate CLI processes); the
-/// counter covers two writers inside one process, and is what makes the
-/// behavior unit-testable without spawning subprocesses.
-///
-/// `rename` is still atomic for readers, which is what keeps a partially
-/// written credential file unobservable. This only fixes writer-vs-writer
-/// collisions on the temp path. `FileKeyringStore::set` remains a
-/// read-modify-write of the whole map with no lock, so simultaneous writers
-/// can still clobber one another's *entries*; making that safe needs file
-/// locking, which is a larger change.
 /// Unlinks a temp file on drop unless [`TempFileGuard::disarm`]ed. Covers
 /// every early return *and* a panic between creating the temp file and
 /// renaming it into place.
@@ -278,6 +257,30 @@ impl Drop for TempFileGuard {
     }
 }
 
+/// Write `data` to `path` atomically: sibling temp file → owner-only
+/// permissions (0600 on Unix) → rename into place.
+///
+/// The temp file name is unique per writer — pid plus a process-local
+/// counter. Deriving it from the target alone meant every concurrent writer
+/// used the *same* sibling (`auth-keyring.tmp`): whichever one renamed first
+/// moved it away, and the rest failed with `ENOENT` from `rename`. That
+/// surfaced as intermittent `auth login --with-token` failures across a
+/// wire-test suite large enough to run many CLI processes at once, killing a
+/// different subset of cases on each run.
+///
+/// The pid covers the case that actually bit us (separate CLI processes); the
+/// counter covers two writers inside one process, and is what makes the
+/// behavior unit-testable without spawning subprocesses.
+///
+/// A [`TempFileGuard`] unlinks the temp file if anything between creating it
+/// and renaming it fails, so unique names cannot accumulate as orphans.
+///
+/// `rename` is still atomic for readers, which is what keeps a partially
+/// written credential file unobservable. This only fixes writer-vs-writer
+/// collisions on the temp path. `FileKeyringStore::set` remains a
+/// read-modify-write of the whole map with no lock, so simultaneous writers
+/// can still clobber one another's *entries*; making that safe needs file
+/// locking, which is a larger change.
 pub(crate) fn atomic_write(path: &Path, data: &[u8]) -> Result<(), CliError> {
     static TMP_SEQ: std::sync::atomic::AtomicUsize = std::sync::atomic::AtomicUsize::new(0);
     let seq = TMP_SEQ.fetch_add(1, std::sync::atomic::Ordering::Relaxed);

--- a/seed/cli/schemaless-request-body-examples/src/auth/oauth_common.rs
+++ b/seed/cli/schemaless-request-body-examples/src/auth/oauth_common.rs
@@ -245,23 +245,56 @@ pub(crate) fn config_dir() -> Option<PathBuf> {
 /// read-modify-write of the whole map with no lock, so simultaneous writers
 /// can still clobber one another's *entries*; making that safe needs file
 /// locking, which is a larger change.
+/// Unlinks a temp file on drop unless [`TempFileGuard::disarm`]ed. Covers
+/// every early return *and* a panic between creating the temp file and
+/// renaming it into place.
+///
+/// This exists because the temp name is unique per writer. The old shared
+/// `auth-keyring.tmp` was self-limiting — a failed write left one stale file
+/// that the next write reused — whereas unique names would leak a distinct
+/// credential-bearing file on every failure, in a directory nothing prunes. A
+/// `SIGKILL` still leaks, since no in-process guard can cover that.
+struct TempFileGuard {
+    path: PathBuf,
+    armed: bool,
+}
+
+impl TempFileGuard {
+    fn new(path: PathBuf) -> Self {
+        Self { path, armed: true }
+    }
+
+    /// Relinquish the file — call once `rename` has moved it into place.
+    fn disarm(&mut self) {
+        self.armed = false;
+    }
+}
+
+impl Drop for TempFileGuard {
+    fn drop(&mut self) {
+        if self.armed {
+            let _ = std::fs::remove_file(&self.path);
+        }
+    }
+}
+
 pub(crate) fn atomic_write(path: &Path, data: &[u8]) -> Result<(), CliError> {
-    static TMP_SEQ: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+    static TMP_SEQ: std::sync::atomic::AtomicUsize = std::sync::atomic::AtomicUsize::new(0);
     let seq = TMP_SEQ.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
     let tmp = path.with_extension(format!("tmp.{}.{}", std::process::id(), seq));
-    std::fs::write(&tmp, data).map_err(|e| {
-        CliError::Auth(format!("Failed to write {}: {e}", tmp.display()))
-    })?;
+    let mut guard = TempFileGuard::new(tmp.clone());
+    std::fs::write(&tmp, data)
+        .map_err(|e| CliError::Auth(format!("Failed to write {}: {e}", tmp.display())))?;
     #[cfg(unix)]
     {
         use std::os::unix::fs::PermissionsExt;
         let perms = std::fs::Permissions::from_mode(0o600);
         let _ = std::fs::set_permissions(&tmp, perms);
     }
-    std::fs::rename(&tmp, path).map_err(|e| {
-        let _ = std::fs::remove_file(&tmp);
-        CliError::Auth(format!("Failed to rename {}: {e}", tmp.display()))
-    })
+    std::fs::rename(&tmp, path)
+        .map_err(|e| CliError::Auth(format!("Failed to rename {}: {e}", tmp.display())))?;
+    guard.disarm();
+    Ok(())
 }
 
 // ---------------------------------------------------------------------------
@@ -315,6 +348,56 @@ mod tests {
             .filter(|n| n.contains(".tmp"))
             .collect();
         assert!(leftovers.is_empty(), "temp files left behind: {leftovers:?}");
+    }
+
+    /// A failed write must not leave its temp file behind. Renaming a file onto
+    /// an existing directory fails on every platform, which drives the error
+    /// path without mocking the filesystem.
+    ///
+    /// The pre-`TempFileGuard` code already cleaned up on a `rename` error, so
+    /// this pins an invariant rather than catching a regression — see
+    /// `temp_file_guard_unlinks_unless_disarmed` for the guard's own coverage.
+    #[test]
+    fn atomic_write_cleans_up_temp_file_on_failure() {
+        let dir = tempfile::tempdir().unwrap();
+
+        // The target is a *directory*, so `rename` cannot replace it.
+        let target = dir.path().join("auth-keyring.json");
+        std::fs::create_dir(&target).unwrap();
+        std::fs::write(target.join("occupant"), b"x").unwrap();
+
+        let result = atomic_write(&target, br#"{"writer":0}"#);
+        assert!(result.is_err(), "expected rename onto a directory to fail");
+
+        let leftovers: Vec<String> = std::fs::read_dir(dir.path())
+            .unwrap()
+            .filter_map(|e| e.ok())
+            .map(|e| e.file_name().to_string_lossy().into_owned())
+            .filter(|n| n.contains(".tmp"))
+            .collect();
+        assert!(leftovers.is_empty(), "temp file leaked after a failed write: {leftovers:?}");
+    }
+
+    /// Pins [`TempFileGuard`]: armed drops unlink, disarmed drops don't. Drop
+    /// running on an armed guard is what covers early returns and unwinding
+    /// panics between `write` and `rename` — paths the old `rename`-only
+    /// cleanup missed. Deleting the guard or the `disarm()` call fails this.
+    #[test]
+    fn temp_file_guard_unlinks_unless_disarmed() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("auth-keyring.tmp.0.0");
+
+        std::fs::write(&path, b"x").unwrap();
+        drop(TempFileGuard::new(path.clone()));
+        assert!(!path.exists(), "armed guard must unlink on drop");
+
+        // The post-`rename` case: the file has been moved away, so the guard
+        // must not touch whatever now sits at that path.
+        std::fs::write(&path, b"x").unwrap();
+        let mut guard = TempFileGuard::new(path.clone());
+        guard.disarm();
+        drop(guard);
+        assert!(path.exists(), "disarmed guard must not unlink");
     }
 
     #[test]

--- a/seed/cli/schemaless-request-body-examples/src/auth/oauth_common.rs
+++ b/seed/cli/schemaless-request-body-examples/src/auth/oauth_common.rs
@@ -226,8 +226,29 @@ pub(crate) fn config_dir() -> Option<PathBuf> {
 
 /// Write `data` to `path` atomically: sibling temp file → owner-only
 /// permissions (0600 on Unix) → rename into place.
+///
+/// The temp file name is unique per writer — pid plus a process-local
+/// counter. Deriving it from the target alone meant every concurrent writer
+/// used the *same* sibling (`auth-keyring.tmp`): whichever one renamed first
+/// moved it away, and the rest failed with `ENOENT` from `rename`. That
+/// surfaced as intermittent `auth login --with-token` failures across a
+/// wire-test suite large enough to run many CLI processes at once, killing a
+/// different subset of cases on each run.
+///
+/// The pid covers the case that actually bit us (separate CLI processes); the
+/// counter covers two writers inside one process, and is what makes the
+/// behavior unit-testable without spawning subprocesses.
+///
+/// `rename` is still atomic for readers, which is what keeps a partially
+/// written credential file unobservable. This only fixes writer-vs-writer
+/// collisions on the temp path. `FileKeyringStore::set` remains a
+/// read-modify-write of the whole map with no lock, so simultaneous writers
+/// can still clobber one another's *entries*; making that safe needs file
+/// locking, which is a larger change.
 pub(crate) fn atomic_write(path: &Path, data: &[u8]) -> Result<(), CliError> {
-    let tmp = path.with_extension("tmp");
+    static TMP_SEQ: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+    let seq = TMP_SEQ.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+    let tmp = path.with_extension(format!("tmp.{}.{}", std::process::id(), seq));
     std::fs::write(&tmp, data).map_err(|e| {
         CliError::Auth(format!("Failed to write {}: {e}", tmp.display()))
     })?;
@@ -250,6 +271,51 @@ pub(crate) fn atomic_write(path: &Path, data: &[u8]) -> Result<(), CliError> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// Regression test for the temp-file collision that made
+    /// `auth login --with-token` fail intermittently: every writer derived the
+    /// same sibling path from the target, so the first `rename` moved it away
+    /// and the rest got `ENOENT`.
+    ///
+    /// Reverting `atomic_write` to a target-derived temp name fails this with
+    /// "Failed to rename ...: No such file or directory".
+    #[test]
+    fn atomic_write_tolerates_concurrent_writers() {
+        let dir = tempfile::tempdir().unwrap();
+        let target = dir.path().join("auth-keyring.json");
+
+        let results: Vec<Result<(), CliError>> = std::thread::scope(|scope| {
+            let handles: Vec<_> = (0..16)
+                .map(|i| {
+                    let target = target.clone();
+                    scope.spawn(move || atomic_write(&target, format!(r#"{{"writer":{i}}}"#).as_bytes()))
+                })
+                .collect();
+            handles.into_iter().map(|h| h.join().unwrap()).collect()
+        });
+
+        let failed: Vec<String> = results
+            .iter()
+            .filter_map(|r| r.as_ref().err().map(|e| e.to_string()))
+            .collect();
+        assert!(failed.is_empty(), "concurrent writers failed: {failed:?}");
+
+        // Last writer wins, but the file must always be one writer's complete
+        // payload — never a mix, and never absent.
+        let contents = std::fs::read_to_string(&target).unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(&contents)
+            .unwrap_or_else(|e| panic!("target is not valid JSON after concurrent writes: {e} in {contents:?}"));
+        assert!(parsed.get("writer").is_some(), "unexpected payload: {contents}");
+
+        // No temp files orphaned in the directory.
+        let leftovers: Vec<String> = std::fs::read_dir(dir.path())
+            .unwrap()
+            .filter_map(|e| e.ok())
+            .map(|e| e.file_name().to_string_lossy().into_owned())
+            .filter(|n| n.contains(".tmp"))
+            .collect();
+        assert!(leftovers.is_empty(), "temp files left behind: {leftovers:?}");
+    }
 
     #[test]
     fn token_bundle_roundtrip() {

--- a/seed/cli/server-sent-events-openapi/src/auth/oauth_common.rs
+++ b/seed/cli/server-sent-events-openapi/src/auth/oauth_common.rs
@@ -224,27 +224,6 @@ pub(crate) fn config_dir() -> Option<PathBuf> {
     }
 }
 
-/// Write `data` to `path` atomically: sibling temp file → owner-only
-/// permissions (0600 on Unix) → rename into place.
-///
-/// The temp file name is unique per writer — pid plus a process-local
-/// counter. Deriving it from the target alone meant every concurrent writer
-/// used the *same* sibling (`auth-keyring.tmp`): whichever one renamed first
-/// moved it away, and the rest failed with `ENOENT` from `rename`. That
-/// surfaced as intermittent `auth login --with-token` failures across a
-/// wire-test suite large enough to run many CLI processes at once, killing a
-/// different subset of cases on each run.
-///
-/// The pid covers the case that actually bit us (separate CLI processes); the
-/// counter covers two writers inside one process, and is what makes the
-/// behavior unit-testable without spawning subprocesses.
-///
-/// `rename` is still atomic for readers, which is what keeps a partially
-/// written credential file unobservable. This only fixes writer-vs-writer
-/// collisions on the temp path. `FileKeyringStore::set` remains a
-/// read-modify-write of the whole map with no lock, so simultaneous writers
-/// can still clobber one another's *entries*; making that safe needs file
-/// locking, which is a larger change.
 /// Unlinks a temp file on drop unless [`TempFileGuard::disarm`]ed. Covers
 /// every early return *and* a panic between creating the temp file and
 /// renaming it into place.
@@ -278,6 +257,30 @@ impl Drop for TempFileGuard {
     }
 }
 
+/// Write `data` to `path` atomically: sibling temp file → owner-only
+/// permissions (0600 on Unix) → rename into place.
+///
+/// The temp file name is unique per writer — pid plus a process-local
+/// counter. Deriving it from the target alone meant every concurrent writer
+/// used the *same* sibling (`auth-keyring.tmp`): whichever one renamed first
+/// moved it away, and the rest failed with `ENOENT` from `rename`. That
+/// surfaced as intermittent `auth login --with-token` failures across a
+/// wire-test suite large enough to run many CLI processes at once, killing a
+/// different subset of cases on each run.
+///
+/// The pid covers the case that actually bit us (separate CLI processes); the
+/// counter covers two writers inside one process, and is what makes the
+/// behavior unit-testable without spawning subprocesses.
+///
+/// A [`TempFileGuard`] unlinks the temp file if anything between creating it
+/// and renaming it fails, so unique names cannot accumulate as orphans.
+///
+/// `rename` is still atomic for readers, which is what keeps a partially
+/// written credential file unobservable. This only fixes writer-vs-writer
+/// collisions on the temp path. `FileKeyringStore::set` remains a
+/// read-modify-write of the whole map with no lock, so simultaneous writers
+/// can still clobber one another's *entries*; making that safe needs file
+/// locking, which is a larger change.
 pub(crate) fn atomic_write(path: &Path, data: &[u8]) -> Result<(), CliError> {
     static TMP_SEQ: std::sync::atomic::AtomicUsize = std::sync::atomic::AtomicUsize::new(0);
     let seq = TMP_SEQ.fetch_add(1, std::sync::atomic::Ordering::Relaxed);

--- a/seed/cli/server-sent-events-openapi/src/auth/oauth_common.rs
+++ b/seed/cli/server-sent-events-openapi/src/auth/oauth_common.rs
@@ -245,23 +245,56 @@ pub(crate) fn config_dir() -> Option<PathBuf> {
 /// read-modify-write of the whole map with no lock, so simultaneous writers
 /// can still clobber one another's *entries*; making that safe needs file
 /// locking, which is a larger change.
+/// Unlinks a temp file on drop unless [`TempFileGuard::disarm`]ed. Covers
+/// every early return *and* a panic between creating the temp file and
+/// renaming it into place.
+///
+/// This exists because the temp name is unique per writer. The old shared
+/// `auth-keyring.tmp` was self-limiting — a failed write left one stale file
+/// that the next write reused — whereas unique names would leak a distinct
+/// credential-bearing file on every failure, in a directory nothing prunes. A
+/// `SIGKILL` still leaks, since no in-process guard can cover that.
+struct TempFileGuard {
+    path: PathBuf,
+    armed: bool,
+}
+
+impl TempFileGuard {
+    fn new(path: PathBuf) -> Self {
+        Self { path, armed: true }
+    }
+
+    /// Relinquish the file — call once `rename` has moved it into place.
+    fn disarm(&mut self) {
+        self.armed = false;
+    }
+}
+
+impl Drop for TempFileGuard {
+    fn drop(&mut self) {
+        if self.armed {
+            let _ = std::fs::remove_file(&self.path);
+        }
+    }
+}
+
 pub(crate) fn atomic_write(path: &Path, data: &[u8]) -> Result<(), CliError> {
-    static TMP_SEQ: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+    static TMP_SEQ: std::sync::atomic::AtomicUsize = std::sync::atomic::AtomicUsize::new(0);
     let seq = TMP_SEQ.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
     let tmp = path.with_extension(format!("tmp.{}.{}", std::process::id(), seq));
-    std::fs::write(&tmp, data).map_err(|e| {
-        CliError::Auth(format!("Failed to write {}: {e}", tmp.display()))
-    })?;
+    let mut guard = TempFileGuard::new(tmp.clone());
+    std::fs::write(&tmp, data)
+        .map_err(|e| CliError::Auth(format!("Failed to write {}: {e}", tmp.display())))?;
     #[cfg(unix)]
     {
         use std::os::unix::fs::PermissionsExt;
         let perms = std::fs::Permissions::from_mode(0o600);
         let _ = std::fs::set_permissions(&tmp, perms);
     }
-    std::fs::rename(&tmp, path).map_err(|e| {
-        let _ = std::fs::remove_file(&tmp);
-        CliError::Auth(format!("Failed to rename {}: {e}", tmp.display()))
-    })
+    std::fs::rename(&tmp, path)
+        .map_err(|e| CliError::Auth(format!("Failed to rename {}: {e}", tmp.display())))?;
+    guard.disarm();
+    Ok(())
 }
 
 // ---------------------------------------------------------------------------
@@ -315,6 +348,56 @@ mod tests {
             .filter(|n| n.contains(".tmp"))
             .collect();
         assert!(leftovers.is_empty(), "temp files left behind: {leftovers:?}");
+    }
+
+    /// A failed write must not leave its temp file behind. Renaming a file onto
+    /// an existing directory fails on every platform, which drives the error
+    /// path without mocking the filesystem.
+    ///
+    /// The pre-`TempFileGuard` code already cleaned up on a `rename` error, so
+    /// this pins an invariant rather than catching a regression — see
+    /// `temp_file_guard_unlinks_unless_disarmed` for the guard's own coverage.
+    #[test]
+    fn atomic_write_cleans_up_temp_file_on_failure() {
+        let dir = tempfile::tempdir().unwrap();
+
+        // The target is a *directory*, so `rename` cannot replace it.
+        let target = dir.path().join("auth-keyring.json");
+        std::fs::create_dir(&target).unwrap();
+        std::fs::write(target.join("occupant"), b"x").unwrap();
+
+        let result = atomic_write(&target, br#"{"writer":0}"#);
+        assert!(result.is_err(), "expected rename onto a directory to fail");
+
+        let leftovers: Vec<String> = std::fs::read_dir(dir.path())
+            .unwrap()
+            .filter_map(|e| e.ok())
+            .map(|e| e.file_name().to_string_lossy().into_owned())
+            .filter(|n| n.contains(".tmp"))
+            .collect();
+        assert!(leftovers.is_empty(), "temp file leaked after a failed write: {leftovers:?}");
+    }
+
+    /// Pins [`TempFileGuard`]: armed drops unlink, disarmed drops don't. Drop
+    /// running on an armed guard is what covers early returns and unwinding
+    /// panics between `write` and `rename` — paths the old `rename`-only
+    /// cleanup missed. Deleting the guard or the `disarm()` call fails this.
+    #[test]
+    fn temp_file_guard_unlinks_unless_disarmed() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("auth-keyring.tmp.0.0");
+
+        std::fs::write(&path, b"x").unwrap();
+        drop(TempFileGuard::new(path.clone()));
+        assert!(!path.exists(), "armed guard must unlink on drop");
+
+        // The post-`rename` case: the file has been moved away, so the guard
+        // must not touch whatever now sits at that path.
+        std::fs::write(&path, b"x").unwrap();
+        let mut guard = TempFileGuard::new(path.clone());
+        guard.disarm();
+        drop(guard);
+        assert!(path.exists(), "disarmed guard must not unlink");
     }
 
     #[test]

--- a/seed/cli/server-sent-events-openapi/src/auth/oauth_common.rs
+++ b/seed/cli/server-sent-events-openapi/src/auth/oauth_common.rs
@@ -226,8 +226,29 @@ pub(crate) fn config_dir() -> Option<PathBuf> {
 
 /// Write `data` to `path` atomically: sibling temp file → owner-only
 /// permissions (0600 on Unix) → rename into place.
+///
+/// The temp file name is unique per writer — pid plus a process-local
+/// counter. Deriving it from the target alone meant every concurrent writer
+/// used the *same* sibling (`auth-keyring.tmp`): whichever one renamed first
+/// moved it away, and the rest failed with `ENOENT` from `rename`. That
+/// surfaced as intermittent `auth login --with-token` failures across a
+/// wire-test suite large enough to run many CLI processes at once, killing a
+/// different subset of cases on each run.
+///
+/// The pid covers the case that actually bit us (separate CLI processes); the
+/// counter covers two writers inside one process, and is what makes the
+/// behavior unit-testable without spawning subprocesses.
+///
+/// `rename` is still atomic for readers, which is what keeps a partially
+/// written credential file unobservable. This only fixes writer-vs-writer
+/// collisions on the temp path. `FileKeyringStore::set` remains a
+/// read-modify-write of the whole map with no lock, so simultaneous writers
+/// can still clobber one another's *entries*; making that safe needs file
+/// locking, which is a larger change.
 pub(crate) fn atomic_write(path: &Path, data: &[u8]) -> Result<(), CliError> {
-    let tmp = path.with_extension("tmp");
+    static TMP_SEQ: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+    let seq = TMP_SEQ.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+    let tmp = path.with_extension(format!("tmp.{}.{}", std::process::id(), seq));
     std::fs::write(&tmp, data).map_err(|e| {
         CliError::Auth(format!("Failed to write {}: {e}", tmp.display()))
     })?;
@@ -250,6 +271,51 @@ pub(crate) fn atomic_write(path: &Path, data: &[u8]) -> Result<(), CliError> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// Regression test for the temp-file collision that made
+    /// `auth login --with-token` fail intermittently: every writer derived the
+    /// same sibling path from the target, so the first `rename` moved it away
+    /// and the rest got `ENOENT`.
+    ///
+    /// Reverting `atomic_write` to a target-derived temp name fails this with
+    /// "Failed to rename ...: No such file or directory".
+    #[test]
+    fn atomic_write_tolerates_concurrent_writers() {
+        let dir = tempfile::tempdir().unwrap();
+        let target = dir.path().join("auth-keyring.json");
+
+        let results: Vec<Result<(), CliError>> = std::thread::scope(|scope| {
+            let handles: Vec<_> = (0..16)
+                .map(|i| {
+                    let target = target.clone();
+                    scope.spawn(move || atomic_write(&target, format!(r#"{{"writer":{i}}}"#).as_bytes()))
+                })
+                .collect();
+            handles.into_iter().map(|h| h.join().unwrap()).collect()
+        });
+
+        let failed: Vec<String> = results
+            .iter()
+            .filter_map(|r| r.as_ref().err().map(|e| e.to_string()))
+            .collect();
+        assert!(failed.is_empty(), "concurrent writers failed: {failed:?}");
+
+        // Last writer wins, but the file must always be one writer's complete
+        // payload — never a mix, and never absent.
+        let contents = std::fs::read_to_string(&target).unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(&contents)
+            .unwrap_or_else(|e| panic!("target is not valid JSON after concurrent writes: {e} in {contents:?}"));
+        assert!(parsed.get("writer").is_some(), "unexpected payload: {contents}");
+
+        // No temp files orphaned in the directory.
+        let leftovers: Vec<String> = std::fs::read_dir(dir.path())
+            .unwrap()
+            .filter_map(|e| e.ok())
+            .map(|e| e.file_name().to_string_lossy().into_owned())
+            .filter(|n| n.contains(".tmp"))
+            .collect();
+        assert!(leftovers.is_empty(), "temp files left behind: {leftovers:?}");
+    }
 
     #[test]
     fn token_bundle_roundtrip() {

--- a/seed/cli/server-url-templating-single-url/src/auth/oauth_common.rs
+++ b/seed/cli/server-url-templating-single-url/src/auth/oauth_common.rs
@@ -224,27 +224,6 @@ pub(crate) fn config_dir() -> Option<PathBuf> {
     }
 }
 
-/// Write `data` to `path` atomically: sibling temp file → owner-only
-/// permissions (0600 on Unix) → rename into place.
-///
-/// The temp file name is unique per writer — pid plus a process-local
-/// counter. Deriving it from the target alone meant every concurrent writer
-/// used the *same* sibling (`auth-keyring.tmp`): whichever one renamed first
-/// moved it away, and the rest failed with `ENOENT` from `rename`. That
-/// surfaced as intermittent `auth login --with-token` failures across a
-/// wire-test suite large enough to run many CLI processes at once, killing a
-/// different subset of cases on each run.
-///
-/// The pid covers the case that actually bit us (separate CLI processes); the
-/// counter covers two writers inside one process, and is what makes the
-/// behavior unit-testable without spawning subprocesses.
-///
-/// `rename` is still atomic for readers, which is what keeps a partially
-/// written credential file unobservable. This only fixes writer-vs-writer
-/// collisions on the temp path. `FileKeyringStore::set` remains a
-/// read-modify-write of the whole map with no lock, so simultaneous writers
-/// can still clobber one another's *entries*; making that safe needs file
-/// locking, which is a larger change.
 /// Unlinks a temp file on drop unless [`TempFileGuard::disarm`]ed. Covers
 /// every early return *and* a panic between creating the temp file and
 /// renaming it into place.
@@ -278,6 +257,30 @@ impl Drop for TempFileGuard {
     }
 }
 
+/// Write `data` to `path` atomically: sibling temp file → owner-only
+/// permissions (0600 on Unix) → rename into place.
+///
+/// The temp file name is unique per writer — pid plus a process-local
+/// counter. Deriving it from the target alone meant every concurrent writer
+/// used the *same* sibling (`auth-keyring.tmp`): whichever one renamed first
+/// moved it away, and the rest failed with `ENOENT` from `rename`. That
+/// surfaced as intermittent `auth login --with-token` failures across a
+/// wire-test suite large enough to run many CLI processes at once, killing a
+/// different subset of cases on each run.
+///
+/// The pid covers the case that actually bit us (separate CLI processes); the
+/// counter covers two writers inside one process, and is what makes the
+/// behavior unit-testable without spawning subprocesses.
+///
+/// A [`TempFileGuard`] unlinks the temp file if anything between creating it
+/// and renaming it fails, so unique names cannot accumulate as orphans.
+///
+/// `rename` is still atomic for readers, which is what keeps a partially
+/// written credential file unobservable. This only fixes writer-vs-writer
+/// collisions on the temp path. `FileKeyringStore::set` remains a
+/// read-modify-write of the whole map with no lock, so simultaneous writers
+/// can still clobber one another's *entries*; making that safe needs file
+/// locking, which is a larger change.
 pub(crate) fn atomic_write(path: &Path, data: &[u8]) -> Result<(), CliError> {
     static TMP_SEQ: std::sync::atomic::AtomicUsize = std::sync::atomic::AtomicUsize::new(0);
     let seq = TMP_SEQ.fetch_add(1, std::sync::atomic::Ordering::Relaxed);

--- a/seed/cli/server-url-templating-single-url/src/auth/oauth_common.rs
+++ b/seed/cli/server-url-templating-single-url/src/auth/oauth_common.rs
@@ -245,23 +245,56 @@ pub(crate) fn config_dir() -> Option<PathBuf> {
 /// read-modify-write of the whole map with no lock, so simultaneous writers
 /// can still clobber one another's *entries*; making that safe needs file
 /// locking, which is a larger change.
+/// Unlinks a temp file on drop unless [`TempFileGuard::disarm`]ed. Covers
+/// every early return *and* a panic between creating the temp file and
+/// renaming it into place.
+///
+/// This exists because the temp name is unique per writer. The old shared
+/// `auth-keyring.tmp` was self-limiting — a failed write left one stale file
+/// that the next write reused — whereas unique names would leak a distinct
+/// credential-bearing file on every failure, in a directory nothing prunes. A
+/// `SIGKILL` still leaks, since no in-process guard can cover that.
+struct TempFileGuard {
+    path: PathBuf,
+    armed: bool,
+}
+
+impl TempFileGuard {
+    fn new(path: PathBuf) -> Self {
+        Self { path, armed: true }
+    }
+
+    /// Relinquish the file — call once `rename` has moved it into place.
+    fn disarm(&mut self) {
+        self.armed = false;
+    }
+}
+
+impl Drop for TempFileGuard {
+    fn drop(&mut self) {
+        if self.armed {
+            let _ = std::fs::remove_file(&self.path);
+        }
+    }
+}
+
 pub(crate) fn atomic_write(path: &Path, data: &[u8]) -> Result<(), CliError> {
-    static TMP_SEQ: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+    static TMP_SEQ: std::sync::atomic::AtomicUsize = std::sync::atomic::AtomicUsize::new(0);
     let seq = TMP_SEQ.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
     let tmp = path.with_extension(format!("tmp.{}.{}", std::process::id(), seq));
-    std::fs::write(&tmp, data).map_err(|e| {
-        CliError::Auth(format!("Failed to write {}: {e}", tmp.display()))
-    })?;
+    let mut guard = TempFileGuard::new(tmp.clone());
+    std::fs::write(&tmp, data)
+        .map_err(|e| CliError::Auth(format!("Failed to write {}: {e}", tmp.display())))?;
     #[cfg(unix)]
     {
         use std::os::unix::fs::PermissionsExt;
         let perms = std::fs::Permissions::from_mode(0o600);
         let _ = std::fs::set_permissions(&tmp, perms);
     }
-    std::fs::rename(&tmp, path).map_err(|e| {
-        let _ = std::fs::remove_file(&tmp);
-        CliError::Auth(format!("Failed to rename {}: {e}", tmp.display()))
-    })
+    std::fs::rename(&tmp, path)
+        .map_err(|e| CliError::Auth(format!("Failed to rename {}: {e}", tmp.display())))?;
+    guard.disarm();
+    Ok(())
 }
 
 // ---------------------------------------------------------------------------
@@ -315,6 +348,56 @@ mod tests {
             .filter(|n| n.contains(".tmp"))
             .collect();
         assert!(leftovers.is_empty(), "temp files left behind: {leftovers:?}");
+    }
+
+    /// A failed write must not leave its temp file behind. Renaming a file onto
+    /// an existing directory fails on every platform, which drives the error
+    /// path without mocking the filesystem.
+    ///
+    /// The pre-`TempFileGuard` code already cleaned up on a `rename` error, so
+    /// this pins an invariant rather than catching a regression — see
+    /// `temp_file_guard_unlinks_unless_disarmed` for the guard's own coverage.
+    #[test]
+    fn atomic_write_cleans_up_temp_file_on_failure() {
+        let dir = tempfile::tempdir().unwrap();
+
+        // The target is a *directory*, so `rename` cannot replace it.
+        let target = dir.path().join("auth-keyring.json");
+        std::fs::create_dir(&target).unwrap();
+        std::fs::write(target.join("occupant"), b"x").unwrap();
+
+        let result = atomic_write(&target, br#"{"writer":0}"#);
+        assert!(result.is_err(), "expected rename onto a directory to fail");
+
+        let leftovers: Vec<String> = std::fs::read_dir(dir.path())
+            .unwrap()
+            .filter_map(|e| e.ok())
+            .map(|e| e.file_name().to_string_lossy().into_owned())
+            .filter(|n| n.contains(".tmp"))
+            .collect();
+        assert!(leftovers.is_empty(), "temp file leaked after a failed write: {leftovers:?}");
+    }
+
+    /// Pins [`TempFileGuard`]: armed drops unlink, disarmed drops don't. Drop
+    /// running on an armed guard is what covers early returns and unwinding
+    /// panics between `write` and `rename` — paths the old `rename`-only
+    /// cleanup missed. Deleting the guard or the `disarm()` call fails this.
+    #[test]
+    fn temp_file_guard_unlinks_unless_disarmed() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("auth-keyring.tmp.0.0");
+
+        std::fs::write(&path, b"x").unwrap();
+        drop(TempFileGuard::new(path.clone()));
+        assert!(!path.exists(), "armed guard must unlink on drop");
+
+        // The post-`rename` case: the file has been moved away, so the guard
+        // must not touch whatever now sits at that path.
+        std::fs::write(&path, b"x").unwrap();
+        let mut guard = TempFileGuard::new(path.clone());
+        guard.disarm();
+        drop(guard);
+        assert!(path.exists(), "disarmed guard must not unlink");
     }
 
     #[test]

--- a/seed/cli/server-url-templating-single-url/src/auth/oauth_common.rs
+++ b/seed/cli/server-url-templating-single-url/src/auth/oauth_common.rs
@@ -226,8 +226,29 @@ pub(crate) fn config_dir() -> Option<PathBuf> {
 
 /// Write `data` to `path` atomically: sibling temp file → owner-only
 /// permissions (0600 on Unix) → rename into place.
+///
+/// The temp file name is unique per writer — pid plus a process-local
+/// counter. Deriving it from the target alone meant every concurrent writer
+/// used the *same* sibling (`auth-keyring.tmp`): whichever one renamed first
+/// moved it away, and the rest failed with `ENOENT` from `rename`. That
+/// surfaced as intermittent `auth login --with-token` failures across a
+/// wire-test suite large enough to run many CLI processes at once, killing a
+/// different subset of cases on each run.
+///
+/// The pid covers the case that actually bit us (separate CLI processes); the
+/// counter covers two writers inside one process, and is what makes the
+/// behavior unit-testable without spawning subprocesses.
+///
+/// `rename` is still atomic for readers, which is what keeps a partially
+/// written credential file unobservable. This only fixes writer-vs-writer
+/// collisions on the temp path. `FileKeyringStore::set` remains a
+/// read-modify-write of the whole map with no lock, so simultaneous writers
+/// can still clobber one another's *entries*; making that safe needs file
+/// locking, which is a larger change.
 pub(crate) fn atomic_write(path: &Path, data: &[u8]) -> Result<(), CliError> {
-    let tmp = path.with_extension("tmp");
+    static TMP_SEQ: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+    let seq = TMP_SEQ.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+    let tmp = path.with_extension(format!("tmp.{}.{}", std::process::id(), seq));
     std::fs::write(&tmp, data).map_err(|e| {
         CliError::Auth(format!("Failed to write {}: {e}", tmp.display()))
     })?;
@@ -250,6 +271,51 @@ pub(crate) fn atomic_write(path: &Path, data: &[u8]) -> Result<(), CliError> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// Regression test for the temp-file collision that made
+    /// `auth login --with-token` fail intermittently: every writer derived the
+    /// same sibling path from the target, so the first `rename` moved it away
+    /// and the rest got `ENOENT`.
+    ///
+    /// Reverting `atomic_write` to a target-derived temp name fails this with
+    /// "Failed to rename ...: No such file or directory".
+    #[test]
+    fn atomic_write_tolerates_concurrent_writers() {
+        let dir = tempfile::tempdir().unwrap();
+        let target = dir.path().join("auth-keyring.json");
+
+        let results: Vec<Result<(), CliError>> = std::thread::scope(|scope| {
+            let handles: Vec<_> = (0..16)
+                .map(|i| {
+                    let target = target.clone();
+                    scope.spawn(move || atomic_write(&target, format!(r#"{{"writer":{i}}}"#).as_bytes()))
+                })
+                .collect();
+            handles.into_iter().map(|h| h.join().unwrap()).collect()
+        });
+
+        let failed: Vec<String> = results
+            .iter()
+            .filter_map(|r| r.as_ref().err().map(|e| e.to_string()))
+            .collect();
+        assert!(failed.is_empty(), "concurrent writers failed: {failed:?}");
+
+        // Last writer wins, but the file must always be one writer's complete
+        // payload — never a mix, and never absent.
+        let contents = std::fs::read_to_string(&target).unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(&contents)
+            .unwrap_or_else(|e| panic!("target is not valid JSON after concurrent writes: {e} in {contents:?}"));
+        assert!(parsed.get("writer").is_some(), "unexpected payload: {contents}");
+
+        // No temp files orphaned in the directory.
+        let leftovers: Vec<String> = std::fs::read_dir(dir.path())
+            .unwrap()
+            .filter_map(|e| e.ok())
+            .map(|e| e.file_name().to_string_lossy().into_owned())
+            .filter(|n| n.contains(".tmp"))
+            .collect();
+        assert!(leftovers.is_empty(), "temp files left behind: {leftovers:?}");
+    }
 
     #[test]
     fn token_bundle_roundtrip() {

--- a/seed/cli/server-url-templating/src/auth/oauth_common.rs
+++ b/seed/cli/server-url-templating/src/auth/oauth_common.rs
@@ -224,27 +224,6 @@ pub(crate) fn config_dir() -> Option<PathBuf> {
     }
 }
 
-/// Write `data` to `path` atomically: sibling temp file → owner-only
-/// permissions (0600 on Unix) → rename into place.
-///
-/// The temp file name is unique per writer — pid plus a process-local
-/// counter. Deriving it from the target alone meant every concurrent writer
-/// used the *same* sibling (`auth-keyring.tmp`): whichever one renamed first
-/// moved it away, and the rest failed with `ENOENT` from `rename`. That
-/// surfaced as intermittent `auth login --with-token` failures across a
-/// wire-test suite large enough to run many CLI processes at once, killing a
-/// different subset of cases on each run.
-///
-/// The pid covers the case that actually bit us (separate CLI processes); the
-/// counter covers two writers inside one process, and is what makes the
-/// behavior unit-testable without spawning subprocesses.
-///
-/// `rename` is still atomic for readers, which is what keeps a partially
-/// written credential file unobservable. This only fixes writer-vs-writer
-/// collisions on the temp path. `FileKeyringStore::set` remains a
-/// read-modify-write of the whole map with no lock, so simultaneous writers
-/// can still clobber one another's *entries*; making that safe needs file
-/// locking, which is a larger change.
 /// Unlinks a temp file on drop unless [`TempFileGuard::disarm`]ed. Covers
 /// every early return *and* a panic between creating the temp file and
 /// renaming it into place.
@@ -278,6 +257,30 @@ impl Drop for TempFileGuard {
     }
 }
 
+/// Write `data` to `path` atomically: sibling temp file → owner-only
+/// permissions (0600 on Unix) → rename into place.
+///
+/// The temp file name is unique per writer — pid plus a process-local
+/// counter. Deriving it from the target alone meant every concurrent writer
+/// used the *same* sibling (`auth-keyring.tmp`): whichever one renamed first
+/// moved it away, and the rest failed with `ENOENT` from `rename`. That
+/// surfaced as intermittent `auth login --with-token` failures across a
+/// wire-test suite large enough to run many CLI processes at once, killing a
+/// different subset of cases on each run.
+///
+/// The pid covers the case that actually bit us (separate CLI processes); the
+/// counter covers two writers inside one process, and is what makes the
+/// behavior unit-testable without spawning subprocesses.
+///
+/// A [`TempFileGuard`] unlinks the temp file if anything between creating it
+/// and renaming it fails, so unique names cannot accumulate as orphans.
+///
+/// `rename` is still atomic for readers, which is what keeps a partially
+/// written credential file unobservable. This only fixes writer-vs-writer
+/// collisions on the temp path. `FileKeyringStore::set` remains a
+/// read-modify-write of the whole map with no lock, so simultaneous writers
+/// can still clobber one another's *entries*; making that safe needs file
+/// locking, which is a larger change.
 pub(crate) fn atomic_write(path: &Path, data: &[u8]) -> Result<(), CliError> {
     static TMP_SEQ: std::sync::atomic::AtomicUsize = std::sync::atomic::AtomicUsize::new(0);
     let seq = TMP_SEQ.fetch_add(1, std::sync::atomic::Ordering::Relaxed);

--- a/seed/cli/server-url-templating/src/auth/oauth_common.rs
+++ b/seed/cli/server-url-templating/src/auth/oauth_common.rs
@@ -245,23 +245,56 @@ pub(crate) fn config_dir() -> Option<PathBuf> {
 /// read-modify-write of the whole map with no lock, so simultaneous writers
 /// can still clobber one another's *entries*; making that safe needs file
 /// locking, which is a larger change.
+/// Unlinks a temp file on drop unless [`TempFileGuard::disarm`]ed. Covers
+/// every early return *and* a panic between creating the temp file and
+/// renaming it into place.
+///
+/// This exists because the temp name is unique per writer. The old shared
+/// `auth-keyring.tmp` was self-limiting — a failed write left one stale file
+/// that the next write reused — whereas unique names would leak a distinct
+/// credential-bearing file on every failure, in a directory nothing prunes. A
+/// `SIGKILL` still leaks, since no in-process guard can cover that.
+struct TempFileGuard {
+    path: PathBuf,
+    armed: bool,
+}
+
+impl TempFileGuard {
+    fn new(path: PathBuf) -> Self {
+        Self { path, armed: true }
+    }
+
+    /// Relinquish the file — call once `rename` has moved it into place.
+    fn disarm(&mut self) {
+        self.armed = false;
+    }
+}
+
+impl Drop for TempFileGuard {
+    fn drop(&mut self) {
+        if self.armed {
+            let _ = std::fs::remove_file(&self.path);
+        }
+    }
+}
+
 pub(crate) fn atomic_write(path: &Path, data: &[u8]) -> Result<(), CliError> {
-    static TMP_SEQ: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+    static TMP_SEQ: std::sync::atomic::AtomicUsize = std::sync::atomic::AtomicUsize::new(0);
     let seq = TMP_SEQ.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
     let tmp = path.with_extension(format!("tmp.{}.{}", std::process::id(), seq));
-    std::fs::write(&tmp, data).map_err(|e| {
-        CliError::Auth(format!("Failed to write {}: {e}", tmp.display()))
-    })?;
+    let mut guard = TempFileGuard::new(tmp.clone());
+    std::fs::write(&tmp, data)
+        .map_err(|e| CliError::Auth(format!("Failed to write {}: {e}", tmp.display())))?;
     #[cfg(unix)]
     {
         use std::os::unix::fs::PermissionsExt;
         let perms = std::fs::Permissions::from_mode(0o600);
         let _ = std::fs::set_permissions(&tmp, perms);
     }
-    std::fs::rename(&tmp, path).map_err(|e| {
-        let _ = std::fs::remove_file(&tmp);
-        CliError::Auth(format!("Failed to rename {}: {e}", tmp.display()))
-    })
+    std::fs::rename(&tmp, path)
+        .map_err(|e| CliError::Auth(format!("Failed to rename {}: {e}", tmp.display())))?;
+    guard.disarm();
+    Ok(())
 }
 
 // ---------------------------------------------------------------------------
@@ -315,6 +348,56 @@ mod tests {
             .filter(|n| n.contains(".tmp"))
             .collect();
         assert!(leftovers.is_empty(), "temp files left behind: {leftovers:?}");
+    }
+
+    /// A failed write must not leave its temp file behind. Renaming a file onto
+    /// an existing directory fails on every platform, which drives the error
+    /// path without mocking the filesystem.
+    ///
+    /// The pre-`TempFileGuard` code already cleaned up on a `rename` error, so
+    /// this pins an invariant rather than catching a regression — see
+    /// `temp_file_guard_unlinks_unless_disarmed` for the guard's own coverage.
+    #[test]
+    fn atomic_write_cleans_up_temp_file_on_failure() {
+        let dir = tempfile::tempdir().unwrap();
+
+        // The target is a *directory*, so `rename` cannot replace it.
+        let target = dir.path().join("auth-keyring.json");
+        std::fs::create_dir(&target).unwrap();
+        std::fs::write(target.join("occupant"), b"x").unwrap();
+
+        let result = atomic_write(&target, br#"{"writer":0}"#);
+        assert!(result.is_err(), "expected rename onto a directory to fail");
+
+        let leftovers: Vec<String> = std::fs::read_dir(dir.path())
+            .unwrap()
+            .filter_map(|e| e.ok())
+            .map(|e| e.file_name().to_string_lossy().into_owned())
+            .filter(|n| n.contains(".tmp"))
+            .collect();
+        assert!(leftovers.is_empty(), "temp file leaked after a failed write: {leftovers:?}");
+    }
+
+    /// Pins [`TempFileGuard`]: armed drops unlink, disarmed drops don't. Drop
+    /// running on an armed guard is what covers early returns and unwinding
+    /// panics between `write` and `rename` — paths the old `rename`-only
+    /// cleanup missed. Deleting the guard or the `disarm()` call fails this.
+    #[test]
+    fn temp_file_guard_unlinks_unless_disarmed() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("auth-keyring.tmp.0.0");
+
+        std::fs::write(&path, b"x").unwrap();
+        drop(TempFileGuard::new(path.clone()));
+        assert!(!path.exists(), "armed guard must unlink on drop");
+
+        // The post-`rename` case: the file has been moved away, so the guard
+        // must not touch whatever now sits at that path.
+        std::fs::write(&path, b"x").unwrap();
+        let mut guard = TempFileGuard::new(path.clone());
+        guard.disarm();
+        drop(guard);
+        assert!(path.exists(), "disarmed guard must not unlink");
     }
 
     #[test]

--- a/seed/cli/server-url-templating/src/auth/oauth_common.rs
+++ b/seed/cli/server-url-templating/src/auth/oauth_common.rs
@@ -226,8 +226,29 @@ pub(crate) fn config_dir() -> Option<PathBuf> {
 
 /// Write `data` to `path` atomically: sibling temp file → owner-only
 /// permissions (0600 on Unix) → rename into place.
+///
+/// The temp file name is unique per writer — pid plus a process-local
+/// counter. Deriving it from the target alone meant every concurrent writer
+/// used the *same* sibling (`auth-keyring.tmp`): whichever one renamed first
+/// moved it away, and the rest failed with `ENOENT` from `rename`. That
+/// surfaced as intermittent `auth login --with-token` failures across a
+/// wire-test suite large enough to run many CLI processes at once, killing a
+/// different subset of cases on each run.
+///
+/// The pid covers the case that actually bit us (separate CLI processes); the
+/// counter covers two writers inside one process, and is what makes the
+/// behavior unit-testable without spawning subprocesses.
+///
+/// `rename` is still atomic for readers, which is what keeps a partially
+/// written credential file unobservable. This only fixes writer-vs-writer
+/// collisions on the temp path. `FileKeyringStore::set` remains a
+/// read-modify-write of the whole map with no lock, so simultaneous writers
+/// can still clobber one another's *entries*; making that safe needs file
+/// locking, which is a larger change.
 pub(crate) fn atomic_write(path: &Path, data: &[u8]) -> Result<(), CliError> {
-    let tmp = path.with_extension("tmp");
+    static TMP_SEQ: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+    let seq = TMP_SEQ.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+    let tmp = path.with_extension(format!("tmp.{}.{}", std::process::id(), seq));
     std::fs::write(&tmp, data).map_err(|e| {
         CliError::Auth(format!("Failed to write {}: {e}", tmp.display()))
     })?;
@@ -250,6 +271,51 @@ pub(crate) fn atomic_write(path: &Path, data: &[u8]) -> Result<(), CliError> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// Regression test for the temp-file collision that made
+    /// `auth login --with-token` fail intermittently: every writer derived the
+    /// same sibling path from the target, so the first `rename` moved it away
+    /// and the rest got `ENOENT`.
+    ///
+    /// Reverting `atomic_write` to a target-derived temp name fails this with
+    /// "Failed to rename ...: No such file or directory".
+    #[test]
+    fn atomic_write_tolerates_concurrent_writers() {
+        let dir = tempfile::tempdir().unwrap();
+        let target = dir.path().join("auth-keyring.json");
+
+        let results: Vec<Result<(), CliError>> = std::thread::scope(|scope| {
+            let handles: Vec<_> = (0..16)
+                .map(|i| {
+                    let target = target.clone();
+                    scope.spawn(move || atomic_write(&target, format!(r#"{{"writer":{i}}}"#).as_bytes()))
+                })
+                .collect();
+            handles.into_iter().map(|h| h.join().unwrap()).collect()
+        });
+
+        let failed: Vec<String> = results
+            .iter()
+            .filter_map(|r| r.as_ref().err().map(|e| e.to_string()))
+            .collect();
+        assert!(failed.is_empty(), "concurrent writers failed: {failed:?}");
+
+        // Last writer wins, but the file must always be one writer's complete
+        // payload — never a mix, and never absent.
+        let contents = std::fs::read_to_string(&target).unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(&contents)
+            .unwrap_or_else(|e| panic!("target is not valid JSON after concurrent writes: {e} in {contents:?}"));
+        assert!(parsed.get("writer").is_some(), "unexpected payload: {contents}");
+
+        // No temp files orphaned in the directory.
+        let leftovers: Vec<String> = std::fs::read_dir(dir.path())
+            .unwrap()
+            .filter_map(|e| e.ok())
+            .map(|e| e.file_name().to_string_lossy().into_owned())
+            .filter(|n| n.contains(".tmp"))
+            .collect();
+        assert!(leftovers.is_empty(), "temp files left behind: {leftovers:?}");
+    }
 
     #[test]
     fn token_bundle_roundtrip() {

--- a/seed/cli/url-form-encoded/src/auth/oauth_common.rs
+++ b/seed/cli/url-form-encoded/src/auth/oauth_common.rs
@@ -224,27 +224,6 @@ pub(crate) fn config_dir() -> Option<PathBuf> {
     }
 }
 
-/// Write `data` to `path` atomically: sibling temp file → owner-only
-/// permissions (0600 on Unix) → rename into place.
-///
-/// The temp file name is unique per writer — pid plus a process-local
-/// counter. Deriving it from the target alone meant every concurrent writer
-/// used the *same* sibling (`auth-keyring.tmp`): whichever one renamed first
-/// moved it away, and the rest failed with `ENOENT` from `rename`. That
-/// surfaced as intermittent `auth login --with-token` failures across a
-/// wire-test suite large enough to run many CLI processes at once, killing a
-/// different subset of cases on each run.
-///
-/// The pid covers the case that actually bit us (separate CLI processes); the
-/// counter covers two writers inside one process, and is what makes the
-/// behavior unit-testable without spawning subprocesses.
-///
-/// `rename` is still atomic for readers, which is what keeps a partially
-/// written credential file unobservable. This only fixes writer-vs-writer
-/// collisions on the temp path. `FileKeyringStore::set` remains a
-/// read-modify-write of the whole map with no lock, so simultaneous writers
-/// can still clobber one another's *entries*; making that safe needs file
-/// locking, which is a larger change.
 /// Unlinks a temp file on drop unless [`TempFileGuard::disarm`]ed. Covers
 /// every early return *and* a panic between creating the temp file and
 /// renaming it into place.
@@ -278,6 +257,30 @@ impl Drop for TempFileGuard {
     }
 }
 
+/// Write `data` to `path` atomically: sibling temp file → owner-only
+/// permissions (0600 on Unix) → rename into place.
+///
+/// The temp file name is unique per writer — pid plus a process-local
+/// counter. Deriving it from the target alone meant every concurrent writer
+/// used the *same* sibling (`auth-keyring.tmp`): whichever one renamed first
+/// moved it away, and the rest failed with `ENOENT` from `rename`. That
+/// surfaced as intermittent `auth login --with-token` failures across a
+/// wire-test suite large enough to run many CLI processes at once, killing a
+/// different subset of cases on each run.
+///
+/// The pid covers the case that actually bit us (separate CLI processes); the
+/// counter covers two writers inside one process, and is what makes the
+/// behavior unit-testable without spawning subprocesses.
+///
+/// A [`TempFileGuard`] unlinks the temp file if anything between creating it
+/// and renaming it fails, so unique names cannot accumulate as orphans.
+///
+/// `rename` is still atomic for readers, which is what keeps a partially
+/// written credential file unobservable. This only fixes writer-vs-writer
+/// collisions on the temp path. `FileKeyringStore::set` remains a
+/// read-modify-write of the whole map with no lock, so simultaneous writers
+/// can still clobber one another's *entries*; making that safe needs file
+/// locking, which is a larger change.
 pub(crate) fn atomic_write(path: &Path, data: &[u8]) -> Result<(), CliError> {
     static TMP_SEQ: std::sync::atomic::AtomicUsize = std::sync::atomic::AtomicUsize::new(0);
     let seq = TMP_SEQ.fetch_add(1, std::sync::atomic::Ordering::Relaxed);

--- a/seed/cli/url-form-encoded/src/auth/oauth_common.rs
+++ b/seed/cli/url-form-encoded/src/auth/oauth_common.rs
@@ -245,23 +245,56 @@ pub(crate) fn config_dir() -> Option<PathBuf> {
 /// read-modify-write of the whole map with no lock, so simultaneous writers
 /// can still clobber one another's *entries*; making that safe needs file
 /// locking, which is a larger change.
+/// Unlinks a temp file on drop unless [`TempFileGuard::disarm`]ed. Covers
+/// every early return *and* a panic between creating the temp file and
+/// renaming it into place.
+///
+/// This exists because the temp name is unique per writer. The old shared
+/// `auth-keyring.tmp` was self-limiting — a failed write left one stale file
+/// that the next write reused — whereas unique names would leak a distinct
+/// credential-bearing file on every failure, in a directory nothing prunes. A
+/// `SIGKILL` still leaks, since no in-process guard can cover that.
+struct TempFileGuard {
+    path: PathBuf,
+    armed: bool,
+}
+
+impl TempFileGuard {
+    fn new(path: PathBuf) -> Self {
+        Self { path, armed: true }
+    }
+
+    /// Relinquish the file — call once `rename` has moved it into place.
+    fn disarm(&mut self) {
+        self.armed = false;
+    }
+}
+
+impl Drop for TempFileGuard {
+    fn drop(&mut self) {
+        if self.armed {
+            let _ = std::fs::remove_file(&self.path);
+        }
+    }
+}
+
 pub(crate) fn atomic_write(path: &Path, data: &[u8]) -> Result<(), CliError> {
-    static TMP_SEQ: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+    static TMP_SEQ: std::sync::atomic::AtomicUsize = std::sync::atomic::AtomicUsize::new(0);
     let seq = TMP_SEQ.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
     let tmp = path.with_extension(format!("tmp.{}.{}", std::process::id(), seq));
-    std::fs::write(&tmp, data).map_err(|e| {
-        CliError::Auth(format!("Failed to write {}: {e}", tmp.display()))
-    })?;
+    let mut guard = TempFileGuard::new(tmp.clone());
+    std::fs::write(&tmp, data)
+        .map_err(|e| CliError::Auth(format!("Failed to write {}: {e}", tmp.display())))?;
     #[cfg(unix)]
     {
         use std::os::unix::fs::PermissionsExt;
         let perms = std::fs::Permissions::from_mode(0o600);
         let _ = std::fs::set_permissions(&tmp, perms);
     }
-    std::fs::rename(&tmp, path).map_err(|e| {
-        let _ = std::fs::remove_file(&tmp);
-        CliError::Auth(format!("Failed to rename {}: {e}", tmp.display()))
-    })
+    std::fs::rename(&tmp, path)
+        .map_err(|e| CliError::Auth(format!("Failed to rename {}: {e}", tmp.display())))?;
+    guard.disarm();
+    Ok(())
 }
 
 // ---------------------------------------------------------------------------
@@ -315,6 +348,56 @@ mod tests {
             .filter(|n| n.contains(".tmp"))
             .collect();
         assert!(leftovers.is_empty(), "temp files left behind: {leftovers:?}");
+    }
+
+    /// A failed write must not leave its temp file behind. Renaming a file onto
+    /// an existing directory fails on every platform, which drives the error
+    /// path without mocking the filesystem.
+    ///
+    /// The pre-`TempFileGuard` code already cleaned up on a `rename` error, so
+    /// this pins an invariant rather than catching a regression — see
+    /// `temp_file_guard_unlinks_unless_disarmed` for the guard's own coverage.
+    #[test]
+    fn atomic_write_cleans_up_temp_file_on_failure() {
+        let dir = tempfile::tempdir().unwrap();
+
+        // The target is a *directory*, so `rename` cannot replace it.
+        let target = dir.path().join("auth-keyring.json");
+        std::fs::create_dir(&target).unwrap();
+        std::fs::write(target.join("occupant"), b"x").unwrap();
+
+        let result = atomic_write(&target, br#"{"writer":0}"#);
+        assert!(result.is_err(), "expected rename onto a directory to fail");
+
+        let leftovers: Vec<String> = std::fs::read_dir(dir.path())
+            .unwrap()
+            .filter_map(|e| e.ok())
+            .map(|e| e.file_name().to_string_lossy().into_owned())
+            .filter(|n| n.contains(".tmp"))
+            .collect();
+        assert!(leftovers.is_empty(), "temp file leaked after a failed write: {leftovers:?}");
+    }
+
+    /// Pins [`TempFileGuard`]: armed drops unlink, disarmed drops don't. Drop
+    /// running on an armed guard is what covers early returns and unwinding
+    /// panics between `write` and `rename` — paths the old `rename`-only
+    /// cleanup missed. Deleting the guard or the `disarm()` call fails this.
+    #[test]
+    fn temp_file_guard_unlinks_unless_disarmed() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("auth-keyring.tmp.0.0");
+
+        std::fs::write(&path, b"x").unwrap();
+        drop(TempFileGuard::new(path.clone()));
+        assert!(!path.exists(), "armed guard must unlink on drop");
+
+        // The post-`rename` case: the file has been moved away, so the guard
+        // must not touch whatever now sits at that path.
+        std::fs::write(&path, b"x").unwrap();
+        let mut guard = TempFileGuard::new(path.clone());
+        guard.disarm();
+        drop(guard);
+        assert!(path.exists(), "disarmed guard must not unlink");
     }
 
     #[test]

--- a/seed/cli/url-form-encoded/src/auth/oauth_common.rs
+++ b/seed/cli/url-form-encoded/src/auth/oauth_common.rs
@@ -226,8 +226,29 @@ pub(crate) fn config_dir() -> Option<PathBuf> {
 
 /// Write `data` to `path` atomically: sibling temp file → owner-only
 /// permissions (0600 on Unix) → rename into place.
+///
+/// The temp file name is unique per writer — pid plus a process-local
+/// counter. Deriving it from the target alone meant every concurrent writer
+/// used the *same* sibling (`auth-keyring.tmp`): whichever one renamed first
+/// moved it away, and the rest failed with `ENOENT` from `rename`. That
+/// surfaced as intermittent `auth login --with-token` failures across a
+/// wire-test suite large enough to run many CLI processes at once, killing a
+/// different subset of cases on each run.
+///
+/// The pid covers the case that actually bit us (separate CLI processes); the
+/// counter covers two writers inside one process, and is what makes the
+/// behavior unit-testable without spawning subprocesses.
+///
+/// `rename` is still atomic for readers, which is what keeps a partially
+/// written credential file unobservable. This only fixes writer-vs-writer
+/// collisions on the temp path. `FileKeyringStore::set` remains a
+/// read-modify-write of the whole map with no lock, so simultaneous writers
+/// can still clobber one another's *entries*; making that safe needs file
+/// locking, which is a larger change.
 pub(crate) fn atomic_write(path: &Path, data: &[u8]) -> Result<(), CliError> {
-    let tmp = path.with_extension("tmp");
+    static TMP_SEQ: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+    let seq = TMP_SEQ.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+    let tmp = path.with_extension(format!("tmp.{}.{}", std::process::id(), seq));
     std::fs::write(&tmp, data).map_err(|e| {
         CliError::Auth(format!("Failed to write {}: {e}", tmp.display()))
     })?;
@@ -250,6 +271,51 @@ pub(crate) fn atomic_write(path: &Path, data: &[u8]) -> Result<(), CliError> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// Regression test for the temp-file collision that made
+    /// `auth login --with-token` fail intermittently: every writer derived the
+    /// same sibling path from the target, so the first `rename` moved it away
+    /// and the rest got `ENOENT`.
+    ///
+    /// Reverting `atomic_write` to a target-derived temp name fails this with
+    /// "Failed to rename ...: No such file or directory".
+    #[test]
+    fn atomic_write_tolerates_concurrent_writers() {
+        let dir = tempfile::tempdir().unwrap();
+        let target = dir.path().join("auth-keyring.json");
+
+        let results: Vec<Result<(), CliError>> = std::thread::scope(|scope| {
+            let handles: Vec<_> = (0..16)
+                .map(|i| {
+                    let target = target.clone();
+                    scope.spawn(move || atomic_write(&target, format!(r#"{{"writer":{i}}}"#).as_bytes()))
+                })
+                .collect();
+            handles.into_iter().map(|h| h.join().unwrap()).collect()
+        });
+
+        let failed: Vec<String> = results
+            .iter()
+            .filter_map(|r| r.as_ref().err().map(|e| e.to_string()))
+            .collect();
+        assert!(failed.is_empty(), "concurrent writers failed: {failed:?}");
+
+        // Last writer wins, but the file must always be one writer's complete
+        // payload — never a mix, and never absent.
+        let contents = std::fs::read_to_string(&target).unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(&contents)
+            .unwrap_or_else(|e| panic!("target is not valid JSON after concurrent writes: {e} in {contents:?}"));
+        assert!(parsed.get("writer").is_some(), "unexpected payload: {contents}");
+
+        // No temp files orphaned in the directory.
+        let leftovers: Vec<String> = std::fs::read_dir(dir.path())
+            .unwrap()
+            .filter_map(|e| e.ok())
+            .map(|e| e.file_name().to_string_lossy().into_owned())
+            .filter(|n| n.contains(".tmp"))
+            .collect();
+        assert!(leftovers.is_empty(), "temp files left behind: {leftovers:?}");
+    }
 
     #[test]
     fn token_bundle_roundtrip() {

--- a/seed/cli/webhook-audience/src/auth/oauth_common.rs
+++ b/seed/cli/webhook-audience/src/auth/oauth_common.rs
@@ -224,27 +224,6 @@ pub(crate) fn config_dir() -> Option<PathBuf> {
     }
 }
 
-/// Write `data` to `path` atomically: sibling temp file → owner-only
-/// permissions (0600 on Unix) → rename into place.
-///
-/// The temp file name is unique per writer — pid plus a process-local
-/// counter. Deriving it from the target alone meant every concurrent writer
-/// used the *same* sibling (`auth-keyring.tmp`): whichever one renamed first
-/// moved it away, and the rest failed with `ENOENT` from `rename`. That
-/// surfaced as intermittent `auth login --with-token` failures across a
-/// wire-test suite large enough to run many CLI processes at once, killing a
-/// different subset of cases on each run.
-///
-/// The pid covers the case that actually bit us (separate CLI processes); the
-/// counter covers two writers inside one process, and is what makes the
-/// behavior unit-testable without spawning subprocesses.
-///
-/// `rename` is still atomic for readers, which is what keeps a partially
-/// written credential file unobservable. This only fixes writer-vs-writer
-/// collisions on the temp path. `FileKeyringStore::set` remains a
-/// read-modify-write of the whole map with no lock, so simultaneous writers
-/// can still clobber one another's *entries*; making that safe needs file
-/// locking, which is a larger change.
 /// Unlinks a temp file on drop unless [`TempFileGuard::disarm`]ed. Covers
 /// every early return *and* a panic between creating the temp file and
 /// renaming it into place.
@@ -278,6 +257,30 @@ impl Drop for TempFileGuard {
     }
 }
 
+/// Write `data` to `path` atomically: sibling temp file → owner-only
+/// permissions (0600 on Unix) → rename into place.
+///
+/// The temp file name is unique per writer — pid plus a process-local
+/// counter. Deriving it from the target alone meant every concurrent writer
+/// used the *same* sibling (`auth-keyring.tmp`): whichever one renamed first
+/// moved it away, and the rest failed with `ENOENT` from `rename`. That
+/// surfaced as intermittent `auth login --with-token` failures across a
+/// wire-test suite large enough to run many CLI processes at once, killing a
+/// different subset of cases on each run.
+///
+/// The pid covers the case that actually bit us (separate CLI processes); the
+/// counter covers two writers inside one process, and is what makes the
+/// behavior unit-testable without spawning subprocesses.
+///
+/// A [`TempFileGuard`] unlinks the temp file if anything between creating it
+/// and renaming it fails, so unique names cannot accumulate as orphans.
+///
+/// `rename` is still atomic for readers, which is what keeps a partially
+/// written credential file unobservable. This only fixes writer-vs-writer
+/// collisions on the temp path. `FileKeyringStore::set` remains a
+/// read-modify-write of the whole map with no lock, so simultaneous writers
+/// can still clobber one another's *entries*; making that safe needs file
+/// locking, which is a larger change.
 pub(crate) fn atomic_write(path: &Path, data: &[u8]) -> Result<(), CliError> {
     static TMP_SEQ: std::sync::atomic::AtomicUsize = std::sync::atomic::AtomicUsize::new(0);
     let seq = TMP_SEQ.fetch_add(1, std::sync::atomic::Ordering::Relaxed);

--- a/seed/cli/webhook-audience/src/auth/oauth_common.rs
+++ b/seed/cli/webhook-audience/src/auth/oauth_common.rs
@@ -245,23 +245,56 @@ pub(crate) fn config_dir() -> Option<PathBuf> {
 /// read-modify-write of the whole map with no lock, so simultaneous writers
 /// can still clobber one another's *entries*; making that safe needs file
 /// locking, which is a larger change.
+/// Unlinks a temp file on drop unless [`TempFileGuard::disarm`]ed. Covers
+/// every early return *and* a panic between creating the temp file and
+/// renaming it into place.
+///
+/// This exists because the temp name is unique per writer. The old shared
+/// `auth-keyring.tmp` was self-limiting — a failed write left one stale file
+/// that the next write reused — whereas unique names would leak a distinct
+/// credential-bearing file on every failure, in a directory nothing prunes. A
+/// `SIGKILL` still leaks, since no in-process guard can cover that.
+struct TempFileGuard {
+    path: PathBuf,
+    armed: bool,
+}
+
+impl TempFileGuard {
+    fn new(path: PathBuf) -> Self {
+        Self { path, armed: true }
+    }
+
+    /// Relinquish the file — call once `rename` has moved it into place.
+    fn disarm(&mut self) {
+        self.armed = false;
+    }
+}
+
+impl Drop for TempFileGuard {
+    fn drop(&mut self) {
+        if self.armed {
+            let _ = std::fs::remove_file(&self.path);
+        }
+    }
+}
+
 pub(crate) fn atomic_write(path: &Path, data: &[u8]) -> Result<(), CliError> {
-    static TMP_SEQ: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+    static TMP_SEQ: std::sync::atomic::AtomicUsize = std::sync::atomic::AtomicUsize::new(0);
     let seq = TMP_SEQ.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
     let tmp = path.with_extension(format!("tmp.{}.{}", std::process::id(), seq));
-    std::fs::write(&tmp, data).map_err(|e| {
-        CliError::Auth(format!("Failed to write {}: {e}", tmp.display()))
-    })?;
+    let mut guard = TempFileGuard::new(tmp.clone());
+    std::fs::write(&tmp, data)
+        .map_err(|e| CliError::Auth(format!("Failed to write {}: {e}", tmp.display())))?;
     #[cfg(unix)]
     {
         use std::os::unix::fs::PermissionsExt;
         let perms = std::fs::Permissions::from_mode(0o600);
         let _ = std::fs::set_permissions(&tmp, perms);
     }
-    std::fs::rename(&tmp, path).map_err(|e| {
-        let _ = std::fs::remove_file(&tmp);
-        CliError::Auth(format!("Failed to rename {}: {e}", tmp.display()))
-    })
+    std::fs::rename(&tmp, path)
+        .map_err(|e| CliError::Auth(format!("Failed to rename {}: {e}", tmp.display())))?;
+    guard.disarm();
+    Ok(())
 }
 
 // ---------------------------------------------------------------------------
@@ -315,6 +348,56 @@ mod tests {
             .filter(|n| n.contains(".tmp"))
             .collect();
         assert!(leftovers.is_empty(), "temp files left behind: {leftovers:?}");
+    }
+
+    /// A failed write must not leave its temp file behind. Renaming a file onto
+    /// an existing directory fails on every platform, which drives the error
+    /// path without mocking the filesystem.
+    ///
+    /// The pre-`TempFileGuard` code already cleaned up on a `rename` error, so
+    /// this pins an invariant rather than catching a regression — see
+    /// `temp_file_guard_unlinks_unless_disarmed` for the guard's own coverage.
+    #[test]
+    fn atomic_write_cleans_up_temp_file_on_failure() {
+        let dir = tempfile::tempdir().unwrap();
+
+        // The target is a *directory*, so `rename` cannot replace it.
+        let target = dir.path().join("auth-keyring.json");
+        std::fs::create_dir(&target).unwrap();
+        std::fs::write(target.join("occupant"), b"x").unwrap();
+
+        let result = atomic_write(&target, br#"{"writer":0}"#);
+        assert!(result.is_err(), "expected rename onto a directory to fail");
+
+        let leftovers: Vec<String> = std::fs::read_dir(dir.path())
+            .unwrap()
+            .filter_map(|e| e.ok())
+            .map(|e| e.file_name().to_string_lossy().into_owned())
+            .filter(|n| n.contains(".tmp"))
+            .collect();
+        assert!(leftovers.is_empty(), "temp file leaked after a failed write: {leftovers:?}");
+    }
+
+    /// Pins [`TempFileGuard`]: armed drops unlink, disarmed drops don't. Drop
+    /// running on an armed guard is what covers early returns and unwinding
+    /// panics between `write` and `rename` — paths the old `rename`-only
+    /// cleanup missed. Deleting the guard or the `disarm()` call fails this.
+    #[test]
+    fn temp_file_guard_unlinks_unless_disarmed() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("auth-keyring.tmp.0.0");
+
+        std::fs::write(&path, b"x").unwrap();
+        drop(TempFileGuard::new(path.clone()));
+        assert!(!path.exists(), "armed guard must unlink on drop");
+
+        // The post-`rename` case: the file has been moved away, so the guard
+        // must not touch whatever now sits at that path.
+        std::fs::write(&path, b"x").unwrap();
+        let mut guard = TempFileGuard::new(path.clone());
+        guard.disarm();
+        drop(guard);
+        assert!(path.exists(), "disarmed guard must not unlink");
     }
 
     #[test]

--- a/seed/cli/webhook-audience/src/auth/oauth_common.rs
+++ b/seed/cli/webhook-audience/src/auth/oauth_common.rs
@@ -226,8 +226,29 @@ pub(crate) fn config_dir() -> Option<PathBuf> {
 
 /// Write `data` to `path` atomically: sibling temp file → owner-only
 /// permissions (0600 on Unix) → rename into place.
+///
+/// The temp file name is unique per writer — pid plus a process-local
+/// counter. Deriving it from the target alone meant every concurrent writer
+/// used the *same* sibling (`auth-keyring.tmp`): whichever one renamed first
+/// moved it away, and the rest failed with `ENOENT` from `rename`. That
+/// surfaced as intermittent `auth login --with-token` failures across a
+/// wire-test suite large enough to run many CLI processes at once, killing a
+/// different subset of cases on each run.
+///
+/// The pid covers the case that actually bit us (separate CLI processes); the
+/// counter covers two writers inside one process, and is what makes the
+/// behavior unit-testable without spawning subprocesses.
+///
+/// `rename` is still atomic for readers, which is what keeps a partially
+/// written credential file unobservable. This only fixes writer-vs-writer
+/// collisions on the temp path. `FileKeyringStore::set` remains a
+/// read-modify-write of the whole map with no lock, so simultaneous writers
+/// can still clobber one another's *entries*; making that safe needs file
+/// locking, which is a larger change.
 pub(crate) fn atomic_write(path: &Path, data: &[u8]) -> Result<(), CliError> {
-    let tmp = path.with_extension("tmp");
+    static TMP_SEQ: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+    let seq = TMP_SEQ.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+    let tmp = path.with_extension(format!("tmp.{}.{}", std::process::id(), seq));
     std::fs::write(&tmp, data).map_err(|e| {
         CliError::Auth(format!("Failed to write {}: {e}", tmp.display()))
     })?;
@@ -250,6 +271,51 @@ pub(crate) fn atomic_write(path: &Path, data: &[u8]) -> Result<(), CliError> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// Regression test for the temp-file collision that made
+    /// `auth login --with-token` fail intermittently: every writer derived the
+    /// same sibling path from the target, so the first `rename` moved it away
+    /// and the rest got `ENOENT`.
+    ///
+    /// Reverting `atomic_write` to a target-derived temp name fails this with
+    /// "Failed to rename ...: No such file or directory".
+    #[test]
+    fn atomic_write_tolerates_concurrent_writers() {
+        let dir = tempfile::tempdir().unwrap();
+        let target = dir.path().join("auth-keyring.json");
+
+        let results: Vec<Result<(), CliError>> = std::thread::scope(|scope| {
+            let handles: Vec<_> = (0..16)
+                .map(|i| {
+                    let target = target.clone();
+                    scope.spawn(move || atomic_write(&target, format!(r#"{{"writer":{i}}}"#).as_bytes()))
+                })
+                .collect();
+            handles.into_iter().map(|h| h.join().unwrap()).collect()
+        });
+
+        let failed: Vec<String> = results
+            .iter()
+            .filter_map(|r| r.as_ref().err().map(|e| e.to_string()))
+            .collect();
+        assert!(failed.is_empty(), "concurrent writers failed: {failed:?}");
+
+        // Last writer wins, but the file must always be one writer's complete
+        // payload — never a mix, and never absent.
+        let contents = std::fs::read_to_string(&target).unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(&contents)
+            .unwrap_or_else(|e| panic!("target is not valid JSON after concurrent writes: {e} in {contents:?}"));
+        assert!(parsed.get("writer").is_some(), "unexpected payload: {contents}");
+
+        // No temp files orphaned in the directory.
+        let leftovers: Vec<String> = std::fs::read_dir(dir.path())
+            .unwrap()
+            .filter_map(|e| e.ok())
+            .map(|e| e.file_name().to_string_lossy().into_owned())
+            .filter(|n| n.contains(".tmp"))
+            .collect();
+        assert!(leftovers.is_empty(), "temp files left behind: {leftovers:?}");
+    }
 
     #[test]
     fn token_bundle_roundtrip() {

--- a/seed/cli/x-fern-default/src/auth/oauth_common.rs
+++ b/seed/cli/x-fern-default/src/auth/oauth_common.rs
@@ -224,27 +224,6 @@ pub(crate) fn config_dir() -> Option<PathBuf> {
     }
 }
 
-/// Write `data` to `path` atomically: sibling temp file → owner-only
-/// permissions (0600 on Unix) → rename into place.
-///
-/// The temp file name is unique per writer — pid plus a process-local
-/// counter. Deriving it from the target alone meant every concurrent writer
-/// used the *same* sibling (`auth-keyring.tmp`): whichever one renamed first
-/// moved it away, and the rest failed with `ENOENT` from `rename`. That
-/// surfaced as intermittent `auth login --with-token` failures across a
-/// wire-test suite large enough to run many CLI processes at once, killing a
-/// different subset of cases on each run.
-///
-/// The pid covers the case that actually bit us (separate CLI processes); the
-/// counter covers two writers inside one process, and is what makes the
-/// behavior unit-testable without spawning subprocesses.
-///
-/// `rename` is still atomic for readers, which is what keeps a partially
-/// written credential file unobservable. This only fixes writer-vs-writer
-/// collisions on the temp path. `FileKeyringStore::set` remains a
-/// read-modify-write of the whole map with no lock, so simultaneous writers
-/// can still clobber one another's *entries*; making that safe needs file
-/// locking, which is a larger change.
 /// Unlinks a temp file on drop unless [`TempFileGuard::disarm`]ed. Covers
 /// every early return *and* a panic between creating the temp file and
 /// renaming it into place.
@@ -278,6 +257,30 @@ impl Drop for TempFileGuard {
     }
 }
 
+/// Write `data` to `path` atomically: sibling temp file → owner-only
+/// permissions (0600 on Unix) → rename into place.
+///
+/// The temp file name is unique per writer — pid plus a process-local
+/// counter. Deriving it from the target alone meant every concurrent writer
+/// used the *same* sibling (`auth-keyring.tmp`): whichever one renamed first
+/// moved it away, and the rest failed with `ENOENT` from `rename`. That
+/// surfaced as intermittent `auth login --with-token` failures across a
+/// wire-test suite large enough to run many CLI processes at once, killing a
+/// different subset of cases on each run.
+///
+/// The pid covers the case that actually bit us (separate CLI processes); the
+/// counter covers two writers inside one process, and is what makes the
+/// behavior unit-testable without spawning subprocesses.
+///
+/// A [`TempFileGuard`] unlinks the temp file if anything between creating it
+/// and renaming it fails, so unique names cannot accumulate as orphans.
+///
+/// `rename` is still atomic for readers, which is what keeps a partially
+/// written credential file unobservable. This only fixes writer-vs-writer
+/// collisions on the temp path. `FileKeyringStore::set` remains a
+/// read-modify-write of the whole map with no lock, so simultaneous writers
+/// can still clobber one another's *entries*; making that safe needs file
+/// locking, which is a larger change.
 pub(crate) fn atomic_write(path: &Path, data: &[u8]) -> Result<(), CliError> {
     static TMP_SEQ: std::sync::atomic::AtomicUsize = std::sync::atomic::AtomicUsize::new(0);
     let seq = TMP_SEQ.fetch_add(1, std::sync::atomic::Ordering::Relaxed);

--- a/seed/cli/x-fern-default/src/auth/oauth_common.rs
+++ b/seed/cli/x-fern-default/src/auth/oauth_common.rs
@@ -245,23 +245,56 @@ pub(crate) fn config_dir() -> Option<PathBuf> {
 /// read-modify-write of the whole map with no lock, so simultaneous writers
 /// can still clobber one another's *entries*; making that safe needs file
 /// locking, which is a larger change.
+/// Unlinks a temp file on drop unless [`TempFileGuard::disarm`]ed. Covers
+/// every early return *and* a panic between creating the temp file and
+/// renaming it into place.
+///
+/// This exists because the temp name is unique per writer. The old shared
+/// `auth-keyring.tmp` was self-limiting — a failed write left one stale file
+/// that the next write reused — whereas unique names would leak a distinct
+/// credential-bearing file on every failure, in a directory nothing prunes. A
+/// `SIGKILL` still leaks, since no in-process guard can cover that.
+struct TempFileGuard {
+    path: PathBuf,
+    armed: bool,
+}
+
+impl TempFileGuard {
+    fn new(path: PathBuf) -> Self {
+        Self { path, armed: true }
+    }
+
+    /// Relinquish the file — call once `rename` has moved it into place.
+    fn disarm(&mut self) {
+        self.armed = false;
+    }
+}
+
+impl Drop for TempFileGuard {
+    fn drop(&mut self) {
+        if self.armed {
+            let _ = std::fs::remove_file(&self.path);
+        }
+    }
+}
+
 pub(crate) fn atomic_write(path: &Path, data: &[u8]) -> Result<(), CliError> {
-    static TMP_SEQ: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+    static TMP_SEQ: std::sync::atomic::AtomicUsize = std::sync::atomic::AtomicUsize::new(0);
     let seq = TMP_SEQ.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
     let tmp = path.with_extension(format!("tmp.{}.{}", std::process::id(), seq));
-    std::fs::write(&tmp, data).map_err(|e| {
-        CliError::Auth(format!("Failed to write {}: {e}", tmp.display()))
-    })?;
+    let mut guard = TempFileGuard::new(tmp.clone());
+    std::fs::write(&tmp, data)
+        .map_err(|e| CliError::Auth(format!("Failed to write {}: {e}", tmp.display())))?;
     #[cfg(unix)]
     {
         use std::os::unix::fs::PermissionsExt;
         let perms = std::fs::Permissions::from_mode(0o600);
         let _ = std::fs::set_permissions(&tmp, perms);
     }
-    std::fs::rename(&tmp, path).map_err(|e| {
-        let _ = std::fs::remove_file(&tmp);
-        CliError::Auth(format!("Failed to rename {}: {e}", tmp.display()))
-    })
+    std::fs::rename(&tmp, path)
+        .map_err(|e| CliError::Auth(format!("Failed to rename {}: {e}", tmp.display())))?;
+    guard.disarm();
+    Ok(())
 }
 
 // ---------------------------------------------------------------------------
@@ -315,6 +348,56 @@ mod tests {
             .filter(|n| n.contains(".tmp"))
             .collect();
         assert!(leftovers.is_empty(), "temp files left behind: {leftovers:?}");
+    }
+
+    /// A failed write must not leave its temp file behind. Renaming a file onto
+    /// an existing directory fails on every platform, which drives the error
+    /// path without mocking the filesystem.
+    ///
+    /// The pre-`TempFileGuard` code already cleaned up on a `rename` error, so
+    /// this pins an invariant rather than catching a regression — see
+    /// `temp_file_guard_unlinks_unless_disarmed` for the guard's own coverage.
+    #[test]
+    fn atomic_write_cleans_up_temp_file_on_failure() {
+        let dir = tempfile::tempdir().unwrap();
+
+        // The target is a *directory*, so `rename` cannot replace it.
+        let target = dir.path().join("auth-keyring.json");
+        std::fs::create_dir(&target).unwrap();
+        std::fs::write(target.join("occupant"), b"x").unwrap();
+
+        let result = atomic_write(&target, br#"{"writer":0}"#);
+        assert!(result.is_err(), "expected rename onto a directory to fail");
+
+        let leftovers: Vec<String> = std::fs::read_dir(dir.path())
+            .unwrap()
+            .filter_map(|e| e.ok())
+            .map(|e| e.file_name().to_string_lossy().into_owned())
+            .filter(|n| n.contains(".tmp"))
+            .collect();
+        assert!(leftovers.is_empty(), "temp file leaked after a failed write: {leftovers:?}");
+    }
+
+    /// Pins [`TempFileGuard`]: armed drops unlink, disarmed drops don't. Drop
+    /// running on an armed guard is what covers early returns and unwinding
+    /// panics between `write` and `rename` — paths the old `rename`-only
+    /// cleanup missed. Deleting the guard or the `disarm()` call fails this.
+    #[test]
+    fn temp_file_guard_unlinks_unless_disarmed() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("auth-keyring.tmp.0.0");
+
+        std::fs::write(&path, b"x").unwrap();
+        drop(TempFileGuard::new(path.clone()));
+        assert!(!path.exists(), "armed guard must unlink on drop");
+
+        // The post-`rename` case: the file has been moved away, so the guard
+        // must not touch whatever now sits at that path.
+        std::fs::write(&path, b"x").unwrap();
+        let mut guard = TempFileGuard::new(path.clone());
+        guard.disarm();
+        drop(guard);
+        assert!(path.exists(), "disarmed guard must not unlink");
     }
 
     #[test]

--- a/seed/cli/x-fern-default/src/auth/oauth_common.rs
+++ b/seed/cli/x-fern-default/src/auth/oauth_common.rs
@@ -226,8 +226,29 @@ pub(crate) fn config_dir() -> Option<PathBuf> {
 
 /// Write `data` to `path` atomically: sibling temp file → owner-only
 /// permissions (0600 on Unix) → rename into place.
+///
+/// The temp file name is unique per writer — pid plus a process-local
+/// counter. Deriving it from the target alone meant every concurrent writer
+/// used the *same* sibling (`auth-keyring.tmp`): whichever one renamed first
+/// moved it away, and the rest failed with `ENOENT` from `rename`. That
+/// surfaced as intermittent `auth login --with-token` failures across a
+/// wire-test suite large enough to run many CLI processes at once, killing a
+/// different subset of cases on each run.
+///
+/// The pid covers the case that actually bit us (separate CLI processes); the
+/// counter covers two writers inside one process, and is what makes the
+/// behavior unit-testable without spawning subprocesses.
+///
+/// `rename` is still atomic for readers, which is what keeps a partially
+/// written credential file unobservable. This only fixes writer-vs-writer
+/// collisions on the temp path. `FileKeyringStore::set` remains a
+/// read-modify-write of the whole map with no lock, so simultaneous writers
+/// can still clobber one another's *entries*; making that safe needs file
+/// locking, which is a larger change.
 pub(crate) fn atomic_write(path: &Path, data: &[u8]) -> Result<(), CliError> {
-    let tmp = path.with_extension("tmp");
+    static TMP_SEQ: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+    let seq = TMP_SEQ.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+    let tmp = path.with_extension(format!("tmp.{}.{}", std::process::id(), seq));
     std::fs::write(&tmp, data).map_err(|e| {
         CliError::Auth(format!("Failed to write {}: {e}", tmp.display()))
     })?;
@@ -250,6 +271,51 @@ pub(crate) fn atomic_write(path: &Path, data: &[u8]) -> Result<(), CliError> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// Regression test for the temp-file collision that made
+    /// `auth login --with-token` fail intermittently: every writer derived the
+    /// same sibling path from the target, so the first `rename` moved it away
+    /// and the rest got `ENOENT`.
+    ///
+    /// Reverting `atomic_write` to a target-derived temp name fails this with
+    /// "Failed to rename ...: No such file or directory".
+    #[test]
+    fn atomic_write_tolerates_concurrent_writers() {
+        let dir = tempfile::tempdir().unwrap();
+        let target = dir.path().join("auth-keyring.json");
+
+        let results: Vec<Result<(), CliError>> = std::thread::scope(|scope| {
+            let handles: Vec<_> = (0..16)
+                .map(|i| {
+                    let target = target.clone();
+                    scope.spawn(move || atomic_write(&target, format!(r#"{{"writer":{i}}}"#).as_bytes()))
+                })
+                .collect();
+            handles.into_iter().map(|h| h.join().unwrap()).collect()
+        });
+
+        let failed: Vec<String> = results
+            .iter()
+            .filter_map(|r| r.as_ref().err().map(|e| e.to_string()))
+            .collect();
+        assert!(failed.is_empty(), "concurrent writers failed: {failed:?}");
+
+        // Last writer wins, but the file must always be one writer's complete
+        // payload — never a mix, and never absent.
+        let contents = std::fs::read_to_string(&target).unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(&contents)
+            .unwrap_or_else(|e| panic!("target is not valid JSON after concurrent writes: {e} in {contents:?}"));
+        assert!(parsed.get("writer").is_some(), "unexpected payload: {contents}");
+
+        // No temp files orphaned in the directory.
+        let leftovers: Vec<String> = std::fs::read_dir(dir.path())
+            .unwrap()
+            .filter_map(|e| e.ok())
+            .map(|e| e.file_name().to_string_lossy().into_owned())
+            .filter(|n| n.contains(".tmp"))
+            .collect();
+        assert!(leftovers.is_empty(), "temp files left behind: {leftovers:?}");
+    }
 
     #[test]
     fn token_bundle_roundtrip() {

--- a/seed/cli/x-fern-global-parameters/no-custom-config/src/auth/oauth_common.rs
+++ b/seed/cli/x-fern-global-parameters/no-custom-config/src/auth/oauth_common.rs
@@ -224,27 +224,6 @@ pub(crate) fn config_dir() -> Option<PathBuf> {
     }
 }
 
-/// Write `data` to `path` atomically: sibling temp file → owner-only
-/// permissions (0600 on Unix) → rename into place.
-///
-/// The temp file name is unique per writer — pid plus a process-local
-/// counter. Deriving it from the target alone meant every concurrent writer
-/// used the *same* sibling (`auth-keyring.tmp`): whichever one renamed first
-/// moved it away, and the rest failed with `ENOENT` from `rename`. That
-/// surfaced as intermittent `auth login --with-token` failures across a
-/// wire-test suite large enough to run many CLI processes at once, killing a
-/// different subset of cases on each run.
-///
-/// The pid covers the case that actually bit us (separate CLI processes); the
-/// counter covers two writers inside one process, and is what makes the
-/// behavior unit-testable without spawning subprocesses.
-///
-/// `rename` is still atomic for readers, which is what keeps a partially
-/// written credential file unobservable. This only fixes writer-vs-writer
-/// collisions on the temp path. `FileKeyringStore::set` remains a
-/// read-modify-write of the whole map with no lock, so simultaneous writers
-/// can still clobber one another's *entries*; making that safe needs file
-/// locking, which is a larger change.
 /// Unlinks a temp file on drop unless [`TempFileGuard::disarm`]ed. Covers
 /// every early return *and* a panic between creating the temp file and
 /// renaming it into place.
@@ -278,6 +257,30 @@ impl Drop for TempFileGuard {
     }
 }
 
+/// Write `data` to `path` atomically: sibling temp file → owner-only
+/// permissions (0600 on Unix) → rename into place.
+///
+/// The temp file name is unique per writer — pid plus a process-local
+/// counter. Deriving it from the target alone meant every concurrent writer
+/// used the *same* sibling (`auth-keyring.tmp`): whichever one renamed first
+/// moved it away, and the rest failed with `ENOENT` from `rename`. That
+/// surfaced as intermittent `auth login --with-token` failures across a
+/// wire-test suite large enough to run many CLI processes at once, killing a
+/// different subset of cases on each run.
+///
+/// The pid covers the case that actually bit us (separate CLI processes); the
+/// counter covers two writers inside one process, and is what makes the
+/// behavior unit-testable without spawning subprocesses.
+///
+/// A [`TempFileGuard`] unlinks the temp file if anything between creating it
+/// and renaming it fails, so unique names cannot accumulate as orphans.
+///
+/// `rename` is still atomic for readers, which is what keeps a partially
+/// written credential file unobservable. This only fixes writer-vs-writer
+/// collisions on the temp path. `FileKeyringStore::set` remains a
+/// read-modify-write of the whole map with no lock, so simultaneous writers
+/// can still clobber one another's *entries*; making that safe needs file
+/// locking, which is a larger change.
 pub(crate) fn atomic_write(path: &Path, data: &[u8]) -> Result<(), CliError> {
     static TMP_SEQ: std::sync::atomic::AtomicUsize = std::sync::atomic::AtomicUsize::new(0);
     let seq = TMP_SEQ.fetch_add(1, std::sync::atomic::Ordering::Relaxed);

--- a/seed/cli/x-fern-global-parameters/no-custom-config/src/auth/oauth_common.rs
+++ b/seed/cli/x-fern-global-parameters/no-custom-config/src/auth/oauth_common.rs
@@ -245,23 +245,56 @@ pub(crate) fn config_dir() -> Option<PathBuf> {
 /// read-modify-write of the whole map with no lock, so simultaneous writers
 /// can still clobber one another's *entries*; making that safe needs file
 /// locking, which is a larger change.
+/// Unlinks a temp file on drop unless [`TempFileGuard::disarm`]ed. Covers
+/// every early return *and* a panic between creating the temp file and
+/// renaming it into place.
+///
+/// This exists because the temp name is unique per writer. The old shared
+/// `auth-keyring.tmp` was self-limiting — a failed write left one stale file
+/// that the next write reused — whereas unique names would leak a distinct
+/// credential-bearing file on every failure, in a directory nothing prunes. A
+/// `SIGKILL` still leaks, since no in-process guard can cover that.
+struct TempFileGuard {
+    path: PathBuf,
+    armed: bool,
+}
+
+impl TempFileGuard {
+    fn new(path: PathBuf) -> Self {
+        Self { path, armed: true }
+    }
+
+    /// Relinquish the file — call once `rename` has moved it into place.
+    fn disarm(&mut self) {
+        self.armed = false;
+    }
+}
+
+impl Drop for TempFileGuard {
+    fn drop(&mut self) {
+        if self.armed {
+            let _ = std::fs::remove_file(&self.path);
+        }
+    }
+}
+
 pub(crate) fn atomic_write(path: &Path, data: &[u8]) -> Result<(), CliError> {
-    static TMP_SEQ: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+    static TMP_SEQ: std::sync::atomic::AtomicUsize = std::sync::atomic::AtomicUsize::new(0);
     let seq = TMP_SEQ.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
     let tmp = path.with_extension(format!("tmp.{}.{}", std::process::id(), seq));
-    std::fs::write(&tmp, data).map_err(|e| {
-        CliError::Auth(format!("Failed to write {}: {e}", tmp.display()))
-    })?;
+    let mut guard = TempFileGuard::new(tmp.clone());
+    std::fs::write(&tmp, data)
+        .map_err(|e| CliError::Auth(format!("Failed to write {}: {e}", tmp.display())))?;
     #[cfg(unix)]
     {
         use std::os::unix::fs::PermissionsExt;
         let perms = std::fs::Permissions::from_mode(0o600);
         let _ = std::fs::set_permissions(&tmp, perms);
     }
-    std::fs::rename(&tmp, path).map_err(|e| {
-        let _ = std::fs::remove_file(&tmp);
-        CliError::Auth(format!("Failed to rename {}: {e}", tmp.display()))
-    })
+    std::fs::rename(&tmp, path)
+        .map_err(|e| CliError::Auth(format!("Failed to rename {}: {e}", tmp.display())))?;
+    guard.disarm();
+    Ok(())
 }
 
 // ---------------------------------------------------------------------------
@@ -315,6 +348,56 @@ mod tests {
             .filter(|n| n.contains(".tmp"))
             .collect();
         assert!(leftovers.is_empty(), "temp files left behind: {leftovers:?}");
+    }
+
+    /// A failed write must not leave its temp file behind. Renaming a file onto
+    /// an existing directory fails on every platform, which drives the error
+    /// path without mocking the filesystem.
+    ///
+    /// The pre-`TempFileGuard` code already cleaned up on a `rename` error, so
+    /// this pins an invariant rather than catching a regression — see
+    /// `temp_file_guard_unlinks_unless_disarmed` for the guard's own coverage.
+    #[test]
+    fn atomic_write_cleans_up_temp_file_on_failure() {
+        let dir = tempfile::tempdir().unwrap();
+
+        // The target is a *directory*, so `rename` cannot replace it.
+        let target = dir.path().join("auth-keyring.json");
+        std::fs::create_dir(&target).unwrap();
+        std::fs::write(target.join("occupant"), b"x").unwrap();
+
+        let result = atomic_write(&target, br#"{"writer":0}"#);
+        assert!(result.is_err(), "expected rename onto a directory to fail");
+
+        let leftovers: Vec<String> = std::fs::read_dir(dir.path())
+            .unwrap()
+            .filter_map(|e| e.ok())
+            .map(|e| e.file_name().to_string_lossy().into_owned())
+            .filter(|n| n.contains(".tmp"))
+            .collect();
+        assert!(leftovers.is_empty(), "temp file leaked after a failed write: {leftovers:?}");
+    }
+
+    /// Pins [`TempFileGuard`]: armed drops unlink, disarmed drops don't. Drop
+    /// running on an armed guard is what covers early returns and unwinding
+    /// panics between `write` and `rename` — paths the old `rename`-only
+    /// cleanup missed. Deleting the guard or the `disarm()` call fails this.
+    #[test]
+    fn temp_file_guard_unlinks_unless_disarmed() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("auth-keyring.tmp.0.0");
+
+        std::fs::write(&path, b"x").unwrap();
+        drop(TempFileGuard::new(path.clone()));
+        assert!(!path.exists(), "armed guard must unlink on drop");
+
+        // The post-`rename` case: the file has been moved away, so the guard
+        // must not touch whatever now sits at that path.
+        std::fs::write(&path, b"x").unwrap();
+        let mut guard = TempFileGuard::new(path.clone());
+        guard.disarm();
+        drop(guard);
+        assert!(path.exists(), "disarmed guard must not unlink");
     }
 
     #[test]

--- a/seed/cli/x-fern-global-parameters/no-custom-config/src/auth/oauth_common.rs
+++ b/seed/cli/x-fern-global-parameters/no-custom-config/src/auth/oauth_common.rs
@@ -226,8 +226,29 @@ pub(crate) fn config_dir() -> Option<PathBuf> {
 
 /// Write `data` to `path` atomically: sibling temp file → owner-only
 /// permissions (0600 on Unix) → rename into place.
+///
+/// The temp file name is unique per writer — pid plus a process-local
+/// counter. Deriving it from the target alone meant every concurrent writer
+/// used the *same* sibling (`auth-keyring.tmp`): whichever one renamed first
+/// moved it away, and the rest failed with `ENOENT` from `rename`. That
+/// surfaced as intermittent `auth login --with-token` failures across a
+/// wire-test suite large enough to run many CLI processes at once, killing a
+/// different subset of cases on each run.
+///
+/// The pid covers the case that actually bit us (separate CLI processes); the
+/// counter covers two writers inside one process, and is what makes the
+/// behavior unit-testable without spawning subprocesses.
+///
+/// `rename` is still atomic for readers, which is what keeps a partially
+/// written credential file unobservable. This only fixes writer-vs-writer
+/// collisions on the temp path. `FileKeyringStore::set` remains a
+/// read-modify-write of the whole map with no lock, so simultaneous writers
+/// can still clobber one another's *entries*; making that safe needs file
+/// locking, which is a larger change.
 pub(crate) fn atomic_write(path: &Path, data: &[u8]) -> Result<(), CliError> {
-    let tmp = path.with_extension("tmp");
+    static TMP_SEQ: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+    let seq = TMP_SEQ.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+    let tmp = path.with_extension(format!("tmp.{}.{}", std::process::id(), seq));
     std::fs::write(&tmp, data).map_err(|e| {
         CliError::Auth(format!("Failed to write {}: {e}", tmp.display()))
     })?;
@@ -250,6 +271,51 @@ pub(crate) fn atomic_write(path: &Path, data: &[u8]) -> Result<(), CliError> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// Regression test for the temp-file collision that made
+    /// `auth login --with-token` fail intermittently: every writer derived the
+    /// same sibling path from the target, so the first `rename` moved it away
+    /// and the rest got `ENOENT`.
+    ///
+    /// Reverting `atomic_write` to a target-derived temp name fails this with
+    /// "Failed to rename ...: No such file or directory".
+    #[test]
+    fn atomic_write_tolerates_concurrent_writers() {
+        let dir = tempfile::tempdir().unwrap();
+        let target = dir.path().join("auth-keyring.json");
+
+        let results: Vec<Result<(), CliError>> = std::thread::scope(|scope| {
+            let handles: Vec<_> = (0..16)
+                .map(|i| {
+                    let target = target.clone();
+                    scope.spawn(move || atomic_write(&target, format!(r#"{{"writer":{i}}}"#).as_bytes()))
+                })
+                .collect();
+            handles.into_iter().map(|h| h.join().unwrap()).collect()
+        });
+
+        let failed: Vec<String> = results
+            .iter()
+            .filter_map(|r| r.as_ref().err().map(|e| e.to_string()))
+            .collect();
+        assert!(failed.is_empty(), "concurrent writers failed: {failed:?}");
+
+        // Last writer wins, but the file must always be one writer's complete
+        // payload — never a mix, and never absent.
+        let contents = std::fs::read_to_string(&target).unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(&contents)
+            .unwrap_or_else(|e| panic!("target is not valid JSON after concurrent writes: {e} in {contents:?}"));
+        assert!(parsed.get("writer").is_some(), "unexpected payload: {contents}");
+
+        // No temp files orphaned in the directory.
+        let leftovers: Vec<String> = std::fs::read_dir(dir.path())
+            .unwrap()
+            .filter_map(|e| e.ok())
+            .map(|e| e.file_name().to_string_lossy().into_owned())
+            .filter(|n| n.contains(".tmp"))
+            .collect();
+        assert!(leftovers.is_empty(), "temp files left behind: {leftovers:?}");
+    }
 
     #[test]
     fn token_bundle_roundtrip() {


### PR DESCRIPTION
## Summary

`atomic_write` derived its temp file name from the target alone, so every concurrent writer used the same sibling path:

```rust
let tmp = path.with_extension("tmp");   // always auth-keyring.tmp
```

Whichever process renamed first moved it away; the rest failed with

```
error[auth]: Failed to rename /home/runner/.config/<cli>/auth-keyring.tmp: No such file or directory (os error 2)
```

The temp name now carries the writer's **pid plus a process-local counter**. The pid covers the case that actually bit us (separate CLI processes); the counter covers two writers inside one process, and is what makes the behavior testable without spawning subprocesses.

A `TempFileGuard` unlinks the temp file on drop, so unique names cannot accumulate. Without it, unique-per-writer naming would trade a bounded leak for an unbounded one: the old shared `auth-keyring.tmp` was self-limiting (a failed write left one stale file that the next write reused), whereas unique names leak a distinct credential-bearing file per failure, in a directory nothing prunes. A `SIGKILL` still leaks — no in-process guard covers that.

## Why 676 cases shared one credential store

This is the part that makes the failure path make sense, and it is not obvious from the harness.

The wire harness already gives **each case its own temp `HOME`** (`harness.ts`), so at first glance no two cases can collide. But `config_dir()` resolves in this order on Linux:

```rust
std::env::var_os("XDG_CONFIG_HOME").map(PathBuf::from).or(Some(home.join(".config")))
```

`$XDG_CONFIG_HOME` wins, and CI runners set it to the real config directory. The `HOME` override is therefore **inert on Linux**, every authenticated case resolves to the same `auth-keyring.json`, and `cargo test` runs them in parallel. That is why the failing path is `/home/runner/.config/...` and not the per-case `/tmp/...` the harness intended.

macOS uses `$HOME/Library/Application Support` and never consults `$XDG_CONFIG_HOME`, so isolation holds there and **this bug cannot reproduce locally on a Mac** — a local run is green 100% of the time, fixed or not. Only Linux CI reproduces it.

Fixing the harness to also set `XDG_CONFIG_HOME`/`APPDATA` is the upstream fix and is deliberately **not** in this PR — it is a different layer and regenerates a different fixture set. This PR makes the shared store safe; that one removes the sharing.

## How it was found

A generated wire-test suite on a ~680-case customer workspace. The harness seeds a token with `auth login --with-token` per authenticated case (676 of 678 declare auth), cargo runs those in parallel, and a different subset of cases died each run:

| Run | Result | Casualties |
|---|---|---|
| 32166037850 | 677 passed, 1 failed | `wire_add_1` |
| 32168511437 | 677 passed, 1 failed | `wire_convert_with_timestamps` |
| 32166125577 | 675 passed, 3 failed | `wire_add_to_knowledge_base`, `..._error`, `wire_create_23_error` |
| 32169639876 | **678 passed** | — (same unfixed code) |

Identical code producing a different *number* of failures — including one fully green run — is what ruled out a deterministic break and identified it as a race. **A green run is not evidence of a fix here**, which is worth stating explicitly: the run-level failure rate is roughly 3-in-4, so single passes happen.

It has since recurred in that customer's **production generation**, on a regenerated suite grown to 755 cases:

```
thread 'wire_delete_12_error' panicked at tests/wire_test.rs:778:9:
auth login --with-token failed: Paste your token (input will be read from stdin):
error[auth]: Failed to rename /home/runner/.config/elevenlabs/auth-keyring.tmp: No such file or directory (os error 2)

test result: FAILED. 754 passed; 1 failed; 0 ignored; 0 measured; 0 filtered out; finished in 859.11s
```

A fourth independent occurrence: same line, same error, a different casualty again. Two details confirm it is this bug rather than something that resembles it:

- **The failure is on `rename`, not `write`.** `atomic_write` creates the temp file first and would report `Failed to write ...` if that failed. It reported `Failed to rename ...`, so the temp file was created and then vanished before the rename. `rename` returns `ENOENT` only if the source is gone or the parent is missing — and the parent existed, since the write succeeded and `write_map` calls `create_dir_all` first. By elimination, another process renamed that exact path away first.
- **The temp name is bare `auth-keyring.tmp`**, with no `.<pid>.<n>` suffix, so the binary predates this fix.

Note the suite grew from 678 to 755 cases and from ~300-600s to 859s. More cases means more overlap, so this becomes marginally *more* likely as the workspace grows, not less.

## Test

Three unit tests, each pinned by reverting the thing it covers:

- `atomic_write_tolerates_concurrent_writers` — 16 threads, one target. **Fails against the old derivation with the exact production error** (15 of 16 writers reporting `Failed to rename .../auth-keyring.tmp: No such file or directory (os error 2)`).
- `temp_file_guard_unlinks_unless_disarmed` — armed drops unlink, disarmed drops don't. **Fails if the guard or the `disarm()` call is removed** (verified by neutering `Drop`).
- `atomic_write_cleans_up_temp_file_on_failure` — no temp file survives a failed write. This one pins an invariant rather than catching a regression: the pre-guard code already cleaned up on a `rename` error.

Also reproduced end-to-end with real `auth login` subprocesses against a shared store (30 concurrent logins, `cli-oauth-login-flow:with-wire-tests`):

| Binary | Concurrent logins | Failures | Orphaned temp files |
|---|---|---|---|
| Before | 30 | **12** | — |
| After | 30 | **0** | 0 |

Full SDK suite: 1817 passed. Fixture wire tests: 8 passed. `cargo clippy --lib` reports nothing in the changed file.

## Scope and what is deliberately left alone

`rename` was already atomic for *readers*, so no partially written credential file was ever observable — only writer-vs-writer collisions on the temp path.

`FileKeyringStore::set` remains an unlocked read-modify-write of the whole map, so simultaneous writers can still clobber one another's **entries** (last writer wins). Benign for the wire harness — `loginTokenSetup` lives on the manifest, not the case, so all 676 writers store the same scheme and the same token and converge on identical content — and unlikely for real users, since concurrent `auth login` isn't a normal thing. Making it airtight needs file locking, a larger change and a separate PR. The doc comment on `atomic_write` says so explicitly rather than leaving the next reader to assume the whole operation is now safe.

Follow-ups worth filing, none blocking:
- `harness.ts` should set `XDG_CONFIG_HOME` and `APPDATA` alongside `HOME`. Windows never isolates at all today, since `%APPDATA%` is always set and wins.
- `read_map` swallows read errors into an empty map (`keyring_store.rs:156-160`), so a transient read failure is indistinguishable from "no credentials stored" — same intermittent signature, separate latent bug.

The counter is `AtomicUsize` rather than `AtomicU64` so the generated CLI still compiles on targets lacking 64-bit atomics.

No new dependencies (`std::process::id`, `AtomicUsize`), so `Cargo.lock` is untouched and **no seed image rebuild is required**.

## Diff shape

48 files: the SDK source, a changelog entry, and **46 seed fixture copies of `src/auth/oauth_common.rs`** — the vendored SDK is copied verbatim into every generated CLI, so one source change becomes 46 identical fixture diffs (verified byte-identical to the source). All 150 seed cases pass.

Regenerating surfaced ~134 files of **unrelated pre-existing drift** — `client.rs`/`config.rs`/`http_client.rs` from `rust 0.45.0`'s custom-reqwest-client, `oauth_login.rs` from #17428's OAuth redirect pages, `app.rs` from #17424's help-footer fix. Earlier PRs regenerated only the fixtures they cared about. I reverted all of it so this diff is exactly the fix; refreshing those folders belongs in its own `chore(seed)` PR.

Generated with [Claude Code](https://claude.com/claude-code)

