### PR TITLE
feat(cli): allow a generator image to be pinned by digest

### DIFF
--- a/packages/cli/cli/changes/unreleased/image-digest-pinning.yml
+++ b/packages/cli/cli/changes/unreleased/image-digest-pinning.yml
@@ -1,0 +1,9 @@
+# yaml-language-server: $schema=../../../../../fern-changes-yml.schema.json
+
+- summary: |
+      A generator image can now be pinned by digest in generators.yml, for example
+      `name: fern-python-sdk@sha256:...`. The digest is passed through to the container runtime
+      unchanged so the exact pinned image runs, while the generator name used for IR version
+      resolution is unaffected. A malformed digest is rejected with an error naming generators.yml.
+      Tag-based references are unchanged.
+  type: internal

--- a/packages/cli/configuration-loader/src/generators-yml/__test__/splitImageDigest.test.ts
+++ b/packages/cli/configuration-loader/src/generators-yml/__test__/splitImageDigest.test.ts
@@ -1,0 +1,50 @@
+import type { TaskContext } from "@fern-api/task-context";
+import { describe, expect, it, vi } from "vitest";
+
+import { splitImageDigest } from "../convertGeneratorsConfiguration.js";
+
+const VALID_DIGEST = `sha256:${"a".repeat(64)}`;
+
+function taskContext(): TaskContext {
+    return {
+        failAndThrow: vi.fn((message?: string) => {
+            throw new Error(message);
+        }),
+        logger: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn(), log: vi.fn() }
+        // biome-ignore lint/suspicious/noExplicitAny: only the members under test are stubbed
+    } as any;
+}
+
+describe("splitImageDigest", () => {
+    it("returns the name untouched when no digest is present", () => {
+        expect(splitImageDigest("fern-python-sdk", taskContext())).toEqual({
+            name: "fern-python-sdk",
+            digest: undefined
+        });
+    });
+
+    it("separates a digest from the image name", () => {
+        expect(splitImageDigest(`fern-python-sdk@${VALID_DIGEST}`, taskContext())).toEqual({
+            name: "fern-python-sdk",
+            digest: VALID_DIGEST
+        });
+    });
+
+    // The name is what IR version resolution is keyed on, so it must survive the split unchanged
+    // even when the image is pinned.
+    it("leaves an org-qualified name intact", () => {
+        expect(splitImageDigest(`fernapi/fern-python-sdk@${VALID_DIGEST}`, taskContext()).name).toBe(
+            "fernapi/fern-python-sdk"
+        );
+    });
+
+    it.each([
+        ["a truncated digest", "sha256:abc123"],
+        ["uppercase hex", `sha256:${"A".repeat(64)}`],
+        ["a missing algorithm prefix", "a".repeat(64)],
+        ["an unsupported algorithm", `sha512:${"a".repeat(64)}`],
+        ["an empty digest", ""]
+    ])("rejects %s with an error naming generators.yml", (_label, digest) => {
+        expect(() => splitImageDigest(`fern-python-sdk@${digest}`, taskContext())).toThrowError(/generators\.yml/);
+    });
+});

--- a/packages/cli/configuration-loader/src/generators-yml/convertGeneratorsConfiguration.ts
+++ b/packages/cli/configuration-loader/src/generators-yml/convertGeneratorsConfiguration.ts
@@ -652,6 +652,37 @@ async function convertGroup({
     };
 }
 
+/**
+ * Separates an optional `@sha256:...` digest from an image name.
+ *
+ * Pinning by digest is how an immutable deployment is expressed: a tag can be repointed, a digest
+ * cannot. The digest is carried on the image reference while the generator name stays clean, because
+ * the name is also what IR version resolution is keyed on.
+ */
+export function splitImageDigest(
+    imageName: string,
+    context: TaskContext
+): { name: string; digest: string | undefined } {
+    const atIndex = imageName.indexOf("@");
+    if (atIndex === -1) {
+        return { name: imageName, digest: undefined };
+    }
+
+    const name = imageName.slice(0, atIndex);
+    const digest = imageName.slice(atIndex + 1);
+
+    // Rejected rather than passed through: an unusable digest that reaches the container runtime
+    // fails with a runtime error that does not name generators.yml as the cause.
+    if (!/^sha256:[0-9a-f]{64}$/.test(digest)) {
+        context.failAndThrow(
+            `Invalid image digest "${digest}" in generators.yml. ` +
+                "A digest must look like sha256: followed by 64 lowercase hex characters."
+        );
+    }
+
+    return { name, digest };
+}
+
 function getGeneratorNameAndImage(
     generator: generatorsYml.GeneratorInvocationSchema,
     context: TaskContext
@@ -664,11 +695,15 @@ function getGeneratorNameAndImage(
         // (FDR expects fully-qualified names like "fernapi/fern-typescript-sdk"), but use the
         // corrected (non-prefixed) name for the containerImage since the fernapi/ Docker Hub
         // org should not appear in custom registry paths.
-        const correctedImageName = correctIncorrectDockerOrgWithWarning(generator.image.name, context);
+        //
+        // A digest is split off before normalization: it belongs to the image reference, not to the
+        // generator identity, and IR version resolution must still see a clean name.
+        const { name: imageNameWithoutDigest, digest } = splitImageDigest(generator.image.name, context);
+        const correctedImageName = correctIncorrectDockerOrgWithWarning(imageNameWithoutDigest, context);
         const normalizedImageName = addDefaultDockerOrgIfNotPresent(correctedImageName);
         return {
             normalizedName: normalizedImageName,
-            containerImage: `${generator.image.registry}/${correctedImageName}`
+            containerImage: `${generator.image.registry}/${correctedImageName}${digest != null ? `@${digest}` : ""}`
         };
     }
     // DefaultGeneratorInvocationSchema — apply Docker Hub org normalization

--- a/packages/cli/generation/local-generation/local-workspace-runner/src/__test__/adapterCapabilityLabels.test.ts
+++ b/packages/cli/generation/local-generation/local-workspace-runner/src/__test__/adapterCapabilityLabels.test.ts
@@ -50,6 +50,28 @@ describe("resolveGeneratorImage", () => {
     });
 });
 
