### PR TITLE
feat(cli): support running a generator container with no network access

### DIFF
--- a/packages/cli/cli/changes/unreleased/generator-network-mode.yml
+++ b/packages/cli/cli/changes/unreleased/generator-network-mode.yml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=../../../../../fern-changes-yml.schema.json
+
+- summary: |
+      Local generation can now run the generator container with a specific network mode, set with the
+      FERN_GENERATOR_NETWORK environment variable. Setting it to `none` runs the generator with no
+      network access, which air-gapped environments require. Unset, container networking is unchanged.
+  type: internal

--- a/packages/cli/generation/local-generation/docker-utils/src/__test__/networkPassthrough.test.ts
+++ b/packages/cli/generation/local-generation/docker-utils/src/__test__/networkPassthrough.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it, vi } from "vitest";
+
+const loggingExeca = vi.hoisted(() => vi.fn());
+
+vi.mock("@fern-api/logging-execa", () => ({ loggingExeca }));
+vi.mock("tmp-promise", () => ({ default: { file: async () => ({ path: "/tmp/logs" }) } }));
+vi.mock("fs/promises", () => ({ writeFile: async () => undefined }));
+
+import { runContainer } from "../runDocker.js";
+
+const logger = { info: vi.fn(), debug: vi.fn(), warn: vi.fn(), error: vi.fn(), log: vi.fn() };
+
+async function capturedArgs(args: Partial<Parameters<typeof runContainer>[0]> = {}): Promise<string[]> {
+    loggingExeca.mockReset();
+    loggingExeca.mockResolvedValue({ stdout: "", stderr: "", exitCode: 0 });
+    await runContainer({
+        // biome-ignore lint/suspicious/noExplicitAny: test logger stub
+        logger: logger as any,
+        imageName: "fernapi/fern-python-sdk:4.0.0",
+        writeLogsToFile: false,
+        ...args
+    });
+    return loggingExeca.mock.calls[0]?.[2] as string[];
+}
+
+describe("runContainer network passthrough", () => {
+    it("passes --network when a mode is supplied", async () => {
+        const argv = await capturedArgs({ network: "none" });
+
+        expect(argv).toContain("--network");
+        expect(argv[argv.indexOf("--network") + 1]).toBe("none");
+    });
+
+    // The flag must never appear unless asked for: adding it unconditionally would change the
+    // networking of every existing generator.
+    it("omits --network entirely by default", async () => {
+        const argv = await capturedArgs();
+
+        expect(argv).not.toContain("--network");
+    });
+
+    it("keeps the network flag ahead of the image and its arguments", async () => {
+        const argv = await capturedArgs({ network: "none", args: ["/fern/config.json"] });
+
+        expect(argv.indexOf("--network")).toBeLessThan(argv.indexOf("fernapi/fern-python-sdk:4.0.0"));
+        expect(argv[argv.length - 1]).toBe("/fern/config.json");
+    });
+});

--- a/packages/cli/generation/local-generation/docker-utils/src/runDocker.ts
+++ b/packages/cli/generation/local-generation/docker-utils/src/runDocker.ts
@@ -29,6 +29,11 @@ export declare namespace runContainer {
          * emulation on other hosts. Leave unset to use the host-native platform.
          */
         platform?: string;
+        /**
+         * Container network mode (`docker run --network <value>`). Pass `"none"` to run a generator
+         * with no network access at all. Leave unset for the runtime default.
+         */
+        network?: string;
         /** AbortSignal to kill the container process on timeout/bail/Ctrl+C */
         signal?: AbortSignal;
     }
