### PR TITLE
fix(cli): bump @fern-api/fdr-sdk to pick up the basepath product-slug fix

### DIFF
--- a/packages/cli/cli/changes/unreleased/bump-fdr-sdk-basepath-product-slug.yml
+++ b/packages/cli/cli/changes/unreleased/bump-fdr-sdk-basepath-product-slug.yml
@@ -1,0 +1,8 @@
+# yaml-language-server: $schema=../../../../../fern-changes-yml.schema.json
+
+- summary: |
+    On a docs site served under a basepath, a section whose explicit `slug` is written relative to
+    the basepath and starts with its own product slug (e.g. `core/introduction` inside product
+    `core`) no longer publishes with the product segment repeated. Such pages previously landed at
+    `/docs/core/core/introduction/...` instead of `/docs/core/introduction/...`.
+  type: fix

--- a/packages/cli/cli/changes/unreleased/bump-fdr-sdk-basepath-product-slug.yml
+++ b/packages/cli/cli/changes/unreleased/bump-fdr-sdk-basepath-product-slug.yml
@@ -1,8 +1,0 @@
-# yaml-language-server: $schema=../../../../../fern-changes-yml.schema.json
-
-- summary: |
-    On a docs site served under a basepath, a section whose explicit `slug` is written relative to
-    the basepath and starts with its own product slug (e.g. `core/introduction` inside product
-    `core`) no longer publishes with the product segment repeated. Such pages previously landed at
-    `/docs/core/core/introduction/...` instead of `/docs/core/introduction/...`.
-  type: fix

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -587,7 +587,7 @@ overrides:
   minimatch: '>=10.2.3'
   qs: 6.15.2
   url-join: ^4.0.1
-  '@fern-api/fdr-sdk': 1.2.92-64cea478ee
+  '@fern-api/fdr-sdk': 1.2.96-e7835c2e07
   form-data: ^4.0.6
   '@fern-api/ui-core-utils': 0.145.12-b50d999d1
   vite: ^7.3.5
@@ -3915,8 +3915,8 @@ importers:
   packages/cli/api-importers/graphql:
     dependencies:
       '@fern-api/fdr-sdk':
-        specifier: 1.2.92-64cea478ee
-        version: 1.2.92-64cea478ee(@opentelemetry/api@1.9.1)(typescript@5.9.3)
+        specifier: 1.2.96-e7835c2e07
+        version: 1.2.96-e7835c2e07(@opentelemetry/api@1.9.1)(typescript@5.9.3)
       '@fern-api/fs-utils':
         specifier: workspace:*
         version: link:../../../commons/fs-utils
@@ -4291,8 +4291,8 @@ importers:
         specifier: workspace:*
         version: link:../../configuration
       '@fern-api/fdr-sdk':
-        specifier: 1.2.92-64cea478ee
-        version: 1.2.92-64cea478ee(@opentelemetry/api@1.9.1)(typescript@5.9.3)
+        specifier: 1.2.96-e7835c2e07
+        version: 1.2.96-e7835c2e07(@opentelemetry/api@1.9.1)(typescript@5.9.3)
       '@fern-api/ir-generator':
         specifier: workspace:*
         version: link:../../generation/ir-generator
@@ -4418,8 +4418,8 @@ importers:
         specifier: workspace:*
         version: link:../yaml/docs-validator
       '@fern-api/fdr-sdk':
-        specifier: 1.2.92-64cea478ee
-        version: 1.2.92-64cea478ee(@opentelemetry/api@1.9.1)(typescript@5.9.3)
+        specifier: 1.2.96-e7835c2e07
+        version: 1.2.96-e7835c2e07(@opentelemetry/api@1.9.1)(typescript@5.9.3)
       '@fern-api/fern-definition-formatter':
         specifier: workspace:*
         version: link:../fern-definition/formatter
@@ -4876,8 +4876,8 @@ importers:
         specifier: workspace:*
         version: link:../yaml/docs-validator
       '@fern-api/fdr-sdk':
-        specifier: 1.2.92-64cea478ee
-        version: 1.2.92-64cea478ee(@opentelemetry/api@1.9.1)(typescript@5.9.3)
+        specifier: 1.2.96-e7835c2e07
+        version: 1.2.96-e7835c2e07(@opentelemetry/api@1.9.1)(typescript@5.9.3)
       '@fern-api/fern-definition-schema':
         specifier: workspace:*
         version: link:../fern-definition/schema
@@ -5081,8 +5081,8 @@ importers:
         specifier: workspace:*
         version: link:../../commons/core-utils
       '@fern-api/fdr-sdk':
