### PR TITLE
chore(ci): reference Jira instead of Linear in the PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,6 +1,7 @@
 ## Description
-Linear ticket: Closes 
-<!-- Use "Closes" to automatically close the ticket when PR merges, or "Refs" to link without closing -->
+Jira ticket: Closes 
+<!-- Link the Jira issue, e.g. Closes FERNDOCS-123 (or paste the full https://postmanlabs.atlassian.net/browse/... URL) -->
+<!-- Use "Closes" to indicate the ticket is resolved by this PR, or "Refs" to link without resolving -->
 <!-- Provide a clear and concise description of the changes made in this PR -->
 
 ## Changes Made


### PR DESCRIPTION
## Description
Jira ticket: Closes [FERNDOCS-64](https://postmanlabs.atlassian.net/browse/FERNDOCS-64)

The PR template asked contributors for a Linear ticket. It now asks for a Jira issue in the `postmanlabs` site, with an example key from the Fern Docs (`FERNDOCS`) project.

## Changes Made
- `.github/pull_request_template.md`: `Linear ticket: Closes` → `Jira ticket: Closes`, plus a comment showing the expected key/URL format
- No workflow or CI check referenced the Linear line, so nothing else needed updating

## Testing
- [ ] Unit tests added/updated
- [x] Manual testing completed — template rendering verified in this PR's own description


Link to Devin session: https://app.devin.ai/sessions/19b72d20d634403a96f3184984571633
Requested by: @Ryan-Amirthan
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/17481" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->