### PR TITLE
feat(cli): support local library git inputs

### DIFF
--- a/packages/cli/cli/changes/unreleased/support-local-library-git-inputs.yml
+++ b/packages/cli/cli/changes/unreleased/support-local-library-git-inputs.yml
@@ -1,0 +1,3 @@
+- summary: |
+    Support git repositories, refs, and repository subpaths when generating library documentation locally.
+  type: feat

--- a/packages/cli/configuration/src/docs-yml/ParsedDocsConfiguration.ts
+++ b/packages/cli/configuration/src/docs-yml/ParsedDocsConfiguration.ts
@@ -560,8 +560,8 @@ export type ParsedApiReferenceLayoutItem =
 
 /**
  * Parsed configuration for the source location of a library documentation source.
- * A `git` input is generated remotely; a `path` input points at a local checkout
- * and is generated with `fern docs md generate --local`.
+ * A `git` input can be generated remotely or resolved locally with `--local`;
+ * a `path` input points at a local checkout and requires `--local`.
  */
 export type ParsedLibraryInputConfiguration =
     | {

--- a/packages/cli/library-docs-generator/package.json
+++ b/packages/cli/library-docs-generator/package.json
@@ -37,6 +37,7 @@
     "@fern-api/docker-utils": "workspace:*",
     "@fern-api/fdr-sdk": "catalog:",
     "@fern-api/fs-utils": "workspace:*",
+    "@fern-api/github": "workspace:*",
     "@fern-api/task-context": "workspace:*",
     "chalk": "catalog:",
     "js-yaml": "catalog:",

--- a/packages/cli/library-docs-generator/src/LocalParserRunner.ts
+++ b/packages/cli/library-docs-generator/src/LocalParserRunner.ts
@@ -56,6 +56,8 @@ export interface LocalParserConfig {
     packagePath?: string;
     /** Source repository URL, embedded in the IR for source links. */
     sourceUrl?: string;
+    /** Source repository ref, embedded in the IR for source links. */
+    branch?: string;
     /** Contents of a Doxyfile, used only by the C++ parser. */
     doxyfileContent?: string;
 }
@@ -97,6 +99,7 @@ export async function runLocalParser({
             JSON.stringify({
                 packagePath: config.packagePath,
                 sourceUrl: config.sourceUrl,
+                branch: config.branch,
                 doxyfileContent: config.doxyfileContent
             })
         );

--- a/packages/cli/library-docs-generator/src/__test__/LocalParserRunner.test.ts
+++ b/packages/cli/library-docs-generator/src/__test__/LocalParserRunner.test.ts
@@ -50,7 +50,7 @@ describe("runLocalParser", () => {
             context: makeContext(),
             sourcePath: AbsoluteFilePath.of("/tmp/src"),
             language: "PYTHON",
-            config: { packagePath: "pkg", sourceUrl: "https://github.com/acme/sdk" }
+            config: { packagePath: "pkg", sourceUrl: "https://github.com/acme/sdk", branch: "v2.0.0" }
         });
 
         // The IR is unwrapped from the `{ ir, metadata }` envelope the parser writes.
@@ -66,7 +66,11 @@ describe("runLocalParser", () => {
         expect(call.platform).toBeUndefined();
         expect(call.binds).toContain("/tmp/src:/repo:ro");
         // `undefined` fields (e.g. doxyfileContent for Python) are dropped by JSON.stringify.
-        expect(writtenConfig).toEqual({ packagePath: "pkg", sourceUrl: "https://github.com/acme/sdk" });
+        expect(writtenConfig).toEqual({
+            packagePath: "pkg",
+            sourceUrl: "https://github.com/acme/sdk",
+            branch: "v2.0.0"
+        });
     });
 
     it("uses the C++ image and forwards doxyfileContent", async () => {

--- a/packages/cli/library-docs-generator/src/__test__/localGeneration.test.ts
+++ b/packages/cli/library-docs-generator/src/__test__/localGeneration.test.ts
@@ -1,3 +1,4 @@
+import { execFileSync } from "node:child_process";
 import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
@@ -20,7 +21,7 @@ import { runLibraryDocsGeneration } from "../orchestrate.js";
 
 /**
  * End-to-end coverage of the `fern docs md generate --local` path for a
- * `path` (local) input library.
+ * local path and git input libraries.
  *
  * Only the Docker boundary (`runContainer`) is mocked — it emits a realistic
  * `{ ir }` envelope to the container's `/output` mount, exactly as the real
@@ -205,10 +206,36 @@ describe("runLibraryDocsGeneration — --local path input (end-to-end to disk)",
         expect(clientPage).toContain("Entry point for the plant store SDK.");
     });
 
-    it("never shells out to Docker for a 'git' input under --local", async () => {
+    it("clones a git input and mounts the resolved checkout in Docker", async () => {
+        const origin = join(docsDir, "sdk-python");
+        execFileSync("git", ["init", "-b", "main"], { cwd: origin });
+        execFileSync("git", ["add", "--", "plantstore/__init__.py"], { cwd: origin });
+        execFileSync(
+            "git",
+            ["-c", "user.name=Fern Test", "-c", "user.email=test@buildwithfern.com", "commit", "-m", "initial"],
+            { cwd: origin }
+        );
+
+        const ir = pythonIr();
+        let parserConfig: Record<string, unknown> | undefined;
+        (runContainer as Mock).mockImplementation(async ({ binds }: { binds: string[] }) => {
+            const repoHostPath = hostPathForMount(binds, "/repo");
+            expect(repoHostPath).not.toBe(origin);
+            expect(existsSync(join(repoHostPath, "plantstore", "__init__.py"))).toBe(true);
+
+            parserConfig = JSON.parse(readFileSync(hostPathForMount(binds, "/input/config.json"), "utf-8")) as Record<
+                string,
+                unknown
+            >;
+            await writeFile(
+                join(hostPathForMount(binds, "/output"), "ir.json"),
+                JSON.stringify({ ir, metadata: { packageName: "plantstore" } })
+            );
+        });
+
         const libraries: Record<string, docsYml.RawSchemas.LibraryConfiguration> = {
             plantstore: {
-                input: { git: "https://github.com/acme/plantstore" },
+                input: { git: origin, ref: "main", subpath: "plantstore" },
                 output: { path: "./static/plant-sdk-docs" },
                 lang: "python"
             }
@@ -222,9 +249,14 @@ describe("runLibraryDocsGeneration — --local path input (end-to-end to disk)",
                 context: makeContext(),
                 local: true
             })
-        ).rejects.toThrow(/'git' inputs are generated remotely/);
+        ).resolves.toEqual({ successful: 1 });
 
-        expect(runContainer as Mock).not.toHaveBeenCalled();
-        expect(existsSync(join(docsDir, "static", "plant-sdk-docs"))).toBe(false);
+        expect(runContainer as Mock).toHaveBeenCalledTimes(1);
+        expect(parserConfig).toEqual({
+            packagePath: "plantstore",
+            sourceUrl: origin,
+            branch: "main"
+        });
+        expect(existsSync(join(docsDir, "static", "plant-sdk-docs", "_navigation.yml"))).toBe(true);
     });
 });

--- a/packages/cli/library-docs-generator/src/__test__/orchestrate.test.ts
+++ b/packages/cli/library-docs-generator/src/__test__/orchestrate.test.ts
@@ -241,24 +241,6 @@ describe("runLibraryDocsGeneration", () => {
         );
     });
 
-    it("rejects 'git' input under --local (git is generated remotely, never cloned locally)", async () => {
-        const context = makeContext();
-        await expect(
-            runLibraryDocsGeneration({
-                libraries: { "my-sdk": pythonConfig() },
-                docsDirectoryPath: DOCS_DIR,
-                orgId: "org",
-                context,
-                local: true
-            })
-        ).rejects.toThrow(/'git' inputs are generated remotely/);
-        // The CLI must never shell out to clone an untrusted git URL.
-        expect(LocalParserRunner.runLocalParser).not.toHaveBeenCalled();
-        // Failures are surfaced only via the thrown error — not also logged here,
-        // which previously double-printed every message.
-        expect(context.logger.error).not.toHaveBeenCalled();
-    });
-
     it("happy path: start → poll → download IR → generate (Python)", async () => {
         const { mockFn, startCalls } = makeMockFetch({
             startResponse: { body: { jobId: "job-1" } },
@@ -284,6 +266,41 @@ describe("runLibraryDocsGeneration", () => {
         expect(startCall.githubUrl).toBe("https://github.com/acme/sdk");
         expect(PythonDocsGenerator.generate).toHaveBeenCalledWith(
             expect.objectContaining({ ir: mockPythonIr, slug: "my-sdk", title: "my-sdk" })
+        );
+    });
+
+    it("remote mode: forwards a git ref and subpath to the generation service", async () => {
+        const { mockFn, startCalls } = makeMockFetch({
+            startResponse: { body: { jobId: "job-ref" } },
+            statusResponses: [{ body: makeStatus("COMPLETED") }]
+        });
+        globalThis.fetch = mockFn as unknown as typeof fetch;
+
+        const promise = runLibraryDocsGeneration({
+            libraries: {
+                "my-sdk": {
+                    input: {
+                        git: "https://github.com/acme/sdk",
+                        ref: "release/2.0",
+                        subpath: "packages/sdk"
+                    },
+                    output: { path: "./docs" },
+                    lang: "python"
+                }
+            },
+            docsDirectoryPath: DOCS_DIR,
+            orgId: "org",
+            tokenValue: "tok",
+            context: makeContext()
+        });
+        await vi.advanceTimersByTimeAsync(3000);
+        await promise;
+
+        expect((startCalls[0] as { config: unknown }).config).toEqual(
+            expect.objectContaining({
+                branch: "release/2.0",
+                packagePath: "packages/sdk"
+            })
         );
     });
 

--- a/packages/cli/library-docs-generator/src/orchestrate.ts
+++ b/packages/cli/library-docs-generator/src/orchestrate.ts
@@ -3,11 +3,12 @@ import { docsYml } from "@fern-api/configuration";
 import { extractErrorMessage } from "@fern-api/core-utils";
 import { FdrAPI } from "@fern-api/fdr-sdk";
 import { AbsoluteFilePath, resolve } from "@fern-api/fs-utils";
+import { cloneRepositoryAtRef, resolveRepositorySubpath } from "@fern-api/github";
 import { CliError, type TaskContext } from "@fern-api/task-context";
 import chalk from "chalk";
 
 import { generateCpp } from "./CppDocsGenerator.js";
-import { runLocalParser } from "./LocalParserRunner.js";
+import { type LocalParserConfig, runLocalParser } from "./LocalParserRunner.js";
 import { generate } from "./PythonDocsGenerator.js";
 import type { CppLibraryDocsIr } from "./types/CppLibraryDocsIr.js";
 
@@ -379,14 +380,9 @@ async function generateIrRemotely({
 }
 
 /**
- * Produces the library-docs IR by running the parser Docker image locally on a
- * `path` input. The source path is resolved relative to the docs directory and
- * mounted into the container.
- *
- * `--local` deliberately does NOT clone `git` inputs: cloning an attacker-
- * controlled repository (or git URL) on the user's machine / CI runner is a
- * code-execution risk, and the point of `--local` is to stay offline. `git`
- * inputs are handled remotely (server-side) instead.
+ * Produces the library-docs IR by running the parser Docker image locally.
+ * Local paths are resolved relative to the docs directory; git inputs are
+ * materialized at the configured branch, tag, or commit before parsing.
  */
 async function generateIrLocally({
     context,
@@ -405,20 +401,38 @@ async function generateIrLocally({
     doxyfileContent: string | undefined;
     wrapStep: StepWrapper;
 }): Promise<unknown> {
-    if (isGitLibraryInput(config.input)) {
-        throw new CliError({
-            message:
-                `Library '${name}': 'git' inputs are generated remotely, not with --local. ` +
-                `For --local, use a 'path' input pointing at a local checkout of the library.`,
-            code: CliError.Code.ConfigError
-        });
-    }
+    let sourcePath: AbsoluteFilePath;
+    let parserConfig: LocalParserConfig;
 
-    const sourcePath = resolve(docsDirectoryPath, config.input.path);
+    if (isGitLibraryInput(config.input)) {
+        const gitInput = config.input;
+        const clonePath = await wrapStep({
+            message: `Library '${name}': cloning ${gitInput.git}${gitInput.ref != null ? ` (ref: ${gitInput.ref})` : ""}`,
+            operation: () => cloneRepositoryAtRef({ repositoryUrl: gitInput.git, ref: gitInput.ref })
+        });
+        if (gitInput.subpath != null) {
+            resolveRepositorySubpath({
+                repositoryRoot: clonePath,
+                subpath: gitInput.subpath,
+                description: `subpath for library '${name}'`
+            });
+        }
+        // The parser reads the package at `packagePath` but resolves imports against the repo root.
+        sourcePath = AbsoluteFilePath.of(clonePath);
+        parserConfig = {
+            packagePath: gitInput.subpath,
+            sourceUrl: gitInput.git,
+            branch: gitInput.ref,
+            doxyfileContent
+        };
+    } else {
+        sourcePath = resolve(docsDirectoryPath, config.input.path);
+        parserConfig = { doxyfileContent };
+    }
 
     const ir = await wrapStep({
         message: `Library '${name}': parsing library source locally`,
-        operation: () => runLocalParser({ context, sourcePath, language, config: { doxyfileContent } })
+        operation: () => runLocalParser({ context, sourcePath, language, config: parserConfig })
     });
     validateLibraryIr(ir, language, name);
     return ir;

--- a/packages/cli/workspace/loader/package.json
+++ b/packages/cli/workspace/loader/package.json
@@ -38,13 +38,12 @@
     "@fern-api/core-utils": "workspace:*",
     "@fern-api/fern-definition-schema": "workspace:*",
     "@fern-api/fs-utils": "workspace:*",
+    "@fern-api/github": "workspace:*",
     "@fern-api/lazy-fern-workspace": "workspace:*",
     "@fern-api/logger": "workspace:*",
     "@fern-api/task-context": "workspace:*",
     "chalk": "catalog:",
     "js-yaml": "catalog:",
-    "simple-git": "catalog:",
-    "tmp-promise": "catalog:",
     "zod": "catalog:"
   },
   "devDependencies": {

--- a/packages/cli/workspace/loader/src/__test__/resolveRemoteSpecs.test.ts
+++ b/packages/cli/workspace/loader/src/__test__/resolveRemoteSpecs.test.ts
@@ -1,44 +1,23 @@
 import { generatorsYml } from "@fern-api/configuration-loader";
 import { AbsoluteFilePath } from "@fern-api/fs-utils";
+import * as Github from "@fern-api/github";
 import { createMockTaskContext } from "@fern-api/task-context";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { resolveRemoteSpecs } from "../resolveRemoteSpecs.js";
 
-// Mock simple-git
-vi.mock("simple-git", () => {
-    const mockClone = vi.fn();
-    const mockFetch = vi.fn();
-    const mockCheckout = vi.fn();
-    return {
-        simpleGit: () => ({
-            clone: mockClone,
-            fetch: mockFetch,
-            checkout: mockCheckout
-        }),
-        __mockClone: mockClone,
-        __mockFetch: mockFetch,
-        __mockCheckout: mockCheckout
-    };
-});
-
-// Mock tmp-promise
-vi.mock("tmp-promise", () => ({
-    default: {
-        dir: vi.fn().mockResolvedValue({ path: "/tmp/mock-clone-dir", cleanup: vi.fn() })
-    }
-}));
-
-// Mock child_process for isGitAvailable
-vi.mock("child_process", () => ({
-    execSync: vi.fn().mockReturnValue("git version 2.40.0")
+vi.mock("@fern-api/github", async (importOriginal) => ({
+    ...(await importOriginal<typeof import("@fern-api/github")>()),
+    cloneRepositoryAtRef: vi.fn()
 }));
 
 describe("resolveRemoteSpecs", () => {
     const context = createMockTaskContext();
+    const cloneRepositoryAtRef = vi.mocked(Github.cloneRepositoryAtRef);
 
     beforeEach(() => {
         vi.clearAllMocks();
+        cloneRepositoryAtRef.mockResolvedValue("/tmp/mock-clone-dir");
     });
 
     it("returns definitions unchanged when no git sources are present", async () => {
@@ -58,9 +37,6 @@ describe("resolveRemoteSpecs", () => {
     });
 
     it("resolves git source definitions to local paths", async () => {
-        const { __mockClone } = (await import("simple-git")) as unknown as { __mockClone: ReturnType<typeof vi.fn> };
-        __mockClone.mockResolvedValue(undefined);
-
         const definitions: generatorsYml.APIDefinitionLocation[] = [
             {
                 schema: { type: "oss", path: "openapi/service.yml" },
@@ -79,14 +55,10 @@ describe("resolveRemoteSpecs", () => {
 
         const result = await resolveRemoteSpecs({ definitions, context });
 
-        expect(__mockClone).toHaveBeenCalledWith("https://github.com/org/specs.git", "/tmp/mock-clone-dir", [
-            "--depth",
-            "1",
-            "--config",
-            "core.symlinks=false",
-            "--branch",
-            "main"
-        ]);
+        expect(cloneRepositoryAtRef).toHaveBeenCalledWith({
+            repositoryUrl: "https://github.com/org/specs.git",
+            ref: "main"
+        });
 
         expect(result[0]?.gitSource).toBeUndefined();
         expect(result[0]?.schema.type).toBe("oss");
@@ -96,9 +68,6 @@ describe("resolveRemoteSpecs", () => {
     });
 
     it("deduplicates clones for same repo+ref", async () => {
-        const { __mockClone } = (await import("simple-git")) as unknown as { __mockClone: ReturnType<typeof vi.fn> };
-        __mockClone.mockResolvedValue(undefined);
-
         const definitions: generatorsYml.APIDefinitionLocation[] = [
             {
                 schema: { type: "oss", path: "openapi/a.yml" },
@@ -131,13 +100,10 @@ describe("resolveRemoteSpecs", () => {
         await resolveRemoteSpecs({ definitions, context });
 
         // Should only clone once since both use the same repo+ref
-        expect(__mockClone).toHaveBeenCalledTimes(1);
+        expect(cloneRepositoryAtRef).toHaveBeenCalledTimes(1);
     });
 
     it("clones different repos separately", async () => {
-        const { __mockClone } = (await import("simple-git")) as unknown as { __mockClone: ReturnType<typeof vi.fn> };
-        __mockClone.mockResolvedValue(undefined);
-
         const definitions: generatorsYml.APIDefinitionLocation[] = [
             {
                 schema: { type: "oss", path: "openapi/a.yml" },
@@ -169,13 +135,10 @@ describe("resolveRemoteSpecs", () => {
 
         await resolveRemoteSpecs({ definitions, context });
 
-        expect(__mockClone).toHaveBeenCalledTimes(2);
+        expect(cloneRepositoryAtRef).toHaveBeenCalledTimes(2);
     });
 
-    it("omits --branch flag when ref is undefined", async () => {
-        const { __mockClone } = (await import("simple-git")) as unknown as { __mockClone: ReturnType<typeof vi.fn> };
-        __mockClone.mockResolvedValue(undefined);
-
+    it("forwards an undefined ref to clone the default branch", async () => {
         const definitions: generatorsYml.APIDefinitionLocation[] = [
             {
                 schema: { type: "oss", path: "spec.yml" },
@@ -194,17 +157,16 @@ describe("resolveRemoteSpecs", () => {
 
         await resolveRemoteSpecs({ definitions, context });
 
-        expect(__mockClone).toHaveBeenCalledWith("https://github.com/org/specs.git", "/tmp/mock-clone-dir", [
-            "--depth",
-            "1",
-            "--config",
-            "core.symlinks=false"
-        ]);
+        expect(cloneRepositoryAtRef).toHaveBeenCalledWith({
+            repositoryUrl: "https://github.com/org/specs.git",
+            ref: undefined
+        });
     });
 
     it("throws auth error on authentication failure", async () => {
-        const { __mockClone } = (await import("simple-git")) as unknown as { __mockClone: ReturnType<typeof vi.fn> };
-        __mockClone.mockRejectedValue(new Error("Authentication failed for 'https://github.com/org/private.git'"));
+        cloneRepositoryAtRef.mockRejectedValue(
+            new Error("Failed to clone https://github.com/org/private.git: authentication failed")
+        );
 
         const definitions: generatorsYml.APIDefinitionLocation[] = [
             {
@@ -226,8 +188,9 @@ describe("resolveRemoteSpecs", () => {
     });
 
     it("throws not-found error when repo does not exist", async () => {
-        const { __mockClone } = (await import("simple-git")) as unknown as { __mockClone: ReturnType<typeof vi.fn> };
-        __mockClone.mockRejectedValue(new Error("Repository not found"));
+        cloneRepositoryAtRef.mockRejectedValue(
+            new Error("Failed to clone https://github.com/org/nonexistent.git: repository not found")
+        );
 
         const definitions: generatorsYml.APIDefinitionLocation[] = [
             {
@@ -249,9 +212,6 @@ describe("resolveRemoteSpecs", () => {
     });
 
     it("resolves protobuf definitions correctly (root and target)", async () => {
-        const { __mockClone } = (await import("simple-git")) as unknown as { __mockClone: ReturnType<typeof vi.fn> };
-        __mockClone.mockResolvedValue(undefined);
-
         const definitions: generatorsYml.APIDefinitionLocation[] = [
             {
                 schema: {
@@ -286,9 +246,6 @@ describe("resolveRemoteSpecs", () => {
     });
 
     it("resolves protobuf target as empty string when not specified", async () => {
-        const { __mockClone } = (await import("simple-git")) as unknown as { __mockClone: ReturnType<typeof vi.fn> };
-        __mockClone.mockResolvedValue(undefined);
-
         const definitions: generatorsYml.APIDefinitionLocation[] = [
             {
                 schema: {
@@ -319,16 +276,7 @@ describe("resolveRemoteSpecs", () => {
         }
     });
 
-    it("uses fetch+checkout flow for commit SHA refs", async () => {
-        const { __mockClone, __mockFetch, __mockCheckout } = (await import("simple-git")) as unknown as {
-            __mockClone: ReturnType<typeof vi.fn>;
-            __mockFetch: ReturnType<typeof vi.fn>;
-            __mockCheckout: ReturnType<typeof vi.fn>;
-        };
-        __mockClone.mockResolvedValue(undefined);
-        __mockFetch.mockResolvedValue(undefined);
-        __mockCheckout.mockResolvedValue(undefined);
-
+    it("forwards commit SHA refs", async () => {
         const definitions: generatorsYml.APIDefinitionLocation[] = [
             {
                 schema: { type: "oss", path: "openapi/service.yml" },
@@ -347,30 +295,13 @@ describe("resolveRemoteSpecs", () => {
 
         await resolveRemoteSpecs({ definitions, context });
 
-        // Should clone without --branch
-        expect(__mockClone).toHaveBeenCalledWith("https://github.com/org/specs.git", "/tmp/mock-clone-dir", [
-            "--depth",
-            "1",
-            "--config",
-            "core.symlinks=false",
-            "--no-checkout"
-        ]);
-        // Should fetch the specific commit
-        expect(__mockFetch).toHaveBeenCalledWith("origin", "a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2", {
-            "--depth": "1"
+        expect(cloneRepositoryAtRef).toHaveBeenCalledWith({
+            repositoryUrl: "https://github.com/org/specs.git",
+            ref: "a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2"
         });
-        // Should checkout the commit
-        expect(__mockCheckout).toHaveBeenCalledWith("a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2");
     });
 
-    it("uses --branch flow for non-SHA refs", async () => {
-        const { __mockClone, __mockFetch } = (await import("simple-git")) as unknown as {
-            __mockClone: ReturnType<typeof vi.fn>;
-            __mockFetch: ReturnType<typeof vi.fn>;
-        };
-        __mockClone.mockResolvedValue(undefined);
-        __mockFetch.mockResolvedValue(undefined);
-
+    it("forwards branch and tag refs", async () => {
         const definitions: generatorsYml.APIDefinitionLocation[] = [
             {
                 schema: { type: "oss", path: "spec.yml" },
@@ -389,23 +320,13 @@ describe("resolveRemoteSpecs", () => {
 
         await resolveRemoteSpecs({ definitions, context });
 
-        // Should use --branch for tags/branches
-        expect(__mockClone).toHaveBeenCalledWith("https://github.com/org/specs.git", "/tmp/mock-clone-dir", [
-            "--depth",
-            "1",
-            "--config",
-            "core.symlinks=false",
-            "--branch",
-            "v1.2.3"
-        ]);
-        // Should NOT use fetch+checkout
-        expect(__mockFetch).not.toHaveBeenCalled();
+        expect(cloneRepositoryAtRef).toHaveBeenCalledWith({
+            repositoryUrl: "https://github.com/org/specs.git",
+            ref: "v1.2.3"
+        });
     });
 
     it("rejects absolute paths that escape the cloned directory", async () => {
-        const { __mockClone } = (await import("simple-git")) as unknown as { __mockClone: ReturnType<typeof vi.fn> };
-        __mockClone.mockResolvedValue(undefined);
-
         const definitions: generatorsYml.APIDefinitionLocation[] = [
             {
                 schema: { type: "oss", path: "/etc/passwd" },
@@ -428,9 +349,6 @@ describe("resolveRemoteSpecs", () => {
     });
 
     it("rejects paths with directory traversal sequences", async () => {
-        const { __mockClone } = (await import("simple-git")) as unknown as { __mockClone: ReturnType<typeof vi.fn> };
-        __mockClone.mockResolvedValue(undefined);
-
         const definitions: generatorsYml.APIDefinitionLocation[] = [
             {
                 schema: { type: "oss", path: "../../proc/self/environ" },

--- a/packages/cli/workspace/loader/src/resolveRemoteSpecs.ts
+++ b/packages/cli/workspace/loader/src/resolveRemoteSpecs.ts
@@ -1,11 +1,7 @@
 import { generatorsYml } from "@fern-api/configuration-loader";
-import { extractErrorMessage, isCommitSha, isGitAvailable } from "@fern-api/core-utils";
 import { AbsoluteFilePath } from "@fern-api/fs-utils";
+import { cloneRepositoryAtRef, resolveRepositorySubpath } from "@fern-api/github";
 import { TaskContext } from "@fern-api/task-context";
-
-import path from "path";
-import { simpleGit } from "simple-git";
-import tmp from "tmp-promise";
 
 interface CloneTarget {
     repo: string;
@@ -33,14 +29,6 @@ export async function resolveRemoteSpecs({
         return definitions;
     }
 
-    if (!isGitAvailable()) {
-        throw new Error(
-            "Git is not installed or not found in PATH. " +
-                "Remote git sources in generators.yml require git to be available. " +
-                "Please install git and ensure it is in your PATH."
-        );
-    }
-
     // Deduplicate repos to clone (same repo+ref → same clone)
     const cloneTargets = new Map<string, CloneTarget>();
     for (const def of gitDefinitions) {
@@ -59,62 +47,8 @@ export async function resolveRemoteSpecs({
     const clonedPaths = new Map<string, AbsoluteFilePath>();
     for (const [key, target] of cloneTargets.entries()) {
         context.logger.info(`Cloning remote spec source: ${target.repo}${target.ref ? `@${target.ref}` : ""}`);
-        const tmpDir = await tmp.dir({ unsafeCleanup: true });
-        const clonePath = AbsoluteFilePath.of(tmpDir.path);
-
-        const git = simpleGit();
-        const useCommitShaFlow = target.ref != null && isCommitSha(target.ref);
-
-        try {
-            if (useCommitShaFlow) {
-                // Commit SHAs cannot be used with --branch; fetch the specific commit instead
-                const ref = target.ref as string;
-                const cloneArgs = ["--depth", "1", "--config", "core.symlinks=false", "--no-checkout"];
-                await git.clone(target.repo, tmpDir.path, cloneArgs);
-                const repoGit = simpleGit(tmpDir.path);
-                await repoGit.fetch("origin", ref, { "--depth": "1" });
-                await repoGit.checkout(ref);
-            } else {
-                const cloneArgs = ["--depth", "1", "--config", "core.symlinks=false"];
-                if (target.ref != null) {
-                    cloneArgs.push("--branch", target.ref);
-                }
-                await git.clone(target.repo, tmpDir.path, cloneArgs);
-            }
-        } catch (error) {
-            const errorMessage = extractErrorMessage(error);
-            if (
-                errorMessage.includes("Authentication failed") ||
-                errorMessage.includes("could not read Username") ||
-                errorMessage.includes("401") ||
-                errorMessage.includes("403")
-            ) {
-                throw new Error(
-                    `Failed to clone remote spec source: authentication failed. ` +
-                        `Ensure your git credentials are configured for ${target.repo}. ` +
-                        `The CLI uses your system's git credential configuration (credential helpers, SSH keys, GIT_ASKPASS). ` +
-                        `Original error: ${errorMessage}`
-                );
-            }
-            if (
-                errorMessage.includes("Repository not found") ||
-                errorMessage.includes("not found") ||
-                errorMessage.includes("404")
-            ) {
-                throw new Error(
-                    `Failed to clone remote spec source: repository not found. ` +
-                        `Check that ${target.repo} exists and your credentials have access. ` +
-                        `Original error: ${errorMessage}`
-                );
-            }
-            throw new Error(
-                `Failed to clone remote spec source ${target.repo}` +
-                    `${target.ref ? ` at ref '${target.ref}'` : ""}. ` +
-                    `Original error: ${errorMessage}`
-            );
-        }
-
-        clonedPaths.set(key, clonePath);
+        const clonePath = await cloneRepositoryAtRef({ repositoryUrl: target.repo, ref: target.ref });
+        clonedPaths.set(key, AbsoluteFilePath.of(clonePath));
     }
 
     // Replace git sources with resolved local paths
@@ -130,29 +64,24 @@ export async function resolveRemoteSpecs({
             throw new Error(`Internal error: no clone found for ${key}`);
         }
 
-        // Validate the path to prevent directory traversal attacks
-        const resolvedPath = AbsoluteFilePath.of(path.resolve(clonedPath, def.gitSource.path));
-        if (!resolvedPath.startsWith(clonedPath + path.sep) && resolvedPath !== clonedPath) {
-            throw new Error(
-                `Invalid git source path '${def.gitSource.path}': ` +
-                    `path must be relative to the repository root and cannot traverse outside it.`
-            );
-        }
+        const resolvedPath = AbsoluteFilePath.of(
+            resolveRepositorySubpath({
+                repositoryRoot: clonedPath,
+                subpath: def.gitSource.path,
+                description: "git source path"
+            })
+        );
 
         if (def.schema.type === "protobuf") {
             // Resolve target relative to the cloned repo root (not the proto root)
             const resolvedTarget =
-                def.schema.target.length > 0 ? path.resolve(clonedPath, def.schema.target) : def.schema.target;
-            if (
-                resolvedTarget.length > 0 &&
-                !resolvedTarget.startsWith(clonedPath + path.sep) &&
-                resolvedTarget !== clonedPath
-            ) {
-                throw new Error(
-                    `Invalid proto target path '${def.schema.target}': ` +
-                        `path must be relative to the repository root and cannot traverse outside it.`
-                );
-            }
+                def.schema.target.length > 0
+                    ? resolveRepositorySubpath({
+                          repositoryRoot: clonedPath,
+                          subpath: def.schema.target,
+                          description: "proto target path"
+                      })
+                    : def.schema.target;
             return {
                 ...def,
                 schema: {

--- a/packages/commons/github/src/__test__/cloneRepositoryAtRef.test.ts
+++ b/packages/commons/github/src/__test__/cloneRepositoryAtRef.test.ts
@@ -1,0 +1,114 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { cloneRepositoryAtRef, resolveRepositorySubpath } from "../cloneRepositoryAtRef.js";
+
+const mocks = vi.hoisted(() => ({
+    checkout: vi.fn(),
+    clone: vi.fn(),
+    fetch: vi.fn()
+}));
+
+vi.mock("@fern-api/core-utils", async (importOriginal) => ({
+    ...(await importOriginal<typeof import("@fern-api/core-utils")>()),
+    isGitAvailable: () => true
+}));
+
+vi.mock("tmp-promise", () => ({
+    default: {
+        dir: vi.fn().mockResolvedValue({ path: "/tmp/clone" })
+    }
+}));
+
+vi.mock("simple-git", () => ({
+    simpleGit: (baseDir?: string) =>
+        baseDir == null
+            ? { clone: mocks.clone }
+            : {
+                  checkout: mocks.checkout,
+                  fetch: mocks.fetch
+              }
+}));
+
+describe("cloneRepositoryAtRef", () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it("clones the default branch when ref is omitted", async () => {
+        await cloneRepositoryAtRef({ repositoryUrl: "https://github.com/acme/sdk", ref: undefined });
+
+        expect(mocks.clone).toHaveBeenCalledWith("https://github.com/acme/sdk", "/tmp/clone", [
+            "--depth",
+            "1",
+            "--config",
+            "core.symlinks=false"
+        ]);
+    });
+
+    it("clones branch and tag refs with --branch", async () => {
+        await cloneRepositoryAtRef({ repositoryUrl: "https://github.com/acme/sdk", ref: "v2.0.0" });
+
+        expect(mocks.clone).toHaveBeenCalledWith("https://github.com/acme/sdk", "/tmp/clone", [
+            "--depth",
+            "1",
+            "--config",
+            "core.symlinks=false",
+            "--branch",
+            "v2.0.0"
+        ]);
+    });
+
+    it("fetches and checks out commit refs", async () => {
+        const ref = "a1b2c3d";
+
+        await cloneRepositoryAtRef({ repositoryUrl: "https://github.com/acme/sdk", ref });
+
+        expect(mocks.clone).toHaveBeenCalledWith("https://github.com/acme/sdk", "/tmp/clone", [
+            "--depth",
+            "1",
+            "--config",
+            "core.symlinks=false",
+            "--no-checkout"
+        ]);
+        expect(mocks.fetch).toHaveBeenCalledWith("origin", ref, { "--depth": "1" });
+        expect(mocks.checkout).toHaveBeenCalledWith(ref);
+    });
+
+    it("includes invalid refs in clone errors", async () => {
+        mocks.clone.mockRejectedValue(new Error("Remote branch missing not found"));
+
+        await expect(
+            cloneRepositoryAtRef({ repositoryUrl: "https://github.com/acme/sdk", ref: "missing" })
+        ).rejects.toThrow("at ref 'missing'");
+    });
+
+    it("identifies missing repositories", async () => {
+        mocks.clone.mockRejectedValue(new Error("remote: Repository not found."));
+
+        await expect(
+            cloneRepositoryAtRef({ repositoryUrl: "https://github.com/acme/missing", ref: undefined })
+        ).rejects.toThrow("repository not found");
+    });
+});
+
+describe("resolveRepositorySubpath", () => {
+    it("resolves paths within the repository", () => {
+        expect(
+            resolveRepositorySubpath({
+                repositoryRoot: "/tmp/clone",
+                subpath: "packages/sdk",
+                description: "library subpath"
+            })
+        ).toBe("/tmp/clone/packages/sdk");
+    });
+
+    it("rejects paths outside the repository", () => {
+        expect(() =>
+            resolveRepositorySubpath({
+                repositoryRoot: "/tmp/clone",
+                subpath: "../outside",
+                description: "library subpath"
+            })
+        ).toThrow("path must be relative to the repository root and cannot traverse outside it");
+    });
+});

--- a/packages/commons/github/src/__test__/cloneRepositoryAtRef.test.ts
+++ b/packages/commons/github/src/__test__/cloneRepositoryAtRef.test.ts
@@ -5,7 +5,8 @@ import { cloneRepositoryAtRef, resolveRepositorySubpath } from "../cloneReposito
 const mocks = vi.hoisted(() => ({
     checkout: vi.fn(),
     clone: vi.fn(),
-    fetch: vi.fn()
+    fetch: vi.fn(),
+    setGracefulCleanup: vi.fn()
 }));
 
 vi.mock("@fern-api/core-utils", async (importOriginal) => ({
@@ -15,7 +16,8 @@ vi.mock("@fern-api/core-utils", async (importOriginal) => ({
 
 vi.mock("tmp-promise", () => ({
     default: {
-        dir: vi.fn().mockResolvedValue({ path: "/tmp/clone" })
+        dir: vi.fn().mockResolvedValue({ path: "/tmp/clone" }),
+        setGracefulCleanup: mocks.setGracefulCleanup
     }
 }));
 
@@ -31,7 +33,13 @@ vi.mock("simple-git", () => ({
 
 describe("cloneRepositoryAtRef", () => {
     beforeEach(() => {
-        vi.clearAllMocks();
+        mocks.checkout.mockReset();
+        mocks.clone.mockReset();
+        mocks.fetch.mockReset();
+    });
+
+    it("registers temporary clones for process-exit cleanup", () => {
+        expect(mocks.setGracefulCleanup).toHaveBeenCalledOnce();
     });
 
     it("clones the default branch when ref is omitted", async () => {

--- a/packages/commons/github/src/cloneRepositoryAtRef.ts
+++ b/packages/commons/github/src/cloneRepositoryAtRef.ts
@@ -3,6 +3,8 @@ import path from "path";
 import { simpleGit } from "simple-git";
 import tmp from "tmp-promise";
 
+tmp.setGracefulCleanup();
+
 /**
  * Shallow-clones `repositoryUrl` at `ref` (a branch, tag, or commit SHA; the
  * default branch when omitted) into a temporary directory and returns its path.

--- a/packages/commons/github/src/cloneRepositoryAtRef.ts
+++ b/packages/commons/github/src/cloneRepositoryAtRef.ts
@@ -1,0 +1,95 @@
+import { extractErrorMessage, isCommitSha, isGitAvailable } from "@fern-api/core-utils";
+import path from "path";
+import { simpleGit } from "simple-git";
+import tmp from "tmp-promise";
+
+/**
+ * Shallow-clones `repositoryUrl` at `ref` (a branch, tag, or commit SHA; the
+ * default branch when omitted) into a temporary directory and returns its path.
+ * Symlinks are not materialized so a checkout cannot point outside itself.
+ */
+export async function cloneRepositoryAtRef({
+    repositoryUrl,
+    ref
+}: {
+    repositoryUrl: string;
+    ref: string | undefined;
+}): Promise<string> {
+    if (!isGitAvailable()) {
+        throw new Error(
+            "Git is not installed or not found in PATH. " +
+                "Cloning a git source requires git to be available. " +
+                "Please install git and ensure it is in your PATH."
+        );
+    }
+
+    const tmpDir = await tmp.dir({ unsafeCleanup: true });
+    const cloneArgs = ["--depth", "1", "--config", "core.symlinks=false"];
+
+    try {
+        if (ref != null && isCommitSha(ref)) {
+            // Commit SHAs cannot be used with --branch; fetch the specific commit instead.
+            await simpleGit().clone(repositoryUrl, tmpDir.path, [...cloneArgs, "--no-checkout"]);
+            const repoGit = simpleGit(tmpDir.path);
+            await repoGit.fetch("origin", ref, { "--depth": "1" });
+            await repoGit.checkout(ref);
+        } else {
+            await simpleGit().clone(
+                repositoryUrl,
+                tmpDir.path,
+                ref != null ? [...cloneArgs, "--branch", ref] : cloneArgs
+            );
+        }
+    } catch (error) {
+        const errorMessage = extractErrorMessage(error);
+        if (
+            errorMessage.includes("Authentication failed") ||
+            errorMessage.includes("could not read Username") ||
+            errorMessage.includes("401") ||
+            errorMessage.includes("403")
+        ) {
+            throw new Error(
+                `Failed to clone ${repositoryUrl}: authentication failed. ` +
+                    `Ensure your git credentials are configured for that repository. ` +
+                    `The CLI uses your system's git credential configuration (credential helpers, SSH keys, GIT_ASKPASS). ` +
+                    `Original error: ${errorMessage}`
+            );
+        }
+        if (errorMessage.toLowerCase().includes("repository not found") || errorMessage.includes("404")) {
+            throw new Error(
+                `Failed to clone ${repositoryUrl}: repository not found. ` +
+                    `Check that it exists and your credentials have access. ` +
+                    `Original error: ${errorMessage}`
+            );
+        }
+        throw new Error(
+            `Failed to clone ${repositoryUrl}${ref != null ? ` at ref '${ref}'` : ""}. ` +
+                `Original error: ${errorMessage}`
+        );
+    }
+
+    return tmpDir.path;
+}
+
+/**
+ * Resolves `subpath` against a cloned repository root, rejecting paths that
+ * escape the clone.
+ */
+export function resolveRepositorySubpath({
+    repositoryRoot,
+    subpath,
+    description
+}: {
+    repositoryRoot: string;
+    subpath: string;
+    description: string;
+}): string {
+    const resolved = path.resolve(repositoryRoot, subpath);
+    if (resolved !== repositoryRoot && !resolved.startsWith(repositoryRoot + path.sep)) {
+        throw new Error(
+            `Invalid ${description} '${subpath}': ` +
+                `path must be relative to the repository root and cannot traverse outside it.`
+        );
+    }
+    return resolved;
+}

--- a/packages/commons/github/src/index.ts
+++ b/packages/commons/github/src/index.ts
@@ -1,5 +1,6 @@
 export { ClonedRepository } from "./ClonedRepository.js";
 export { cloneRepository } from "./cloneRepository.js";
+export { cloneRepositoryAtRef, resolveRepositorySubpath } from "./cloneRepositoryAtRef.js";
 export { createOrUpdatePullRequest } from "./createOrUpdatePullRequest.js";
 export { deleteBranch } from "./deleteBranch.js";
 export { expandFernignorePatterns } from "./expandFernignorePatterns.js";

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6591,6 +6591,9 @@ importers:
       '@fern-api/fs-utils':
         specifier: workspace:*
         version: link:../../commons/fs-utils
+      '@fern-api/github':
+        specifier: workspace:*
+        version: link:../../commons/github
       '@fern-api/task-context':
         specifier: workspace:*
         version: link:../task-context
@@ -7251,6 +7254,9 @@ importers:
       '@fern-api/fs-utils':
         specifier: workspace:*
         version: link:../../../commons/fs-utils
+      '@fern-api/github':
+        specifier: workspace:*
+        version: link:../../../commons/github
       '@fern-api/lazy-fern-workspace':
         specifier: workspace:*
         version: link:../lazy-fern-workspace
@@ -7266,12 +7272,6 @@ importers:
       js-yaml:
         specifier: '>=4.2.0'
         version: 4.2.0
-      simple-git:
-        specifier: 'catalog:'
-        version: 3.36.0
-      tmp-promise:
-        specifier: 'catalog:'
-        version: 3.0.3
       zod:
         specifier: 'catalog:'
         version: 3.25.76


### PR DESCRIPTION
## Description
Linear ticket: Closes 

Allow `fern docs md generate --local` to resolve library documentation inputs from git repositories, including optional refs and repository-relative subpaths.

## Changes Made
- Extract the existing shallow clone/ref materialization behavior from remote spec loading into `@fern-api/github`, preserving default-branch, branch/tag, and commit-SHA handling.
- Reuse that helper for local library docs, mount the repository root at `/repo`, and forward `packagePath`, source URL, and configured ref to the parser.
- Register process-exit cleanup for temporary repository checkouts.
- Add focused clone/path validation tests, a local git generation integration test, remote metadata regression coverage, and a CLI changelog entry.
- [ ] Updated README.md generator (if applicable)

## Testing
- [x] Unit tests added/updated
- [ ] Manual testing completed
- `pnpm turbo run compile --filter @fern-api/github --filter @fern-api/configuration-loader --filter @fern-api/library-docs-generator --filter @fern-api/workspace-loader`
- `pnpm turbo run test --filter @fern-api/github --filter @fern-api/library-docs-generator --filter @fern-api/workspace-loader`
- `pnpm turbo run test --filter @fern-api/configuration-loader -- src/docs-yml/__test__/gitRefVersioning.matrix.test.ts`
- `pnpm turbo run depcheck --filter @fern-api/github --filter @fern-api/configuration-loader --filter @fern-api/library-docs-generator --filter @fern-api/workspace-loader`
- `pnpm lint:biome --fix && pnpm format:fix && pnpm check:fix`
- `pnpm test:ete` ran 168 passing tests; the suite still reported two `.fernignore` timeouts, a missing `FERN_ORG_TOKEN_DEV`, and an existing validate snapshot mismatch.

Link to Devin session: https://app.devin.ai/sessions/33a7d2928e6a4665be1498ed388596ac
Requested by: @Ryan-Amirthan
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/17510" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->