-        specifier: 1.2.92-64cea478ee
-        version: 1.2.92-64cea478ee(@opentelemetry/api@1.9.1)(typescript@5.9.3)
+        specifier: 1.2.96-e7835c2e07
+        version: 1.2.96-e7835c2e07(@opentelemetry/api@1.9.1)(typescript@5.9.3)
       '@fern-api/fern-definition-schema':
         specifier: workspace:*
         version: link:../fern-definition/schema
@@ -5118,8 +5118,8 @@ importers:
         specifier: workspace:*
         version: link:../../commons/core-utils
       '@fern-api/fdr-sdk':
-        specifier: 1.2.92-64cea478ee
-        version: 1.2.92-64cea478ee(@opentelemetry/api@1.9.1)(typescript@5.9.3)
+        specifier: 1.2.96-e7835c2e07
+        version: 1.2.96-e7835c2e07(@opentelemetry/api@1.9.1)(typescript@5.9.3)
       '@fern-api/fs-utils':
         specifier: workspace:*
         version: link:../../commons/fs-utils
@@ -5197,8 +5197,8 @@ importers:
         specifier: workspace:*
         version: link:../../configuration
       '@fern-api/fdr-sdk':
-        specifier: 1.2.92-64cea478ee
-        version: 1.2.92-64cea478ee(@opentelemetry/api@1.9.1)(typescript@5.9.3)
+        specifier: 1.2.96-e7835c2e07
+        version: 1.2.96-e7835c2e07(@opentelemetry/api@1.9.1)(typescript@5.9.3)
       '@fern-api/fs-utils':
         specifier: workspace:*
         version: link:../../../commons/fs-utils
@@ -5237,8 +5237,8 @@ importers:
         specifier: workspace:*
         version: link:../commons
       '@fern-api/fdr-sdk':
-        specifier: 1.2.92-64cea478ee
-        version: 1.2.92-64cea478ee(@opentelemetry/api@1.9.1)(typescript@5.9.3)
+        specifier: 1.2.96-e7835c2e07
+        version: 1.2.96-e7835c2e07(@opentelemetry/api@1.9.1)(typescript@5.9.3)
       '@fern-api/fs-utils':
         specifier: workspace:*
         version: link:../../../commons/fs-utils
@@ -5277,8 +5277,8 @@ importers:
         specifier: workspace:*
         version: link:../commons
       '@fern-api/fdr-sdk':
-        specifier: 1.2.92-64cea478ee
-        version: 1.2.92-64cea478ee(@opentelemetry/api@1.9.1)(typescript@5.9.3)
+        specifier: 1.2.96-e7835c2e07
+        version: 1.2.96-e7835c2e07(@opentelemetry/api@1.9.1)(typescript@5.9.3)
       '@fern-api/fs-utils':
         specifier: workspace:*
         version: link:../../../commons/fs-utils
@@ -5344,8 +5344,8 @@ importers:
   packages/cli/docs-markdown-utils:
     dependencies:
       '@fern-api/fdr-sdk':
-        specifier: 1.2.92-64cea478ee
-        version: 1.2.92-64cea478ee(@opentelemetry/api@1.9.1)(typescript@5.9.3)
+        specifier: 1.2.96-e7835c2e07
+        version: 1.2.96-e7835c2e07(@opentelemetry/api@1.9.1)(typescript@5.9.3)
       '@fern-api/fs-utils':
         specifier: workspace:*
         version: link:../../commons/fs-utils
@@ -5435,8 +5435,8 @@ importers:
         specifier: workspace:*
         version: link:../docs-resolver
       '@fern-api/fdr-sdk':
-        specifier: 1.2.92-64cea478ee
-        version: 1.2.92-64cea478ee(@opentelemetry/api@1.9.1)(typescript@5.9.3)
+        specifier: 1.2.96-e7835c2e07
+        version: 1.2.96-e7835c2e07(@opentelemetry/api@1.9.1)(typescript@5.9.3)
       '@fern-api/fs-utils':
         specifier: workspace:*
         version: link:../../commons/fs-utils
@@ -5550,8 +5550,8 @@ importers:
         specifier: workspace:*
         version: link:../docs-markdown-utils
       '@fern-api/fdr-sdk':
-        specifier: 1.2.92-64cea478ee
-        version: 1.2.92-64cea478ee(@opentelemetry/api@1.9.1)(typescript@5.9.3)
+        specifier: 1.2.96-e7835c2e07
+        version: 1.2.96-e7835c2e07(@opentelemetry/api@1.9.1)(typescript@5.9.3)
       '@fern-api/fs-utils':
         specifier: workspace:*
         version: link:../../commons/fs-utils
@@ -5653,8 +5653,8 @@ importers:
         specifier: workspace:*
         version: link:../configuration
       '@fern-api/fdr-sdk':
