### PR TITLE
fix(cli): stabilize global theme asset paths

### DIFF
--- a/packages/cli/cli/changes/unreleased/fix-stable-global-theme-asset-path.yml
+++ b/packages/cli/cli/changes/unreleased/fix-stable-global-theme-asset-path.yml
@@ -1,0 +1,3 @@
+- summary: |
+    Make global theme asset paths stable across publishes of the same organization and theme.
+  type: fix

--- a/packages/cli/docs-resolver/src/__test__/stitchGlobalTheme.test.ts
+++ b/packages/cli/docs-resolver/src/__test__/stitchGlobalTheme.test.ts
@@ -2,10 +2,12 @@ import { AbsoluteFilePath } from "@fern-api/fs-utils";
 import { createMockTaskContext } from "@fern-api/task-context";
 
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import path from "path";
 
 import {
     deepMergeGlobalWins,
     filenameFromUrl,
+    getGlobalThemeAssetDirectoryPath,
     isPresignedUrl,
     isRemoteUrl,
     mergeThemeOverride,
@@ -115,6 +117,28 @@ describe("filenameFromUrl", () => {
         const encoded = encodeURIComponent('attachment; filename="abc123"');
         const url = `https://s3.amazonaws.com/bucket/hash?response-content-disposition=${encoded}`;
         expect(filenameFromUrl(url)).toBeUndefined();
+    });
+});
+
+describe("getGlobalThemeAssetDirectoryPath", () => {
+    it("returns the same path for the same organization and theme", () => {
+        expect(getGlobalThemeAssetDirectoryPath("acme", "docs")).toBe(getGlobalThemeAssetDirectoryPath("acme", "docs"));
+    });
+
+    it("returns different paths for different organizations or themes", () => {
+        expect(getGlobalThemeAssetDirectoryPath("acme", "docs")).not.toBe(
+            getGlobalThemeAssetDirectoryPath("other-org", "docs")
+        );
+        expect(getGlobalThemeAssetDirectoryPath("acme", "docs")).not.toBe(
+            getGlobalThemeAssetDirectoryPath("acme", "other-theme")
+        );
+    });
+
+    it("uses a safe single-segment directory name for unsafe inputs", () => {
+        const directoryPath = getGlobalThemeAssetDirectoryPath("org/with spaces", "theme\\with?unsafe");
+        expect(path.basename(directoryPath)).toMatch(/^fern-theme-[0-9a-f]{16}$/);
+        expect(path.basename(directoryPath)).not.toContain("/");
+        expect(path.basename(directoryPath)).not.toContain("\\");
     });
 });
 

--- a/packages/cli/docs-resolver/src/__test__/stitchGlobalTheme.test.ts
+++ b/packages/cli/docs-resolver/src/__test__/stitchGlobalTheme.test.ts
@@ -1,11 +1,14 @@
 import { AbsoluteFilePath } from "@fern-api/fs-utils";
 import { createMockTaskContext } from "@fern-api/task-context";
 
+import { mkdir, mkdtemp, rm, symlink } from "fs/promises";
+import { tmpdir } from "os";
 import path from "path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import {
     deepMergeGlobalWins,
+    ensureGlobalThemeAssetDirectory,
     filenameFromUrl,
     getGlobalThemeAssetDirectoryPath,
     isPresignedUrl,
@@ -139,6 +142,24 @@ describe("getGlobalThemeAssetDirectoryPath", () => {
         expect(path.basename(directoryPath)).toMatch(/^fern-theme-[0-9a-f]{16}$/);
         expect(path.basename(directoryPath)).not.toContain("/");
         expect(path.basename(directoryPath)).not.toContain("\\");
+    });
+});
+
+describe("ensureGlobalThemeAssetDirectory", () => {
+    it.skipIf(process.platform === "win32")("rejects a symlinked directory", async () => {
+        const parentDirectory = await mkdtemp(path.join(tmpdir(), "fern-theme-test-"));
+        const targetDirectory = path.join(parentDirectory, "target");
+        const symlinkPath = path.join(parentDirectory, "theme");
+        await mkdir(targetDirectory);
+        await symlink(targetDirectory, symlinkPath);
+
+        try {
+            await expect(ensureGlobalThemeAssetDirectory(symlinkPath)).rejects.toThrow(
+                `Global theme asset directory "${symlinkPath}" is not a secure directory`
+            );
+        } finally {
+            await rm(parentDirectory, { force: true, recursive: true });
+        }
     });
 });
 

--- a/packages/cli/docs-resolver/src/__test__/stitchGlobalTheme.test.ts
+++ b/packages/cli/docs-resolver/src/__test__/stitchGlobalTheme.test.ts
@@ -1,8 +1,8 @@
 import { AbsoluteFilePath } from "@fern-api/fs-utils";
 import { createMockTaskContext } from "@fern-api/task-context";
 
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import path from "path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import {
     deepMergeGlobalWins,