@@ -50,6 +55,7 @@ export async function runContainer({
     runner,
     pull = false,
     platform,
+    network,
     signal
 }: runContainer.Args): Promise<void> {
     const tryRun = () =>
@@ -65,6 +71,7 @@ export async function runContainer({
             runner,
             pull,
             platform,
+            network,
             signal
         });
     try {
@@ -119,6 +126,7 @@ async function tryRunContainer({
     runner,
     pull = false,
     platform,
+    network,
     signal
 }: {
     logger: Logger;
@@ -132,6 +140,7 @@ async function tryRunContainer({
     runner?: ContainerRunner;
     pull?: boolean;
     platform?: string;
+    network?: string;
     signal?: AbortSignal;
 }): Promise<void> {
     const { envVars: containerEnvVars, forwardedFromHost } = buildContainerEnvVars({
@@ -145,6 +154,7 @@ async function tryRunContainer({
         "root",
         ...(pull ? ["--pull", "always"] : []),
         ...(platform != null ? ["--platform", platform] : []),
+        ...(network != null ? ["--network", network] : []),
         ...binds.flatMap((bind) => ["-v", bind]),
         ...Object.entries(containerEnvVars).flatMap(([key, value]) => ["-e", `${key}=\"${value}\"`]),
         ...Object.entries(ports).flatMap(([hostPort, containerPort]) => ["-p", `${hostPort}:${containerPort}`]),

--- a/packages/cli/generation/local-generation/local-workspace-runner/src/ContainerExecutionEnvironment.ts
+++ b/packages/cli/generation/local-generation/local-workspace-runner/src/ContainerExecutionEnvironment.ts
@@ -19,12 +19,14 @@ export class ContainerExecutionEnvironment implements ExecutionEnvironment {
     private readonly keepContainer: boolean;
     private readonly runner?: ContainerRunner;
     private readonly disableTelemetry: boolean;
+    private readonly network?: string;
 
     constructor({
         containerImage,
         keepContainer,
         runner,
         disableTelemetry,
+        network,
         dockerImage,
         keepDocker
     }: {
@@ -33,6 +35,12 @@ export class ContainerExecutionEnvironment implements ExecutionEnvironment {
         runner?: ContainerRunner;
         /** When true, disables telemetry collection inside the generator container. */
         disableTelemetry?: boolean;
+        /**
+         * Container network mode. `"none"` runs the generator with no network access, which is what
+         * an air-gapped generation requires: the guarantee has to hold for the customer's run, not
+         * only for a CI check.
+         */
+        network?: string;
         /** @deprecated Use containerImage instead */
         dockerImage?: string;
         /** @deprecated Use keepContainer instead */
@@ -42,6 +50,7 @@ export class ContainerExecutionEnvironment implements ExecutionEnvironment {
         this.keepContainer = keepContainer ?? keepDocker ?? false;
         this.runner = runner;
         this.disableTelemetry = disableTelemetry ?? false;
+        this.network = network;
     }
 
     public async execute({
@@ -105,7 +114,8 @@ export class ContainerExecutionEnvironment implements ExecutionEnvironment {
                 envVars,
                 ports,
                 removeAfterCompletion: !this.keepContainer,
-                runner: this.runner ?? runner
+                runner: this.runner ?? runner,
+                ...(this.network != null ? { network: this.network } : {})
             });
         } catch (error) {
             if (error instanceof CliError) {

--- a/packages/cli/generation/local-generation/local-workspace-runner/src/constants.ts
+++ b/packages/cli/generation/local-generation/local-workspace-runner/src/constants.ts
@@ -60,3 +60,16 @@ const GENERATORS_WANTING_SPECS: ReadonlySet<string> = new Set(["fernapi/fern-cli
 export function generatorWantsSpecs(generatorName: string): boolean {
     return GENERATORS_WANTING_SPECS.has(generatorName);
 }
+
+/**
+ * Opts a local generation run into a specific container network mode, `none` being the useful value.
+ *
+ * An environment variable rather than a generators.yml key so the switch exists without a schema
+ * change; a first-class config field or CLI flag is the natural follow-up if that is preferred.
+ */
+export const GENERATOR_NETWORK_ENV_VAR = "FERN_GENERATOR_NETWORK";
+
+export function getConfiguredGeneratorNetwork(env: NodeJS.ProcessEnv = process.env): string | undefined {
+    const value = env[GENERATOR_NETWORK_ENV_VAR]?.trim();
+    return value !== undefined && value !== "" ? value : undefined;
+}

--- a/packages/cli/generation/local-generation/local-workspace-runner/src/runGenerator.ts
+++ b/packages/cli/generation/local-generation/local-workspace-runner/src/runGenerator.ts
@@ -30,6 +30,7 @@ import {
     CONTAINER_SOURCES_DIRECTORY,
     CONTAINER_SPECS_DIRECTORY,
     GENERATOR_CONFIG_FILENAME,
+    getConfiguredGeneratorNetwork,
     IR_FILENAME,
     SPECS_DIRECTORY_NAME,
     SPECS_MANIFEST_FILENAME
@@ -196,7 +197,8 @@ export async function writeFilesToDiskAndRunGenerator({
                 ? `${generatorInvocation.containerImage}:${generatorInvocation.version}`
                 : `${generatorInvocation.name}:${generatorInvocation.version}`,
             keepContainer: keepDocker,
-            disableTelemetry
+            disableTelemetry,
+            ...(getConfiguredGeneratorNetwork() != null ? { network: getConfiguredGeneratorNetwork() } : {})
         });
 
     const paths = environment.usesContainerPaths


### PR DESCRIPTION
## Description

`runDocker` assembles `docker run --user root [--pull always] [--platform ...] -v ... -e ... image args`. There is no `--network` flag at any point, so a generator container always runs with default bridge networking, and there is currently no way to generate offline.

This adds an optional network mode, threaded from `ContainerExecutionEnvironment` through `runContainer`, following the same shape as the existing `platform` and `pull` options.

```bash
FERN_GENERATOR_NETWORK=none fern generate --local
```

Unset, the flag is not passed and container networking is unchanged for every existing generator.

## Why

Air-gapped and regulated environments need the generator to demonstrably have no network path. Today that isolation can only be enforced outside the CLI, which means the guarantee holds in a vendor's CI but not in the customer's actual run — the gap between "air-gap is provable" and "air-gap is what the customer gets".

## Why an environment variable

It gives the capability without touching the `generators.yml` schema. A first-class config field or a CLI flag is the natural follow-up if that is preferred — happy to change it, this was the smallest surface that works.

## Testing

Three tests assert the assembled argv rather than mocking at a higher level:

- `--network <mode>` appears when requested
- the flag is **absent entirely** by default, so existing generators cannot have their networking changed
- it is positioned ahead of the image and its arguments

All 13 existing `docker-utils` tests still pass, including the `basic-writer` integration test that runs a real container.

I also confirmed against real Docker that the flag does what the PR claims: a `busybox` container reaches the network by default and is blocked with `--network none` in the position we emit it.

## Note

Draft while related work settles. Independent of #17508, though both touch `docker-utils`.