-        specifier: 1.2.92-64cea478ee
-        version: 1.2.92-64cea478ee(@opentelemetry/api@1.9.1)(typescript@5.9.3)
+        specifier: 1.2.96-e7835c2e07
+        version: 1.2.96-e7835c2e07(@opentelemetry/api@1.9.1)(typescript@5.9.3)
       '@fern-api/fs-utils':
         specifier: workspace:*
         version: link:../../commons/fs-utils
@@ -6361,8 +6361,8 @@ importers:
         specifier: 'catalog:'
         version: 0.0.6-2ee1b7e28
       '@fern-api/fdr-sdk':
-        specifier: 1.2.92-64cea478ee
-        version: 1.2.92-64cea478ee(@opentelemetry/api@1.9.1)(typescript@5.9.3)
+        specifier: 1.2.96-e7835c2e07
+        version: 1.2.96-e7835c2e07(@opentelemetry/api@1.9.1)(typescript@5.9.3)
       '@fern-api/fs-utils':
         specifier: workspace:*
         version: link:../../../../commons/fs-utils
@@ -6586,8 +6586,8 @@ importers:
         specifier: workspace:*
         version: link:../generation/local-generation/docker-utils
       '@fern-api/fdr-sdk':
-        specifier: 1.2.92-64cea478ee
-        version: 1.2.92-64cea478ee(@opentelemetry/api@1.9.1)(typescript@5.9.3)
+        specifier: 1.2.96-e7835c2e07
+        version: 1.2.96-e7835c2e07(@opentelemetry/api@1.9.1)(typescript@5.9.3)
       '@fern-api/fs-utils':
         specifier: workspace:*
         version: link:../../commons/fs-utils
@@ -6832,8 +6832,8 @@ importers:
         specifier: workspace:*
         version: link:../../commons/core-utils
       '@fern-api/fdr-sdk':
-        specifier: 1.2.92-64cea478ee
-        version: 1.2.92-64cea478ee(@opentelemetry/api@1.9.1)(typescript@5.9.3)
+        specifier: 1.2.96-e7835c2e07
+        version: 1.2.96-e7835c2e07(@opentelemetry/api@1.9.1)(typescript@5.9.3)
       '@fern-api/fs-utils':
         specifier: workspace:*
         version: link:../../commons/fs-utils
@@ -7028,8 +7028,8 @@ importers:
         specifier: workspace:*
         version: link:../../../commons/core-utils
       '@fern-api/fdr-sdk':
-        specifier: 1.2.92-64cea478ee
-        version: 1.2.92-64cea478ee(@opentelemetry/api@1.9.1)(typescript@5.9.3)
+        specifier: 1.2.96-e7835c2e07
+        version: 1.2.96-e7835c2e07(@opentelemetry/api@1.9.1)(typescript@5.9.3)
       '@fern-api/ir-sdk':
         specifier: workspace:*
         version: link:../../../ir-sdk
@@ -7113,8 +7113,8 @@ importers:
         specifier: workspace:*
         version: link:../../../commons/core-utils
       '@fern-api/fdr-sdk':
-        specifier: 1.2.92-64cea478ee
-        version: 1.2.92-64cea478ee(@opentelemetry/api@1.9.1)(typescript@5.9.3)
+        specifier: 1.2.96-e7835c2e07
+        version: 1.2.96-e7835c2e07(@opentelemetry/api@1.9.1)(typescript@5.9.3)
       '@fern-api/fern-definition-schema':
         specifier: workspace:*
         version: link:../../fern-definition/schema
@@ -7359,8 +7359,8 @@ importers:
         specifier: workspace:*
         version: link:../../docs-resolver
       '@fern-api/fdr-sdk':
-        specifier: 1.2.92-64cea478ee
-        version: 1.2.92-64cea478ee(@opentelemetry/api@1.9.1)(typescript@5.9.3)
+        specifier: 1.2.96-e7835c2e07
+        version: 1.2.96-e7835c2e07(@opentelemetry/api@1.9.1)(typescript@5.9.3)
       '@fern-api/fern-definition-schema':
         specifier: workspace:*
         version: link:../../fern-definition/schema
@@ -8004,8 +8004,8 @@ importers:
   packages/core:
     dependencies:
       '@fern-api/fdr-sdk':
-        specifier: 1.2.92-64cea478ee
-        version: 1.2.92-64cea478ee(@opentelemetry/api@1.9.1)(typescript@5.9.3)
+        specifier: 1.2.96-e7835c2e07
+        version: 1.2.96-e7835c2e07(@opentelemetry/api@1.9.1)(typescript@5.9.3)
       '@fern-api/venus-api-sdk':
         specifier: 'catalog:'
         version: 5.0.0