--- a/packages/cli/docs-resolver/src/stitchGlobalTheme.ts
+++ b/packages/cli/docs-resolver/src/stitchGlobalTheme.ts
@@ -5,7 +5,7 @@ import { CliError, TaskContext } from "@fern-api/task-context";
 import { DocsWorkspace } from "@fern-api/workspace-loader";
 
 import { createHash, randomUUID } from "crypto";
-import { mkdir, rename, unlink, writeFile } from "fs/promises";
+import { chmod, lstat, mkdir, rename, unlink, writeFile } from "fs/promises";
 import mime from "mime-types";
 import { tmpdir } from "os";
 import path from "path";
@@ -52,6 +52,22 @@ export function getGlobalThemeAssetDirectoryPath(organization: string, themeName
     const themeKey = `${organization}\0${themeName}`;
     const themeHash = createHash("sha256").update(themeKey).digest("hex").slice(0, 16);
     return path.join(tmpdir(), `fern-theme-${themeHash}`);
+}
+
+export async function ensureGlobalThemeAssetDirectory(directoryPath: string): Promise<void> {
+    await mkdir(directoryPath, { mode: 0o700, recursive: true });
+
+    const stats = await lstat(directoryPath);
+    const processUid = typeof process.getuid === "function" ? process.getuid() : undefined;
+    if (!stats.isDirectory() || (processUid !== undefined && stats.uid !== processUid)) {
+        throw new Error(
+            `Global theme asset directory "${directoryPath}" is not a secure directory. Remove it and retry.`
+        );
+    }
+
+    if ((stats.mode & 0o777) !== 0o700) {
+        await chmod(directoryPath, 0o700);
+    }
 }
 
 async function writeFileAtomically(filePath: string, data: string | Uint8Array): Promise<void> {
@@ -408,7 +424,16 @@ export async function stitchGlobalTheme({
 
     // Reuse a deterministic directory so asset paths remain stable across publishes.
     const tmpDirPath = getGlobalThemeAssetDirectoryPath(organization, themeName);
-    await mkdir(tmpDirPath, { recursive: true });
+    try {
+        await ensureGlobalThemeAssetDirectory(tmpDirPath);
+    } catch (err) {
+        taskContext.failAndThrow(
+            `Could not prepare global theme asset directory "${tmpDirPath}". Remove it and retry.`,
+            err,
+            { code: CliError.Code.ConfigError }
+        );
+        return docsWorkspace;
+    }
     taskContext.logger.debug(`Downloading theme assets to ${tmpDirPath}`);
 
     let resolvedConfig: Record<string, unknown>;

--- a/packages/cli/docs-resolver/src/stitchGlobalTheme.ts
+++ b/packages/cli/docs-resolver/src/stitchGlobalTheme.ts
@@ -4,10 +4,11 @@ import { AbsoluteFilePath } from "@fern-api/fs-utils";
 import { CliError, TaskContext } from "@fern-api/task-context";
 import { DocsWorkspace } from "@fern-api/workspace-loader";
 
-import { writeFile } from "fs/promises";
+import { createHash, randomUUID } from "crypto";
+import { mkdir, rename, unlink, writeFile } from "fs/promises";
 import mime from "mime-types";
+import { tmpdir } from "os";
 import path from "path";
-import tmp from "tmp-promise";
 
 type RawDocsConfig = docsYml.RawSchemas.DocsConfiguration;
 
@@ -44,6 +45,22 @@ export function filenameFromUrl(url: string): string | undefined {
         return parseFilenameFromDisposition(rcd);
     } catch {
         return undefined;
+    }
+}
+
+export function getGlobalThemeAssetDirectoryPath(organization: string, themeName: string): string {
+    const themeKey = `${organization}\0${themeName}`;
+    const themeHash = createHash("sha256").update(themeKey).digest("hex").slice(0, 16);
+    return path.join(tmpdir(), `fern-theme-${themeHash}`);
+}
+
+async function writeFileAtomically(filePath: string, data: string | Uint8Array): Promise<void> {
+    const tempPath = path.join(path.dirname(filePath), `.${path.basename(filePath)}.${randomUUID()}.tmp`);
+    try {
+        await writeFile(tempPath, data);
+        await rename(tempPath, filePath);
+    } finally {
+        await unlink(tempPath).catch(() => undefined);
     }
 }
 
@@ -92,7 +109,7 @@ async function downloadToTemp(url: string, tmpDir: string, index: number): Promi
 
     const dest = path.join(tmpDir, filename);
     const buf = Buffer.from(await res.arrayBuffer());
-    await writeFile(dest, buf);
+    await writeFileAtomically(dest, buf);
     return dest;
 }
 
@@ -291,7 +308,7 @@ interface StitchGlobalThemeArgs {
  * FDR, downloads any file assets to a temp directory, and returns a new DocsWorkspace
  * whose raw config has the theme values merged in (theme wins for branding fields).
  *
- * The temp directory is cleaned up on process exit.
+ * The theme asset directory is reused across publishes of the same theme.
  * If no global-theme is declared, returns the workspace unchanged.
  */
 export async function stitchGlobalTheme({
@@ -389,8 +406,9 @@ export async function stitchGlobalTheme({
         throw err;
     }
 
-    // Download file assets to a temp directory that lives for the duration of the process
-    const { path: tmpDirPath } = await tmp.dir({ prefix: "fern-theme-", unsafeCleanup: true });
+    // Reuse a deterministic directory so asset paths remain stable across publishes.
+    const tmpDirPath = getGlobalThemeAssetDirectoryPath(organization, themeName);
+    await mkdir(tmpDirPath, { recursive: true });
     taskContext.logger.debug(`Downloading theme assets to ${tmpDirPath}`);
 
     let resolvedConfig: Record<string, unknown>;
@@ -406,11 +424,9 @@ export async function stitchGlobalTheme({
 
     const mergedRawConfig = mergeThemeOverride(docsWorkspace.config, resolvedConfig);
 
-    taskContext.logger.info(
-        `Applied global theme "${themeName}" — ${AbsoluteFilePath.of(tmpDirPath)} (cleaned up on exit)`
-    );
+    taskContext.logger.info(`Applied global theme "${themeName}" — ${AbsoluteFilePath.of(tmpDirPath)}`);
     const stitchedPath = path.join(tmpDirPath, "stitched-docs.yml.json");
-    await writeFile(stitchedPath, JSON.stringify(mergedRawConfig, null, 2));
+    await writeFileAtomically(stitchedPath, JSON.stringify(mergedRawConfig, null, 2));
     taskContext.logger.debug(`Stitched docs.yml after importing theme written to: ${stitchedPath}`);
 
     return { ...docsWorkspace, config: mergedRawConfig };


### PR DESCRIPTION
## Description

Global-theme stitching downloaded theme assets into a random per-process temp dir (`tmp.dir({ prefix: "fern-theme-" })`), so every publish of the same theme produced a *different* asset path:

```
/tmp/fern-theme--2123-kY46I5owUYrT/theme_asset_1.png   # publish A
/tmp/fern-theme--2100-Nxv5JiQhE3RZ/theme_asset_1.png   # publish B, same theme
```

Publish relativizes that absolute path, so the config ends up naming `_dot_dot_/…/tmp/fern-theme--2123-kY46I5owUYrT/theme_asset_1.png` — a brand-new file key and S3 object on every publish, and a logo path that is not reproducible across publishes. Verified against a customer's ledger deployments: four publishes in one afternoon, four distinct `fern-theme--<pid>-<rand>` directories.

Consequences: asset churn in the bucket on every publish, and any consumer holding a config from one publish alongside a file map from another (e.g. the dashboard visual editor's cached loader state) names a key the file map doesn't have — the logo `src` then falls back to the raw relative path, 404s, and renders as clipped alt text.

The directory is now derived from the theme's identity instead of the process:

```ts
getGlobalThemeAssetDirectoryPath(organization, themeName)
// => `${os.tmpdir()}/fern-theme-${sha256(`${organization}\0${themeName}`).slice(0, 16)}`
```

Asset filenames are unchanged, so the full path is byte-identical across publishes of the same theme. Since the directory is now reused rather than process-private, assets and `stitched-docs.yml.json` are written to a unique temp file and atomically renamed into place, so a concurrent publish can never read a torn file. The exit-time cleanup (and the log line advertising it) is gone — deleting a shared, reused directory would defeat the stability and could race another publish.

A predictable path in a world-writable tmpdir also gives up the 0700-random-name protection `tmp.dir()` provided, so `ensureGlobalThemeAssetDirectory` creates the directory at mode `0o700` and, before anything is written, `lstat`s it and refuses to proceed unless it is a real directory owned by the current uid (tightening the mode back to `0700` when we own a loosened directory). A pre-created or symlinked path fails the publish loudly via `failAndThrow` instead of silently redirecting our writes.

## Changes Made
- `stitchGlobalTheme.ts`: deterministic, reused theme asset directory; atomic writes; no exit cleanup
- `ensureGlobalThemeAssetDirectory`: 0700 creation + ownership/symlink guard
- Unit tests for the directory-name helper (determinism, org/theme separation, unsafe inputs) and the symlink rejection
- CLI changelog entry (`type: fix`)

## Testing
- [x] Unit tests added/updated — `pnpm turbo run test --filter @fern-api/docs-resolver` (112 tests pass); `compile`, `lint:biome`, `format:fix` clean
- [x] Manual testing completed — dev CLI built from this branch, DEV publishes with before/after control and a dashboard-editor check; see the [verification comment](https://github.com/fern-api/fern/pull/17494#issuecomment-5362362817)


Link to Devin session: https://app.devin.ai/sessions/21f651485fc34eac869d118d0898128e
Requested by: @ctondreau
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/17494" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->