+describe("resolveGeneratorImage with a pinned digest", () => {
+    it("returns the digest reference unchanged rather than appending a tag", () => {
+        expect(
+            resolveGeneratorImage({
+                containerImage: "ghcr.io/acme/fern-python-sdk@sha256:" + "a".repeat(64),
+                name: "fernapi/fern-python-sdk",
+                version: "4.0.0"
+            })
+        ).toBe("ghcr.io/acme/fern-python-sdk@sha256:" + "a".repeat(64));
+    });
+
+    it("still tags a reference that carries no digest", () => {
+        expect(
+            resolveGeneratorImage({
+                containerImage: "ghcr.io/acme/fern-python-sdk",
+                name: "fernapi/fern-python-sdk",
+                version: "4.0.0"
+            })
+        ).toBe("ghcr.io/acme/fern-python-sdk:4.0.0");
+    });
+});
+
 describe("generatorWantsSpecs", () => {
     it("keeps the existing first-party allowlist working", () => {
         expect(generatorWantsSpecs("fernapi/fern-cli-generator")).toBe(true);

--- a/packages/cli/generation/local-generation/local-workspace-runner/src/constants.ts
+++ b/packages/cli/generation/local-generation/local-workspace-runner/src/constants.ts
@@ -85,5 +85,10 @@ export function resolveGeneratorImage(generatorInvocation: {
     version: string;
 }): string {
     const repository = generatorInvocation.containerImage ?? generatorInvocation.name;
+    // A digest already identifies an exact image, and `repo@sha256:...:1.2.3` is not a valid
+    // reference. Appending the version would also defeat the point of pinning.
+    if (repository.includes("@sha256:")) {
+        return repository;
+    }
     return `${repository}:${generatorInvocation.version}`;
 }


### PR DESCRIPTION
## Description

`generators.yml` can express a generator image by registry and name, resolved as `${registry}/${name}:${version}`. There is no digest path anywhere in that chain, so an image can only be identified by a tag — and a tag can be repointed at different content after the fact.

This accepts a digest in the image object:

```yaml
- image:
    name: fern-python-sdk@sha256:0f5a...  # 64 hex chars
    registry: ghcr.io/your-org
  version: 4.0.0
```

## How

- **The digest is split off before name normalization.** The name is also what IR version resolution is keyed on, so it has to stay clean — `fernapi/fern-python-sdk` still resolves the correct IR version while the image reference carries the pin.
- **Reattached to the container image reference**, so the exact pinned image runs.
- **Image resolution skips appending the version when a digest is present.** `repo@sha256:...:1.2.3` is not a valid reference, and tagging a digest would defeat the pin anyway.
- **A malformed digest is rejected at configuration load**, with an error naming `generators.yml`. Passing it through means failing later as an opaque container runtime error that does not point at the config.

Tag-based references are unchanged.

## Testing

8 tests on the digest split — clean names pass through untouched, org-qualified names survive, and truncated digests, uppercase hex, missing algorithm prefix, unsupported algorithm and empty digests are each rejected. Plus 2 on image resolution: a digest reference is returned unchanged, a tag reference is still tagged.

I also confirmed against real Docker that the reference shape we emit is valid and runs: `docker run busybox@sha256:73aaf090...` executes the pinned image.

One pre-existing failure in this package, `docs-yml/gitRefVersioning.matrix.test.ts`, fails identically on `main` without these changes.

## Deviation from the obvious approach

The ticket behind this also asked to "surface a clear error when a digest is supplied but unsupported by the configured runner". Both Docker and Podman support digest references, so I could not produce a runner that fails this way and did not want to write a guard I could not exercise. Digest *format* validation is implemented instead, which is the failure mode users will actually hit. Happy to add runner detection if you know of a case that needs it.

## Note

Stacked on #17508 — review that one first. Draft while related work settles.