@@ -9558,8 +9558,8 @@ packages:
     resolution: {integrity: sha512-3qhAAuc4ZJWLaFtyZzaYXfF9OQ5iviNrvLDXtjKScKUNS134fR3v3c3xedCidTq5KedapuBECziUaOmmd6KXVA==}
     engines: {node: '>=18.0.0'}
 
-  '@fern-api/fdr-sdk@1.2.92-64cea478ee':
-    resolution: {integrity: sha512-yCHZAbOJbl60d4o/focZbaX71Mx1zEyZvnu1U5pF8qadA91L3zAMcQ7jKEn6+wN/v5rmqCFNbBMQ3rB9LSBAFw==}
+  '@fern-api/fdr-sdk@1.2.96-e7835c2e07':
+    resolution: {integrity: sha512-KNP3ifbZzpOd2U1fkXudVz+p7+KqRzzfUtw0594M+sK/x+UdYyatFW8qQq7N2ilKFbJUZZS0Lnzq1pA36/jmRg==}
 
   '@fern-api/generator-cli@0.9.53':
     resolution: {integrity: sha512-737p5KbB8DZQFhU3JhW6hvI2If2O8ySDUb4bWXB1OzFT/dhAqSxhCDpAp9vrQH53ldtEEzAYqR44yAxw/0wUgA==}
@@ -16523,7 +16523,7 @@ snapshots:
 
   '@fern-api/fai-sdk@0.0.6-2ee1b7e28': {}
 
-  '@fern-api/fdr-sdk@1.2.92-64cea478ee(@opentelemetry/api@1.9.1)(typescript@5.9.3)':
+  '@fern-api/fdr-sdk@1.2.96-e7835c2e07(@opentelemetry/api@1.9.1)(typescript@5.9.3)':
     dependencies:
       '@fern-api/ui-core-utils': 0.145.12-b50d999d1
       '@orpc/client': 1.13.9(@opentelemetry/api@1.9.1)

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -61,7 +61,7 @@ catalog:
   "@bufbuild/protobuf": ^2.2.5
   "@bufbuild/protoplugin": 2.2.5
   "@fern-api/fai-sdk": 0.0.6-2ee1b7e28
-  "@fern-api/fdr-sdk": 1.2.92-64cea478ee
+  "@fern-api/fdr-sdk": 1.2.96-e7835c2e07
   "@fern-api/generator-cli": 0.9.53
   "@fern-api/ui-core-utils": 0.129.4-b6c699ad2
   "@fern-api/venus-api-sdk": 5.0.0
@@ -263,7 +263,7 @@ overrides:
   minimatch: ">=10.2.3"
   qs: 6.15.2
   url-join: ^4.0.1
-  "@fern-api/fdr-sdk": 1.2.92-64cea478ee
+  "@fern-api/fdr-sdk": 1.2.96-e7835c2e07
   form-data: ^4.0.6
   "@fern-api/ui-core-utils": 0.145.12-b50d999d1
   vite: ^7.3.5


### PR DESCRIPTION
## Description

Bumps the `@fern-api/fdr-sdk` catalog pin from `1.2.92-64cea478ee` to `1.2.96-e7835c2e07` so the CLI picks up fern-api/fern-platform#14137.

Slugs are computed CLI-side by `DocsDefinitionResolver` via `FernNavigation.V1.n` (`SlugGenerator`) from `@fern-api/fdr-sdk`, so that fix has no effect until this pin moves — deploying FDR does nothing for it. Concretely, on a site served under a basepath, a section whose explicit `slug` is written relative to the basepath and starts with its own product slug (`core/introduction` inside product `core`) published at `/docs/core/core/introduction/...`.

`fern-dev-tests/tests/basepath-product-slug.spec.ts` (fern-api/fern-platform#14138) hard-fails until a `fern-dev` prerelease containing this bump exists, since CI installs the latest published CLI.

**Deliberately no changelog entry.** A file under `packages/cli/cli/changes/**` triggers `release-software.yml`, which bumps `versions.yml` and cuts a prod CLI release. This bump is only needed for `fern-dev` (dev job on any push to `main`), so the entry is omitted to keep it dev-only; the new SDK will ride along with the next prod CLI release cut by a normal feature PR.

## Changes Made

- `pnpm-workspace.yaml`: bump `@fern-api/fdr-sdk` in both the `catalog` and `overrides` blocks
- `pnpm-lock.yaml`: regenerated

## Testing
- [x] Unit tests added/updated — covered upstream by `SlugGenerator.test.ts` in fern-api/fern-platform#14137
- [x] Manual testing completed — verified `1.2.96-e7835c2e07` is on npm and resolves; end-to-end verification is the dev-tests spec above, which should go green on the run after this merges


Link to Devin session: https://app.devin.ai/sessions/127979d404ed4206be220072e3e1adaa
Requested by: @Ryan-Amirthan
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/17493" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->