### PR TITLE
fix(go): return the response when the deadline is shorter than the retry backoff

### DIFF
--- a/generators/go-v2/base/src/asIs/internal/retrier.go_
+++ b/generators/go-v2/base/src/asIs/internal/retrier.go_
@@ -145,12 +145,20 @@ func (r *Retrier) run(
 	}
 
 	if r.shouldRetry(response) {
-		defer func() { _ = response.Body.Close() }()
-
 		delay, err := r.retryDelay(response, retryAttempt)
 		if err != nil {
+			_ = response.Body.Close()
 			return nil, err
 		}
+
+		// If the context's deadline would elapse before the backoff completes, return
+		// the response instead of sleeping through it. The caller then sees why the
+		// request actually failed (e.g. a 429) rather than a context deadline error.
+		if deadline, ok := request.Context().Deadline(); ok && time.Until(deadline) < delay {
+			return response, nil
+		}
+
+		defer func() { _ = response.Body.Close() }()
 
 		if err := sleepWithContext(request.Context(), delay); err != nil {
 			return nil, err

--- a/generators/go-v2/base/src/asIs/internal/retrier_test.go_
+++ b/generators/go-v2/base/src/asIs/internal/retrier_test.go_
@@ -295,7 +295,50 @@ func TestRetryWithRequestBody(t *testing.T) {
 	assert.Equal(t, expectedBody, requestBodies[1], "Second request body should match expected (retry should re-send body)")
 }
 
+// An explicit cancel (e.g. Ctrl-C wired to cancel()) must interrupt the backoff
+// wait. There is no deadline here, so the retrier cannot know the wait is futile
+// up front -- it has to be woken by the context.
 func TestRetryWaitIsInterruptedByContext(t *testing.T) {
+	var requestCount int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		w.Header().Set("Retry-After", "5")
+		w.WriteHeader(http.StatusTooManyRequests)
+	}))
+	defer server.Close()
+
+	caller := NewCaller(&CallerParams{
+		Client: server.Client(),
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		time.Sleep(100 * time.Millisecond)
+		cancel()
+	}()
+	defer cancel()
+
+	start := time.Now()
+	_, err := caller.Call(
+		ctx,
+		&CallParams{
+			URL:         server.URL,
+			Method:      http.MethodGet,
+			Request:     &InternalTestRequest{},
+			MaxAttempts: 3,
+		},
+	)
+	elapsed := time.Since(start)
+
+	assert.ErrorIs(t, err, context.Canceled)
+	assert.Equal(t, 1, requestCount, "Expected the retry to be abandoned once the context was cancelled")
+	assert.Less(t, elapsed, time.Second, "Expected the backoff to be interrupted by the context, took %v", elapsed)
+}
+
+// When the caller's deadline would elapse before the backoff finishes, sleeping
+// only guarantees a context error. Return the response instead so the caller
+// learns why the request actually failed.
+func TestRetryReturnsResponseWhenDeadlineShorterThanBackoff(t *testing.T) {
 	var requestCount int
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		requestCount++
@@ -323,9 +366,50 @@ func TestRetryWaitIsInterruptedByContext(t *testing.T) {
 	)
 	elapsed := time.Since(start)
 
-	assert.ErrorIs(t, err, context.DeadlineExceeded)
-	assert.Equal(t, 1, requestCount, "Expected the retry to be abandoned once the context expired")
-	assert.Less(t, elapsed, time.Second, "Expected the backoff to be interrupted by the context, took %v", elapsed)
+	// The caller gets the 429, not context.DeadlineExceeded.
+	var apiError *core.APIError
+	require.ErrorAs(t, err, &apiError)
+	assert.Equal(t, http.StatusTooManyRequests, apiError.StatusCode)
+	assert.NotErrorIs(t, err, context.DeadlineExceeded)
+	assert.Equal(t, 1, requestCount, "Expected no retry once the deadline was known to be too short")
+	assert.Less(t, elapsed, time.Second, "Expected to return immediately rather than sleep, took %v", elapsed)
+}
+
+// A deadline with room for the backoff must still retry as normal.
+func TestRetryProceedsWhenDeadlineLongerThanBackoff(t *testing.T) {
+	var requestCount int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		if requestCount == 1 {
+			w.Header().Set("Retry-After", "1")
+			w.WriteHeader(http.StatusTooManyRequests)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("{}"))
+	}))
+	defer server.Close()
+
+	caller := NewCaller(&CallerParams{
+		Client: server.Client(),
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	_, err := caller.Call(
+		ctx,
+		&CallParams{
+			URL:         server.URL,
+			Method:      http.MethodGet,
+			Request:     &InternalTestRequest{},
+			Response:    &InternalTestResponse{},
+			MaxAttempts: 3,
+		},
+	)
+
+	assert.NoError(t, err)
+	assert.Equal(t, 2, requestCount, "Expected the retry to proceed when the deadline allows it")
 }
 
 func TestDisableRetries(t *testing.T) {

--- a/generators/go/sdk/changes/unreleased/return-response-when-deadline-shorter-than-backoff.yml
+++ b/generators/go/sdk/changes/unreleased/return-response-when-deadline-shorter-than-backoff.yml
@@ -1,0 +1,10 @@
+# yaml-language-server: $schema=../../../../../fern-changes-yml.schema.json
+
+- summary: |
+    When a request's context deadline would elapse before the retry backoff
+    completes, the retrier now returns the response instead of sleeping through
+    the remaining deadline. Callers see why the request actually failed (for
+    example a `429` with its `Retry-After` and body) rather than a
+    `context deadline exceeded` error. An explicit `cancel()` during the
+    backoff still returns the context's error.
+  type: fix

--- a/seed/go-sdk/accept-header/internal/retrier.go
+++ b/seed/go-sdk/accept-header/internal/retrier.go
@@ -145,12 +145,20 @@ func (r *Retrier) run(
 	}
 
 	if r.shouldRetry(response) {
-		defer func() { _ = response.Body.Close() }()
-
 		delay, err := r.retryDelay(response, retryAttempt)
 		if err != nil {
+			_ = response.Body.Close()
 			return nil, err
 		}
+
+		// If the context's deadline would elapse before the backoff completes, return
+		// the response instead of sleeping through it. The caller then sees why the
+		// request actually failed (e.g. a 429) rather than a context deadline error.
+		if deadline, ok := request.Context().Deadline(); ok && time.Until(deadline) < delay {
+			return response, nil
+		}
+
+		defer func() { _ = response.Body.Close() }()
 
 		if err := sleepWithContext(request.Context(), delay); err != nil {
 			return nil, err

--- a/seed/go-sdk/accept-header/internal/retrier_test.go
+++ b/seed/go-sdk/accept-header/internal/retrier_test.go
@@ -295,7 +295,50 @@ func TestRetryWithRequestBody(t *testing.T) {
 	assert.Equal(t, expectedBody, requestBodies[1], "Second request body should match expected (retry should re-send body)")
 }
 
+// An explicit cancel (e.g. Ctrl-C wired to cancel()) must interrupt the backoff
+// wait. There is no deadline here, so the retrier cannot know the wait is futile
+// up front -- it has to be woken by the context.
 func TestRetryWaitIsInterruptedByContext(t *testing.T) {
+	var requestCount int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		w.Header().Set("Retry-After", "5")
+		w.WriteHeader(http.StatusTooManyRequests)
+	}))
+	defer server.Close()
+
+	caller := NewCaller(&CallerParams{
+		Client: server.Client(),
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		time.Sleep(100 * time.Millisecond)
+		cancel()
+	}()
+	defer cancel()
+
+	start := time.Now()
+	_, err := caller.Call(
+		ctx,
+		&CallParams{
+			URL:         server.URL,
+			Method:      http.MethodGet,
+			Request:     &InternalTestRequest{},
+			MaxAttempts: 3,
+		},
+	)
+	elapsed := time.Since(start)
+
+	assert.ErrorIs(t, err, context.Canceled)
+	assert.Equal(t, 1, requestCount, "Expected the retry to be abandoned once the context was cancelled")
+	assert.Less(t, elapsed, time.Second, "Expected the backoff to be interrupted by the context, took %v", elapsed)
+}
+
+// When the caller's deadline would elapse before the backoff finishes, sleeping
+// only guarantees a context error. Return the response instead so the caller
+// learns why the request actually failed.
+func TestRetryReturnsResponseWhenDeadlineShorterThanBackoff(t *testing.T) {
 	var requestCount int
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		requestCount++
@@ -323,9 +366,50 @@ func TestRetryWaitIsInterruptedByContext(t *testing.T) {
 	)
 	elapsed := time.Since(start)
 
-	assert.ErrorIs(t, err, context.DeadlineExceeded)
-	assert.Equal(t, 1, requestCount, "Expected the retry to be abandoned once the context expired")
-	assert.Less(t, elapsed, time.Second, "Expected the backoff to be interrupted by the context, took %v", elapsed)
+	// The caller gets the 429, not context.DeadlineExceeded.
+	var apiError *core.APIError
+	require.ErrorAs(t, err, &apiError)
+	assert.Equal(t, http.StatusTooManyRequests, apiError.StatusCode)
+	assert.NotErrorIs(t, err, context.DeadlineExceeded)
+	assert.Equal(t, 1, requestCount, "Expected no retry once the deadline was known to be too short")
+	assert.Less(t, elapsed, time.Second, "Expected to return immediately rather than sleep, took %v", elapsed)
+}
+
+// A deadline with room for the backoff must still retry as normal.
+func TestRetryProceedsWhenDeadlineLongerThanBackoff(t *testing.T) {
+	var requestCount int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		if requestCount == 1 {
+			w.Header().Set("Retry-After", "1")
+			w.WriteHeader(http.StatusTooManyRequests)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("{}"))
+	}))
+	defer server.Close()
+
+	caller := NewCaller(&CallerParams{
+		Client: server.Client(),
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	_, err := caller.Call(
+		ctx,
+		&CallParams{
+			URL:         server.URL,
+			Method:      http.MethodGet,
+			Request:     &InternalTestRequest{},
+			Response:    &InternalTestResponse{},
+			MaxAttempts: 3,
+		},
+	)
+
+	assert.NoError(t, err)
+	assert.Equal(t, 2, requestCount, "Expected the retry to proceed when the deadline allows it")
 }
 
 func TestDisableRetries(t *testing.T) {

--- a/seed/go-sdk/alias-extends/internal/retrier.go
+++ b/seed/go-sdk/alias-extends/internal/retrier.go
@@ -145,12 +145,20 @@ func (r *Retrier) run(
 	}
 
 	if r.shouldRetry(response) {
-		defer func() { _ = response.Body.Close() }()
-
 		delay, err := r.retryDelay(response, retryAttempt)
 		if err != nil {
+			_ = response.Body.Close()
 			return nil, err
 		}
+
+		// If the context's deadline would elapse before the backoff completes, return
+		// the response instead of sleeping through it. The caller then sees why the
+		// request actually failed (e.g. a 429) rather than a context deadline error.
+		if deadline, ok := request.Context().Deadline(); ok && time.Until(deadline) < delay {
+			return response, nil
+		}
+
+		defer func() { _ = response.Body.Close() }()
 
 		if err := sleepWithContext(request.Context(), delay); err != nil {
 			return nil, err

--- a/seed/go-sdk/alias-extends/internal/retrier_test.go
+++ b/seed/go-sdk/alias-extends/internal/retrier_test.go
@@ -295,7 +295,50 @@ func TestRetryWithRequestBody(t *testing.T) {
 	assert.Equal(t, expectedBody, requestBodies[1], "Second request body should match expected (retry should re-send body)")
 }
 
+// An explicit cancel (e.g. Ctrl-C wired to cancel()) must interrupt the backoff
+// wait. There is no deadline here, so the retrier cannot know the wait is futile
+// up front -- it has to be woken by the context.
 func TestRetryWaitIsInterruptedByContext(t *testing.T) {
+	var requestCount int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		w.Header().Set("Retry-After", "5")
+		w.WriteHeader(http.StatusTooManyRequests)
+	}))
+	defer server.Close()
+
+	caller := NewCaller(&CallerParams{
+		Client: server.Client(),
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		time.Sleep(100 * time.Millisecond)
+		cancel()
+	}()
+	defer cancel()
+
+	start := time.Now()
+	_, err := caller.Call(
+		ctx,
+		&CallParams{
+			URL:         server.URL,
+			Method:      http.MethodGet,
+			Request:     &InternalTestRequest{},
+			MaxAttempts: 3,
+		},
+	)
+	elapsed := time.Since(start)
+
+	assert.ErrorIs(t, err, context.Canceled)
+	assert.Equal(t, 1, requestCount, "Expected the retry to be abandoned once the context was cancelled")
+	assert.Less(t, elapsed, time.Second, "Expected the backoff to be interrupted by the context, took %v", elapsed)
+}
+
+// When the caller's deadline would elapse before the backoff finishes, sleeping
+// only guarantees a context error. Return the response instead so the caller
+// learns why the request actually failed.
+func TestRetryReturnsResponseWhenDeadlineShorterThanBackoff(t *testing.T) {
 	var requestCount int
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		requestCount++
@@ -323,9 +366,50 @@ func TestRetryWaitIsInterruptedByContext(t *testing.T) {
 	)
 	elapsed := time.Since(start)
 
-	assert.ErrorIs(t, err, context.DeadlineExceeded)
-	assert.Equal(t, 1, requestCount, "Expected the retry to be abandoned once the context expired")
-	assert.Less(t, elapsed, time.Second, "Expected the backoff to be interrupted by the context, took %v", elapsed)
+	// The caller gets the 429, not context.DeadlineExceeded.
+	var apiError *core.APIError
+	require.ErrorAs(t, err, &apiError)
+	assert.Equal(t, http.StatusTooManyRequests, apiError.StatusCode)
+	assert.NotErrorIs(t, err, context.DeadlineExceeded)
+	assert.Equal(t, 1, requestCount, "Expected no retry once the deadline was known to be too short")
+	assert.Less(t, elapsed, time.Second, "Expected to return immediately rather than sleep, took %v", elapsed)
+}
+
+// A deadline with room for the backoff must still retry as normal.
+func TestRetryProceedsWhenDeadlineLongerThanBackoff(t *testing.T) {
+	var requestCount int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		if requestCount == 1 {
+			w.Header().Set("Retry-After", "1")
+			w.WriteHeader(http.StatusTooManyRequests)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("{}"))
+	}))
+	defer server.Close()
+
+	caller := NewCaller(&CallerParams{
+		Client: server.Client(),
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	_, err := caller.Call(
+		ctx,
+		&CallParams{
+			URL:         server.URL,
+			Method:      http.MethodGet,
+			Request:     &InternalTestRequest{},
+			Response:    &InternalTestResponse{},
+			MaxAttempts: 3,
+		},
+	)
+
+	assert.NoError(t, err)
+	assert.Equal(t, 2, requestCount, "Expected the retry to proceed when the deadline allows it")
 }
 
 func TestDisableRetries(t *testing.T) {

--- a/seed/go-sdk/alias/internal/retrier.go
+++ b/seed/go-sdk/alias/internal/retrier.go
@@ -145,12 +145,20 @@ func (r *Retrier) run(
 	}
 
 	if r.shouldRetry(response) {
-		defer func() { _ = response.Body.Close() }()
-
 		delay, err := r.retryDelay(response, retryAttempt)
 		if err != nil {
+			_ = response.Body.Close()
 			return nil, err
 		}
+
+		// If the context's deadline would elapse before the backoff completes, return
+		// the response instead of sleeping through it. The caller then sees why the
+		// request actually failed (e.g. a 429) rather than a context deadline error.
+		if deadline, ok := request.Context().Deadline(); ok && time.Until(deadline) < delay {
+			return response, nil
+		}
+
+		defer func() { _ = response.Body.Close() }()
 
 		if err := sleepWithContext(request.Context(), delay); err != nil {
 			return nil, err

--- a/seed/go-sdk/alias/internal/retrier_test.go
+++ b/seed/go-sdk/alias/internal/retrier_test.go
@@ -295,7 +295,50 @@ func TestRetryWithRequestBody(t *testing.T) {
 	assert.Equal(t, expectedBody, requestBodies[1], "Second request body should match expected (retry should re-send body)")
 }
 
+// An explicit cancel (e.g. Ctrl-C wired to cancel()) must interrupt the backoff
+// wait. There is no deadline here, so the retrier cannot know the wait is futile
+// up front -- it has to be woken by the context.
 func TestRetryWaitIsInterruptedByContext(t *testing.T) {
+	var requestCount int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		w.Header().Set("Retry-After", "5")
+		w.WriteHeader(http.StatusTooManyRequests)
+	}))
+	defer server.Close()
+
+	caller := NewCaller(&CallerParams{
+		Client: server.Client(),
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		time.Sleep(100 * time.Millisecond)
+		cancel()
+	}()
+	defer cancel()
+
+	start := time.Now()
+	_, err := caller.Call(
+		ctx,
+		&CallParams{
+			URL:         server.URL,
+			Method:      http.MethodGet,
+			Request:     &InternalTestRequest{},
+			MaxAttempts: 3,
+		},
+	)
+	elapsed := time.Since(start)
+
+	assert.ErrorIs(t, err, context.Canceled)
+	assert.Equal(t, 1, requestCount, "Expected the retry to be abandoned once the context was cancelled")
+	assert.Less(t, elapsed, time.Second, "Expected the backoff to be interrupted by the context, took %v", elapsed)
+}
+
+// When the caller's deadline would elapse before the backoff finishes, sleeping
+// only guarantees a context error. Return the response instead so the caller
+// learns why the request actually failed.
+func TestRetryReturnsResponseWhenDeadlineShorterThanBackoff(t *testing.T) {
 	var requestCount int
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		requestCount++
@@ -323,9 +366,50 @@ func TestRetryWaitIsInterruptedByContext(t *testing.T) {
 	)
 	elapsed := time.Since(start)
 
-	assert.ErrorIs(t, err, context.DeadlineExceeded)
-	assert.Equal(t, 1, requestCount, "Expected the retry to be abandoned once the context expired")
-	assert.Less(t, elapsed, time.Second, "Expected the backoff to be interrupted by the context, took %v", elapsed)
+	// The caller gets the 429, not context.DeadlineExceeded.
+	var apiError *core.APIError
+	require.ErrorAs(t, err, &apiError)
+	assert.Equal(t, http.StatusTooManyRequests, apiError.StatusCode)
+	assert.NotErrorIs(t, err, context.DeadlineExceeded)
+	assert.Equal(t, 1, requestCount, "Expected no retry once the deadline was known to be too short")
+	assert.Less(t, elapsed, time.Second, "Expected to return immediately rather than sleep, took %v", elapsed)
+}
+
+// A deadline with room for the backoff must still retry as normal.
+func TestRetryProceedsWhenDeadlineLongerThanBackoff(t *testing.T) {
+	var requestCount int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		if requestCount == 1 {
+			w.Header().Set("Retry-After", "1")
+			w.WriteHeader(http.StatusTooManyRequests)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("{}"))
+	}))
+	defer server.Close()
+
+	caller := NewCaller(&CallerParams{
+		Client: server.Client(),
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	_, err := caller.Call(
+		ctx,
+		&CallParams{
+			URL:         server.URL,
+			Method:      http.MethodGet,
+			Request:     &InternalTestRequest{},
+			Response:    &InternalTestResponse{},
+			MaxAttempts: 3,
+		},
+	)
+
+	assert.NoError(t, err)
+	assert.Equal(t, 2, requestCount, "Expected the retry to proceed when the deadline allows it")
 }
 
 func TestDisableRetries(t *testing.T) {

--- a/seed/go-sdk/allof-inline/internal/retrier.go
+++ b/seed/go-sdk/allof-inline/internal/retrier.go
@@ -145,12 +145,20 @@ func (r *Retrier) run(
 	}
 
 	if r.shouldRetry(response) {
-		defer func() { _ = response.Body.Close() }()
-
 		delay, err := r.retryDelay(response, retryAttempt)
 		if err != nil {
+			_ = response.Body.Close()
 			return nil, err
 		}
+
+		// If the context's deadline would elapse before the backoff completes, return
+		// the response instead of sleeping through it. The caller then sees why the
+		// request actually failed (e.g. a 429) rather than a context deadline error.
+		if deadline, ok := request.Context().Deadline(); ok && time.Until(deadline) < delay {
+			return response, nil
+		}
+
+		defer func() { _ = response.Body.Close() }()
 
 		if err := sleepWithContext(request.Context(), delay); err != nil {
 			return nil, err

--- a/seed/go-sdk/allof-inline/internal/retrier_test.go
+++ b/seed/go-sdk/allof-inline/internal/retrier_test.go
@@ -295,7 +295,50 @@ func TestRetryWithRequestBody(t *testing.T) {
 	assert.Equal(t, expectedBody, requestBodies[1], "Second request body should match expected (retry should re-send body)")
 }
 
+// An explicit cancel (e.g. Ctrl-C wired to cancel()) must interrupt the backoff
+// wait. There is no deadline here, so the retrier cannot know the wait is futile
+// up front -- it has to be woken by the context.
 func TestRetryWaitIsInterruptedByContext(t *testing.T) {
+	var requestCount int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		w.Header().Set("Retry-After", "5")
+		w.WriteHeader(http.StatusTooManyRequests)
+	}))
+	defer server.Close()
+
+	caller := NewCaller(&CallerParams{
+		Client: server.Client(),
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		time.Sleep(100 * time.Millisecond)
+		cancel()
+	}()
+	defer cancel()
+
+	start := time.Now()
+	_, err := caller.Call(
+		ctx,
+		&CallParams{
+			URL:         server.URL,
+			Method:      http.MethodGet,
+			Request:     &InternalTestRequest{},
+			MaxAttempts: 3,
+		},
+	)
+	elapsed := time.Since(start)
+
+	assert.ErrorIs(t, err, context.Canceled)
+	assert.Equal(t, 1, requestCount, "Expected the retry to be abandoned once the context was cancelled")
+	assert.Less(t, elapsed, time.Second, "Expected the backoff to be interrupted by the context, took %v", elapsed)
+}
+
+// When the caller's deadline would elapse before the backoff finishes, sleeping
+// only guarantees a context error. Return the response instead so the caller
+// learns why the request actually failed.
+func TestRetryReturnsResponseWhenDeadlineShorterThanBackoff(t *testing.T) {
 	var requestCount int
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		requestCount++
@@ -323,9 +366,50 @@ func TestRetryWaitIsInterruptedByContext(t *testing.T) {
 	)
 	elapsed := time.Since(start)
 
-	assert.ErrorIs(t, err, context.DeadlineExceeded)
-	assert.Equal(t, 1, requestCount, "Expected the retry to be abandoned once the context expired")
-	assert.Less(t, elapsed, time.Second, "Expected the backoff to be interrupted by the context, took %v", elapsed)
+	// The caller gets the 429, not context.DeadlineExceeded.
+	var apiError *core.APIError
+	require.ErrorAs(t, err, &apiError)
+	assert.Equal(t, http.StatusTooManyRequests, apiError.StatusCode)
+	assert.NotErrorIs(t, err, context.DeadlineExceeded)
+	assert.Equal(t, 1, requestCount, "Expected no retry once the deadline was known to be too short")
+	assert.Less(t, elapsed, time.Second, "Expected to return immediately rather than sleep, took %v", elapsed)
+}
+
+// A deadline with room for the backoff must still retry as normal.
+func TestRetryProceedsWhenDeadlineLongerThanBackoff(t *testing.T) {
+	var requestCount int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		if requestCount == 1 {
+			w.Header().Set("Retry-After", "1")
+			w.WriteHeader(http.StatusTooManyRequests)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("{}"))
+	}))
+	defer server.Close()
+
+	caller := NewCaller(&CallerParams{
+		Client: server.Client(),
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	_, err := caller.Call(
+		ctx,
+		&CallParams{
+			URL:         server.URL,
+			Method:      http.MethodGet,
+			Request:     &InternalTestRequest{},
+			Response:    &InternalTestResponse{},
+			MaxAttempts: 3,
+		},
+	)
+
+	assert.NoError(t, err)
+	assert.Equal(t, 2, requestCount, "Expected the retry to proceed when the deadline allows it")
 }
 
 func TestDisableRetries(t *testing.T) {

--- a/seed/go-sdk/allof/internal/retrier.go
+++ b/seed/go-sdk/allof/internal/retrier.go
@@ -145,12 +145,20 @@ func (r *Retrier) run(
 	}
 
 	if r.shouldRetry(response) {
-		defer func() { _ = response.Body.Close() }()
-
 		delay, err := r.retryDelay(response, retryAttempt)
 		if err != nil {
+			_ = response.Body.Close()
 			return nil, err
 		}
+
+		// If the context's deadline would elapse before the backoff completes, return
+		// the response instead of sleeping through it. The caller then sees why the
+		// request actually failed (e.g. a 429) rather than a context deadline error.
+		if deadline, ok := request.Context().Deadline(); ok && time.Until(deadline) < delay {
+			return response, nil
+		}
+
+		defer func() { _ = response.Body.Close() }()
 
 		if err := sleepWithContext(request.Context(), delay); err != nil {
 			return nil, err

--- a/seed/go-sdk/allof/internal/retrier_test.go
+++ b/seed/go-sdk/allof/internal/retrier_test.go
@@ -295,7 +295,50 @@ func TestRetryWithRequestBody(t *testing.T) {
 	assert.Equal(t, expectedBody, requestBodies[1], "Second request body should match expected (retry should re-send body)")
 }
 
+// An explicit cancel (e.g. Ctrl-C wired to cancel()) must interrupt the backoff
+// wait. There is no deadline here, so the retrier cannot know the wait is futile
+// up front -- it has to be woken by the context.
 func TestRetryWaitIsInterruptedByContext(t *testing.T) {
+	var requestCount int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		w.Header().Set("Retry-After", "5")
+		w.WriteHeader(http.StatusTooManyRequests)
+	}))
+	defer server.Close()
+
+	caller := NewCaller(&CallerParams{
+		Client: server.Client(),
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		time.Sleep(100 * time.Millisecond)
+		cancel()
+	}()
+	defer cancel()
+
+	start := time.Now()
+	_, err := caller.Call(
+		ctx,
+		&CallParams{
+			URL:         server.URL,
+			Method:      http.MethodGet,
+			Request:     &InternalTestRequest{},
+			MaxAttempts: 3,
+		},
+	)
+	elapsed := time.Since(start)
+
+	assert.ErrorIs(t, err, context.Canceled)
+	assert.Equal(t, 1, requestCount, "Expected the retry to be abandoned once the context was cancelled")
+	assert.Less(t, elapsed, time.Second, "Expected the backoff to be interrupted by the context, took %v", elapsed)
+}
+
+// When the caller's deadline would elapse before the backoff finishes, sleeping
+// only guarantees a context error. Return the response instead so the caller
+// learns why the request actually failed.
+func TestRetryReturnsResponseWhenDeadlineShorterThanBackoff(t *testing.T) {
 	var requestCount int
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		requestCount++
@@ -323,9 +366,50 @@ func TestRetryWaitIsInterruptedByContext(t *testing.T) {
 	)
 	elapsed := time.Since(start)
 
-	assert.ErrorIs(t, err, context.DeadlineExceeded)
-	assert.Equal(t, 1, requestCount, "Expected the retry to be abandoned once the context expired")
-	assert.Less(t, elapsed, time.Second, "Expected the backoff to be interrupted by the context, took %v", elapsed)
+	// The caller gets the 429, not context.DeadlineExceeded.
+	var apiError *core.APIError
+	require.ErrorAs(t, err, &apiError)
+	assert.Equal(t, http.StatusTooManyRequests, apiError.StatusCode)
+	assert.NotErrorIs(t, err, context.DeadlineExceeded)
+	assert.Equal(t, 1, requestCount, "Expected no retry once the deadline was known to be too short")
+	assert.Less(t, elapsed, time.Second, "Expected to return immediately rather than sleep, took %v", elapsed)
+}
+
+// A deadline with room for the backoff must still retry as normal.
+func TestRetryProceedsWhenDeadlineLongerThanBackoff(t *testing.T) {
+	var requestCount int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		if requestCount == 1 {
+			w.Header().Set("Retry-After", "1")
+			w.WriteHeader(http.StatusTooManyRequests)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("{}"))
+	}))
+	defer server.Close()
+
+	caller := NewCaller(&CallerParams{
+		Client: server.Client(),
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	_, err := caller.Call(
+		ctx,
+		&CallParams{
+			URL:         server.URL,
+			Method:      http.MethodGet,
+			Request:     &InternalTestRequest{},
+			Response:    &InternalTestResponse{},
+			MaxAttempts: 3,
+		},
+	)
+
+	assert.NoError(t, err)
+	assert.Equal(t, 2, requestCount, "Expected the retry to proceed when the deadline allows it")
 }
 
 func TestDisableRetries(t *testing.T) {

--- a/seed/go-sdk/any-auth/internal/retrier.go
+++ b/seed/go-sdk/any-auth/internal/retrier.go
@@ -145,12 +145,20 @@ func (r *Retrier) run(
 	}
 
 	if r.shouldRetry(response) {
-		defer func() { _ = response.Body.Close() }()
-
 		delay, err := r.retryDelay(response, retryAttempt)
 		if err != nil {
+			_ = response.Body.Close()
 			return nil, err
 		}
+
+		// If the context's deadline would elapse before the backoff completes, return
+		// the response instead of sleeping through it. The caller then sees why the
+		// request actually failed (e.g. a 429) rather than a context deadline error.
+		if deadline, ok := request.Context().Deadline(); ok && time.Until(deadline) < delay {
+			return response, nil
+		}
+
+		defer func() { _ = response.Body.Close() }()
 
 		if err := sleepWithContext(request.Context(), delay); err != nil {
 			return nil, err

--- a/seed/go-sdk/any-auth/internal/retrier_test.go
+++ b/seed/go-sdk/any-auth/internal/retrier_test.go
@@ -295,7 +295,50 @@ func TestRetryWithRequestBody(t *testing.T) {
 	assert.Equal(t, expectedBody, requestBodies[1], "Second request body should match expected (retry should re-send body)")
 }
 
+// An explicit cancel (e.g. Ctrl-C wired to cancel()) must interrupt the backoff
+// wait. There is no deadline here, so the retrier cannot know the wait is futile
+// up front -- it has to be woken by the context.
 func TestRetryWaitIsInterruptedByContext(t *testing.T) {
+	var requestCount int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		w.Header().Set("Retry-After", "5")
+		w.WriteHeader(http.StatusTooManyRequests)
+	}))
+	defer server.Close()
+
+	caller := NewCaller(&CallerParams{
+		Client: server.Client(),
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		time.Sleep(100 * time.Millisecond)
+		cancel()
+	}()
+	defer cancel()
+
+	start := time.Now()
+	_, err := caller.Call(
+		ctx,
+		&CallParams{
+			URL:         server.URL,
+			Method:      http.MethodGet,
+			Request:     &InternalTestRequest{},
+			MaxAttempts: 3,
+		},
+	)
+	elapsed := time.Since(start)
+
+	assert.ErrorIs(t, err, context.Canceled)
+	assert.Equal(t, 1, requestCount, "Expected the retry to be abandoned once the context was cancelled")
+	assert.Less(t, elapsed, time.Second, "Expected the backoff to be interrupted by the context, took %v", elapsed)
+}
+
+// When the caller's deadline would elapse before the backoff finishes, sleeping
+// only guarantees a context error. Return the response instead so the caller
+// learns why the request actually failed.
+func TestRetryReturnsResponseWhenDeadlineShorterThanBackoff(t *testing.T) {
 	var requestCount int
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		requestCount++
@@ -323,9 +366,50 @@ func TestRetryWaitIsInterruptedByContext(t *testing.T) {
 	)
 	elapsed := time.Since(start)
 
-	assert.ErrorIs(t, err, context.DeadlineExceeded)
-	assert.Equal(t, 1, requestCount, "Expected the retry to be abandoned once the context expired")
-	assert.Less(t, elapsed, time.Second, "Expected the backoff to be interrupted by the context, took %v", elapsed)
+	// The caller gets the 429, not context.DeadlineExceeded.
+	var apiError *core.APIError
+	require.ErrorAs(t, err, &apiError)
+	assert.Equal(t, http.StatusTooManyRequests, apiError.StatusCode)
+	assert.NotErrorIs(t, err, context.DeadlineExceeded)
+	assert.Equal(t, 1, requestCount, "Expected no retry once the deadline was known to be too short")
+	assert.Less(t, elapsed, time.Second, "Expected to return immediately rather than sleep, took %v", elapsed)
+}
+
+// A deadline with room for the backoff must still retry as normal.
+func TestRetryProceedsWhenDeadlineLongerThanBackoff(t *testing.T) {
+	var requestCount int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		if requestCount == 1 {
+			w.Header().Set("Retry-After", "1")
+			w.WriteHeader(http.StatusTooManyRequests)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("{}"))
+	}))
+	defer server.Close()
+
+	caller := NewCaller(&CallerParams{
+		Client: server.Client(),
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	_, err := caller.Call(
+		ctx,
+		&CallParams{
+			URL:         server.URL,
+			Method:      http.MethodGet,
+			Request:     &InternalTestRequest{},
+			Response:    &InternalTestResponse{},
+			MaxAttempts: 3,
+		},
+	)
+
+	assert.NoError(t, err)
+	assert.Equal(t, 2, requestCount, "Expected the retry to proceed when the deadline allows it")
 }
 
 func TestDisableRetries(t *testing.T) {

--- a/seed/go-sdk/api-wide-base-path-with-default/internal/retrier.go
+++ b/seed/go-sdk/api-wide-base-path-with-default/internal/retrier.go
@@ -145,12 +145,20 @@ func (r *Retrier) run(
 	}
 
 	if r.shouldRetry(response) {
-		defer func() { _ = response.Body.Close() }()
-
 		delay, err := r.retryDelay(response, retryAttempt)
 		if err != nil {
+			_ = response.Body.Close()
 			return nil, err
 		}
+
+		// If the context's deadline would elapse before the backoff completes, return
+		// the response instead of sleeping through it. The caller then sees why the
+		// request actually failed (e.g. a 429) rather than a context deadline error.
+		if deadline, ok := request.Context().Deadline(); ok && time.Until(deadline) < delay {
+			return response, nil
+		}
+
+		defer func() { _ = response.Body.Close() }()
 
 		if err := sleepWithContext(request.Context(), delay); err != nil {
 			return nil, err

--- a/seed/go-sdk/api-wide-base-path-with-default/internal/retrier_test.go
+++ b/seed/go-sdk/api-wide-base-path-with-default/internal/retrier_test.go
@@ -295,7 +295,50 @@ func TestRetryWithRequestBody(t *testing.T) {
 	assert.Equal(t, expectedBody, requestBodies[1], "Second request body should match expected (retry should re-send body)")
 }
 
+// An explicit cancel (e.g. Ctrl-C wired to cancel()) must interrupt the backoff
+// wait. There is no deadline here, so the retrier cannot know the wait is futile
+// up front -- it has to be woken by the context.
 func TestRetryWaitIsInterruptedByContext(t *testing.T) {
+	var requestCount int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		w.Header().Set("Retry-After", "5")
+		w.WriteHeader(http.StatusTooManyRequests)
+	}))
+	defer server.Close()
+
+	caller := NewCaller(&CallerParams{
+		Client: server.Client(),
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		time.Sleep(100 * time.Millisecond)
+		cancel()
+	}()
+	defer cancel()
+
+	start := time.Now()
+	_, err := caller.Call(
+		ctx,
+		&CallParams{
+			URL:         server.URL,
+			Method:      http.MethodGet,
+			Request:     &InternalTestRequest{},
+			MaxAttempts: 3,
+		},
+	)
+	elapsed := time.Since(start)
+
+	assert.ErrorIs(t, err, context.Canceled)
+	assert.Equal(t, 1, requestCount, "Expected the retry to be abandoned once the context was cancelled")
+	assert.Less(t, elapsed, time.Second, "Expected the backoff to be interrupted by the context, took %v", elapsed)
+}
+
+// When the caller's deadline would elapse before the backoff finishes, sleeping
+// only guarantees a context error. Return the response instead so the caller
+// learns why the request actually failed.
+func TestRetryReturnsResponseWhenDeadlineShorterThanBackoff(t *testing.T) {
 	var requestCount int
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		requestCount++
@@ -323,9 +366,50 @@ func TestRetryWaitIsInterruptedByContext(t *testing.T) {
 	)
 	elapsed := time.Since(start)
 
-	assert.ErrorIs(t, err, context.DeadlineExceeded)
-	assert.Equal(t, 1, requestCount, "Expected the retry to be abandoned once the context expired")
-	assert.Less(t, elapsed, time.Second, "Expected the backoff to be interrupted by the context, took %v", elapsed)
+	// The caller gets the 429, not context.DeadlineExceeded.
+	var apiError *core.APIError
+	require.ErrorAs(t, err, &apiError)
+	assert.Equal(t, http.StatusTooManyRequests, apiError.StatusCode)
+	assert.NotErrorIs(t, err, context.DeadlineExceeded)
+	assert.Equal(t, 1, requestCount, "Expected no retry once the deadline was known to be too short")
+	assert.Less(t, elapsed, time.Second, "Expected to return immediately rather than sleep, took %v", elapsed)
+}
+
+// A deadline with room for the backoff must still retry as normal.
+func TestRetryProceedsWhenDeadlineLongerThanBackoff(t *testing.T) {
+	var requestCount int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		if requestCount == 1 {
+			w.Header().Set("Retry-After", "1")
+			w.WriteHeader(http.StatusTooManyRequests)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("{}"))
+	}))
+	defer server.Close()
+
+	caller := NewCaller(&CallerParams{
+		Client: server.Client(),
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	_, err := caller.Call(
+		ctx,
+		&CallParams{
+			URL:         server.URL,
+			Method:      http.MethodGet,
+			Request:     &InternalTestRequest{},
+			Response:    &InternalTestResponse{},
+			MaxAttempts: 3,
+		},
+	)
+
+	assert.NoError(t, err)
+	assert.Equal(t, 2, requestCount, "Expected the retry to proceed when the deadline allows it")
 }
 
 func TestDisableRetries(t *testing.T) {

--- a/seed/go-sdk/api-wide-base-path/internal/retrier.go
+++ b/seed/go-sdk/api-wide-base-path/internal/retrier.go
@@ -145,12 +145,20 @@ func (r *Retrier) run(
 	}
 
 	if r.shouldRetry(response) {
-		defer func() { _ = response.Body.Close() }()
-
 		delay, err := r.retryDelay(response, retryAttempt)
 		if err != nil {
+			_ = response.Body.Close()
 			return nil, err
 		}
+
+		// If the context's deadline would elapse before the backoff completes, return
+		// the response instead of sleeping through it. The caller then sees why the
+		// request actually failed (e.g. a 429) rather than a context deadline error.
+		if deadline, ok := request.Context().Deadline(); ok && time.Until(deadline) < delay {
+			return response, nil
+		}
+
+		defer func() { _ = response.Body.Close() }()
 
 		if err := sleepWithContext(request.Context(), delay); err != nil {
 			return nil, err

--- a/seed/go-sdk/api-wide-base-path/internal/retrier_test.go
+++ b/seed/go-sdk/api-wide-base-path/internal/retrier_test.go
@@ -295,7 +295,50 @@ func TestRetryWithRequestBody(t *testing.T) {
 	assert.Equal(t, expectedBody, requestBodies[1], "Second request body should match expected (retry should re-send body)")
 }
 
+// An explicit cancel (e.g. Ctrl-C wired to cancel()) must interrupt the backoff
+// wait. There is no deadline here, so the retrier cannot know the wait is futile
+// up front -- it has to be woken by the context.
 func TestRetryWaitIsInterruptedByContext(t *testing.T) {
+	var requestCount int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		w.Header().Set("Retry-After", "5")
+		w.WriteHeader(http.StatusTooManyRequests)
+	}))
+	defer server.Close()
+
+	caller := NewCaller(&CallerParams{
+		Client: server.Client(),
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		time.Sleep(100 * time.Millisecond)
+		cancel()
+	}()
+	defer cancel()
+
+	start := time.Now()
+	_, err := caller.Call(
+		ctx,
+		&CallParams{
+			URL:         server.URL,
+			Method:      http.MethodGet,
+			Request:     &InternalTestRequest{},
+			MaxAttempts: 3,
+		},
+	)
+	elapsed := time.Since(start)
+
+	assert.ErrorIs(t, err, context.Canceled)
+	assert.Equal(t, 1, requestCount, "Expected the retry to be abandoned once the context was cancelled")
+	assert.Less(t, elapsed, time.Second, "Expected the backoff to be interrupted by the context, took %v", elapsed)
+}
+
+// When the caller's deadline would elapse before the backoff finishes, sleeping
+// only guarantees a context error. Return the response instead so the caller
+// learns why the request actually failed.
+func TestRetryReturnsResponseWhenDeadlineShorterThanBackoff(t *testing.T) {
 	var requestCount int
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		requestCount++
@@ -323,9 +366,50 @@ func TestRetryWaitIsInterruptedByContext(t *testing.T) {
 	)
 	elapsed := time.Since(start)
 
-	assert.ErrorIs(t, err, context.DeadlineExceeded)
-	assert.Equal(t, 1, requestCount, "Expected the retry to be abandoned once the context expired")
-	assert.Less(t, elapsed, time.Second, "Expected the backoff to be interrupted by the context, took %v", elapsed)
+	// The caller gets the 429, not context.DeadlineExceeded.
+	var apiError *core.APIError
+	require.ErrorAs(t, err, &apiError)
+	assert.Equal(t, http.StatusTooManyRequests, apiError.StatusCode)
+	assert.NotErrorIs(t, err, context.DeadlineExceeded)
+	assert.Equal(t, 1, requestCount, "Expected no retry once the deadline was known to be too short")
+	assert.Less(t, elapsed, time.Second, "Expected to return immediately rather than sleep, took %v", elapsed)
+}
+
+// A deadline with room for the backoff must still retry as normal.
+func TestRetryProceedsWhenDeadlineLongerThanBackoff(t *testing.T) {
+	var requestCount int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		if requestCount == 1 {
+			w.Header().Set("Retry-After", "1")
+			w.WriteHeader(http.StatusTooManyRequests)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("{}"))
+	}))
+	defer server.Close()
+
+	caller := NewCaller(&CallerParams{
+		Client: server.Client(),
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	_, err := caller.Call(
+		ctx,
+		&CallParams{
+			URL:         server.URL,
+			Method:      http.MethodGet,
+			Request:     &InternalTestRequest{},
+			Response:    &InternalTestResponse{},
+			MaxAttempts: 3,
+		},
+	)
+
+	assert.NoError(t, err)
+	assert.Equal(t, 2, requestCount, "Expected the retry to proceed when the deadline allows it")
 }
 
 func TestDisableRetries(t *testing.T) {

--- a/seed/go-sdk/audiences/internal/retrier.go
+++ b/seed/go-sdk/audiences/internal/retrier.go
@@ -145,12 +145,20 @@ func (r *Retrier) run(
 	}
 
 	if r.shouldRetry(response) {
-		defer func() { _ = response.Body.Close() }()
-
 		delay, err := r.retryDelay(response, retryAttempt)
 		if err != nil {
+			_ = response.Body.Close()
 			return nil, err
 		}
+
+		// If the context's deadline would elapse before the backoff completes, return
+		// the response instead of sleeping through it. The caller then sees why the
+		// request actually failed (e.g. a 429) rather than a context deadline error.
+		if deadline, ok := request.Context().Deadline(); ok && time.Until(deadline) < delay {
+			return response, nil
+		}
+
+		defer func() { _ = response.Body.Close() }()
 
 		if err := sleepWithContext(request.Context(), delay); err != nil {
 			return nil, err

--- a/seed/go-sdk/audiences/internal/retrier_test.go
+++ b/seed/go-sdk/audiences/internal/retrier_test.go
@@ -295,7 +295,50 @@ func TestRetryWithRequestBody(t *testing.T) {
 	assert.Equal(t, expectedBody, requestBodies[1], "Second request body should match expected (retry should re-send body)")
 }
 
+// An explicit cancel (e.g. Ctrl-C wired to cancel()) must interrupt the backoff
+// wait. There is no deadline here, so the retrier cannot know the wait is futile
+// up front -- it has to be woken by the context.
 func TestRetryWaitIsInterruptedByContext(t *testing.T) {
+	var requestCount int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		w.Header().Set("Retry-After", "5")
+		w.WriteHeader(http.StatusTooManyRequests)
+	}))
+	defer server.Close()
+
+	caller := NewCaller(&CallerParams{
+		Client: server.Client(),
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		time.Sleep(100 * time.Millisecond)
+		cancel()
+	}()
+	defer cancel()
+
+	start := time.Now()
+	_, err := caller.Call(
+		ctx,
+		&CallParams{
+			URL:         server.URL,
+			Method:      http.MethodGet,
+			Request:     &InternalTestRequest{},
+			MaxAttempts: 3,
+		},
+	)
+	elapsed := time.Since(start)
+
+	assert.ErrorIs(t, err, context.Canceled)
+	assert.Equal(t, 1, requestCount, "Expected the retry to be abandoned once the context was cancelled")
+	assert.Less(t, elapsed, time.Second, "Expected the backoff to be interrupted by the context, took %v", elapsed)
+}
+
+// When the caller's deadline would elapse before the backoff finishes, sleeping
+// only guarantees a context error. Return the response instead so the caller
+// learns why the request actually failed.
+func TestRetryReturnsResponseWhenDeadlineShorterThanBackoff(t *testing.T) {
 	var requestCount int
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		requestCount++
@@ -323,9 +366,50 @@ func TestRetryWaitIsInterruptedByContext(t *testing.T) {
 	)
 	elapsed := time.Since(start)
 
-	assert.ErrorIs(t, err, context.DeadlineExceeded)
-	assert.Equal(t, 1, requestCount, "Expected the retry to be abandoned once the context expired")
-	assert.Less(t, elapsed, time.Second, "Expected the backoff to be interrupted by the context, took %v", elapsed)
+	// The caller gets the 429, not context.DeadlineExceeded.
+	var apiError *core.APIError
+	require.ErrorAs(t, err, &apiError)
+	assert.Equal(t, http.StatusTooManyRequests, apiError.StatusCode)
+	assert.NotErrorIs(t, err, context.DeadlineExceeded)
+	assert.Equal(t, 1, requestCount, "Expected no retry once the deadline was known to be too short")
+	assert.Less(t, elapsed, time.Second, "Expected to return immediately rather than sleep, took %v", elapsed)
+}
+
+// A deadline with room for the backoff must still retry as normal.
+func TestRetryProceedsWhenDeadlineLongerThanBackoff(t *testing.T) {
+	var requestCount int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		if requestCount == 1 {
+			w.Header().Set("Retry-After", "1")
+			w.WriteHeader(http.StatusTooManyRequests)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("{}"))
+	}))
+	defer server.Close()
+
+	caller := NewCaller(&CallerParams{
+		Client: server.Client(),
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	_, err := caller.Call(
+		ctx,
+		&CallParams{
+			URL:         server.URL,
+			Method:      http.MethodGet,
+			Request:     &InternalTestRequest{},
+			Response:    &InternalTestResponse{},
+			MaxAttempts: 3,
+		},
+	)
+
+	assert.NoError(t, err)
+	assert.Equal(t, 2, requestCount, "Expected the retry to proceed when the deadline allows it")
 }
 
 func TestDisableRetries(t *testing.T) {

--- a/seed/go-sdk/basic-auth-environment-variables/internal/retrier.go
+++ b/seed/go-sdk/basic-auth-environment-variables/internal/retrier.go
@@ -145,12 +145,20 @@ func (r *Retrier) run(
 	}
 
 	if r.shouldRetry(response) {
-		defer func() { _ = response.Body.Close() }()
-
 		delay, err := r.retryDelay(response, retryAttempt)
 		if err != nil {
+			_ = response.Body.Close()
 			return nil, err
 		}
+
+		// If the context's deadline would elapse before the backoff completes, return
+		// the response instead of sleeping through it. The caller then sees why the
+		// request actually failed (e.g. a 429) rather than a context deadline error.
+		if deadline, ok := request.Context().Deadline(); ok && time.Until(deadline) < delay {
+			return response, nil
+		}
+
+		defer func() { _ = response.Body.Close() }()
 
 		if err := sleepWithContext(request.Context(), delay); err != nil {
 			return nil, err

--- a/seed/go-sdk/basic-auth-environment-variables/internal/retrier_test.go
+++ b/seed/go-sdk/basic-auth-environment-variables/internal/retrier_test.go
@@ -295,7 +295,50 @@ func TestRetryWithRequestBody(t *testing.T) {
 	assert.Equal(t, expectedBody, requestBodies[1], "Second request body should match expected (retry should re-send body)")
 }
 
+// An explicit cancel (e.g. Ctrl-C wired to cancel()) must interrupt the backoff
+// wait. There is no deadline here, so the retrier cannot know the wait is futile
+// up front -- it has to be woken by the context.
 func TestRetryWaitIsInterruptedByContext(t *testing.T) {
+	var requestCount int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		w.Header().Set("Retry-After", "5")
+		w.WriteHeader(http.StatusTooManyRequests)
+	}))
+	defer server.Close()
+
+	caller := NewCaller(&CallerParams{
+		Client: server.Client(),
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		time.Sleep(100 * time.Millisecond)
+		cancel()
+	}()
+	defer cancel()
+
+	start := time.Now()
+	_, err := caller.Call(
+		ctx,
+		&CallParams{
+			URL:         server.URL,
+			Method:      http.MethodGet,
+			Request:     &InternalTestRequest{},
+			MaxAttempts: 3,
+		},
+	)
+	elapsed := time.Since(start)
+
+	assert.ErrorIs(t, err, context.Canceled)
+	assert.Equal(t, 1, requestCount, "Expected the retry to be abandoned once the context was cancelled")
+	assert.Less(t, elapsed, time.Second, "Expected the backoff to be interrupted by the context, took %v", elapsed)
+}
+
+// When the caller's deadline would elapse before the backoff finishes, sleeping
+// only guarantees a context error. Return the response instead so the caller
+// learns why the request actually failed.
+func TestRetryReturnsResponseWhenDeadlineShorterThanBackoff(t *testing.T) {
 	var requestCount int
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		requestCount++
@@ -323,9 +366,50 @@ func TestRetryWaitIsInterruptedByContext(t *testing.T) {
 	)
 	elapsed := time.Since(start)
 
-	assert.ErrorIs(t, err, context.DeadlineExceeded)
-	assert.Equal(t, 1, requestCount, "Expected the retry to be abandoned once the context expired")
-	assert.Less(t, elapsed, time.Second, "Expected the backoff to be interrupted by the context, took %v", elapsed)
+	// The caller gets the 429, not context.DeadlineExceeded.
+	var apiError *core.APIError
+	require.ErrorAs(t, err, &apiError)
+	assert.Equal(t, http.StatusTooManyRequests, apiError.StatusCode)
+	assert.NotErrorIs(t, err, context.DeadlineExceeded)
+	assert.Equal(t, 1, requestCount, "Expected no retry once the deadline was known to be too short")
+	assert.Less(t, elapsed, time.Second, "Expected to return immediately rather than sleep, took %v", elapsed)
+}
+
+// A deadline with room for the backoff must still retry as normal.
+func TestRetryProceedsWhenDeadlineLongerThanBackoff(t *testing.T) {
+	var requestCount int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		if requestCount == 1 {
+			w.Header().Set("Retry-After", "1")
+			w.WriteHeader(http.StatusTooManyRequests)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("{}"))
+	}))
+	defer server.Close()
+
+	caller := NewCaller(&CallerParams{
+		Client: server.Client(),
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	_, err := caller.Call(
+		ctx,
+		&CallParams{
+			URL:         server.URL,
+			Method:      http.MethodGet,
+			Request:     &InternalTestRequest{},
+			Response:    &InternalTestResponse{},
+			MaxAttempts: 3,
+		},
+	)
+
+	assert.NoError(t, err)
+	assert.Equal(t, 2, requestCount, "Expected the retry to proceed when the deadline allows it")
 }
 
 func TestDisableRetries(t *testing.T) {

--- a/seed/go-sdk/basic-auth-pw-omitted/wire-tests/internal/retrier.go
+++ b/seed/go-sdk/basic-auth-pw-omitted/wire-tests/internal/retrier.go
@@ -145,12 +145,20 @@ func (r *Retrier) run(
 	}
 
 	if r.shouldRetry(response) {
-		defer func() { _ = response.Body.Close() }()
-
 		delay, err := r.retryDelay(response, retryAttempt)
 		if err != nil {
+			_ = response.Body.Close()
 			return nil, err
 		}
+
+		// If the context's deadline would elapse before the backoff completes, return
+		// the response instead of sleeping through it. The caller then sees why the
+		// request actually failed (e.g. a 429) rather than a context deadline error.
+		if deadline, ok := request.Context().Deadline(); ok && time.Until(deadline) < delay {
+			return response, nil
+		}
+
+		defer func() { _ = response.Body.Close() }()
 
 		if err := sleepWithContext(request.Context(), delay); err != nil {
 			return nil, err

--- a/seed/go-sdk/basic-auth-pw-omitted/wire-tests/internal/retrier_test.go
+++ b/seed/go-sdk/basic-auth-pw-omitted/wire-tests/internal/retrier_test.go
@@ -295,7 +295,50 @@ func TestRetryWithRequestBody(t *testing.T) {
 	assert.Equal(t, expectedBody, requestBodies[1], "Second request body should match expected (retry should re-send body)")
 }
 
+// An explicit cancel (e.g. Ctrl-C wired to cancel()) must interrupt the backoff
+// wait. There is no deadline here, so the retrier cannot know the wait is futile
+// up front -- it has to be woken by the context.
 func TestRetryWaitIsInterruptedByContext(t *testing.T) {
+	var requestCount int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		w.Header().Set("Retry-After", "5")
+		w.WriteHeader(http.StatusTooManyRequests)
+	}))
+	defer server.Close()
+
+	caller := NewCaller(&CallerParams{
+		Client: server.Client(),
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		time.Sleep(100 * time.Millisecond)
+		cancel()
+	}()
+	defer cancel()
+
+	start := time.Now()
+	_, err := caller.Call(
+		ctx,
+		&CallParams{
+			URL:         server.URL,
+			Method:      http.MethodGet,
+			Request:     &InternalTestRequest{},
+			MaxAttempts: 3,
+		},
+	)
+	elapsed := time.Since(start)
+
+	assert.ErrorIs(t, err, context.Canceled)
+	assert.Equal(t, 1, requestCount, "Expected the retry to be abandoned once the context was cancelled")
+	assert.Less(t, elapsed, time.Second, "Expected the backoff to be interrupted by the context, took %v", elapsed)
+}
+
+// When the caller's deadline would elapse before the backoff finishes, sleeping
+// only guarantees a context error. Return the response instead so the caller
+// learns why the request actually failed.
+func TestRetryReturnsResponseWhenDeadlineShorterThanBackoff(t *testing.T) {
 	var requestCount int
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		requestCount++
@@ -323,9 +366,50 @@ func TestRetryWaitIsInterruptedByContext(t *testing.T) {
 	)
 	elapsed := time.Since(start)
 
-	assert.ErrorIs(t, err, context.DeadlineExceeded)
-	assert.Equal(t, 1, requestCount, "Expected the retry to be abandoned once the context expired")
-	assert.Less(t, elapsed, time.Second, "Expected the backoff to be interrupted by the context, took %v", elapsed)
+	// The caller gets the 429, not context.DeadlineExceeded.
+	var apiError *core.APIError
+	require.ErrorAs(t, err, &apiError)
+	assert.Equal(t, http.StatusTooManyRequests, apiError.StatusCode)
+	assert.NotErrorIs(t, err, context.DeadlineExceeded)
+	assert.Equal(t, 1, requestCount, "Expected no retry once the deadline was known to be too short")
+	assert.Less(t, elapsed, time.Second, "Expected to return immediately rather than sleep, took %v", elapsed)
+}
+
+// A deadline with room for the backoff must still retry as normal.
+func TestRetryProceedsWhenDeadlineLongerThanBackoff(t *testing.T) {
+	var requestCount int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		if requestCount == 1 {
+			w.Header().Set("Retry-After", "1")
+			w.WriteHeader(http.StatusTooManyRequests)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("{}"))
+	}))
+	defer server.Close()
+
+	caller := NewCaller(&CallerParams{
+		Client: server.Client(),
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	_, err := caller.Call(
+		ctx,
+		&CallParams{
+			URL:         server.URL,
+			Method:      http.MethodGet,
+			Request:     &InternalTestRequest{},
+			Response:    &InternalTestResponse{},
+			MaxAttempts: 3,
+		},
+	)
+
+	assert.NoError(t, err)
+	assert.Equal(t, 2, requestCount, "Expected the retry to proceed when the deadline allows it")
 }
 
 func TestDisableRetries(t *testing.T) {

--- a/seed/go-sdk/basic-auth/internal/retrier.go
+++ b/seed/go-sdk/basic-auth/internal/retrier.go
@@ -145,12 +145,20 @@ func (r *Retrier) run(
 	}
 
 	if r.shouldRetry(response) {
-		defer func() { _ = response.Body.Close() }()
-
 		delay, err := r.retryDelay(response, retryAttempt)
 		if err != nil {
+			_ = response.Body.Close()
 			return nil, err
 		}
+
+		// If the context's deadline would elapse before the backoff completes, return
+		// the response instead of sleeping through it. The caller then sees why the
+		// request actually failed (e.g. a 429) rather than a context deadline error.
+		if deadline, ok := request.Context().Deadline(); ok && time.Until(deadline) < delay {
+			return response, nil
+		}
+
+		defer func() { _ = response.Body.Close() }()
 
 		if err := sleepWithContext(request.Context(), delay); err != nil {
 			return nil, err

--- a/seed/go-sdk/basic-auth/internal/retrier_test.go
+++ b/seed/go-sdk/basic-auth/internal/retrier_test.go
@@ -295,7 +295,50 @@ func TestRetryWithRequestBody(t *testing.T) {
 	assert.Equal(t, expectedBody, requestBodies[1], "Second request body should match expected (retry should re-send body)")
 }
 
+// An explicit cancel (e.g. Ctrl-C wired to cancel()) must interrupt the backoff
+// wait. There is no deadline here, so the retrier cannot know the wait is futile
+// up front -- it has to be woken by the context.
 func TestRetryWaitIsInterruptedByContext(t *testing.T) {
+	var requestCount int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		w.Header().Set("Retry-After", "5")
+		w.WriteHeader(http.StatusTooManyRequests)
+	}))
+	defer server.Close()
+
+	caller := NewCaller(&CallerParams{
+		Client: server.Client(),
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		time.Sleep(100 * time.Millisecond)
+		cancel()
+	}()
+	defer cancel()
+
+	start := time.Now()
+	_, err := caller.Call(
+		ctx,
+		&CallParams{
+			URL:         server.URL,
+			Method:      http.MethodGet,
+			Request:     &InternalTestRequest{},
+			MaxAttempts: 3,
+		},
+	)
+	elapsed := time.Since(start)
+
+	assert.ErrorIs(t, err, context.Canceled)
+	assert.Equal(t, 1, requestCount, "Expected the retry to be abandoned once the context was cancelled")
+	assert.Less(t, elapsed, time.Second, "Expected the backoff to be interrupted by the context, took %v", elapsed)
+}
+
+// When the caller's deadline would elapse before the backoff finishes, sleeping
+// only guarantees a context error. Return the response instead so the caller
+// learns why the request actually failed.
+func TestRetryReturnsResponseWhenDeadlineShorterThanBackoff(t *testing.T) {
 	var requestCount int
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		requestCount++
@@ -323,9 +366,50 @@ func TestRetryWaitIsInterruptedByContext(t *testing.T) {
 	)
 	elapsed := time.Since(start)
 
-	assert.ErrorIs(t, err, context.DeadlineExceeded)
-	assert.Equal(t, 1, requestCount, "Expected the retry to be abandoned once the context expired")
-	assert.Less(t, elapsed, time.Second, "Expected the backoff to be interrupted by the context, took %v", elapsed)
+	// The caller gets the 429, not context.DeadlineExceeded.
+	var apiError *core.APIError
+	require.ErrorAs(t, err, &apiError)
+	assert.Equal(t, http.StatusTooManyRequests, apiError.StatusCode)
+	assert.NotErrorIs(t, err, context.DeadlineExceeded)
+	assert.Equal(t, 1, requestCount, "Expected no retry once the deadline was known to be too short")
+	assert.Less(t, elapsed, time.Second, "Expected to return immediately rather than sleep, took %v", elapsed)
+}
+
+// A deadline with room for the backoff must still retry as normal.
+func TestRetryProceedsWhenDeadlineLongerThanBackoff(t *testing.T) {
+	var requestCount int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		if requestCount == 1 {
+			w.Header().Set("Retry-After", "1")
+			w.WriteHeader(http.StatusTooManyRequests)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("{}"))
+	}))
+	defer server.Close()
+
+	caller := NewCaller(&CallerParams{
+		Client: server.Client(),
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	_, err := caller.Call(
+		ctx,
+		&CallParams{
+			URL:         server.URL,
+			Method:      http.MethodGet,
+			Request:     &InternalTestRequest{},
+			Response:    &InternalTestResponse{},
+			MaxAttempts: 3,
+		},
+	)
+
+	assert.NoError(t, err)
+	assert.Equal(t, 2, requestCount, "Expected the retry to proceed when the deadline allows it")
 }
 
 func TestDisableRetries(t *testing.T) {

--- a/seed/go-sdk/bearer-token-environment-variable/internal/retrier.go
+++ b/seed/go-sdk/bearer-token-environment-variable/internal/retrier.go
@@ -145,12 +145,20 @@ func (r *Retrier) run(
 	}
 
 	if r.shouldRetry(response) {
-		defer func() { _ = response.Body.Close() }()
-
 		delay, err := r.retryDelay(response, retryAttempt)
 		if err != nil {
+			_ = response.Body.Close()
 			return nil, err
 		}
+
+		// If the context's deadline would elapse before the backoff completes, return
+		// the response instead of sleeping through it. The caller then sees why the
+		// request actually failed (e.g. a 429) rather than a context deadline error.
+		if deadline, ok := request.Context().Deadline(); ok && time.Until(deadline) < delay {
+			return response, nil
+		}
+
+		defer func() { _ = response.Body.Close() }()
 
 		if err := sleepWithContext(request.Context(), delay); err != nil {
 			return nil, err

--- a/seed/go-sdk/bearer-token-environment-variable/internal/retrier_test.go
+++ b/seed/go-sdk/bearer-token-environment-variable/internal/retrier_test.go
@@ -295,7 +295,50 @@ func TestRetryWithRequestBody(t *testing.T) {
 	assert.Equal(t, expectedBody, requestBodies[1], "Second request body should match expected (retry should re-send body)")
 }
 
+// An explicit cancel (e.g. Ctrl-C wired to cancel()) must interrupt the backoff
+// wait. There is no deadline here, so the retrier cannot know the wait is futile
+// up front -- it has to be woken by the context.
 func TestRetryWaitIsInterruptedByContext(t *testing.T) {
+	var requestCount int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		w.Header().Set("Retry-After", "5")
+		w.WriteHeader(http.StatusTooManyRequests)
+	}))
+	defer server.Close()
+
+	caller := NewCaller(&CallerParams{
+		Client: server.Client(),
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		time.Sleep(100 * time.Millisecond)
+		cancel()
+	}()
+	defer cancel()
+
+	start := time.Now()
+	_, err := caller.Call(
+		ctx,
+		&CallParams{
+			URL:         server.URL,
+			Method:      http.MethodGet,
+			Request:     &InternalTestRequest{},
+			MaxAttempts: 3,
+		},
+	)
+	elapsed := time.Since(start)
+
+	assert.ErrorIs(t, err, context.Canceled)
+	assert.Equal(t, 1, requestCount, "Expected the retry to be abandoned once the context was cancelled")
+	assert.Less(t, elapsed, time.Second, "Expected the backoff to be interrupted by the context, took %v", elapsed)
+}
+
+// When the caller's deadline would elapse before the backoff finishes, sleeping
+// only guarantees a context error. Return the response instead so the caller
+// learns why the request actually failed.
+func TestRetryReturnsResponseWhenDeadlineShorterThanBackoff(t *testing.T) {
 	var requestCount int
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		requestCount++
@@ -323,9 +366,50 @@ func TestRetryWaitIsInterruptedByContext(t *testing.T) {
 	)
 	elapsed := time.Since(start)
 
-	assert.ErrorIs(t, err, context.DeadlineExceeded)
-	assert.Equal(t, 1, requestCount, "Expected the retry to be abandoned once the context expired")
-	assert.Less(t, elapsed, time.Second, "Expected the backoff to be interrupted by the context, took %v", elapsed)
+	// The caller gets the 429, not context.DeadlineExceeded.
+	var apiError *core.APIError
+	require.ErrorAs(t, err, &apiError)
+	assert.Equal(t, http.StatusTooManyRequests, apiError.StatusCode)
+	assert.NotErrorIs(t, err, context.DeadlineExceeded)
+	assert.Equal(t, 1, requestCount, "Expected no retry once the deadline was known to be too short")
+	assert.Less(t, elapsed, time.Second, "Expected to return immediately rather than sleep, took %v", elapsed)
+}
+
+// A deadline with room for the backoff must still retry as normal.
+func TestRetryProceedsWhenDeadlineLongerThanBackoff(t *testing.T) {
+	var requestCount int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		if requestCount == 1 {
+			w.Header().Set("Retry-After", "1")
+			w.WriteHeader(http.StatusTooManyRequests)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("{}"))
+	}))
+	defer server.Close()
+
+	caller := NewCaller(&CallerParams{
+		Client: server.Client(),
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	_, err := caller.Call(
+		ctx,
+		&CallParams{
+			URL:         server.URL,
+			Method:      http.MethodGet,
+			Request:     &InternalTestRequest{},
+			Response:    &InternalTestResponse{},
+			MaxAttempts: 3,
+		},
+	)
+
+	assert.NoError(t, err)
+	assert.Equal(t, 2, requestCount, "Expected the retry to proceed when the deadline allows it")
 }
 
 func TestDisableRetries(t *testing.T) {

--- a/seed/go-sdk/bytes-download/internal/retrier.go
+++ b/seed/go-sdk/bytes-download/internal/retrier.go
@@ -145,12 +145,20 @@ func (r *Retrier) run(
 	}
 
 	if r.shouldRetry(response) {
-		defer func() { _ = response.Body.Close() }()
-
 		delay, err := r.retryDelay(response, retryAttempt)
 		if err != nil {
+			_ = response.Body.Close()
 			return nil, err
 		}
+
+		// If the context's deadline would elapse before the backoff completes, return
+		// the response instead of sleeping through it. The caller then sees why the
+		// request actually failed (e.g. a 429) rather than a context deadline error.
+		if deadline, ok := request.Context().Deadline(); ok && time.Until(deadline) < delay {
+			return response, nil
+		}
+
+		defer func() { _ = response.Body.Close() }()
 
 		if err := sleepWithContext(request.Context(), delay); err != nil {
 			return nil, err

--- a/seed/go-sdk/bytes-download/internal/retrier_test.go
+++ b/seed/go-sdk/bytes-download/internal/retrier_test.go
@@ -295,7 +295,50 @@ func TestRetryWithRequestBody(t *testing.T) {
 	assert.Equal(t, expectedBody, requestBodies[1], "Second request body should match expected (retry should re-send body)")
 }
 
+// An explicit cancel (e.g. Ctrl-C wired to cancel()) must interrupt the backoff
+// wait. There is no deadline here, so the retrier cannot know the wait is futile
+// up front -- it has to be woken by the context.
 func TestRetryWaitIsInterruptedByContext(t *testing.T) {
+	var requestCount int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		w.Header().Set("Retry-After", "5")
+		w.WriteHeader(http.StatusTooManyRequests)
+	}))
+	defer server.Close()
+
+	caller := NewCaller(&CallerParams{
+		Client: server.Client(),
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		time.Sleep(100 * time.Millisecond)
+		cancel()
+	}()
+	defer cancel()
+
+	start := time.Now()
+	_, err := caller.Call(
+		ctx,
+		&CallParams{
+			URL:         server.URL,
+			Method:      http.MethodGet,
+			Request:     &InternalTestRequest{},
+			MaxAttempts: 3,
+		},
+	)
+	elapsed := time.Since(start)
+
+	assert.ErrorIs(t, err, context.Canceled)
+	assert.Equal(t, 1, requestCount, "Expected the retry to be abandoned once the context was cancelled")
+	assert.Less(t, elapsed, time.Second, "Expected the backoff to be interrupted by the context, took %v", elapsed)
+}
+
+// When the caller's deadline would elapse before the backoff finishes, sleeping
+// only guarantees a context error. Return the response instead so the caller
+// learns why the request actually failed.
+func TestRetryReturnsResponseWhenDeadlineShorterThanBackoff(t *testing.T) {
 	var requestCount int
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		requestCount++
@@ -323,9 +366,50 @@ func TestRetryWaitIsInterruptedByContext(t *testing.T) {
 	)
 	elapsed := time.Since(start)
 
-	assert.ErrorIs(t, err, context.DeadlineExceeded)
-	assert.Equal(t, 1, requestCount, "Expected the retry to be abandoned once the context expired")
-	assert.Less(t, elapsed, time.Second, "Expected the backoff to be interrupted by the context, took %v", elapsed)
+	// The caller gets the 429, not context.DeadlineExceeded.
+	var apiError *core.APIError
+	require.ErrorAs(t, err, &apiError)
+	assert.Equal(t, http.StatusTooManyRequests, apiError.StatusCode)
+	assert.NotErrorIs(t, err, context.DeadlineExceeded)
+	assert.Equal(t, 1, requestCount, "Expected no retry once the deadline was known to be too short")
+	assert.Less(t, elapsed, time.Second, "Expected to return immediately rather than sleep, took %v", elapsed)
+}
+
+// A deadline with room for the backoff must still retry as normal.
+func TestRetryProceedsWhenDeadlineLongerThanBackoff(t *testing.T) {
+	var requestCount int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		if requestCount == 1 {
+			w.Header().Set("Retry-After", "1")
+			w.WriteHeader(http.StatusTooManyRequests)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("{}"))
+	}))
+	defer server.Close()
+
+	caller := NewCaller(&CallerParams{
+		Client: server.Client(),
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	_, err := caller.Call(
+		ctx,
+		&CallParams{
+			URL:         server.URL,
+			Method:      http.MethodGet,
+			Request:     &InternalTestRequest{},
+			Response:    &InternalTestResponse{},
+			MaxAttempts: 3,
+		},
+	)
+
+	assert.NoError(t, err)
+	assert.Equal(t, 2, requestCount, "Expected the retry to proceed when the deadline allows it")
 }
 
 func TestDisableRetries(t *testing.T) {

--- a/seed/go-sdk/bytes-upload/internal/retrier.go
+++ b/seed/go-sdk/bytes-upload/internal/retrier.go
@@ -145,12 +145,20 @@ func (r *Retrier) run(
 	}
 
 	if r.shouldRetry(response) {
-		defer func() { _ = response.Body.Close() }()
-
 		delay, err := r.retryDelay(response, retryAttempt)
 		if err != nil {
+			_ = response.Body.Close()
 			return nil, err
 		}
+
+		// If the context's deadline would elapse before the backoff completes, return
+		// the response instead of sleeping through it. The caller then sees why the
+		// request actually failed (e.g. a 429) rather than a context deadline error.
+		if deadline, ok := request.Context().Deadline(); ok && time.Until(deadline) < delay {
+			return response, nil
+		}
+
+		defer func() { _ = response.Body.Close() }()
 
 		if err := sleepWithContext(request.Context(), delay); err != nil {
 			return nil, err

--- a/seed/go-sdk/bytes-upload/internal/retrier_test.go
+++ b/seed/go-sdk/bytes-upload/internal/retrier_test.go
@@ -295,7 +295,50 @@ func TestRetryWithRequestBody(t *testing.T) {
 	assert.Equal(t, expectedBody, requestBodies[1], "Second request body should match expected (retry should re-send body)")
 }
 
+// An explicit cancel (e.g. Ctrl-C wired to cancel()) must interrupt the backoff
+// wait. There is no deadline here, so the retrier cannot know the wait is futile
+// up front -- it has to be woken by the context.
 func TestRetryWaitIsInterruptedByContext(t *testing.T) {
+	var requestCount int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		w.Header().Set("Retry-After", "5")
+		w.WriteHeader(http.StatusTooManyRequests)
+	}))
+	defer server.Close()
+
+	caller := NewCaller(&CallerParams{
+		Client: server.Client(),
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		time.Sleep(100 * time.Millisecond)
+		cancel()
+	}()
+	defer cancel()
+
+	start := time.Now()
+	_, err := caller.Call(
+		ctx,
+		&CallParams{
+			URL:         server.URL,
+			Method:      http.MethodGet,
+			Request:     &InternalTestRequest{},
+			MaxAttempts: 3,
+		},
+	)
+	elapsed := time.Since(start)
+
+	assert.ErrorIs(t, err, context.Canceled)
+	assert.Equal(t, 1, requestCount, "Expected the retry to be abandoned once the context was cancelled")
+	assert.Less(t, elapsed, time.Second, "Expected the backoff to be interrupted by the context, took %v", elapsed)
+}
+
+// When the caller's deadline would elapse before the backoff finishes, sleeping
+// only guarantees a context error. Return the response instead so the caller
+// learns why the request actually failed.
+func TestRetryReturnsResponseWhenDeadlineShorterThanBackoff(t *testing.T) {
 	var requestCount int
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		requestCount++
@@ -323,9 +366,50 @@ func TestRetryWaitIsInterruptedByContext(t *testing.T) {
 	)
 	elapsed := time.Since(start)
 
-	assert.ErrorIs(t, err, context.DeadlineExceeded)
-	assert.Equal(t, 1, requestCount, "Expected the retry to be abandoned once the context expired")
-	assert.Less(t, elapsed, time.Second, "Expected the backoff to be interrupted by the context, took %v", elapsed)
+	// The caller gets the 429, not context.DeadlineExceeded.
+	var apiError *core.APIError
+	require.ErrorAs(t, err, &apiError)
+	assert.Equal(t, http.StatusTooManyRequests, apiError.StatusCode)
+	assert.NotErrorIs(t, err, context.DeadlineExceeded)
+	assert.Equal(t, 1, requestCount, "Expected no retry once the deadline was known to be too short")
+	assert.Less(t, elapsed, time.Second, "Expected to return immediately rather than sleep, took %v", elapsed)
+}
+
+// A deadline with room for the backoff must still retry as normal.
+func TestRetryProceedsWhenDeadlineLongerThanBackoff(t *testing.T) {
+	var requestCount int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		if requestCount == 1 {
+			w.Header().Set("Retry-After", "1")
+			w.WriteHeader(http.StatusTooManyRequests)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("{}"))
+	}))
+	defer server.Close()
+
+	caller := NewCaller(&CallerParams{
+		Client: server.Client(),
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	_, err := caller.Call(
+		ctx,
+		&CallParams{
+			URL:         server.URL,
+			Method:      http.MethodGet,
+			Request:     &InternalTestRequest{},
+			Response:    &InternalTestResponse{},
+			MaxAttempts: 3,
+		},
+	)
+
+	assert.NoError(t, err)
+	assert.Equal(t, 2, requestCount, "Expected the retry to proceed when the deadline allows it")
 }
 
 func TestDisableRetries(t *testing.T) {

--- a/seed/go-sdk/circular-references-advanced/internal/retrier.go
+++ b/seed/go-sdk/circular-references-advanced/internal/retrier.go
@@ -145,12 +145,20 @@ func (r *Retrier) run(
 	}
 
 	if r.shouldRetry(response) {
-		defer func() { _ = response.Body.Close() }()
-
 		delay, err := r.retryDelay(response, retryAttempt)
 		if err != nil {
+			_ = response.Body.Close()
 			return nil, err
 		}
+
+		// If the context's deadline would elapse before the backoff completes, return
+		// the response instead of sleeping through it. The caller then sees why the
+		// request actually failed (e.g. a 429) rather than a context deadline error.
+		if deadline, ok := request.Context().Deadline(); ok && time.Until(deadline) < delay {
+			return response, nil
+		}
+
+		defer func() { _ = response.Body.Close() }()
 
 		if err := sleepWithContext(request.Context(), delay); err != nil {
 			return nil, err

--- a/seed/go-sdk/circular-references-advanced/internal/retrier_test.go
+++ b/seed/go-sdk/circular-references-advanced/internal/retrier_test.go
@@ -295,7 +295,50 @@ func TestRetryWithRequestBody(t *testing.T) {
 	assert.Equal(t, expectedBody, requestBodies[1], "Second request body should match expected (retry should re-send body)")
 }
 
+// An explicit cancel (e.g. Ctrl-C wired to cancel()) must interrupt the backoff
+// wait. There is no deadline here, so the retrier cannot know the wait is futile
+// up front -- it has to be woken by the context.
 func TestRetryWaitIsInterruptedByContext(t *testing.T) {
+	var requestCount int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		w.Header().Set("Retry-After", "5")
+		w.WriteHeader(http.StatusTooManyRequests)
+	}))
+	defer server.Close()
+
+	caller := NewCaller(&CallerParams{
+		Client: server.Client(),
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		time.Sleep(100 * time.Millisecond)
+		cancel()
+	}()
+	defer cancel()
+
+	start := time.Now()
+	_, err := caller.Call(
+		ctx,
+		&CallParams{
+			URL:         server.URL,
+			Method:      http.MethodGet,
+			Request:     &InternalTestRequest{},
+			MaxAttempts: 3,
+		},
+	)
+	elapsed := time.Since(start)
+
+	assert.ErrorIs(t, err, context.Canceled)
+	assert.Equal(t, 1, requestCount, "Expected the retry to be abandoned once the context was cancelled")
+	assert.Less(t, elapsed, time.Second, "Expected the backoff to be interrupted by the context, took %v", elapsed)
+}
+
+// When the caller's deadline would elapse before the backoff finishes, sleeping
+// only guarantees a context error. Return the response instead so the caller
+// learns why the request actually failed.
+func TestRetryReturnsResponseWhenDeadlineShorterThanBackoff(t *testing.T) {
 	var requestCount int
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		requestCount++
@@ -323,9 +366,50 @@ func TestRetryWaitIsInterruptedByContext(t *testing.T) {
 	)
 	elapsed := time.Since(start)
 
-	assert.ErrorIs(t, err, context.DeadlineExceeded)
-	assert.Equal(t, 1, requestCount, "Expected the retry to be abandoned once the context expired")
-	assert.Less(t, elapsed, time.Second, "Expected the backoff to be interrupted by the context, took %v", elapsed)
+	// The caller gets the 429, not context.DeadlineExceeded.
+	var apiError *core.APIError
+	require.ErrorAs(t, err, &apiError)
+	assert.Equal(t, http.StatusTooManyRequests, apiError.StatusCode)
+	assert.NotErrorIs(t, err, context.DeadlineExceeded)
+	assert.Equal(t, 1, requestCount, "Expected no retry once the deadline was known to be too short")
+	assert.Less(t, elapsed, time.Second, "Expected to return immediately rather than sleep, took %v", elapsed)
+}
+
+// A deadline with room for the backoff must still retry as normal.
+func TestRetryProceedsWhenDeadlineLongerThanBackoff(t *testing.T) {
+	var requestCount int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		if requestCount == 1 {
+			w.Header().Set("Retry-After", "1")
+			w.WriteHeader(http.StatusTooManyRequests)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("{}"))
+	}))
+	defer server.Close()
+
+	caller := NewCaller(&CallerParams{
+		Client: server.Client(),
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	_, err := caller.Call(
+		ctx,
+		&CallParams{
+			URL:         server.URL,
+			Method:      http.MethodGet,
+			Request:     &InternalTestRequest{},
+			Response:    &InternalTestResponse{},
+			MaxAttempts: 3,
+		},
+	)
+
+	assert.NoError(t, err)
+	assert.Equal(t, 2, requestCount, "Expected the retry to proceed when the deadline allows it")
 }
 
 func TestDisableRetries(t *testing.T) {

--- a/seed/go-sdk/circular-references-extends/internal/retrier.go
+++ b/seed/go-sdk/circular-references-extends/internal/retrier.go
@@ -145,12 +145,20 @@ func (r *Retrier) run(
 	}
 
 	if r.shouldRetry(response) {
-		defer func() { _ = response.Body.Close() }()
-
 		delay, err := r.retryDelay(response, retryAttempt)
 		if err != nil {
+			_ = response.Body.Close()
 			return nil, err
 		}
+
+		// If the context's deadline would elapse before the backoff completes, return
+		// the response instead of sleeping through it. The caller then sees why the
+		// request actually failed (e.g. a 429) rather than a context deadline error.
+		if deadline, ok := request.Context().Deadline(); ok && time.Until(deadline) < delay {
+			return response, nil
+		}
+
+		defer func() { _ = response.Body.Close() }()
 
 		if err := sleepWithContext(request.Context(), delay); err != nil {
 			return nil, err

--- a/seed/go-sdk/circular-references-extends/internal/retrier_test.go
+++ b/seed/go-sdk/circular-references-extends/internal/retrier_test.go
@@ -295,7 +295,50 @@ func TestRetryWithRequestBody(t *testing.T) {
 	assert.Equal(t, expectedBody, requestBodies[1], "Second request body should match expected (retry should re-send body)")
 }
 
+// An explicit cancel (e.g. Ctrl-C wired to cancel()) must interrupt the backoff
+// wait. There is no deadline here, so the retrier cannot know the wait is futile
+// up front -- it has to be woken by the context.
 func TestRetryWaitIsInterruptedByContext(t *testing.T) {
+	var requestCount int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		w.Header().Set("Retry-After", "5")
+		w.WriteHeader(http.StatusTooManyRequests)
+	}))
+	defer server.Close()
+
+	caller := NewCaller(&CallerParams{
+		Client: server.Client(),
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		time.Sleep(100 * time.Millisecond)
+		cancel()
+	}()
+	defer cancel()
+
+	start := time.Now()
+	_, err := caller.Call(
+		ctx,
+		&CallParams{
+			URL:         server.URL,
+			Method:      http.MethodGet,
+			Request:     &InternalTestRequest{},
+			MaxAttempts: 3,
+		},
+	)
+	elapsed := time.Since(start)
+
+	assert.ErrorIs(t, err, context.Canceled)
+	assert.Equal(t, 1, requestCount, "Expected the retry to be abandoned once the context was cancelled")
+	assert.Less(t, elapsed, time.Second, "Expected the backoff to be interrupted by the context, took %v", elapsed)
+}
+
+// When the caller's deadline would elapse before the backoff finishes, sleeping
+// only guarantees a context error. Return the response instead so the caller
+// learns why the request actually failed.
+func TestRetryReturnsResponseWhenDeadlineShorterThanBackoff(t *testing.T) {
 	var requestCount int
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		requestCount++
@@ -323,9 +366,50 @@ func TestRetryWaitIsInterruptedByContext(t *testing.T) {
 	)
 	elapsed := time.Since(start)
 
-	assert.ErrorIs(t, err, context.DeadlineExceeded)
-	assert.Equal(t, 1, requestCount, "Expected the retry to be abandoned once the context expired")
-	assert.Less(t, elapsed, time.Second, "Expected the backoff to be interrupted by the context, took %v", elapsed)
+	// The caller gets the 429, not context.DeadlineExceeded.
+	var apiError *core.APIError
+	require.ErrorAs(t, err, &apiError)
+	assert.Equal(t, http.StatusTooManyRequests, apiError.StatusCode)
+	assert.NotErrorIs(t, err, context.DeadlineExceeded)
+	assert.Equal(t, 1, requestCount, "Expected no retry once the deadline was known to be too short")
+	assert.Less(t, elapsed, time.Second, "Expected to return immediately rather than sleep, took %v", elapsed)
+}
+
+// A deadline with room for the backoff must still retry as normal.
+func TestRetryProceedsWhenDeadlineLongerThanBackoff(t *testing.T) {
+	var requestCount int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		if requestCount == 1 {
+			w.Header().Set("Retry-After", "1")
+			w.WriteHeader(http.StatusTooManyRequests)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("{}"))
+	}))
+	defer server.Close()
+
+	caller := NewCaller(&CallerParams{
+		Client: server.Client(),
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	_, err := caller.Call(
+		ctx,
+		&CallParams{
+			URL:         server.URL,
+			Method:      http.MethodGet,
+			Request:     &InternalTestRequest{},
+			Response:    &InternalTestResponse{},
+			MaxAttempts: 3,
+		},
+	)
+
+	assert.NoError(t, err)
+	assert.Equal(t, 2, requestCount, "Expected the retry to proceed when the deadline allows it")
 }
 
 func TestDisableRetries(t *testing.T) {

--- a/seed/go-sdk/circular-references/internal/retrier.go
+++ b/seed/go-sdk/circular-references/internal/retrier.go
@@ -145,12 +145,20 @@ func (r *Retrier) run(
 	}
 
 	if r.shouldRetry(response) {
-		defer func() { _ = response.Body.Close() }()
-
 		delay, err := r.retryDelay(response, retryAttempt)
 		if err != nil {
+			_ = response.Body.Close()
 			return nil, err
 		}
+
+		// If the context's deadline would elapse before the backoff completes, return
+		// the response instead of sleeping through it. The caller then sees why the
+		// request actually failed (e.g. a 429) rather than a context deadline error.
+		if deadline, ok := request.Context().Deadline(); ok && time.Until(deadline) < delay {
+			return response, nil
+		}
+
+		defer func() { _ = response.Body.Close() }()
 
 		if err := sleepWithContext(request.Context(), delay); err != nil {
 			return nil, err

--- a/seed/go-sdk/circular-references/internal/retrier_test.go
+++ b/seed/go-sdk/circular-references/internal/retrier_test.go
@@ -295,7 +295,50 @@ func TestRetryWithRequestBody(t *testing.T) {
 	assert.Equal(t, expectedBody, requestBodies[1], "Second request body should match expected (retry should re-send body)")
 }
 
+// An explicit cancel (e.g. Ctrl-C wired to cancel()) must interrupt the backoff
+// wait. There is no deadline here, so the retrier cannot know the wait is futile
+// up front -- it has to be woken by the context.
 func TestRetryWaitIsInterruptedByContext(t *testing.T) {
+	var requestCount int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		w.Header().Set("Retry-After", "5")
+		w.WriteHeader(http.StatusTooManyRequests)
+	}))
+	defer server.Close()
+
+	caller := NewCaller(&CallerParams{
+		Client: server.Client(),
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		time.Sleep(100 * time.Millisecond)
+		cancel()
+	}()
+	defer cancel()
+
+	start := time.Now()
+	_, err := caller.Call(
+		ctx,
+		&CallParams{
+			URL:         server.URL,
+			Method:      http.MethodGet,
+			Request:     &InternalTestRequest{},
+			MaxAttempts: 3,
+		},
+	)
+	elapsed := time.Since(start)
+
+	assert.ErrorIs(t, err, context.Canceled)
+	assert.Equal(t, 1, requestCount, "Expected the retry to be abandoned once the context was cancelled")
+	assert.Less(t, elapsed, time.Second, "Expected the backoff to be interrupted by the context, took %v", elapsed)
+}
+
+// When the caller's deadline would elapse before the backoff finishes, sleeping
+// only guarantees a context error. Return the response instead so the caller
+// learns why the request actually failed.
+func TestRetryReturnsResponseWhenDeadlineShorterThanBackoff(t *testing.T) {
 	var requestCount int
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		requestCount++
@@ -323,9 +366,50 @@ func TestRetryWaitIsInterruptedByContext(t *testing.T) {
 	)
 	elapsed := time.Since(start)
 
-	assert.ErrorIs(t, err, context.DeadlineExceeded)
-	assert.Equal(t, 1, requestCount, "Expected the retry to be abandoned once the context expired")
-	assert.Less(t, elapsed, time.Second, "Expected the backoff to be interrupted by the context, took %v", elapsed)
+	// The caller gets the 429, not context.DeadlineExceeded.
+	var apiError *core.APIError
+	require.ErrorAs(t, err, &apiError)
+	assert.Equal(t, http.StatusTooManyRequests, apiError.StatusCode)
+	assert.NotErrorIs(t, err, context.DeadlineExceeded)
+	assert.Equal(t, 1, requestCount, "Expected no retry once the deadline was known to be too short")
+	assert.Less(t, elapsed, time.Second, "Expected to return immediately rather than sleep, took %v", elapsed)
+}
+
+// A deadline with room for the backoff must still retry as normal.
+func TestRetryProceedsWhenDeadlineLongerThanBackoff(t *testing.T) {
+	var requestCount int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		if requestCount == 1 {
+			w.Header().Set("Retry-After", "1")
+			w.WriteHeader(http.StatusTooManyRequests)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("{}"))
+	}))
+	defer server.Close()
+
+	caller := NewCaller(&CallerParams{
+		Client: server.Client(),
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	_, err := caller.Call(
+		ctx,
+		&CallParams{
+			URL:         server.URL,
+			Method:      http.MethodGet,
+			Request:     &InternalTestRequest{},
+			Response:    &InternalTestResponse{},
+			MaxAttempts: 3,
+		},
+	)
+
+	assert.NoError(t, err)
+	assert.Equal(t, 2, requestCount, "Expected the retry to proceed when the deadline allows it")
 }
 
 func TestDisableRetries(t *testing.T) {

--- a/seed/go-sdk/client-side-params/internal/retrier.go
+++ b/seed/go-sdk/client-side-params/internal/retrier.go
@@ -145,12 +145,20 @@ func (r *Retrier) run(
 	}
 
 	if r.shouldRetry(response) {
-		defer func() { _ = response.Body.Close() }()
-
 		delay, err := r.retryDelay(response, retryAttempt)
 		if err != nil {
+			_ = response.Body.Close()
 			return nil, err
 		}
+
+		// If the context's deadline would elapse before the backoff completes, return
+		// the response instead of sleeping through it. The caller then sees why the
+		// request actually failed (e.g. a 429) rather than a context deadline error.
+		if deadline, ok := request.Context().Deadline(); ok && time.Until(deadline) < delay {
+			return response, nil
+		}
+
+		defer func() { _ = response.Body.Close() }()
 
 		if err := sleepWithContext(request.Context(), delay); err != nil {
 			return nil, err

--- a/seed/go-sdk/client-side-params/internal/retrier_test.go
+++ b/seed/go-sdk/client-side-params/internal/retrier_test.go
@@ -295,7 +295,50 @@ func TestRetryWithRequestBody(t *testing.T) {
 	assert.Equal(t, expectedBody, requestBodies[1], "Second request body should match expected (retry should re-send body)")
 }
 
+// An explicit cancel (e.g. Ctrl-C wired to cancel()) must interrupt the backoff
+// wait. There is no deadline here, so the retrier cannot know the wait is futile
+// up front -- it has to be woken by the context.
 func TestRetryWaitIsInterruptedByContext(t *testing.T) {
+	var requestCount int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		w.Header().Set("Retry-After", "5")
+		w.WriteHeader(http.StatusTooManyRequests)
+	}))
+	defer server.Close()
+
+	caller := NewCaller(&CallerParams{
+		Client: server.Client(),
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		time.Sleep(100 * time.Millisecond)
+		cancel()
+	}()
+	defer cancel()
+
+	start := time.Now()
+	_, err := caller.Call(
+		ctx,
+		&CallParams{
+			URL:         server.URL,
+			Method:      http.MethodGet,
+			Request:     &InternalTestRequest{},
+			MaxAttempts: 3,
+		},
+	)
+	elapsed := time.Since(start)
+
+	assert.ErrorIs(t, err, context.Canceled)
+	assert.Equal(t, 1, requestCount, "Expected the retry to be abandoned once the context was cancelled")
+	assert.Less(t, elapsed, time.Second, "Expected the backoff to be interrupted by the context, took %v", elapsed)
+}
+
+// When the caller's deadline would elapse before the backoff finishes, sleeping
+// only guarantees a context error. Return the response instead so the caller
+// learns why the request actually failed.
+func TestRetryReturnsResponseWhenDeadlineShorterThanBackoff(t *testing.T) {
 	var requestCount int
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		requestCount++
@@ -323,9 +366,50 @@ func TestRetryWaitIsInterruptedByContext(t *testing.T) {
 	)
 	elapsed := time.Since(start)
 
-	assert.ErrorIs(t, err, context.DeadlineExceeded)
-	assert.Equal(t, 1, requestCount, "Expected the retry to be abandoned once the context expired")
-	assert.Less(t, elapsed, time.Second, "Expected the backoff to be interrupted by the context, took %v", elapsed)
+	// The caller gets the 429, not context.DeadlineExceeded.
+	var apiError *core.APIError
+	require.ErrorAs(t, err, &apiError)
+	assert.Equal(t, http.StatusTooManyRequests, apiError.StatusCode)
+	assert.NotErrorIs(t, err, context.DeadlineExceeded)
+	assert.Equal(t, 1, requestCount, "Expected no retry once the deadline was known to be too short")
+	assert.Less(t, elapsed, time.Second, "Expected to return immediately rather than sleep, took %v", elapsed)
+}
+
+// A deadline with room for the backoff must still retry as normal.
+func TestRetryProceedsWhenDeadlineLongerThanBackoff(t *testing.T) {
+	var requestCount int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		if requestCount == 1 {
+			w.Header().Set("Retry-After", "1")
+			w.WriteHeader(http.StatusTooManyRequests)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("{}"))
+	}))
+	defer server.Close()
+
+	caller := NewCaller(&CallerParams{
+		Client: server.Client(),
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	_, err := caller.Call(
+		ctx,
+		&CallParams{
+			URL:         server.URL,
+			Method:      http.MethodGet,
+			Request:     &InternalTestRequest{},
+			Response:    &InternalTestResponse{},
+			MaxAttempts: 3,
+		},
+	)
+
+	assert.NoError(t, err)
+	assert.Equal(t, 2, requestCount, "Expected the retry to proceed when the deadline allows it")
 }
 
 func TestDisableRetries(t *testing.T) {

--- a/seed/go-sdk/content-type/internal/retrier.go
+++ b/seed/go-sdk/content-type/internal/retrier.go
@@ -145,12 +145,20 @@ func (r *Retrier) run(
 	}
 
 	if r.shouldRetry(response) {
-		defer func() { _ = response.Body.Close() }()
-
 		delay, err := r.retryDelay(response, retryAttempt)
 		if err != nil {
+			_ = response.Body.Close()
 			return nil, err
 		}
+
+		// If the context's deadline would elapse before the backoff completes, return
+		// the response instead of sleeping through it. The caller then sees why the
+		// request actually failed (e.g. a 429) rather than a context deadline error.
+		if deadline, ok := request.Context().Deadline(); ok && time.Until(deadline) < delay {
+			return response, nil
+		}
+
+		defer func() { _ = response.Body.Close() }()
 
 		if err := sleepWithContext(request.Context(), delay); err != nil {
 			return nil, err

--- a/seed/go-sdk/content-type/internal/retrier_test.go
+++ b/seed/go-sdk/content-type/internal/retrier_test.go
@@ -295,7 +295,50 @@ func TestRetryWithRequestBody(t *testing.T) {
 	assert.Equal(t, expectedBody, requestBodies[1], "Second request body should match expected (retry should re-send body)")
 }
 
+// An explicit cancel (e.g. Ctrl-C wired to cancel()) must interrupt the backoff
+// wait. There is no deadline here, so the retrier cannot know the wait is futile
+// up front -- it has to be woken by the context.
 func TestRetryWaitIsInterruptedByContext(t *testing.T) {
+	var requestCount int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		w.Header().Set("Retry-After", "5")
+		w.WriteHeader(http.StatusTooManyRequests)
+	}))
+	defer server.Close()
+
+	caller := NewCaller(&CallerParams{
+		Client: server.Client(),
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		time.Sleep(100 * time.Millisecond)
+		cancel()
+	}()
+	defer cancel()
+
+	start := time.Now()
+	_, err := caller.Call(
+		ctx,
+		&CallParams{
+			URL:         server.URL,
+			Method:      http.MethodGet,
+			Request:     &InternalTestRequest{},
+			MaxAttempts: 3,
+		},
+	)
+	elapsed := time.Since(start)
+
+	assert.ErrorIs(t, err, context.Canceled)
+	assert.Equal(t, 1, requestCount, "Expected the retry to be abandoned once the context was cancelled")
+	assert.Less(t, elapsed, time.Second, "Expected the backoff to be interrupted by the context, took %v", elapsed)
+}
+
+// When the caller's deadline would elapse before the backoff finishes, sleeping
+// only guarantees a context error. Return the response instead so the caller
+// learns why the request actually failed.
+func TestRetryReturnsResponseWhenDeadlineShorterThanBackoff(t *testing.T) {
 	var requestCount int
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		requestCount++
@@ -323,9 +366,50 @@ func TestRetryWaitIsInterruptedByContext(t *testing.T) {
 	)
 	elapsed := time.Since(start)
 
-	assert.ErrorIs(t, err, context.DeadlineExceeded)
-	assert.Equal(t, 1, requestCount, "Expected the retry to be abandoned once the context expired")
-	assert.Less(t, elapsed, time.Second, "Expected the backoff to be interrupted by the context, took %v", elapsed)
+	// The caller gets the 429, not context.DeadlineExceeded.
+	var apiError *core.APIError
+	require.ErrorAs(t, err, &apiError)
+	assert.Equal(t, http.StatusTooManyRequests, apiError.StatusCode)
+	assert.NotErrorIs(t, err, context.DeadlineExceeded)
+	assert.Equal(t, 1, requestCount, "Expected no retry once the deadline was known to be too short")
+	assert.Less(t, elapsed, time.Second, "Expected to return immediately rather than sleep, took %v", elapsed)
+}
+
+// A deadline with room for the backoff must still retry as normal.
+func TestRetryProceedsWhenDeadlineLongerThanBackoff(t *testing.T) {
+	var requestCount int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		if requestCount == 1 {
+			w.Header().Set("Retry-After", "1")
+			w.WriteHeader(http.StatusTooManyRequests)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("{}"))
+	}))
+	defer server.Close()
+
+	caller := NewCaller(&CallerParams{
+		Client: server.Client(),
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	_, err := caller.Call(
+		ctx,
+		&CallParams{
+			URL:         server.URL,
+			Method:      http.MethodGet,
+			Request:     &InternalTestRequest{},
+			Response:    &InternalTestResponse{},
+			MaxAttempts: 3,
+		},
+	)
+
+	assert.NoError(t, err)
+	assert.Equal(t, 2, requestCount, "Expected the retry to proceed when the deadline allows it")
 }
 
 func TestDisableRetries(t *testing.T) {

--- a/seed/go-sdk/cross-package-type-names/internal/retrier.go
+++ b/seed/go-sdk/cross-package-type-names/internal/retrier.go
@@ -145,12 +145,20 @@ func (r *Retrier) run(
 	}
 
 	if r.shouldRetry(response) {
-		defer func() { _ = response.Body.Close() }()
-
 		delay, err := r.retryDelay(response, retryAttempt)
 		if err != nil {
+			_ = response.Body.Close()
 			return nil, err
 		}
+
+		// If the context's deadline would elapse before the backoff completes, return
+		// the response instead of sleeping through it. The caller then sees why the
+		// request actually failed (e.g. a 429) rather than a context deadline error.
+		if deadline, ok := request.Context().Deadline(); ok && time.Until(deadline) < delay {
+			return response, nil
+		}
+
+		defer func() { _ = response.Body.Close() }()
 
 		if err := sleepWithContext(request.Context(), delay); err != nil {
 			return nil, err

--- a/seed/go-sdk/cross-package-type-names/internal/retrier_test.go
+++ b/seed/go-sdk/cross-package-type-names/internal/retrier_test.go
@@ -295,7 +295,50 @@ func TestRetryWithRequestBody(t *testing.T) {
 	assert.Equal(t, expectedBody, requestBodies[1], "Second request body should match expected (retry should re-send body)")
 }
 
+// An explicit cancel (e.g. Ctrl-C wired to cancel()) must interrupt the backoff
+// wait. There is no deadline here, so the retrier cannot know the wait is futile
+// up front -- it has to be woken by the context.
 func TestRetryWaitIsInterruptedByContext(t *testing.T) {
+	var requestCount int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		w.Header().Set("Retry-After", "5")
+		w.WriteHeader(http.StatusTooManyRequests)
+	}))
+	defer server.Close()
+
+	caller := NewCaller(&CallerParams{
+		Client: server.Client(),
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		time.Sleep(100 * time.Millisecond)
+		cancel()
+	}()
+	defer cancel()
+
+	start := time.Now()
+	_, err := caller.Call(
+		ctx,
+		&CallParams{
+			URL:         server.URL,
+			Method:      http.MethodGet,
+			Request:     &InternalTestRequest{},
+			MaxAttempts: 3,
+		},
+	)
+	elapsed := time.Since(start)
+
+	assert.ErrorIs(t, err, context.Canceled)
+	assert.Equal(t, 1, requestCount, "Expected the retry to be abandoned once the context was cancelled")
+	assert.Less(t, elapsed, time.Second, "Expected the backoff to be interrupted by the context, took %v", elapsed)
+}
+
+// When the caller's deadline would elapse before the backoff finishes, sleeping
+// only guarantees a context error. Return the response instead so the caller
+// learns why the request actually failed.
+func TestRetryReturnsResponseWhenDeadlineShorterThanBackoff(t *testing.T) {
 	var requestCount int
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		requestCount++
@@ -323,9 +366,50 @@ func TestRetryWaitIsInterruptedByContext(t *testing.T) {
 	)
 	elapsed := time.Since(start)
 
-	assert.ErrorIs(t, err, context.DeadlineExceeded)
-	assert.Equal(t, 1, requestCount, "Expected the retry to be abandoned once the context expired")
-	assert.Less(t, elapsed, time.Second, "Expected the backoff to be interrupted by the context, took %v", elapsed)
+	// The caller gets the 429, not context.DeadlineExceeded.
+	var apiError *core.APIError
+	require.ErrorAs(t, err, &apiError)
+	assert.Equal(t, http.StatusTooManyRequests, apiError.StatusCode)
+	assert.NotErrorIs(t, err, context.DeadlineExceeded)
+	assert.Equal(t, 1, requestCount, "Expected no retry once the deadline was known to be too short")
+	assert.Less(t, elapsed, time.Second, "Expected to return immediately rather than sleep, took %v", elapsed)
+}
+
+// A deadline with room for the backoff must still retry as normal.
+func TestRetryProceedsWhenDeadlineLongerThanBackoff(t *testing.T) {
+	var requestCount int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		if requestCount == 1 {
+			w.Header().Set("Retry-After", "1")
+			w.WriteHeader(http.StatusTooManyRequests)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("{}"))
+	}))
+	defer server.Close()
+
+	caller := NewCaller(&CallerParams{
+		Client: server.Client(),
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	_, err := caller.Call(
+		ctx,
+		&CallParams{
+			URL:         server.URL,
+			Method:      http.MethodGet,
+			Request:     &InternalTestRequest{},
+			Response:    &InternalTestResponse{},
+			MaxAttempts: 3,
+		},
+	)
+
+	assert.NoError(t, err)
+	assert.Equal(t, 2, requestCount, "Expected the retry to proceed when the deadline allows it")
 }
 
 func TestDisableRetries(t *testing.T) {

--- a/seed/go-sdk/discriminated-union-with-nested-oneof/internal/retrier.go
+++ b/seed/go-sdk/discriminated-union-with-nested-oneof/internal/retrier.go
@@ -145,12 +145,20 @@ func (r *Retrier) run(
 	}
 
 	if r.shouldRetry(response) {
-		defer func() { _ = response.Body.Close() }()
-
 		delay, err := r.retryDelay(response, retryAttempt)
 		if err != nil {
+			_ = response.Body.Close()
 			return nil, err
 		}
+
+		// If the context's deadline would elapse before the backoff completes, return
+		// the response instead of sleeping through it. The caller then sees why the
+		// request actually failed (e.g. a 429) rather than a context deadline error.
+		if deadline, ok := request.Context().Deadline(); ok && time.Until(deadline) < delay {
+			return response, nil
+		}
+
+		defer func() { _ = response.Body.Close() }()
 
 		if err := sleepWithContext(request.Context(), delay); err != nil {
 			return nil, err

--- a/seed/go-sdk/discriminated-union-with-nested-oneof/internal/retrier_test.go
+++ b/seed/go-sdk/discriminated-union-with-nested-oneof/internal/retrier_test.go
@@ -295,7 +295,50 @@ func TestRetryWithRequestBody(t *testing.T) {
 	assert.Equal(t, expectedBody, requestBodies[1], "Second request body should match expected (retry should re-send body)")
 }
 
+// An explicit cancel (e.g. Ctrl-C wired to cancel()) must interrupt the backoff
+// wait. There is no deadline here, so the retrier cannot know the wait is futile
+// up front -- it has to be woken by the context.
 func TestRetryWaitIsInterruptedByContext(t *testing.T) {
+	var requestCount int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		w.Header().Set("Retry-After", "5")
+		w.WriteHeader(http.StatusTooManyRequests)
+	}))
+	defer server.Close()
+
+	caller := NewCaller(&CallerParams{
+		Client: server.Client(),
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		time.Sleep(100 * time.Millisecond)
+		cancel()
+	}()
+	defer cancel()
+
+	start := time.Now()
+	_, err := caller.Call(
+		ctx,
+		&CallParams{
+			URL:         server.URL,
+			Method:      http.MethodGet,
+			Request:     &InternalTestRequest{},
+			MaxAttempts: 3,
+		},
+	)
+	elapsed := time.Since(start)
+
+	assert.ErrorIs(t, err, context.Canceled)
+	assert.Equal(t, 1, requestCount, "Expected the retry to be abandoned once the context was cancelled")
+	assert.Less(t, elapsed, time.Second, "Expected the backoff to be interrupted by the context, took %v", elapsed)
+}
+
+// When the caller's deadline would elapse before the backoff finishes, sleeping
+// only guarantees a context error. Return the response instead so the caller
+// learns why the request actually failed.
+func TestRetryReturnsResponseWhenDeadlineShorterThanBackoff(t *testing.T) {
 	var requestCount int
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		requestCount++
@@ -323,9 +366,50 @@ func TestRetryWaitIsInterruptedByContext(t *testing.T) {
 	)
 	elapsed := time.Since(start)
 
-	assert.ErrorIs(t, err, context.DeadlineExceeded)
-	assert.Equal(t, 1, requestCount, "Expected the retry to be abandoned once the context expired")
-	assert.Less(t, elapsed, time.Second, "Expected the backoff to be interrupted by the context, took %v", elapsed)
+	// The caller gets the 429, not context.DeadlineExceeded.
+	var apiError *core.APIError
+	require.ErrorAs(t, err, &apiError)
+	assert.Equal(t, http.StatusTooManyRequests, apiError.StatusCode)
+	assert.NotErrorIs(t, err, context.DeadlineExceeded)
+	assert.Equal(t, 1, requestCount, "Expected no retry once the deadline was known to be too short")
+	assert.Less(t, elapsed, time.Second, "Expected to return immediately rather than sleep, took %v", elapsed)
+}
+
+// A deadline with room for the backoff must still retry as normal.
+func TestRetryProceedsWhenDeadlineLongerThanBackoff(t *testing.T) {
+	var requestCount int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		if requestCount == 1 {
+			w.Header().Set("Retry-After", "1")
+			w.WriteHeader(http.StatusTooManyRequests)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("{}"))
+	}))
+	defer server.Close()
+
+	caller := NewCaller(&CallerParams{
+		Client: server.Client(),
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	_, err := caller.Call(
+		ctx,
+		&CallParams{
+			URL:         server.URL,
+			Method:      http.MethodGet,
+			Request:     &InternalTestRequest{},
+			Response:    &InternalTestResponse{},
+			MaxAttempts: 3,
+		},
+	)
+
+	assert.NoError(t, err)
+	assert.Equal(t, 2, requestCount, "Expected the retry to proceed when the deadline allows it")
 }
 
 func TestDisableRetries(t *testing.T) {

--- a/seed/go-sdk/dollar-string-examples/internal/retrier.go
+++ b/seed/go-sdk/dollar-string-examples/internal/retrier.go
@@ -145,12 +145,20 @@ func (r *Retrier) run(
 	}
 
 	if r.shouldRetry(response) {
-		defer func() { _ = response.Body.Close() }()
-
 		delay, err := r.retryDelay(response, retryAttempt)
 		if err != nil {
+			_ = response.Body.Close()
 			return nil, err
 		}
+
+		// If the context's deadline would elapse before the backoff completes, return
+		// the response instead of sleeping through it. The caller then sees why the
+		// request actually failed (e.g. a 429) rather than a context deadline error.
+		if deadline, ok := request.Context().Deadline(); ok && time.Until(deadline) < delay {
+			return response, nil
+		}
+
+		defer func() { _ = response.Body.Close() }()
 
 		if err := sleepWithContext(request.Context(), delay); err != nil {
 			return nil, err

--- a/seed/go-sdk/dollar-string-examples/internal/retrier_test.go
+++ b/seed/go-sdk/dollar-string-examples/internal/retrier_test.go
@@ -295,7 +295,50 @@ func TestRetryWithRequestBody(t *testing.T) {
 	assert.Equal(t, expectedBody, requestBodies[1], "Second request body should match expected (retry should re-send body)")
 }
 
+// An explicit cancel (e.g. Ctrl-C wired to cancel()) must interrupt the backoff
+// wait. There is no deadline here, so the retrier cannot know the wait is futile
+// up front -- it has to be woken by the context.
 func TestRetryWaitIsInterruptedByContext(t *testing.T) {
+	var requestCount int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		w.Header().Set("Retry-After", "5")
+		w.WriteHeader(http.StatusTooManyRequests)
+	}))
+	defer server.Close()
+
+	caller := NewCaller(&CallerParams{
+		Client: server.Client(),
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		time.Sleep(100 * time.Millisecond)
+		cancel()
+	}()
+	defer cancel()
+
+	start := time.Now()
+	_, err := caller.Call(
+		ctx,
+		&CallParams{
+			URL:         server.URL,
+			Method:      http.MethodGet,
+			Request:     &InternalTestRequest{},
+			MaxAttempts: 3,
+		},
+	)
+	elapsed := time.Since(start)
+
+	assert.ErrorIs(t, err, context.Canceled)
+	assert.Equal(t, 1, requestCount, "Expected the retry to be abandoned once the context was cancelled")
+	assert.Less(t, elapsed, time.Second, "Expected the backoff to be interrupted by the context, took %v", elapsed)
+}
+
+// When the caller's deadline would elapse before the backoff finishes, sleeping
+// only guarantees a context error. Return the response instead so the caller
+// learns why the request actually failed.
+func TestRetryReturnsResponseWhenDeadlineShorterThanBackoff(t *testing.T) {
 	var requestCount int
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		requestCount++
@@ -323,9 +366,50 @@ func TestRetryWaitIsInterruptedByContext(t *testing.T) {
 	)
 	elapsed := time.Since(start)
 
-	assert.ErrorIs(t, err, context.DeadlineExceeded)
-	assert.Equal(t, 1, requestCount, "Expected the retry to be abandoned once the context expired")
-	assert.Less(t, elapsed, time.Second, "Expected the backoff to be interrupted by the context, took %v", elapsed)
+	// The caller gets the 429, not context.DeadlineExceeded.
+	var apiError *core.APIError
+	require.ErrorAs(t, err, &apiError)
+	assert.Equal(t, http.StatusTooManyRequests, apiError.StatusCode)
+	assert.NotErrorIs(t, err, context.DeadlineExceeded)
+	assert.Equal(t, 1, requestCount, "Expected no retry once the deadline was known to be too short")
+	assert.Less(t, elapsed, time.Second, "Expected to return immediately rather than sleep, took %v", elapsed)
+}
+
+// A deadline with room for the backoff must still retry as normal.
+func TestRetryProceedsWhenDeadlineLongerThanBackoff(t *testing.T) {
+	var requestCount int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		if requestCount == 1 {
+			w.Header().Set("Retry-After", "1")
+			w.WriteHeader(http.StatusTooManyRequests)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("{}"))
+	}))
+	defer server.Close()
+
+	caller := NewCaller(&CallerParams{
+		Client: server.Client(),
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	_, err := caller.Call(
+		ctx,
+		&CallParams{
+			URL:         server.URL,
+			Method:      http.MethodGet,
+			Request:     &InternalTestRequest{},
+			Response:    &InternalTestResponse{},
+			MaxAttempts: 3,
+		},
+	)
+
+	assert.NoError(t, err)
+	assert.Equal(t, 2, requestCount, "Expected the retry to proceed when the deadline allows it")
 }
 
 func TestDisableRetries(t *testing.T) {

--- a/seed/go-sdk/empty-clients/internal/retrier.go
+++ b/seed/go-sdk/empty-clients/internal/retrier.go
@@ -145,12 +145,20 @@ func (r *Retrier) run(
 	}
 
 	if r.shouldRetry(response) {
-		defer func() { _ = response.Body.Close() }()
-
 		delay, err := r.retryDelay(response, retryAttempt)
 		if err != nil {
+			_ = response.Body.Close()
 			return nil, err
 		}
+
+		// If the context's deadline would elapse before the backoff completes, return
+		// the response instead of sleeping through it. The caller then sees why the
+		// request actually failed (e.g. a 429) rather than a context deadline error.
+		if deadline, ok := request.Context().Deadline(); ok && time.Until(deadline) < delay {
+			return response, nil
+		}
+
+		defer func() { _ = response.Body.Close() }()
 
 		if err := sleepWithContext(request.Context(), delay); err != nil {
 			return nil, err

--- a/seed/go-sdk/empty-clients/internal/retrier_test.go
+++ b/seed/go-sdk/empty-clients/internal/retrier_test.go
@@ -295,7 +295,50 @@ func TestRetryWithRequestBody(t *testing.T) {
 	assert.Equal(t, expectedBody, requestBodies[1], "Second request body should match expected (retry should re-send body)")
 }
 
+// An explicit cancel (e.g. Ctrl-C wired to cancel()) must interrupt the backoff
+// wait. There is no deadline here, so the retrier cannot know the wait is futile
+// up front -- it has to be woken by the context.
 func TestRetryWaitIsInterruptedByContext(t *testing.T) {
+	var requestCount int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		w.Header().Set("Retry-After", "5")
+		w.WriteHeader(http.StatusTooManyRequests)
+	}))
+	defer server.Close()
+
+	caller := NewCaller(&CallerParams{
+		Client: server.Client(),
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		time.Sleep(100 * time.Millisecond)
+		cancel()
+	}()
+	defer cancel()
+
+	start := time.Now()
+	_, err := caller.Call(
+		ctx,
+		&CallParams{
+			URL:         server.URL,
+			Method:      http.MethodGet,
+			Request:     &InternalTestRequest{},
+			MaxAttempts: 3,
+		},
+	)
+	elapsed := time.Since(start)
+
+	assert.ErrorIs(t, err, context.Canceled)
+	assert.Equal(t, 1, requestCount, "Expected the retry to be abandoned once the context was cancelled")
+	assert.Less(t, elapsed, time.Second, "Expected the backoff to be interrupted by the context, took %v", elapsed)
+}
+
+// When the caller's deadline would elapse before the backoff finishes, sleeping
+// only guarantees a context error. Return the response instead so the caller
+// learns why the request actually failed.
+func TestRetryReturnsResponseWhenDeadlineShorterThanBackoff(t *testing.T) {
 	var requestCount int
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		requestCount++
@@ -323,9 +366,50 @@ func TestRetryWaitIsInterruptedByContext(t *testing.T) {
 	)
 	elapsed := time.Since(start)
 
-	assert.ErrorIs(t, err, context.DeadlineExceeded)
-	assert.Equal(t, 1, requestCount, "Expected the retry to be abandoned once the context expired")
-	assert.Less(t, elapsed, time.Second, "Expected the backoff to be interrupted by the context, took %v", elapsed)
+	// The caller gets the 429, not context.DeadlineExceeded.
+	var apiError *core.APIError
+	require.ErrorAs(t, err, &apiError)
+	assert.Equal(t, http.StatusTooManyRequests, apiError.StatusCode)
+	assert.NotErrorIs(t, err, context.DeadlineExceeded)
+	assert.Equal(t, 1, requestCount, "Expected no retry once the deadline was known to be too short")
+	assert.Less(t, elapsed, time.Second, "Expected to return immediately rather than sleep, took %v", elapsed)
+}
+
+// A deadline with room for the backoff must still retry as normal.
+func TestRetryProceedsWhenDeadlineLongerThanBackoff(t *testing.T) {
+	var requestCount int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		if requestCount == 1 {
+			w.Header().Set("Retry-After", "1")
+			w.WriteHeader(http.StatusTooManyRequests)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("{}"))
+	}))
+	defer server.Close()
+
+	caller := NewCaller(&CallerParams{
+		Client: server.Client(),
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	_, err := caller.Call(
+		ctx,
+		&CallParams{
+			URL:         server.URL,
+			Method:      http.MethodGet,
+			Request:     &InternalTestRequest{},
+			Response:    &InternalTestResponse{},
+			MaxAttempts: 3,
+		},
+	)
+
+	assert.NoError(t, err)
+	assert.Equal(t, 2, requestCount, "Expected the retry to proceed when the deadline allows it")
 }
 
 func TestDisableRetries(t *testing.T) {

--- a/seed/go-sdk/endpoint-security-auth/internal/retrier.go
+++ b/seed/go-sdk/endpoint-security-auth/internal/retrier.go
@@ -145,12 +145,20 @@ func (r *Retrier) run(
 	}
 
 	if r.shouldRetry(response) {
-		defer func() { _ = response.Body.Close() }()
-
 		delay, err := r.retryDelay(response, retryAttempt)
 		if err != nil {
+			_ = response.Body.Close()
 			return nil, err
 		}
+
+		// If the context's deadline would elapse before the backoff completes, return
+		// the response instead of sleeping through it. The caller then sees why the
+		// request actually failed (e.g. a 429) rather than a context deadline error.
+		if deadline, ok := request.Context().Deadline(); ok && time.Until(deadline) < delay {
+			return response, nil
+		}
+
+		defer func() { _ = response.Body.Close() }()
 
 		if err := sleepWithContext(request.Context(), delay); err != nil {
 			return nil, err

--- a/seed/go-sdk/endpoint-security-auth/internal/retrier_test.go
+++ b/seed/go-sdk/endpoint-security-auth/internal/retrier_test.go
@@ -295,7 +295,50 @@ func TestRetryWithRequestBody(t *testing.T) {
 	assert.Equal(t, expectedBody, requestBodies[1], "Second request body should match expected (retry should re-send body)")
 }
 
+// An explicit cancel (e.g. Ctrl-C wired to cancel()) must interrupt the backoff
+// wait. There is no deadline here, so the retrier cannot know the wait is futile
+// up front -- it has to be woken by the context.
 func TestRetryWaitIsInterruptedByContext(t *testing.T) {
+	var requestCount int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		w.Header().Set("Retry-After", "5")
+		w.WriteHeader(http.StatusTooManyRequests)
+	}))
+	defer server.Close()
+
+	caller := NewCaller(&CallerParams{
+		Client: server.Client(),
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		time.Sleep(100 * time.Millisecond)
+		cancel()
+	}()
+	defer cancel()
+
+	start := time.Now()
+	_, err := caller.Call(
+		ctx,
+		&CallParams{
+			URL:         server.URL,
+			Method:      http.MethodGet,
+			Request:     &InternalTestRequest{},
+			MaxAttempts: 3,
+		},
+	)
+	elapsed := time.Since(start)
+
+	assert.ErrorIs(t, err, context.Canceled)
+	assert.Equal(t, 1, requestCount, "Expected the retry to be abandoned once the context was cancelled")
+	assert.Less(t, elapsed, time.Second, "Expected the backoff to be interrupted by the context, took %v", elapsed)
+}
+
+// When the caller's deadline would elapse before the backoff finishes, sleeping
+// only guarantees a context error. Return the response instead so the caller
+// learns why the request actually failed.
+func TestRetryReturnsResponseWhenDeadlineShorterThanBackoff(t *testing.T) {
 	var requestCount int
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		requestCount++
@@ -323,9 +366,50 @@ func TestRetryWaitIsInterruptedByContext(t *testing.T) {
 	)
 	elapsed := time.Since(start)
 
-	assert.ErrorIs(t, err, context.DeadlineExceeded)
-	assert.Equal(t, 1, requestCount, "Expected the retry to be abandoned once the context expired")
-	assert.Less(t, elapsed, time.Second, "Expected the backoff to be interrupted by the context, took %v", elapsed)
+	// The caller gets the 429, not context.DeadlineExceeded.
+	var apiError *core.APIError
+	require.ErrorAs(t, err, &apiError)
+	assert.Equal(t, http.StatusTooManyRequests, apiError.StatusCode)
+	assert.NotErrorIs(t, err, context.DeadlineExceeded)
+	assert.Equal(t, 1, requestCount, "Expected no retry once the deadline was known to be too short")
+	assert.Less(t, elapsed, time.Second, "Expected to return immediately rather than sleep, took %v", elapsed)
+}
+
+// A deadline with room for the backoff must still retry as normal.
+func TestRetryProceedsWhenDeadlineLongerThanBackoff(t *testing.T) {
+	var requestCount int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		if requestCount == 1 {
+			w.Header().Set("Retry-After", "1")
+			w.WriteHeader(http.StatusTooManyRequests)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("{}"))
+	}))
+	defer server.Close()
+
+	caller := NewCaller(&CallerParams{
+		Client: server.Client(),
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	_, err := caller.Call(
+		ctx,
+		&CallParams{
+			URL:         server.URL,
+			Method:      http.MethodGet,
+			Request:     &InternalTestRequest{},
+			Response:    &InternalTestResponse{},
+			MaxAttempts: 3,
+		},
+	)
+
+	assert.NoError(t, err)
+	assert.Equal(t, 2, requestCount, "Expected the retry to proceed when the deadline allows it")
 }
 
 func TestDisableRetries(t *testing.T) {

--- a/seed/go-sdk/enum/internal/retrier.go
+++ b/seed/go-sdk/enum/internal/retrier.go
@@ -145,12 +145,20 @@ func (r *Retrier) run(
 	}
 
 	if r.shouldRetry(response) {
-		defer func() { _ = response.Body.Close() }()
-
 		delay, err := r.retryDelay(response, retryAttempt)
 		if err != nil {
+			_ = response.Body.Close()
 			return nil, err
 		}
+
+		// If the context's deadline would elapse before the backoff completes, return
+		// the response instead of sleeping through it. The caller then sees why the
+		// request actually failed (e.g. a 429) rather than a context deadline error.
+		if deadline, ok := request.Context().Deadline(); ok && time.Until(deadline) < delay {
+			return response, nil
+		}
+
+		defer func() { _ = response.Body.Close() }()
 
 		if err := sleepWithContext(request.Context(), delay); err != nil {
 			return nil, err

--- a/seed/go-sdk/enum/internal/retrier_test.go
+++ b/seed/go-sdk/enum/internal/retrier_test.go
@@ -295,7 +295,50 @@ func TestRetryWithRequestBody(t *testing.T) {
 	assert.Equal(t, expectedBody, requestBodies[1], "Second request body should match expected (retry should re-send body)")
 }
 
+// An explicit cancel (e.g. Ctrl-C wired to cancel()) must interrupt the backoff
+// wait. There is no deadline here, so the retrier cannot know the wait is futile
+// up front -- it has to be woken by the context.
 func TestRetryWaitIsInterruptedByContext(t *testing.T) {
+	var requestCount int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		w.Header().Set("Retry-After", "5")
+		w.WriteHeader(http.StatusTooManyRequests)
+	}))
+	defer server.Close()
+
+	caller := NewCaller(&CallerParams{
+		Client: server.Client(),
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		time.Sleep(100 * time.Millisecond)
+		cancel()
+	}()
+	defer cancel()
+
+	start := time.Now()
+	_, err := caller.Call(
+		ctx,
+		&CallParams{
+			URL:         server.URL,
+			Method:      http.MethodGet,
+			Request:     &InternalTestRequest{},
+			MaxAttempts: 3,
+		},
+	)
+	elapsed := time.Since(start)
+
+	assert.ErrorIs(t, err, context.Canceled)
+	assert.Equal(t, 1, requestCount, "Expected the retry to be abandoned once the context was cancelled")
+	assert.Less(t, elapsed, time.Second, "Expected the backoff to be interrupted by the context, took %v", elapsed)
+}
+
+// When the caller's deadline would elapse before the backoff finishes, sleeping
+// only guarantees a context error. Return the response instead so the caller
+// learns why the request actually failed.
+func TestRetryReturnsResponseWhenDeadlineShorterThanBackoff(t *testing.T) {
 	var requestCount int
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		requestCount++
@@ -323,9 +366,50 @@ func TestRetryWaitIsInterruptedByContext(t *testing.T) {
 	)
 	elapsed := time.Since(start)
 
-	assert.ErrorIs(t, err, context.DeadlineExceeded)
-	assert.Equal(t, 1, requestCount, "Expected the retry to be abandoned once the context expired")
-	assert.Less(t, elapsed, time.Second, "Expected the backoff to be interrupted by the context, took %v", elapsed)
+	// The caller gets the 429, not context.DeadlineExceeded.
+	var apiError *core.APIError
+	require.ErrorAs(t, err, &apiError)
+	assert.Equal(t, http.StatusTooManyRequests, apiError.StatusCode)
+	assert.NotErrorIs(t, err, context.DeadlineExceeded)
+	assert.Equal(t, 1, requestCount, "Expected no retry once the deadline was known to be too short")
+	assert.Less(t, elapsed, time.Second, "Expected to return immediately rather than sleep, took %v", elapsed)
+}
+
+// A deadline with room for the backoff must still retry as normal.
+func TestRetryProceedsWhenDeadlineLongerThanBackoff(t *testing.T) {
+	var requestCount int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		if requestCount == 1 {
+			w.Header().Set("Retry-After", "1")
+			w.WriteHeader(http.StatusTooManyRequests)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("{}"))
+	}))
+	defer server.Close()
+
+	caller := NewCaller(&CallerParams{
+		Client: server.Client(),
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	_, err := caller.Call(
+		ctx,
+		&CallParams{
+			URL:         server.URL,
+			Method:      http.MethodGet,
+			Request:     &InternalTestRequest{},
+			Response:    &InternalTestResponse{},
+			MaxAttempts: 3,
+		},
+	)
+
+	assert.NoError(t, err)
+	assert.Equal(t, 2, requestCount, "Expected the retry to proceed when the deadline allows it")
 }
 
 func TestDisableRetries(t *testing.T) {

--- a/seed/go-sdk/error-property/internal/retrier.go
+++ b/seed/go-sdk/error-property/internal/retrier.go
@@ -145,12 +145,20 @@ func (r *Retrier) run(
 	}
 
 	if r.shouldRetry(response) {
-		defer func() { _ = response.Body.Close() }()
-
 		delay, err := r.retryDelay(response, retryAttempt)
 		if err != nil {
+			_ = response.Body.Close()
 			return nil, err
 		}
+
+		// If the context's deadline would elapse before the backoff completes, return
+		// the response instead of sleeping through it. The caller then sees why the
+		// request actually failed (e.g. a 429) rather than a context deadline error.
+		if deadline, ok := request.Context().Deadline(); ok && time.Until(deadline) < delay {
+			return response, nil
+		}
+
+		defer func() { _ = response.Body.Close() }()
 
 		if err := sleepWithContext(request.Context(), delay); err != nil {
 			return nil, err

--- a/seed/go-sdk/error-property/internal/retrier_test.go
+++ b/seed/go-sdk/error-property/internal/retrier_test.go
@@ -295,7 +295,50 @@ func TestRetryWithRequestBody(t *testing.T) {
 	assert.Equal(t, expectedBody, requestBodies[1], "Second request body should match expected (retry should re-send body)")
 }
 
+// An explicit cancel (e.g. Ctrl-C wired to cancel()) must interrupt the backoff
+// wait. There is no deadline here, so the retrier cannot know the wait is futile
+// up front -- it has to be woken by the context.
 func TestRetryWaitIsInterruptedByContext(t *testing.T) {
+	var requestCount int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		w.Header().Set("Retry-After", "5")
+		w.WriteHeader(http.StatusTooManyRequests)
+	}))
+	defer server.Close()
+
+	caller := NewCaller(&CallerParams{
+		Client: server.Client(),
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		time.Sleep(100 * time.Millisecond)
+		cancel()
+	}()
+	defer cancel()
+
+	start := time.Now()
+	_, err := caller.Call(
+		ctx,
+		&CallParams{
+			URL:         server.URL,
+			Method:      http.MethodGet,
+			Request:     &InternalTestRequest{},
+			MaxAttempts: 3,
+		},
+	)
+	elapsed := time.Since(start)
+
+	assert.ErrorIs(t, err, context.Canceled)
+	assert.Equal(t, 1, requestCount, "Expected the retry to be abandoned once the context was cancelled")
+	assert.Less(t, elapsed, time.Second, "Expected the backoff to be interrupted by the context, took %v", elapsed)
+}
+
+// When the caller's deadline would elapse before the backoff finishes, sleeping
+// only guarantees a context error. Return the response instead so the caller
+// learns why the request actually failed.
+func TestRetryReturnsResponseWhenDeadlineShorterThanBackoff(t *testing.T) {
 	var requestCount int
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		requestCount++
@@ -323,9 +366,50 @@ func TestRetryWaitIsInterruptedByContext(t *testing.T) {
 	)
 	elapsed := time.Since(start)
 
-	assert.ErrorIs(t, err, context.DeadlineExceeded)
-	assert.Equal(t, 1, requestCount, "Expected the retry to be abandoned once the context expired")
-	assert.Less(t, elapsed, time.Second, "Expected the backoff to be interrupted by the context, took %v", elapsed)
+	// The caller gets the 429, not context.DeadlineExceeded.
+	var apiError *core.APIError
+	require.ErrorAs(t, err, &apiError)
+	assert.Equal(t, http.StatusTooManyRequests, apiError.StatusCode)
+	assert.NotErrorIs(t, err, context.DeadlineExceeded)
+	assert.Equal(t, 1, requestCount, "Expected no retry once the deadline was known to be too short")
+	assert.Less(t, elapsed, time.Second, "Expected to return immediately rather than sleep, took %v", elapsed)
+}
+
+// A deadline with room for the backoff must still retry as normal.
+func TestRetryProceedsWhenDeadlineLongerThanBackoff(t *testing.T) {
+	var requestCount int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		if requestCount == 1 {
+			w.Header().Set("Retry-After", "1")
+			w.WriteHeader(http.StatusTooManyRequests)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("{}"))
+	}))
+	defer server.Close()
+
+	caller := NewCaller(&CallerParams{
+		Client: server.Client(),
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	_, err := caller.Call(
+		ctx,
+		&CallParams{
+			URL:         server.URL,
+			Method:      http.MethodGet,
+			Request:     &InternalTestRequest{},
+			Response:    &InternalTestResponse{},
+			MaxAttempts: 3,
+		},
+	)
+
+	assert.NoError(t, err)
+	assert.Equal(t, 2, requestCount, "Expected the retry to proceed when the deadline allows it")
 }
 
 func TestDisableRetries(t *testing.T) {

--- a/seed/go-sdk/errors/internal/retrier.go
+++ b/seed/go-sdk/errors/internal/retrier.go
@@ -145,12 +145,20 @@ func (r *Retrier) run(
 	}
 
 	if r.shouldRetry(response) {
-		defer func() { _ = response.Body.Close() }()
-
 		delay, err := r.retryDelay(response, retryAttempt)
 		if err != nil {
+			_ = response.Body.Close()
 			return nil, err
 		}
+
+		// If the context's deadline would elapse before the backoff completes, return
+		// the response instead of sleeping through it. The caller then sees why the
+		// request actually failed (e.g. a 429) rather than a context deadline error.
+		if deadline, ok := request.Context().Deadline(); ok && time.Until(deadline) < delay {
+			return response, nil
+		}
+
+		defer func() { _ = response.Body.Close() }()
 
 		if err := sleepWithContext(request.Context(), delay); err != nil {
 			return nil, err

--- a/seed/go-sdk/errors/internal/retrier_test.go
+++ b/seed/go-sdk/errors/internal/retrier_test.go
@@ -295,7 +295,50 @@ func TestRetryWithRequestBody(t *testing.T) {
 	assert.Equal(t, expectedBody, requestBodies[1], "Second request body should match expected (retry should re-send body)")
 }
 
+// An explicit cancel (e.g. Ctrl-C wired to cancel()) must interrupt the backoff
+// wait. There is no deadline here, so the retrier cannot know the wait is futile
+// up front -- it has to be woken by the context.
 func TestRetryWaitIsInterruptedByContext(t *testing.T) {
+	var requestCount int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		w.Header().Set("Retry-After", "5")
+		w.WriteHeader(http.StatusTooManyRequests)
+	}))
+	defer server.Close()
+
+	caller := NewCaller(&CallerParams{
+		Client: server.Client(),
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		time.Sleep(100 * time.Millisecond)
+		cancel()
+	}()
+	defer cancel()
+
+	start := time.Now()
+	_, err := caller.Call(
+		ctx,
+		&CallParams{
+			URL:         server.URL,
+			Method:      http.MethodGet,
+			Request:     &InternalTestRequest{},
+			MaxAttempts: 3,
+		},
+	)
+	elapsed := time.Since(start)
+
+	assert.ErrorIs(t, err, context.Canceled)
+	assert.Equal(t, 1, requestCount, "Expected the retry to be abandoned once the context was cancelled")
+	assert.Less(t, elapsed, time.Second, "Expected the backoff to be interrupted by the context, took %v", elapsed)
+}
+
+// When the caller's deadline would elapse before the backoff finishes, sleeping
+// only guarantees a context error. Return the response instead so the caller
+// learns why the request actually failed.
+func TestRetryReturnsResponseWhenDeadlineShorterThanBackoff(t *testing.T) {
 	var requestCount int
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		requestCount++
@@ -323,9 +366,50 @@ func TestRetryWaitIsInterruptedByContext(t *testing.T) {
 	)
 	elapsed := time.Since(start)
 
-	assert.ErrorIs(t, err, context.DeadlineExceeded)
-	assert.Equal(t, 1, requestCount, "Expected the retry to be abandoned once the context expired")
-	assert.Less(t, elapsed, time.Second, "Expected the backoff to be interrupted by the context, took %v", elapsed)
+	// The caller gets the 429, not context.DeadlineExceeded.
+	var apiError *core.APIError
+	require.ErrorAs(t, err, &apiError)
+	assert.Equal(t, http.StatusTooManyRequests, apiError.StatusCode)
+	assert.NotErrorIs(t, err, context.DeadlineExceeded)
+	assert.Equal(t, 1, requestCount, "Expected no retry once the deadline was known to be too short")
+	assert.Less(t, elapsed, time.Second, "Expected to return immediately rather than sleep, took %v", elapsed)
+}
+
+// A deadline with room for the backoff must still retry as normal.
+func TestRetryProceedsWhenDeadlineLongerThanBackoff(t *testing.T) {
+	var requestCount int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		if requestCount == 1 {
+			w.Header().Set("Retry-After", "1")
+			w.WriteHeader(http.StatusTooManyRequests)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("{}"))
+	}))
+	defer server.Close()
+
+	caller := NewCaller(&CallerParams{
+		Client: server.Client(),
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	_, err := caller.Call(
+		ctx,
+		&CallParams{
+			URL:         server.URL,
+			Method:      http.MethodGet,
+			Request:     &InternalTestRequest{},
+			Response:    &InternalTestResponse{},
+			MaxAttempts: 3,
+		},
+	)
+
+	assert.NoError(t, err)
+	assert.Equal(t, 2, requestCount, "Expected the retry to proceed when the deadline allows it")
 }
 
 func TestDisableRetries(t *testing.T) {

--- a/seed/go-sdk/examples/always-send-required-properties/internal/retrier.go
+++ b/seed/go-sdk/examples/always-send-required-properties/internal/retrier.go
@@ -145,12 +145,20 @@ func (r *Retrier) run(
 	}
 
 	if r.shouldRetry(response) {
-		defer func() { _ = response.Body.Close() }()
-
 		delay, err := r.retryDelay(response, retryAttempt)
 		if err != nil {
+			_ = response.Body.Close()
 			return nil, err
 		}
+
+		// If the context's deadline would elapse before the backoff completes, return
+		// the response instead of sleeping through it. The caller then sees why the
+		// request actually failed (e.g. a 429) rather than a context deadline error.
+		if deadline, ok := request.Context().Deadline(); ok && time.Until(deadline) < delay {
+			return response, nil
+		}
+
+		defer func() { _ = response.Body.Close() }()
 
 		if err := sleepWithContext(request.Context(), delay); err != nil {
 			return nil, err

--- a/seed/go-sdk/examples/always-send-required-properties/internal/retrier_test.go
+++ b/seed/go-sdk/examples/always-send-required-properties/internal/retrier_test.go
@@ -295,7 +295,50 @@ func TestRetryWithRequestBody(t *testing.T) {
 	assert.Equal(t, expectedBody, requestBodies[1], "Second request body should match expected (retry should re-send body)")
 }
 
+// An explicit cancel (e.g. Ctrl-C wired to cancel()) must interrupt the backoff
+// wait. There is no deadline here, so the retrier cannot know the wait is futile
+// up front -- it has to be woken by the context.
 func TestRetryWaitIsInterruptedByContext(t *testing.T) {
+	var requestCount int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		w.Header().Set("Retry-After", "5")
+		w.WriteHeader(http.StatusTooManyRequests)
+	}))
+	defer server.Close()
+
+	caller := NewCaller(&CallerParams{
+		Client: server.Client(),
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		time.Sleep(100 * time.Millisecond)
+		cancel()
+	}()
+	defer cancel()
+
+	start := time.Now()
+	_, err := caller.Call(
+		ctx,
+		&CallParams{
+			URL:         server.URL,
+			Method:      http.MethodGet,
+			Request:     &InternalTestRequest{},
+			MaxAttempts: 3,
+		},
+	)
+	elapsed := time.Since(start)
+
+	assert.ErrorIs(t, err, context.Canceled)
+	assert.Equal(t, 1, requestCount, "Expected the retry to be abandoned once the context was cancelled")
+	assert.Less(t, elapsed, time.Second, "Expected the backoff to be interrupted by the context, took %v", elapsed)
+}
+
+// When the caller's deadline would elapse before the backoff finishes, sleeping
+// only guarantees a context error. Return the response instead so the caller
+// learns why the request actually failed.
+func TestRetryReturnsResponseWhenDeadlineShorterThanBackoff(t *testing.T) {
 	var requestCount int
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		requestCount++
@@ -323,9 +366,50 @@ func TestRetryWaitIsInterruptedByContext(t *testing.T) {
 	)
 	elapsed := time.Since(start)
 
-	assert.ErrorIs(t, err, context.DeadlineExceeded)
-	assert.Equal(t, 1, requestCount, "Expected the retry to be abandoned once the context expired")
-	assert.Less(t, elapsed, time.Second, "Expected the backoff to be interrupted by the context, took %v", elapsed)
+	// The caller gets the 429, not context.DeadlineExceeded.
+	var apiError *core.APIError
+	require.ErrorAs(t, err, &apiError)
+	assert.Equal(t, http.StatusTooManyRequests, apiError.StatusCode)
+	assert.NotErrorIs(t, err, context.DeadlineExceeded)
+	assert.Equal(t, 1, requestCount, "Expected no retry once the deadline was known to be too short")
+	assert.Less(t, elapsed, time.Second, "Expected to return immediately rather than sleep, took %v", elapsed)
+}
+
+// A deadline with room for the backoff must still retry as normal.
+func TestRetryProceedsWhenDeadlineLongerThanBackoff(t *testing.T) {
+	var requestCount int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		if requestCount == 1 {
+			w.Header().Set("Retry-After", "1")
+			w.WriteHeader(http.StatusTooManyRequests)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("{}"))
+	}))
+	defer server.Close()
+
+	caller := NewCaller(&CallerParams{
+		Client: server.Client(),
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	_, err := caller.Call(
+		ctx,
+		&CallParams{
+			URL:         server.URL,
+			Method:      http.MethodGet,
+			Request:     &InternalTestRequest{},
+			Response:    &InternalTestResponse{},
+			MaxAttempts: 3,
+		},
+	)
+
+	assert.NoError(t, err)
+	assert.Equal(t, 2, requestCount, "Expected the retry to proceed when the deadline allows it")
 }
 
 func TestDisableRetries(t *testing.T) {

--- a/seed/go-sdk/examples/client-name-with-custom-constructor-name/internal/retrier.go
+++ b/seed/go-sdk/examples/client-name-with-custom-constructor-name/internal/retrier.go
@@ -145,12 +145,20 @@ func (r *Retrier) run(
 	}
 
 	if r.shouldRetry(response) {
-		defer func() { _ = response.Body.Close() }()
-
 		delay, err := r.retryDelay(response, retryAttempt)
 		if err != nil {
+			_ = response.Body.Close()
 			return nil, err
 		}
+
+		// If the context's deadline would elapse before the backoff completes, return
+		// the response instead of sleeping through it. The caller then sees why the
+		// request actually failed (e.g. a 429) rather than a context deadline error.
+		if deadline, ok := request.Context().Deadline(); ok && time.Until(deadline) < delay {
+			return response, nil
+		}
+
+		defer func() { _ = response.Body.Close() }()
 
 		if err := sleepWithContext(request.Context(), delay); err != nil {
 			return nil, err

--- a/seed/go-sdk/examples/client-name-with-custom-constructor-name/internal/retrier_test.go
+++ b/seed/go-sdk/examples/client-name-with-custom-constructor-name/internal/retrier_test.go
@@ -295,7 +295,50 @@ func TestRetryWithRequestBody(t *testing.T) {
 	assert.Equal(t, expectedBody, requestBodies[1], "Second request body should match expected (retry should re-send body)")
 }
 
+// An explicit cancel (e.g. Ctrl-C wired to cancel()) must interrupt the backoff
+// wait. There is no deadline here, so the retrier cannot know the wait is futile
+// up front -- it has to be woken by the context.
 func TestRetryWaitIsInterruptedByContext(t *testing.T) {
+	var requestCount int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		w.Header().Set("Retry-After", "5")
+		w.WriteHeader(http.StatusTooManyRequests)
+	}))
+	defer server.Close()
+
+	caller := NewCaller(&CallerParams{
+		Client: server.Client(),
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		time.Sleep(100 * time.Millisecond)
+		cancel()
+	}()
+	defer cancel()
+
+	start := time.Now()
+	_, err := caller.Call(
+		ctx,
+		&CallParams{
+			URL:         server.URL,
+			Method:      http.MethodGet,
+			Request:     &InternalTestRequest{},
+			MaxAttempts: 3,
+		},
+	)
+	elapsed := time.Since(start)
+
+	assert.ErrorIs(t, err, context.Canceled)
+	assert.Equal(t, 1, requestCount, "Expected the retry to be abandoned once the context was cancelled")
+	assert.Less(t, elapsed, time.Second, "Expected the backoff to be interrupted by the context, took %v", elapsed)
+}
+
+// When the caller's deadline would elapse before the backoff finishes, sleeping
+// only guarantees a context error. Return the response instead so the caller
+// learns why the request actually failed.
+func TestRetryReturnsResponseWhenDeadlineShorterThanBackoff(t *testing.T) {
 	var requestCount int
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		requestCount++
@@ -323,9 +366,50 @@ func TestRetryWaitIsInterruptedByContext(t *testing.T) {
 	)
 	elapsed := time.Since(start)
 
-	assert.ErrorIs(t, err, context.DeadlineExceeded)
-	assert.Equal(t, 1, requestCount, "Expected the retry to be abandoned once the context expired")
-	assert.Less(t, elapsed, time.Second, "Expected the backoff to be interrupted by the context, took %v", elapsed)
+	// The caller gets the 429, not context.DeadlineExceeded.
+	var apiError *core.APIError
+	require.ErrorAs(t, err, &apiError)
+	assert.Equal(t, http.StatusTooManyRequests, apiError.StatusCode)
+	assert.NotErrorIs(t, err, context.DeadlineExceeded)
+	assert.Equal(t, 1, requestCount, "Expected no retry once the deadline was known to be too short")
+	assert.Less(t, elapsed, time.Second, "Expected to return immediately rather than sleep, took %v", elapsed)
+}
+
+// A deadline with room for the backoff must still retry as normal.
+func TestRetryProceedsWhenDeadlineLongerThanBackoff(t *testing.T) {
+	var requestCount int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		if requestCount == 1 {
+			w.Header().Set("Retry-After", "1")
+			w.WriteHeader(http.StatusTooManyRequests)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("{}"))
+	}))
+	defer server.Close()
+
+	caller := NewCaller(&CallerParams{
+		Client: server.Client(),
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	_, err := caller.Call(
+		ctx,
+		&CallParams{
+			URL:         server.URL,
+			Method:      http.MethodGet,
+			Request:     &InternalTestRequest{},
+			Response:    &InternalTestResponse{},
+			MaxAttempts: 3,
+		},
+	)
+
+	assert.NoError(t, err)
+	assert.Equal(t, 2, requestCount, "Expected the retry to proceed when the deadline allows it")
 }
 
 func TestDisableRetries(t *testing.T) {

--- a/seed/go-sdk/examples/client-name/internal/retrier.go
+++ b/seed/go-sdk/examples/client-name/internal/retrier.go
@@ -145,12 +145,20 @@ func (r *Retrier) run(
 	}
 
 	if r.shouldRetry(response) {
-		defer func() { _ = response.Body.Close() }()
-
 		delay, err := r.retryDelay(response, retryAttempt)
 		if err != nil {
+			_ = response.Body.Close()
 			return nil, err
 		}
+
+		// If the context's deadline would elapse before the backoff completes, return
+		// the response instead of sleeping through it. The caller then sees why the
+		// request actually failed (e.g. a 429) rather than a context deadline error.
+		if deadline, ok := request.Context().Deadline(); ok && time.Until(deadline) < delay {
+			return response, nil
+		}
+
+		defer func() { _ = response.Body.Close() }()
 
 		if err := sleepWithContext(request.Context(), delay); err != nil {
 			return nil, err

--- a/seed/go-sdk/examples/client-name/internal/retrier_test.go
+++ b/seed/go-sdk/examples/client-name/internal/retrier_test.go
@@ -295,7 +295,50 @@ func TestRetryWithRequestBody(t *testing.T) {
 	assert.Equal(t, expectedBody, requestBodies[1], "Second request body should match expected (retry should re-send body)")
 }
 
+// An explicit cancel (e.g. Ctrl-C wired to cancel()) must interrupt the backoff
+// wait. There is no deadline here, so the retrier cannot know the wait is futile
+// up front -- it has to be woken by the context.
 func TestRetryWaitIsInterruptedByContext(t *testing.T) {
+	var requestCount int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		w.Header().Set("Retry-After", "5")
+		w.WriteHeader(http.StatusTooManyRequests)
+	}))
+	defer server.Close()
+
+	caller := NewCaller(&CallerParams{
+		Client: server.Client(),
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		time.Sleep(100 * time.Millisecond)
+		cancel()
+	}()
+	defer cancel()
+
+	start := time.Now()
+	_, err := caller.Call(
+		ctx,
+		&CallParams{
+			URL:         server.URL,
+			Method:      http.MethodGet,
+			Request:     &InternalTestRequest{},
+			MaxAttempts: 3,
+		},
+	)
+	elapsed := time.Since(start)
+
+	assert.ErrorIs(t, err, context.Canceled)
+	assert.Equal(t, 1, requestCount, "Expected the retry to be abandoned once the context was cancelled")
+	assert.Less(t, elapsed, time.Second, "Expected the backoff to be interrupted by the context, took %v", elapsed)
+}
+
+// When the caller's deadline would elapse before the backoff finishes, sleeping
+// only guarantees a context error. Return the response instead so the caller
+// learns why the request actually failed.
+func TestRetryReturnsResponseWhenDeadlineShorterThanBackoff(t *testing.T) {
 	var requestCount int
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		requestCount++
@@ -323,9 +366,50 @@ func TestRetryWaitIsInterruptedByContext(t *testing.T) {
 	)
 	elapsed := time.Since(start)
 
-	assert.ErrorIs(t, err, context.DeadlineExceeded)
-	assert.Equal(t, 1, requestCount, "Expected the retry to be abandoned once the context expired")
-	assert.Less(t, elapsed, time.Second, "Expected the backoff to be interrupted by the context, took %v", elapsed)
+	// The caller gets the 429, not context.DeadlineExceeded.
+	var apiError *core.APIError
+	require.ErrorAs(t, err, &apiError)
+	assert.Equal(t, http.StatusTooManyRequests, apiError.StatusCode)
+	assert.NotErrorIs(t, err, context.DeadlineExceeded)
+	assert.Equal(t, 1, requestCount, "Expected no retry once the deadline was known to be too short")
+	assert.Less(t, elapsed, time.Second, "Expected to return immediately rather than sleep, took %v", elapsed)
+}
+
+// A deadline with room for the backoff must still retry as normal.
+func TestRetryProceedsWhenDeadlineLongerThanBackoff(t *testing.T) {
+	var requestCount int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		if requestCount == 1 {
+			w.Header().Set("Retry-After", "1")
+			w.WriteHeader(http.StatusTooManyRequests)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("{}"))
+	}))
+	defer server.Close()
+
+	caller := NewCaller(&CallerParams{
+		Client: server.Client(),
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	_, err := caller.Call(
+		ctx,
+		&CallParams{
+			URL:         server.URL,
+			Method:      http.MethodGet,
+			Request:     &InternalTestRequest{},
+			Response:    &InternalTestResponse{},
+			MaxAttempts: 3,
+		},
+	)
+
+	assert.NoError(t, err)
+	assert.Equal(t, 2, requestCount, "Expected the retry to proceed when the deadline allows it")
 }
 
 func TestDisableRetries(t *testing.T) {

--- a/seed/go-sdk/examples/export-all-requests-at-root/internal/retrier.go
+++ b/seed/go-sdk/examples/export-all-requests-at-root/internal/retrier.go
@@ -145,12 +145,20 @@ func (r *Retrier) run(
 	}
 
 	if r.shouldRetry(response) {
-		defer func() { _ = response.Body.Close() }()
-
 		delay, err := r.retryDelay(response, retryAttempt)
 		if err != nil {
+			_ = response.Body.Close()
 			return nil, err
 		}
+
+		// If the context's deadline would elapse before the backoff completes, return
+		// the response instead of sleeping through it. The caller then sees why the
+		// request actually failed (e.g. a 429) rather than a context deadline error.
+		if deadline, ok := request.Context().Deadline(); ok && time.Until(deadline) < delay {
+			return response, nil
+		}
+
+		defer func() { _ = response.Body.Close() }()
 
 		if err := sleepWithContext(request.Context(), delay); err != nil {
 			return nil, err

--- a/seed/go-sdk/examples/export-all-requests-at-root/internal/retrier_test.go
+++ b/seed/go-sdk/examples/export-all-requests-at-root/internal/retrier_test.go
@@ -295,7 +295,50 @@ func TestRetryWithRequestBody(t *testing.T) {
 	assert.Equal(t, expectedBody, requestBodies[1], "Second request body should match expected (retry should re-send body)")
 }
 
+// An explicit cancel (e.g. Ctrl-C wired to cancel()) must interrupt the backoff
+// wait. There is no deadline here, so the retrier cannot know the wait is futile
+// up front -- it has to be woken by the context.
 func TestRetryWaitIsInterruptedByContext(t *testing.T) {
+	var requestCount int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		w.Header().Set("Retry-After", "5")
+		w.WriteHeader(http.StatusTooManyRequests)
+	}))
+	defer server.Close()
+
+	caller := NewCaller(&CallerParams{
+		Client: server.Client(),
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		time.Sleep(100 * time.Millisecond)
+		cancel()
+	}()
+	defer cancel()
+
+	start := time.Now()
+	_, err := caller.Call(
+		ctx,
+		&CallParams{
+			URL:         server.URL,
+			Method:      http.MethodGet,
+			Request:     &InternalTestRequest{},
+			MaxAttempts: 3,
+		},
+	)
+	elapsed := time.Since(start)
+
+	assert.ErrorIs(t, err, context.Canceled)
+	assert.Equal(t, 1, requestCount, "Expected the retry to be abandoned once the context was cancelled")
+	assert.Less(t, elapsed, time.Second, "Expected the backoff to be interrupted by the context, took %v", elapsed)
+}
+
+// When the caller's deadline would elapse before the backoff finishes, sleeping
+// only guarantees a context error. Return the response instead so the caller
+// learns why the request actually failed.
+func TestRetryReturnsResponseWhenDeadlineShorterThanBackoff(t *testing.T) {
 	var requestCount int
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		requestCount++
@@ -323,9 +366,50 @@ func TestRetryWaitIsInterruptedByContext(t *testing.T) {
 	)
 	elapsed := time.Since(start)
 
-	assert.ErrorIs(t, err, context.DeadlineExceeded)
-	assert.Equal(t, 1, requestCount, "Expected the retry to be abandoned once the context expired")
-	assert.Less(t, elapsed, time.Second, "Expected the backoff to be interrupted by the context, took %v", elapsed)
+	// The caller gets the 429, not context.DeadlineExceeded.
+	var apiError *core.APIError
+	require.ErrorAs(t, err, &apiError)
+	assert.Equal(t, http.StatusTooManyRequests, apiError.StatusCode)
+	assert.NotErrorIs(t, err, context.DeadlineExceeded)
+	assert.Equal(t, 1, requestCount, "Expected no retry once the deadline was known to be too short")
+	assert.Less(t, elapsed, time.Second, "Expected to return immediately rather than sleep, took %v", elapsed)
+}
+
+// A deadline with room for the backoff must still retry as normal.
+func TestRetryProceedsWhenDeadlineLongerThanBackoff(t *testing.T) {
+	var requestCount int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		if requestCount == 1 {
+			w.Header().Set("Retry-After", "1")
+			w.WriteHeader(http.StatusTooManyRequests)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("{}"))
+	}))
+	defer server.Close()
+
+	caller := NewCaller(&CallerParams{
+		Client: server.Client(),
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	_, err := caller.Call(
+		ctx,
+		&CallParams{
+			URL:         server.URL,
+			Method:      http.MethodGet,
+			Request:     &InternalTestRequest{},
+			Response:    &InternalTestResponse{},
+			MaxAttempts: 3,
+		},
+	)
+
+	assert.NoError(t, err)
+	assert.Equal(t, 2, requestCount, "Expected the retry to proceed when the deadline allows it")
 }
 
 func TestDisableRetries(t *testing.T) {

--- a/seed/go-sdk/examples/exported-client-name/internal/retrier.go
+++ b/seed/go-sdk/examples/exported-client-name/internal/retrier.go
@@ -145,12 +145,20 @@ func (r *Retrier) run(
 	}
 
 	if r.shouldRetry(response) {
-		defer func() { _ = response.Body.Close() }()
-
 		delay, err := r.retryDelay(response, retryAttempt)
 		if err != nil {
+			_ = response.Body.Close()
 			return nil, err
 		}
+
+		// If the context's deadline would elapse before the backoff completes, return
+		// the response instead of sleeping through it. The caller then sees why the
+		// request actually failed (e.g. a 429) rather than a context deadline error.
+		if deadline, ok := request.Context().Deadline(); ok && time.Until(deadline) < delay {
+			return response, nil
+		}
+
+		defer func() { _ = response.Body.Close() }()
 
 		if err := sleepWithContext(request.Context(), delay); err != nil {
 			return nil, err

--- a/seed/go-sdk/examples/exported-client-name/internal/retrier_test.go
+++ b/seed/go-sdk/examples/exported-client-name/internal/retrier_test.go
@@ -295,7 +295,50 @@ func TestRetryWithRequestBody(t *testing.T) {
 	assert.Equal(t, expectedBody, requestBodies[1], "Second request body should match expected (retry should re-send body)")
 }
 
+// An explicit cancel (e.g. Ctrl-C wired to cancel()) must interrupt the backoff
+// wait. There is no deadline here, so the retrier cannot know the wait is futile
+// up front -- it has to be woken by the context.
 func TestRetryWaitIsInterruptedByContext(t *testing.T) {
+	var requestCount int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		w.Header().Set("Retry-After", "5")
+		w.WriteHeader(http.StatusTooManyRequests)
+	}))
+	defer server.Close()
+
+	caller := NewCaller(&CallerParams{
+		Client: server.Client(),
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		time.Sleep(100 * time.Millisecond)
+		cancel()
+	}()
+	defer cancel()
+
+	start := time.Now()
+	_, err := caller.Call(
+		ctx,
+		&CallParams{
+			URL:         server.URL,
+			Method:      http.MethodGet,
+			Request:     &InternalTestRequest{},
+			MaxAttempts: 3,
+		},
+	)
+	elapsed := time.Since(start)
+
+	assert.ErrorIs(t, err, context.Canceled)
+	assert.Equal(t, 1, requestCount, "Expected the retry to be abandoned once the context was cancelled")
+	assert.Less(t, elapsed, time.Second, "Expected the backoff to be interrupted by the context, took %v", elapsed)
+}
+
+// When the caller's deadline would elapse before the backoff finishes, sleeping
+// only guarantees a context error. Return the response instead so the caller
+// learns why the request actually failed.
+func TestRetryReturnsResponseWhenDeadlineShorterThanBackoff(t *testing.T) {
 	var requestCount int
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		requestCount++
@@ -323,9 +366,50 @@ func TestRetryWaitIsInterruptedByContext(t *testing.T) {
 	)
 	elapsed := time.Since(start)
 
-	assert.ErrorIs(t, err, context.DeadlineExceeded)
-	assert.Equal(t, 1, requestCount, "Expected the retry to be abandoned once the context expired")
-	assert.Less(t, elapsed, time.Second, "Expected the backoff to be interrupted by the context, took %v", elapsed)
+	// The caller gets the 429, not context.DeadlineExceeded.
+	var apiError *core.APIError
+	require.ErrorAs(t, err, &apiError)
+	assert.Equal(t, http.StatusTooManyRequests, apiError.StatusCode)
+	assert.NotErrorIs(t, err, context.DeadlineExceeded)
+	assert.Equal(t, 1, requestCount, "Expected no retry once the deadline was known to be too short")
+	assert.Less(t, elapsed, time.Second, "Expected to return immediately rather than sleep, took %v", elapsed)
+}
+
+// A deadline with room for the backoff must still retry as normal.
+func TestRetryProceedsWhenDeadlineLongerThanBackoff(t *testing.T) {
+	var requestCount int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		if requestCount == 1 {
+			w.Header().Set("Retry-After", "1")
+			w.WriteHeader(http.StatusTooManyRequests)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("{}"))
+	}))
+	defer server.Close()
+
+	caller := NewCaller(&CallerParams{
+		Client: server.Client(),
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	_, err := caller.Call(
+		ctx,
+		&CallParams{
+			URL:         server.URL,
+			Method:      http.MethodGet,
+			Request:     &InternalTestRequest{},
+			Response:    &InternalTestResponse{},
+			MaxAttempts: 3,
+		},
+	)
+
+	assert.NoError(t, err)
+	assert.Equal(t, 2, requestCount, "Expected the retry to proceed when the deadline allows it")
 }
 
 func TestDisableRetries(t *testing.T) {

--- a/seed/go-sdk/examples/getters-pass-by-value/internal/retrier.go
+++ b/seed/go-sdk/examples/getters-pass-by-value/internal/retrier.go
@@ -145,12 +145,20 @@ func (r *Retrier) run(
 	}
 
 	if r.shouldRetry(response) {
-		defer func() { _ = response.Body.Close() }()
-
 		delay, err := r.retryDelay(response, retryAttempt)
 		if err != nil {
+			_ = response.Body.Close()
 			return nil, err
 		}
+
+		// If the context's deadline would elapse before the backoff completes, return
+		// the response instead of sleeping through it. The caller then sees why the
+		// request actually failed (e.g. a 429) rather than a context deadline error.
+		if deadline, ok := request.Context().Deadline(); ok && time.Until(deadline) < delay {
+			return response, nil
+		}
+
+		defer func() { _ = response.Body.Close() }()
 
 		if err := sleepWithContext(request.Context(), delay); err != nil {
 			return nil, err

--- a/seed/go-sdk/examples/getters-pass-by-value/internal/retrier_test.go
+++ b/seed/go-sdk/examples/getters-pass-by-value/internal/retrier_test.go
@@ -295,7 +295,50 @@ func TestRetryWithRequestBody(t *testing.T) {
 	assert.Equal(t, expectedBody, requestBodies[1], "Second request body should match expected (retry should re-send body)")
 }
 
+// An explicit cancel (e.g. Ctrl-C wired to cancel()) must interrupt the backoff
+// wait. There is no deadline here, so the retrier cannot know the wait is futile
+// up front -- it has to be woken by the context.
 func TestRetryWaitIsInterruptedByContext(t *testing.T) {
+	var requestCount int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		w.Header().Set("Retry-After", "5")
+		w.WriteHeader(http.StatusTooManyRequests)
+	}))
+	defer server.Close()
+
+	caller := NewCaller(&CallerParams{
+		Client: server.Client(),
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		time.Sleep(100 * time.Millisecond)
+		cancel()
+	}()
+	defer cancel()
+
+	start := time.Now()
+	_, err := caller.Call(
+		ctx,
+		&CallParams{
+			URL:         server.URL,
+			Method:      http.MethodGet,
+			Request:     &InternalTestRequest{},
+			MaxAttempts: 3,
+		},
+	)
+	elapsed := time.Since(start)
+
+	assert.ErrorIs(t, err, context.Canceled)
+	assert.Equal(t, 1, requestCount, "Expected the retry to be abandoned once the context was cancelled")
+	assert.Less(t, elapsed, time.Second, "Expected the backoff to be interrupted by the context, took %v", elapsed)
+}
+
+// When the caller's deadline would elapse before the backoff finishes, sleeping
+// only guarantees a context error. Return the response instead so the caller
+// learns why the request actually failed.
+func TestRetryReturnsResponseWhenDeadlineShorterThanBackoff(t *testing.T) {
 	var requestCount int
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		requestCount++
@@ -323,9 +366,50 @@ func TestRetryWaitIsInterruptedByContext(t *testing.T) {
 	)
 	elapsed := time.Since(start)
 
-	assert.ErrorIs(t, err, context.DeadlineExceeded)
-	assert.Equal(t, 1, requestCount, "Expected the retry to be abandoned once the context expired")
-	assert.Less(t, elapsed, time.Second, "Expected the backoff to be interrupted by the context, took %v", elapsed)
+	// The caller gets the 429, not context.DeadlineExceeded.
+	var apiError *core.APIError
+	require.ErrorAs(t, err, &apiError)
+	assert.Equal(t, http.StatusTooManyRequests, apiError.StatusCode)
+	assert.NotErrorIs(t, err, context.DeadlineExceeded)
+	assert.Equal(t, 1, requestCount, "Expected no retry once the deadline was known to be too short")
+	assert.Less(t, elapsed, time.Second, "Expected to return immediately rather than sleep, took %v", elapsed)
+}
+
+// A deadline with room for the backoff must still retry as normal.
+func TestRetryProceedsWhenDeadlineLongerThanBackoff(t *testing.T) {
+	var requestCount int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		if requestCount == 1 {
+			w.Header().Set("Retry-After", "1")
+			w.WriteHeader(http.StatusTooManyRequests)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("{}"))
+	}))
+	defer server.Close()
+
+	caller := NewCaller(&CallerParams{
+		Client: server.Client(),
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	_, err := caller.Call(
+		ctx,
+		&CallParams{
+			URL:         server.URL,
+			Method:      http.MethodGet,
+			Request:     &InternalTestRequest{},
+			Response:    &InternalTestResponse{},
+			MaxAttempts: 3,
+		},
+	)
+
+	assert.NoError(t, err)
+	assert.Equal(t, 2, requestCount, "Expected the retry to proceed when the deadline allows it")
 }
 
 func TestDisableRetries(t *testing.T) {

--- a/seed/go-sdk/examples/no-custom-config/internal/retrier.go
+++ b/seed/go-sdk/examples/no-custom-config/internal/retrier.go
@@ -145,12 +145,20 @@ func (r *Retrier) run(
 	}
 
 	if r.shouldRetry(response) {
-		defer func() { _ = response.Body.Close() }()
-
 		delay, err := r.retryDelay(response, retryAttempt)
 		if err != nil {
+			_ = response.Body.Close()
 			return nil, err
 		}
+
+		// If the context's deadline would elapse before the backoff completes, return
+		// the response instead of sleeping through it. The caller then sees why the
+		// request actually failed (e.g. a 429) rather than a context deadline error.
+		if deadline, ok := request.Context().Deadline(); ok && time.Until(deadline) < delay {
+			return response, nil
+		}
+
+		defer func() { _ = response.Body.Close() }()
 
 		if err := sleepWithContext(request.Context(), delay); err != nil {
 			return nil, err

--- a/seed/go-sdk/examples/no-custom-config/internal/retrier_test.go
+++ b/seed/go-sdk/examples/no-custom-config/internal/retrier_test.go
@@ -295,7 +295,50 @@ func TestRetryWithRequestBody(t *testing.T) {
 	assert.Equal(t, expectedBody, requestBodies[1], "Second request body should match expected (retry should re-send body)")
 }
 
+// An explicit cancel (e.g. Ctrl-C wired to cancel()) must interrupt the backoff
+// wait. There is no deadline here, so the retrier cannot know the wait is futile
+// up front -- it has to be woken by the context.
 func TestRetryWaitIsInterruptedByContext(t *testing.T) {
+	var requestCount int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		w.Header().Set("Retry-After", "5")
+		w.WriteHeader(http.StatusTooManyRequests)
+	}))
+	defer server.Close()
+
+	caller := NewCaller(&CallerParams{
+		Client: server.Client(),
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		time.Sleep(100 * time.Millisecond)
+		cancel()
+	}()
+	defer cancel()
+
+	start := time.Now()
+	_, err := caller.Call(
+		ctx,
+		&CallParams{
+			URL:         server.URL,
+			Method:      http.MethodGet,
+			Request:     &InternalTestRequest{},
+			MaxAttempts: 3,
+		},
+	)
+	elapsed := time.Since(start)
+
+	assert.ErrorIs(t, err, context.Canceled)
+	assert.Equal(t, 1, requestCount, "Expected the retry to be abandoned once the context was cancelled")
+	assert.Less(t, elapsed, time.Second, "Expected the backoff to be interrupted by the context, took %v", elapsed)
+}
+
+// When the caller's deadline would elapse before the backoff finishes, sleeping
+// only guarantees a context error. Return the response instead so the caller
+// learns why the request actually failed.
+func TestRetryReturnsResponseWhenDeadlineShorterThanBackoff(t *testing.T) {
 	var requestCount int
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		requestCount++
@@ -323,9 +366,50 @@ func TestRetryWaitIsInterruptedByContext(t *testing.T) {
 	)
 	elapsed := time.Since(start)
 
-	assert.ErrorIs(t, err, context.DeadlineExceeded)
-	assert.Equal(t, 1, requestCount, "Expected the retry to be abandoned once the context expired")
-	assert.Less(t, elapsed, time.Second, "Expected the backoff to be interrupted by the context, took %v", elapsed)
+	// The caller gets the 429, not context.DeadlineExceeded.
+	var apiError *core.APIError
+	require.ErrorAs(t, err, &apiError)
+	assert.Equal(t, http.StatusTooManyRequests, apiError.StatusCode)
+	assert.NotErrorIs(t, err, context.DeadlineExceeded)
+	assert.Equal(t, 1, requestCount, "Expected no retry once the deadline was known to be too short")
+	assert.Less(t, elapsed, time.Second, "Expected to return immediately rather than sleep, took %v", elapsed)
+}
+
+// A deadline with room for the backoff must still retry as normal.
+func TestRetryProceedsWhenDeadlineLongerThanBackoff(t *testing.T) {
+	var requestCount int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		if requestCount == 1 {
+			w.Header().Set("Retry-After", "1")
+			w.WriteHeader(http.StatusTooManyRequests)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("{}"))
+	}))
+	defer server.Close()
+
+	caller := NewCaller(&CallerParams{
+		Client: server.Client(),
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	_, err := caller.Call(
+		ctx,
+		&CallParams{
+			URL:         server.URL,
+			Method:      http.MethodGet,
+			Request:     &InternalTestRequest{},
+			Response:    &InternalTestResponse{},
+			MaxAttempts: 3,
+		},
+	)
+
+	assert.NoError(t, err)
+	assert.Equal(t, 2, requestCount, "Expected the retry to proceed when the deadline allows it")
 }
 
 func TestDisableRetries(t *testing.T) {

--- a/seed/go-sdk/examples/package-path/pleaseinhere/internal/retrier.go
+++ b/seed/go-sdk/examples/package-path/pleaseinhere/internal/retrier.go
@@ -145,12 +145,20 @@ func (r *Retrier) run(
 	}
 
 	if r.shouldRetry(response) {
-		defer func() { _ = response.Body.Close() }()
-
 		delay, err := r.retryDelay(response, retryAttempt)
 		if err != nil {
+			_ = response.Body.Close()
 			return nil, err
 		}
+
+		// If the context's deadline would elapse before the backoff completes, return
+		// the response instead of sleeping through it. The caller then sees why the
+		// request actually failed (e.g. a 429) rather than a context deadline error.
+		if deadline, ok := request.Context().Deadline(); ok && time.Until(deadline) < delay {
+			return response, nil
+		}
+
+		defer func() { _ = response.Body.Close() }()
 
 		if err := sleepWithContext(request.Context(), delay); err != nil {
 			return nil, err

--- a/seed/go-sdk/examples/package-path/pleaseinhere/internal/retrier_test.go
+++ b/seed/go-sdk/examples/package-path/pleaseinhere/internal/retrier_test.go
@@ -295,7 +295,50 @@ func TestRetryWithRequestBody(t *testing.T) {
 	assert.Equal(t, expectedBody, requestBodies[1], "Second request body should match expected (retry should re-send body)")
 }
 
+// An explicit cancel (e.g. Ctrl-C wired to cancel()) must interrupt the backoff
+// wait. There is no deadline here, so the retrier cannot know the wait is futile
+// up front -- it has to be woken by the context.
 func TestRetryWaitIsInterruptedByContext(t *testing.T) {
+	var requestCount int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		w.Header().Set("Retry-After", "5")
+		w.WriteHeader(http.StatusTooManyRequests)
+	}))
+	defer server.Close()
+
+	caller := NewCaller(&CallerParams{
+		Client: server.Client(),
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		time.Sleep(100 * time.Millisecond)
+		cancel()
+	}()
+	defer cancel()
+
+	start := time.Now()
+	_, err := caller.Call(
+		ctx,
+		&CallParams{
+			URL:         server.URL,
+			Method:      http.MethodGet,
+			Request:     &InternalTestRequest{},
+			MaxAttempts: 3,
+		},
+	)
+	elapsed := time.Since(start)
+
+	assert.ErrorIs(t, err, context.Canceled)
+	assert.Equal(t, 1, requestCount, "Expected the retry to be abandoned once the context was cancelled")
+	assert.Less(t, elapsed, time.Second, "Expected the backoff to be interrupted by the context, took %v", elapsed)
+}
+
+// When the caller's deadline would elapse before the backoff finishes, sleeping
+// only guarantees a context error. Return the response instead so the caller
+// learns why the request actually failed.
+func TestRetryReturnsResponseWhenDeadlineShorterThanBackoff(t *testing.T) {
 	var requestCount int
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		requestCount++
@@ -323,9 +366,50 @@ func TestRetryWaitIsInterruptedByContext(t *testing.T) {
 	)
 	elapsed := time.Since(start)
 
-	assert.ErrorIs(t, err, context.DeadlineExceeded)
-	assert.Equal(t, 1, requestCount, "Expected the retry to be abandoned once the context expired")
-	assert.Less(t, elapsed, time.Second, "Expected the backoff to be interrupted by the context, took %v", elapsed)
+	// The caller gets the 429, not context.DeadlineExceeded.
+	var apiError *core.APIError
+	require.ErrorAs(t, err, &apiError)
+	assert.Equal(t, http.StatusTooManyRequests, apiError.StatusCode)
+	assert.NotErrorIs(t, err, context.DeadlineExceeded)
+	assert.Equal(t, 1, requestCount, "Expected no retry once the deadline was known to be too short")
+	assert.Less(t, elapsed, time.Second, "Expected to return immediately rather than sleep, took %v", elapsed)
+}
+
+// A deadline with room for the backoff must still retry as normal.
+func TestRetryProceedsWhenDeadlineLongerThanBackoff(t *testing.T) {
+	var requestCount int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		if requestCount == 1 {
+			w.Header().Set("Retry-After", "1")
+			w.WriteHeader(http.StatusTooManyRequests)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("{}"))
+	}))
+	defer server.Close()
+
+	caller := NewCaller(&CallerParams{
+		Client: server.Client(),
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	_, err := caller.Call(
+		ctx,
+		&CallParams{
+			URL:         server.URL,
+			Method:      http.MethodGet,
+			Request:     &InternalTestRequest{},
+			Response:    &InternalTestResponse{},
+			MaxAttempts: 3,
+		},
+	)
+
+	assert.NoError(t, err)
+	assert.Equal(t, 2, requestCount, "Expected the retry to proceed when the deadline allows it")
 }
 
 func TestDisableRetries(t *testing.T) {

--- a/seed/go-sdk/examples/readme-config/internal/retrier.go
+++ b/seed/go-sdk/examples/readme-config/internal/retrier.go
@@ -145,12 +145,20 @@ func (r *Retrier) run(
 	}
 
 	if r.shouldRetry(response) {
-		defer func() { _ = response.Body.Close() }()
-
 		delay, err := r.retryDelay(response, retryAttempt)
 		if err != nil {
+			_ = response.Body.Close()
 			return nil, err
 		}
+
+		// If the context's deadline would elapse before the backoff completes, return
+		// the response instead of sleeping through it. The caller then sees why the
+		// request actually failed (e.g. a 429) rather than a context deadline error.
+		if deadline, ok := request.Context().Deadline(); ok && time.Until(deadline) < delay {
+			return response, nil
+		}
+
+		defer func() { _ = response.Body.Close() }()
 
 		if err := sleepWithContext(request.Context(), delay); err != nil {
 			return nil, err

--- a/seed/go-sdk/examples/readme-config/internal/retrier_test.go
+++ b/seed/go-sdk/examples/readme-config/internal/retrier_test.go
@@ -295,7 +295,50 @@ func TestRetryWithRequestBody(t *testing.T) {
 	assert.Equal(t, expectedBody, requestBodies[1], "Second request body should match expected (retry should re-send body)")
 }
 
+// An explicit cancel (e.g. Ctrl-C wired to cancel()) must interrupt the backoff
+// wait. There is no deadline here, so the retrier cannot know the wait is futile
+// up front -- it has to be woken by the context.
 func TestRetryWaitIsInterruptedByContext(t *testing.T) {
+	var requestCount int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		w.Header().Set("Retry-After", "5")
+		w.WriteHeader(http.StatusTooManyRequests)
+	}))
+	defer server.Close()
+
+	caller := NewCaller(&CallerParams{
+		Client: server.Client(),
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		time.Sleep(100 * time.Millisecond)
+		cancel()
+	}()
+	defer cancel()
+
+	start := time.Now()
+	_, err := caller.Call(
+		ctx,
+		&CallParams{
+			URL:         server.URL,
+			Method:      http.MethodGet,
+			Request:     &InternalTestRequest{},
+			MaxAttempts: 3,
+		},
+	)
+	elapsed := time.Since(start)
+
+	assert.ErrorIs(t, err, context.Canceled)
+	assert.Equal(t, 1, requestCount, "Expected the retry to be abandoned once the context was cancelled")
+	assert.Less(t, elapsed, time.Second, "Expected the backoff to be interrupted by the context, took %v", elapsed)
+}
+
+// When the caller's deadline would elapse before the backoff finishes, sleeping
+// only guarantees a context error. Return the response instead so the caller
+// learns why the request actually failed.
+func TestRetryReturnsResponseWhenDeadlineShorterThanBackoff(t *testing.T) {
 	var requestCount int
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		requestCount++
@@ -323,9 +366,50 @@ func TestRetryWaitIsInterruptedByContext(t *testing.T) {
 	)
 	elapsed := time.Since(start)
 
-	assert.ErrorIs(t, err, context.DeadlineExceeded)
-	assert.Equal(t, 1, requestCount, "Expected the retry to be abandoned once the context expired")
-	assert.Less(t, elapsed, time.Second, "Expected the backoff to be interrupted by the context, took %v", elapsed)
+	// The caller gets the 429, not context.DeadlineExceeded.
+	var apiError *core.APIError
+	require.ErrorAs(t, err, &apiError)
+	assert.Equal(t, http.StatusTooManyRequests, apiError.StatusCode)
+	assert.NotErrorIs(t, err, context.DeadlineExceeded)
+	assert.Equal(t, 1, requestCount, "Expected no retry once the deadline was known to be too short")
+	assert.Less(t, elapsed, time.Second, "Expected to return immediately rather than sleep, took %v", elapsed)
+}
+
+// A deadline with room for the backoff must still retry as normal.
+func TestRetryProceedsWhenDeadlineLongerThanBackoff(t *testing.T) {
+	var requestCount int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		if requestCount == 1 {
+			w.Header().Set("Retry-After", "1")
+			w.WriteHeader(http.StatusTooManyRequests)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("{}"))
+	}))
+	defer server.Close()
+
+	caller := NewCaller(&CallerParams{
+		Client: server.Client(),
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	_, err := caller.Call(
+		ctx,
+		&CallParams{
+			URL:         server.URL,
+			Method:      http.MethodGet,
+			Request:     &InternalTestRequest{},
+			Response:    &InternalTestResponse{},
+			MaxAttempts: 3,
+		},
+	)
+
+	assert.NoError(t, err)
+	assert.Equal(t, 2, requestCount, "Expected the retry to proceed when the deadline allows it")
 }
 
 func TestDisableRetries(t *testing.T) {

--- a/seed/go-sdk/examples/v0/internal/retrier.go
+++ b/seed/go-sdk/examples/v0/internal/retrier.go
@@ -145,12 +145,20 @@ func (r *Retrier) run(
 	}
 
 	if r.shouldRetry(response) {
-		defer func() { _ = response.Body.Close() }()
-
 		delay, err := r.retryDelay(response, retryAttempt)
 		if err != nil {
+			_ = response.Body.Close()
 			return nil, err
 		}
+
+		// If the context's deadline would elapse before the backoff completes, return
+		// the response instead of sleeping through it. The caller then sees why the
+		// request actually failed (e.g. a 429) rather than a context deadline error.
+		if deadline, ok := request.Context().Deadline(); ok && time.Until(deadline) < delay {
+			return response, nil
+		}
+
+		defer func() { _ = response.Body.Close() }()
 
 		if err := sleepWithContext(request.Context(), delay); err != nil {
 			return nil, err

--- a/seed/go-sdk/examples/v0/internal/retrier_test.go
+++ b/seed/go-sdk/examples/v0/internal/retrier_test.go
@@ -295,7 +295,50 @@ func TestRetryWithRequestBody(t *testing.T) {
 	assert.Equal(t, expectedBody, requestBodies[1], "Second request body should match expected (retry should re-send body)")
 }
 
+// An explicit cancel (e.g. Ctrl-C wired to cancel()) must interrupt the backoff
+// wait. There is no deadline here, so the retrier cannot know the wait is futile
+// up front -- it has to be woken by the context.
 func TestRetryWaitIsInterruptedByContext(t *testing.T) {
+	var requestCount int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		w.Header().Set("Retry-After", "5")
+		w.WriteHeader(http.StatusTooManyRequests)
+	}))
+	defer server.Close()
+
+	caller := NewCaller(&CallerParams{
+		Client: server.Client(),
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		time.Sleep(100 * time.Millisecond)
+		cancel()
+	}()
+	defer cancel()
+
+	start := time.Now()
+	_, err := caller.Call(
+		ctx,
+		&CallParams{
+			URL:         server.URL,
+			Method:      http.MethodGet,
+			Request:     &InternalTestRequest{},
+			MaxAttempts: 3,
+		},
+	)
+	elapsed := time.Since(start)
+
+	assert.ErrorIs(t, err, context.Canceled)
+	assert.Equal(t, 1, requestCount, "Expected the retry to be abandoned once the context was cancelled")
+	assert.Less(t, elapsed, time.Second, "Expected the backoff to be interrupted by the context, took %v", elapsed)
+}
+
+// When the caller's deadline would elapse before the backoff finishes, sleeping
+// only guarantees a context error. Return the response instead so the caller
+// learns why the request actually failed.
+func TestRetryReturnsResponseWhenDeadlineShorterThanBackoff(t *testing.T) {
 	var requestCount int
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		requestCount++
@@ -323,9 +366,50 @@ func TestRetryWaitIsInterruptedByContext(t *testing.T) {
 	)
 	elapsed := time.Since(start)
 
-	assert.ErrorIs(t, err, context.DeadlineExceeded)
-	assert.Equal(t, 1, requestCount, "Expected the retry to be abandoned once the context expired")
-	assert.Less(t, elapsed, time.Second, "Expected the backoff to be interrupted by the context, took %v", elapsed)
+	// The caller gets the 429, not context.DeadlineExceeded.
+	var apiError *core.APIError
+	require.ErrorAs(t, err, &apiError)
+	assert.Equal(t, http.StatusTooManyRequests, apiError.StatusCode)
+	assert.NotErrorIs(t, err, context.DeadlineExceeded)
+	assert.Equal(t, 1, requestCount, "Expected no retry once the deadline was known to be too short")
+	assert.Less(t, elapsed, time.Second, "Expected to return immediately rather than sleep, took %v", elapsed)
+}
+
+// A deadline with room for the backoff must still retry as normal.
+func TestRetryProceedsWhenDeadlineLongerThanBackoff(t *testing.T) {
+	var requestCount int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		if requestCount == 1 {
+			w.Header().Set("Retry-After", "1")
+			w.WriteHeader(http.StatusTooManyRequests)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("{}"))
+	}))
+	defer server.Close()
+
+	caller := NewCaller(&CallerParams{
+		Client: server.Client(),
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	_, err := caller.Call(
+		ctx,
+		&CallParams{
+			URL:         server.URL,
+			Method:      http.MethodGet,
+			Request:     &InternalTestRequest{},
+			Response:    &InternalTestResponse{},
+			MaxAttempts: 3,
+		},
+	)
+
+	assert.NoError(t, err)
+	assert.Equal(t, 2, requestCount, "Expected the retry to proceed when the deadline allows it")
 }
 
 func TestDisableRetries(t *testing.T) {

--- a/seed/go-sdk/exhaustive/no-custom-config/internal/retrier.go
+++ b/seed/go-sdk/exhaustive/no-custom-config/internal/retrier.go
@@ -145,12 +145,20 @@ func (r *Retrier) run(
 	}
 
 	if r.shouldRetry(response) {
-		defer func() { _ = response.Body.Close() }()
-
 		delay, err := r.retryDelay(response, retryAttempt)
 		if err != nil {
+			_ = response.Body.Close()
 			return nil, err
 		}
+
+		// If the context's deadline would elapse before the backoff completes, return
+		// the response instead of sleeping through it. The caller then sees why the
+		// request actually failed (e.g. a 429) rather than a context deadline error.
+		if deadline, ok := request.Context().Deadline(); ok && time.Until(deadline) < delay {
+			return response, nil
+		}
+
+		defer func() { _ = response.Body.Close() }()
 
 		if err := sleepWithContext(request.Context(), delay); err != nil {
 			return nil, err

--- a/seed/go-sdk/exhaustive/no-custom-config/internal/retrier_test.go
+++ b/seed/go-sdk/exhaustive/no-custom-config/internal/retrier_test.go
@@ -295,7 +295,50 @@ func TestRetryWithRequestBody(t *testing.T) {
 	assert.Equal(t, expectedBody, requestBodies[1], "Second request body should match expected (retry should re-send body)")
 }
 
+// An explicit cancel (e.g. Ctrl-C wired to cancel()) must interrupt the backoff
+// wait. There is no deadline here, so the retrier cannot know the wait is futile
+// up front -- it has to be woken by the context.
 func TestRetryWaitIsInterruptedByContext(t *testing.T) {
+	var requestCount int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		w.Header().Set("Retry-After", "5")
+		w.WriteHeader(http.StatusTooManyRequests)
+	}))
+	defer server.Close()
+
+	caller := NewCaller(&CallerParams{
+		Client: server.Client(),
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		time.Sleep(100 * time.Millisecond)
+		cancel()
+	}()
+	defer cancel()
+
+	start := time.Now()
+	_, err := caller.Call(
+		ctx,
+		&CallParams{
+			URL:         server.URL,
+			Method:      http.MethodGet,
+			Request:     &InternalTestRequest{},
+			MaxAttempts: 3,
+		},
+	)
+	elapsed := time.Since(start)
+
+	assert.ErrorIs(t, err, context.Canceled)
+	assert.Equal(t, 1, requestCount, "Expected the retry to be abandoned once the context was cancelled")
+	assert.Less(t, elapsed, time.Second, "Expected the backoff to be interrupted by the context, took %v", elapsed)
+}
+
+// When the caller's deadline would elapse before the backoff finishes, sleeping
+// only guarantees a context error. Return the response instead so the caller
+// learns why the request actually failed.
+func TestRetryReturnsResponseWhenDeadlineShorterThanBackoff(t *testing.T) {
 	var requestCount int
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		requestCount++
@@ -323,9 +366,50 @@ func TestRetryWaitIsInterruptedByContext(t *testing.T) {
 	)
 	elapsed := time.Since(start)
 
-	assert.ErrorIs(t, err, context.DeadlineExceeded)
-	assert.Equal(t, 1, requestCount, "Expected the retry to be abandoned once the context expired")
-	assert.Less(t, elapsed, time.Second, "Expected the backoff to be interrupted by the context, took %v", elapsed)
+	// The caller gets the 429, not context.DeadlineExceeded.
+	var apiError *core.APIError
+	require.ErrorAs(t, err, &apiError)
+	assert.Equal(t, http.StatusTooManyRequests, apiError.StatusCode)
+	assert.NotErrorIs(t, err, context.DeadlineExceeded)
+	assert.Equal(t, 1, requestCount, "Expected no retry once the deadline was known to be too short")
+	assert.Less(t, elapsed, time.Second, "Expected to return immediately rather than sleep, took %v", elapsed)
+}
+
+// A deadline with room for the backoff must still retry as normal.
+func TestRetryProceedsWhenDeadlineLongerThanBackoff(t *testing.T) {
+	var requestCount int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		if requestCount == 1 {
+			w.Header().Set("Retry-After", "1")
+			w.WriteHeader(http.StatusTooManyRequests)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("{}"))
+	}))
+	defer server.Close()
+
+	caller := NewCaller(&CallerParams{
+		Client: server.Client(),
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	_, err := caller.Call(
+		ctx,
+		&CallParams{
+			URL:         server.URL,
+			Method:      http.MethodGet,
+			Request:     &InternalTestRequest{},
+			Response:    &InternalTestResponse{},
+			MaxAttempts: 3,
+		},
+	)
+
+	assert.NoError(t, err)
+	assert.Equal(t, 2, requestCount, "Expected the retry to proceed when the deadline allows it")
 }
 
 func TestDisableRetries(t *testing.T) {

--- a/seed/go-sdk/exhaustive/omit-empty-request-wrappers/internal/retrier.go
+++ b/seed/go-sdk/exhaustive/omit-empty-request-wrappers/internal/retrier.go
@@ -145,12 +145,20 @@ func (r *Retrier) run(
 	}
 
 	if r.shouldRetry(response) {
-		defer func() { _ = response.Body.Close() }()
-
 		delay, err := r.retryDelay(response, retryAttempt)
 		if err != nil {
+			_ = response.Body.Close()
 			return nil, err
 		}
+
+		// If the context's deadline would elapse before the backoff completes, return
+		// the response instead of sleeping through it. The caller then sees why the
+		// request actually failed (e.g. a 429) rather than a context deadline error.
+		if deadline, ok := request.Context().Deadline(); ok && time.Until(deadline) < delay {
+			return response, nil
+		}
+
+		defer func() { _ = response.Body.Close() }()
 
 		if err := sleepWithContext(request.Context(), delay); err != nil {
 			return nil, err

--- a/seed/go-sdk/exhaustive/omit-empty-request-wrappers/internal/retrier_test.go
+++ b/seed/go-sdk/exhaustive/omit-empty-request-wrappers/internal/retrier_test.go
@@ -295,7 +295,50 @@ func TestRetryWithRequestBody(t *testing.T) {
 	assert.Equal(t, expectedBody, requestBodies[1], "Second request body should match expected (retry should re-send body)")
 }
 
+// An explicit cancel (e.g. Ctrl-C wired to cancel()) must interrupt the backoff
+// wait. There is no deadline here, so the retrier cannot know the wait is futile
+// up front -- it has to be woken by the context.
 func TestRetryWaitIsInterruptedByContext(t *testing.T) {
+	var requestCount int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		w.Header().Set("Retry-After", "5")
+		w.WriteHeader(http.StatusTooManyRequests)
+	}))
+	defer server.Close()
+
+	caller := NewCaller(&CallerParams{
+		Client: server.Client(),
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		time.Sleep(100 * time.Millisecond)
+		cancel()
+	}()
+	defer cancel()
+
+	start := time.Now()
+	_, err := caller.Call(
+		ctx,
+		&CallParams{
+			URL:         server.URL,
+			Method:      http.MethodGet,
+			Request:     &InternalTestRequest{},
+			MaxAttempts: 3,
+		},
+	)
+	elapsed := time.Since(start)
+
+	assert.ErrorIs(t, err, context.Canceled)
+	assert.Equal(t, 1, requestCount, "Expected the retry to be abandoned once the context was cancelled")
+	assert.Less(t, elapsed, time.Second, "Expected the backoff to be interrupted by the context, took %v", elapsed)
+}
+
+// When the caller's deadline would elapse before the backoff finishes, sleeping
+// only guarantees a context error. Return the response instead so the caller
+// learns why the request actually failed.
+func TestRetryReturnsResponseWhenDeadlineShorterThanBackoff(t *testing.T) {
 	var requestCount int
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		requestCount++
@@ -323,9 +366,50 @@ func TestRetryWaitIsInterruptedByContext(t *testing.T) {
 	)
 	elapsed := time.Since(start)
 
-	assert.ErrorIs(t, err, context.DeadlineExceeded)
-	assert.Equal(t, 1, requestCount, "Expected the retry to be abandoned once the context expired")
-	assert.Less(t, elapsed, time.Second, "Expected the backoff to be interrupted by the context, took %v", elapsed)
+	// The caller gets the 429, not context.DeadlineExceeded.
+	var apiError *core.APIError
+	require.ErrorAs(t, err, &apiError)
+	assert.Equal(t, http.StatusTooManyRequests, apiError.StatusCode)
+	assert.NotErrorIs(t, err, context.DeadlineExceeded)
+	assert.Equal(t, 1, requestCount, "Expected no retry once the deadline was known to be too short")
+	assert.Less(t, elapsed, time.Second, "Expected to return immediately rather than sleep, took %v", elapsed)
+}
+
+// A deadline with room for the backoff must still retry as normal.
+func TestRetryProceedsWhenDeadlineLongerThanBackoff(t *testing.T) {
+	var requestCount int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		if requestCount == 1 {
+			w.Header().Set("Retry-After", "1")
+			w.WriteHeader(http.StatusTooManyRequests)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("{}"))
+	}))
+	defer server.Close()
+
+	caller := NewCaller(&CallerParams{
+		Client: server.Client(),
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	_, err := caller.Call(
+		ctx,
+		&CallParams{
+			URL:         server.URL,
+			Method:      http.MethodGet,
+			Request:     &InternalTestRequest{},
+			Response:    &InternalTestResponse{},
+			MaxAttempts: 3,
+		},
+	)
+
+	assert.NoError(t, err)
+	assert.Equal(t, 2, requestCount, "Expected the retry to proceed when the deadline allows it")
 }
 
 func TestDisableRetries(t *testing.T) {

--- a/seed/go-sdk/extends/internal/retrier.go
+++ b/seed/go-sdk/extends/internal/retrier.go
@@ -145,12 +145,20 @@ func (r *Retrier) run(
 	}
 
 	if r.shouldRetry(response) {
-		defer func() { _ = response.Body.Close() }()
-
 		delay, err := r.retryDelay(response, retryAttempt)
 		if err != nil {
+			_ = response.Body.Close()
 			return nil, err
 		}
+
+		// If the context's deadline would elapse before the backoff completes, return
+		// the response instead of sleeping through it. The caller then sees why the
+		// request actually failed (e.g. a 429) rather than a context deadline error.
+		if deadline, ok := request.Context().Deadline(); ok && time.Until(deadline) < delay {
+			return response, nil
+		}
+
+		defer func() { _ = response.Body.Close() }()
 
 		if err := sleepWithContext(request.Context(), delay); err != nil {
 			return nil, err

--- a/seed/go-sdk/extends/internal/retrier_test.go
+++ b/seed/go-sdk/extends/internal/retrier_test.go
@@ -295,7 +295,50 @@ func TestRetryWithRequestBody(t *testing.T) {
 	assert.Equal(t, expectedBody, requestBodies[1], "Second request body should match expected (retry should re-send body)")
 }
 
+// An explicit cancel (e.g. Ctrl-C wired to cancel()) must interrupt the backoff
+// wait. There is no deadline here, so the retrier cannot know the wait is futile
+// up front -- it has to be woken by the context.
 func TestRetryWaitIsInterruptedByContext(t *testing.T) {
+	var requestCount int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		w.Header().Set("Retry-After", "5")
+		w.WriteHeader(http.StatusTooManyRequests)
+	}))
+	defer server.Close()
+
+	caller := NewCaller(&CallerParams{
+		Client: server.Client(),
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		time.Sleep(100 * time.Millisecond)
+		cancel()
+	}()
+	defer cancel()
+
+	start := time.Now()
+	_, err := caller.Call(
+		ctx,
+		&CallParams{
+			URL:         server.URL,
+			Method:      http.MethodGet,
+			Request:     &InternalTestRequest{},
+			MaxAttempts: 3,
+		},
+	)
+	elapsed := time.Since(start)
+
+	assert.ErrorIs(t, err, context.Canceled)
+	assert.Equal(t, 1, requestCount, "Expected the retry to be abandoned once the context was cancelled")
+	assert.Less(t, elapsed, time.Second, "Expected the backoff to be interrupted by the context, took %v", elapsed)
+}
+
+// When the caller's deadline would elapse before the backoff finishes, sleeping
+// only guarantees a context error. Return the response instead so the caller
+// learns why the request actually failed.
+func TestRetryReturnsResponseWhenDeadlineShorterThanBackoff(t *testing.T) {
 	var requestCount int
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		requestCount++
@@ -323,9 +366,50 @@ func TestRetryWaitIsInterruptedByContext(t *testing.T) {
 	)
 	elapsed := time.Since(start)
 
-	assert.ErrorIs(t, err, context.DeadlineExceeded)
-	assert.Equal(t, 1, requestCount, "Expected the retry to be abandoned once the context expired")
-	assert.Less(t, elapsed, time.Second, "Expected the backoff to be interrupted by the context, took %v", elapsed)
+	// The caller gets the 429, not context.DeadlineExceeded.
+	var apiError *core.APIError
+	require.ErrorAs(t, err, &apiError)
+	assert.Equal(t, http.StatusTooManyRequests, apiError.StatusCode)
+	assert.NotErrorIs(t, err, context.DeadlineExceeded)
+	assert.Equal(t, 1, requestCount, "Expected no retry once the deadline was known to be too short")
+	assert.Less(t, elapsed, time.Second, "Expected to return immediately rather than sleep, took %v", elapsed)
+}
+
+// A deadline with room for the backoff must still retry as normal.
+func TestRetryProceedsWhenDeadlineLongerThanBackoff(t *testing.T) {
+	var requestCount int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		if requestCount == 1 {
+			w.Header().Set("Retry-After", "1")
+			w.WriteHeader(http.StatusTooManyRequests)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("{}"))
+	}))
+	defer server.Close()
+
+	caller := NewCaller(&CallerParams{
+		Client: server.Client(),
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	_, err := caller.Call(
+		ctx,
+		&CallParams{
+			URL:         server.URL,
+			Method:      http.MethodGet,
+			Request:     &InternalTestRequest{},
+			Response:    &InternalTestResponse{},
+			MaxAttempts: 3,
+		},
+	)
+
+	assert.NoError(t, err)
+	assert.Equal(t, 2, requestCount, "Expected the retry to proceed when the deadline allows it")
 }
 
 func TestDisableRetries(t *testing.T) {

--- a/seed/go-sdk/extra-properties/internal/retrier.go
+++ b/seed/go-sdk/extra-properties/internal/retrier.go
@@ -145,12 +145,20 @@ func (r *Retrier) run(
 	}
 
 	if r.shouldRetry(response) {
-		defer func() { _ = response.Body.Close() }()
-
 		delay, err := r.retryDelay(response, retryAttempt)
 		if err != nil {
+			_ = response.Body.Close()
 			return nil, err
 		}
+
+		// If the context's deadline would elapse before the backoff completes, return
+		// the response instead of sleeping through it. The caller then sees why the
+		// request actually failed (e.g. a 429) rather than a context deadline error.
+		if deadline, ok := request.Context().Deadline(); ok && time.Until(deadline) < delay {
+			return response, nil
+		}
+
+		defer func() { _ = response.Body.Close() }()
 
 		if err := sleepWithContext(request.Context(), delay); err != nil {
 			return nil, err

--- a/seed/go-sdk/extra-properties/internal/retrier_test.go
+++ b/seed/go-sdk/extra-properties/internal/retrier_test.go
@@ -295,7 +295,50 @@ func TestRetryWithRequestBody(t *testing.T) {
 	assert.Equal(t, expectedBody, requestBodies[1], "Second request body should match expected (retry should re-send body)")
 }
 
+// An explicit cancel (e.g. Ctrl-C wired to cancel()) must interrupt the backoff
+// wait. There is no deadline here, so the retrier cannot know the wait is futile
+// up front -- it has to be woken by the context.
 func TestRetryWaitIsInterruptedByContext(t *testing.T) {
+	var requestCount int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		w.Header().Set("Retry-After", "5")
+		w.WriteHeader(http.StatusTooManyRequests)
+	}))
+	defer server.Close()
+
+	caller := NewCaller(&CallerParams{
+		Client: server.Client(),
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		time.Sleep(100 * time.Millisecond)
+		cancel()
+	}()
+	defer cancel()
+
+	start := time.Now()
+	_, err := caller.Call(
+		ctx,
+		&CallParams{
+			URL:         server.URL,
+			Method:      http.MethodGet,
+			Request:     &InternalTestRequest{},
+			MaxAttempts: 3,
+		},
+	)
+	elapsed := time.Since(start)
+
+	assert.ErrorIs(t, err, context.Canceled)
+	assert.Equal(t, 1, requestCount, "Expected the retry to be abandoned once the context was cancelled")
+	assert.Less(t, elapsed, time.Second, "Expected the backoff to be interrupted by the context, took %v", elapsed)
+}
+
+// When the caller's deadline would elapse before the backoff finishes, sleeping
+// only guarantees a context error. Return the response instead so the caller
+// learns why the request actually failed.
+func TestRetryReturnsResponseWhenDeadlineShorterThanBackoff(t *testing.T) {
 	var requestCount int
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		requestCount++
@@ -323,9 +366,50 @@ func TestRetryWaitIsInterruptedByContext(t *testing.T) {
 	)
 	elapsed := time.Since(start)
 
-	assert.ErrorIs(t, err, context.DeadlineExceeded)
-	assert.Equal(t, 1, requestCount, "Expected the retry to be abandoned once the context expired")
-	assert.Less(t, elapsed, time.Second, "Expected the backoff to be interrupted by the context, took %v", elapsed)
+	// The caller gets the 429, not context.DeadlineExceeded.
+	var apiError *core.APIError
+	require.ErrorAs(t, err, &apiError)
+	assert.Equal(t, http.StatusTooManyRequests, apiError.StatusCode)
+	assert.NotErrorIs(t, err, context.DeadlineExceeded)
+	assert.Equal(t, 1, requestCount, "Expected no retry once the deadline was known to be too short")
+	assert.Less(t, elapsed, time.Second, "Expected to return immediately rather than sleep, took %v", elapsed)
+}
+
+// A deadline with room for the backoff must still retry as normal.
+func TestRetryProceedsWhenDeadlineLongerThanBackoff(t *testing.T) {
+	var requestCount int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		if requestCount == 1 {
+			w.Header().Set("Retry-After", "1")
+			w.WriteHeader(http.StatusTooManyRequests)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("{}"))
+	}))
+	defer server.Close()
+
+	caller := NewCaller(&CallerParams{
+		Client: server.Client(),
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	_, err := caller.Call(
+		ctx,
+		&CallParams{
+			URL:         server.URL,
+			Method:      http.MethodGet,
+			Request:     &InternalTestRequest{},
+			Response:    &InternalTestResponse{},
+			MaxAttempts: 3,
+		},
+	)
+
+	assert.NoError(t, err)
+	assert.Equal(t, 2, requestCount, "Expected the retry to proceed when the deadline allows it")
 }
 
 func TestDisableRetries(t *testing.T) {

--- a/seed/go-sdk/file-download/internal/retrier.go
+++ b/seed/go-sdk/file-download/internal/retrier.go
@@ -145,12 +145,20 @@ func (r *Retrier) run(
 	}
 
 	if r.shouldRetry(response) {
-		defer func() { _ = response.Body.Close() }()
-
 		delay, err := r.retryDelay(response, retryAttempt)
 		if err != nil {
+			_ = response.Body.Close()
 			return nil, err
 		}
+
+		// If the context's deadline would elapse before the backoff completes, return
+		// the response instead of sleeping through it. The caller then sees why the
+		// request actually failed (e.g. a 429) rather than a context deadline error.
+		if deadline, ok := request.Context().Deadline(); ok && time.Until(deadline) < delay {
+			return response, nil
+		}
+
+		defer func() { _ = response.Body.Close() }()
 
 		if err := sleepWithContext(request.Context(), delay); err != nil {
 			return nil, err

--- a/seed/go-sdk/file-download/internal/retrier_test.go
+++ b/seed/go-sdk/file-download/internal/retrier_test.go
@@ -295,7 +295,50 @@ func TestRetryWithRequestBody(t *testing.T) {
 	assert.Equal(t, expectedBody, requestBodies[1], "Second request body should match expected (retry should re-send body)")
 }
 
+// An explicit cancel (e.g. Ctrl-C wired to cancel()) must interrupt the backoff
+// wait. There is no deadline here, so the retrier cannot know the wait is futile
+// up front -- it has to be woken by the context.
 func TestRetryWaitIsInterruptedByContext(t *testing.T) {
+	var requestCount int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		w.Header().Set("Retry-After", "5")
+		w.WriteHeader(http.StatusTooManyRequests)
+	}))
+	defer server.Close()
+
+	caller := NewCaller(&CallerParams{
+		Client: server.Client(),
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		time.Sleep(100 * time.Millisecond)
+		cancel()
+	}()
+	defer cancel()
+
+	start := time.Now()
+	_, err := caller.Call(
+		ctx,
+		&CallParams{
+			URL:         server.URL,
+			Method:      http.MethodGet,
+			Request:     &InternalTestRequest{},
+			MaxAttempts: 3,
+		},
+	)
+	elapsed := time.Since(start)
+
+	assert.ErrorIs(t, err, context.Canceled)
+	assert.Equal(t, 1, requestCount, "Expected the retry to be abandoned once the context was cancelled")
+	assert.Less(t, elapsed, time.Second, "Expected the backoff to be interrupted by the context, took %v", elapsed)
+}
+
+// When the caller's deadline would elapse before the backoff finishes, sleeping
+// only guarantees a context error. Return the response instead so the caller
+// learns why the request actually failed.
+func TestRetryReturnsResponseWhenDeadlineShorterThanBackoff(t *testing.T) {
 	var requestCount int
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		requestCount++
@@ -323,9 +366,50 @@ func TestRetryWaitIsInterruptedByContext(t *testing.T) {
 	)
 	elapsed := time.Since(start)
 
-	assert.ErrorIs(t, err, context.DeadlineExceeded)
-	assert.Equal(t, 1, requestCount, "Expected the retry to be abandoned once the context expired")
-	assert.Less(t, elapsed, time.Second, "Expected the backoff to be interrupted by the context, took %v", elapsed)
+	// The caller gets the 429, not context.DeadlineExceeded.
+	var apiError *core.APIError
+	require.ErrorAs(t, err, &apiError)
+	assert.Equal(t, http.StatusTooManyRequests, apiError.StatusCode)
+	assert.NotErrorIs(t, err, context.DeadlineExceeded)
+	assert.Equal(t, 1, requestCount, "Expected no retry once the deadline was known to be too short")
+	assert.Less(t, elapsed, time.Second, "Expected to return immediately rather than sleep, took %v", elapsed)
+}
+
+// A deadline with room for the backoff must still retry as normal.
+func TestRetryProceedsWhenDeadlineLongerThanBackoff(t *testing.T) {
+	var requestCount int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		if requestCount == 1 {
+			w.Header().Set("Retry-After", "1")
+			w.WriteHeader(http.StatusTooManyRequests)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("{}"))
+	}))
+	defer server.Close()
+
+	caller := NewCaller(&CallerParams{
+		Client: server.Client(),
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	_, err := caller.Call(
+		ctx,
+		&CallParams{
+			URL:         server.URL,
+			Method:      http.MethodGet,
+			Request:     &InternalTestRequest{},
+			Response:    &InternalTestResponse{},
+			MaxAttempts: 3,
+		},
+	)
+
+	assert.NoError(t, err)
+	assert.Equal(t, 2, requestCount, "Expected the retry to proceed when the deadline allows it")
 }
 
 func TestDisableRetries(t *testing.T) {

--- a/seed/go-sdk/file-upload-openapi/internal/retrier.go
+++ b/seed/go-sdk/file-upload-openapi/internal/retrier.go
@@ -145,12 +145,20 @@ func (r *Retrier) run(
 	}
 
 	if r.shouldRetry(response) {
-		defer func() { _ = response.Body.Close() }()
-
 		delay, err := r.retryDelay(response, retryAttempt)
 		if err != nil {
+			_ = response.Body.Close()
 			return nil, err
 		}
+
+		// If the context's deadline would elapse before the backoff completes, return
+		// the response instead of sleeping through it. The caller then sees why the
+		// request actually failed (e.g. a 429) rather than a context deadline error.
+		if deadline, ok := request.Context().Deadline(); ok && time.Until(deadline) < delay {
+			return response, nil
+		}
+
+		defer func() { _ = response.Body.Close() }()
 
 		if err := sleepWithContext(request.Context(), delay); err != nil {
 			return nil, err

--- a/seed/go-sdk/file-upload-openapi/internal/retrier_test.go
+++ b/seed/go-sdk/file-upload-openapi/internal/retrier_test.go
@@ -295,7 +295,50 @@ func TestRetryWithRequestBody(t *testing.T) {
 	assert.Equal(t, expectedBody, requestBodies[1], "Second request body should match expected (retry should re-send body)")
 }
 
+// An explicit cancel (e.g. Ctrl-C wired to cancel()) must interrupt the backoff
+// wait. There is no deadline here, so the retrier cannot know the wait is futile
+// up front -- it has to be woken by the context.
 func TestRetryWaitIsInterruptedByContext(t *testing.T) {
+	var requestCount int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		w.Header().Set("Retry-After", "5")
+		w.WriteHeader(http.StatusTooManyRequests)
+	}))
+	defer server.Close()
+
+	caller := NewCaller(&CallerParams{
+		Client: server.Client(),
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		time.Sleep(100 * time.Millisecond)
+		cancel()
+	}()
+	defer cancel()
+
+	start := time.Now()
+	_, err := caller.Call(
+		ctx,
+		&CallParams{
+			URL:         server.URL,
+			Method:      http.MethodGet,
+			Request:     &InternalTestRequest{},
+			MaxAttempts: 3,
+		},
+	)
+	elapsed := time.Since(start)
+
+	assert.ErrorIs(t, err, context.Canceled)
+	assert.Equal(t, 1, requestCount, "Expected the retry to be abandoned once the context was cancelled")
+	assert.Less(t, elapsed, time.Second, "Expected the backoff to be interrupted by the context, took %v", elapsed)
+}
+
+// When the caller's deadline would elapse before the backoff finishes, sleeping
+// only guarantees a context error. Return the response instead so the caller
+// learns why the request actually failed.
+func TestRetryReturnsResponseWhenDeadlineShorterThanBackoff(t *testing.T) {
 	var requestCount int
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		requestCount++
@@ -323,9 +366,50 @@ func TestRetryWaitIsInterruptedByContext(t *testing.T) {
 	)
 	elapsed := time.Since(start)
 
-	assert.ErrorIs(t, err, context.DeadlineExceeded)
-	assert.Equal(t, 1, requestCount, "Expected the retry to be abandoned once the context expired")
-	assert.Less(t, elapsed, time.Second, "Expected the backoff to be interrupted by the context, took %v", elapsed)
+	// The caller gets the 429, not context.DeadlineExceeded.
+	var apiError *core.APIError
+	require.ErrorAs(t, err, &apiError)
+	assert.Equal(t, http.StatusTooManyRequests, apiError.StatusCode)
+	assert.NotErrorIs(t, err, context.DeadlineExceeded)
+	assert.Equal(t, 1, requestCount, "Expected no retry once the deadline was known to be too short")
+	assert.Less(t, elapsed, time.Second, "Expected to return immediately rather than sleep, took %v", elapsed)
+}
+
+// A deadline with room for the backoff must still retry as normal.
+func TestRetryProceedsWhenDeadlineLongerThanBackoff(t *testing.T) {
+	var requestCount int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		if requestCount == 1 {
+			w.Header().Set("Retry-After", "1")
+			w.WriteHeader(http.StatusTooManyRequests)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("{}"))
+	}))
+	defer server.Close()
+
+	caller := NewCaller(&CallerParams{
+		Client: server.Client(),
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	_, err := caller.Call(
+		ctx,
+		&CallParams{
+			URL:         server.URL,
+			Method:      http.MethodGet,
+			Request:     &InternalTestRequest{},
+			Response:    &InternalTestResponse{},
+			MaxAttempts: 3,
+		},
+	)
+
+	assert.NoError(t, err)
+	assert.Equal(t, 2, requestCount, "Expected the retry to proceed when the deadline allows it")
 }
 
 func TestDisableRetries(t *testing.T) {

--- a/seed/go-sdk/file-upload/no-custom-config/internal/retrier.go
+++ b/seed/go-sdk/file-upload/no-custom-config/internal/retrier.go
@@ -145,12 +145,20 @@ func (r *Retrier) run(
 	}
 
 	if r.shouldRetry(response) {
-		defer func() { _ = response.Body.Close() }()
-
 		delay, err := r.retryDelay(response, retryAttempt)
 		if err != nil {
+			_ = response.Body.Close()
 			return nil, err
 		}
+
+		// If the context's deadline would elapse before the backoff completes, return
+		// the response instead of sleeping through it. The caller then sees why the
+		// request actually failed (e.g. a 429) rather than a context deadline error.
+		if deadline, ok := request.Context().Deadline(); ok && time.Until(deadline) < delay {
+			return response, nil
+		}
+
+		defer func() { _ = response.Body.Close() }()
 
 		if err := sleepWithContext(request.Context(), delay); err != nil {
 			return nil, err

--- a/seed/go-sdk/file-upload/no-custom-config/internal/retrier_test.go
+++ b/seed/go-sdk/file-upload/no-custom-config/internal/retrier_test.go
@@ -295,7 +295,50 @@ func TestRetryWithRequestBody(t *testing.T) {
 	assert.Equal(t, expectedBody, requestBodies[1], "Second request body should match expected (retry should re-send body)")
 }
 
+// An explicit cancel (e.g. Ctrl-C wired to cancel()) must interrupt the backoff
+// wait. There is no deadline here, so the retrier cannot know the wait is futile
+// up front -- it has to be woken by the context.
 func TestRetryWaitIsInterruptedByContext(t *testing.T) {
+	var requestCount int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		w.Header().Set("Retry-After", "5")
+		w.WriteHeader(http.StatusTooManyRequests)
+	}))
+	defer server.Close()
+
+	caller := NewCaller(&CallerParams{
+		Client: server.Client(),
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		time.Sleep(100 * time.Millisecond)
+		cancel()
+	}()
+	defer cancel()
+
+	start := time.Now()
+	_, err := caller.Call(
+		ctx,
+		&CallParams{
+			URL:         server.URL,
+			Method:      http.MethodGet,
+			Request:     &InternalTestRequest{},
+			MaxAttempts: 3,
+		},
+	)
+	elapsed := time.Since(start)
+
+	assert.ErrorIs(t, err, context.Canceled)
+	assert.Equal(t, 1, requestCount, "Expected the retry to be abandoned once the context was cancelled")
+	assert.Less(t, elapsed, time.Second, "Expected the backoff to be interrupted by the context, took %v", elapsed)
+}
+
+// When the caller's deadline would elapse before the backoff finishes, sleeping
+// only guarantees a context error. Return the response instead so the caller
+// learns why the request actually failed.
+func TestRetryReturnsResponseWhenDeadlineShorterThanBackoff(t *testing.T) {
 	var requestCount int
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		requestCount++
@@ -323,9 +366,50 @@ func TestRetryWaitIsInterruptedByContext(t *testing.T) {
 	)
 	elapsed := time.Since(start)
 
-	assert.ErrorIs(t, err, context.DeadlineExceeded)
-	assert.Equal(t, 1, requestCount, "Expected the retry to be abandoned once the context expired")
-	assert.Less(t, elapsed, time.Second, "Expected the backoff to be interrupted by the context, took %v", elapsed)
+	// The caller gets the 429, not context.DeadlineExceeded.
+	var apiError *core.APIError
+	require.ErrorAs(t, err, &apiError)
+	assert.Equal(t, http.StatusTooManyRequests, apiError.StatusCode)
+	assert.NotErrorIs(t, err, context.DeadlineExceeded)
+	assert.Equal(t, 1, requestCount, "Expected no retry once the deadline was known to be too short")
+	assert.Less(t, elapsed, time.Second, "Expected to return immediately rather than sleep, took %v", elapsed)
+}
+
+// A deadline with room for the backoff must still retry as normal.
+func TestRetryProceedsWhenDeadlineLongerThanBackoff(t *testing.T) {
+	var requestCount int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		if requestCount == 1 {
+			w.Header().Set("Retry-After", "1")
+			w.WriteHeader(http.StatusTooManyRequests)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("{}"))
+	}))
+	defer server.Close()
+
+	caller := NewCaller(&CallerParams{
+		Client: server.Client(),
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	_, err := caller.Call(
+		ctx,
+		&CallParams{
+			URL:         server.URL,
+			Method:      http.MethodGet,
+			Request:     &InternalTestRequest{},
+			Response:    &InternalTestResponse{},
+			MaxAttempts: 3,
+		},
+	)
+
+	assert.NoError(t, err)
+	assert.Equal(t, 2, requestCount, "Expected the retry to proceed when the deadline allows it")
 }
 
 func TestDisableRetries(t *testing.T) {

--- a/seed/go-sdk/file-upload/package-name/internal/retrier.go
+++ b/seed/go-sdk/file-upload/package-name/internal/retrier.go
@@ -145,12 +145,20 @@ func (r *Retrier) run(
 	}
 
 	if r.shouldRetry(response) {
-		defer func() { _ = response.Body.Close() }()
-
 		delay, err := r.retryDelay(response, retryAttempt)
 		if err != nil {
+			_ = response.Body.Close()
 			return nil, err
 		}
+
+		// If the context's deadline would elapse before the backoff completes, return
+		// the response instead of sleeping through it. The caller then sees why the
+		// request actually failed (e.g. a 429) rather than a context deadline error.
+		if deadline, ok := request.Context().Deadline(); ok && time.Until(deadline) < delay {
+			return response, nil
+		}
+
+		defer func() { _ = response.Body.Close() }()
 
 		if err := sleepWithContext(request.Context(), delay); err != nil {
 			return nil, err

--- a/seed/go-sdk/file-upload/package-name/internal/retrier_test.go
+++ b/seed/go-sdk/file-upload/package-name/internal/retrier_test.go
@@ -295,7 +295,50 @@ func TestRetryWithRequestBody(t *testing.T) {
 	assert.Equal(t, expectedBody, requestBodies[1], "Second request body should match expected (retry should re-send body)")
 }
 
+// An explicit cancel (e.g. Ctrl-C wired to cancel()) must interrupt the backoff
+// wait. There is no deadline here, so the retrier cannot know the wait is futile
+// up front -- it has to be woken by the context.
 func TestRetryWaitIsInterruptedByContext(t *testing.T) {
+	var requestCount int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		w.Header().Set("Retry-After", "5")
+		w.WriteHeader(http.StatusTooManyRequests)
+	}))
+	defer server.Close()
+
+	caller := NewCaller(&CallerParams{
+		Client: server.Client(),
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		time.Sleep(100 * time.Millisecond)
+		cancel()
+	}()
+	defer cancel()
+
+	start := time.Now()
+	_, err := caller.Call(
+		ctx,
+		&CallParams{
+			URL:         server.URL,
+			Method:      http.MethodGet,
+			Request:     &InternalTestRequest{},
+			MaxAttempts: 3,
+		},
+	)
+	elapsed := time.Since(start)
+
+	assert.ErrorIs(t, err, context.Canceled)
+	assert.Equal(t, 1, requestCount, "Expected the retry to be abandoned once the context was cancelled")
+	assert.Less(t, elapsed, time.Second, "Expected the backoff to be interrupted by the context, took %v", elapsed)
+}
+
+// When the caller's deadline would elapse before the backoff finishes, sleeping
+// only guarantees a context error. Return the response instead so the caller
+// learns why the request actually failed.
+func TestRetryReturnsResponseWhenDeadlineShorterThanBackoff(t *testing.T) {
 	var requestCount int
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		requestCount++
@@ -323,9 +366,50 @@ func TestRetryWaitIsInterruptedByContext(t *testing.T) {
 	)
 	elapsed := time.Since(start)
 
-	assert.ErrorIs(t, err, context.DeadlineExceeded)
-	assert.Equal(t, 1, requestCount, "Expected the retry to be abandoned once the context expired")
-	assert.Less(t, elapsed, time.Second, "Expected the backoff to be interrupted by the context, took %v", elapsed)
+	// The caller gets the 429, not context.DeadlineExceeded.
+	var apiError *core.APIError
+	require.ErrorAs(t, err, &apiError)
+	assert.Equal(t, http.StatusTooManyRequests, apiError.StatusCode)
+	assert.NotErrorIs(t, err, context.DeadlineExceeded)
+	assert.Equal(t, 1, requestCount, "Expected no retry once the deadline was known to be too short")
+	assert.Less(t, elapsed, time.Second, "Expected to return immediately rather than sleep, took %v", elapsed)
+}
+
+// A deadline with room for the backoff must still retry as normal.
+func TestRetryProceedsWhenDeadlineLongerThanBackoff(t *testing.T) {
+	var requestCount int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		if requestCount == 1 {
+			w.Header().Set("Retry-After", "1")
+			w.WriteHeader(http.StatusTooManyRequests)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("{}"))
+	}))
+	defer server.Close()
+
+	caller := NewCaller(&CallerParams{
+		Client: server.Client(),
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	_, err := caller.Call(
+		ctx,
+		&CallParams{
+			URL:         server.URL,
+			Method:      http.MethodGet,
+			Request:     &InternalTestRequest{},
+			Response:    &InternalTestResponse{},
+			MaxAttempts: 3,
+		},
+	)
+
+	assert.NoError(t, err)
+	assert.Equal(t, 2, requestCount, "Expected the retry to proceed when the deadline allows it")
 }
 
 func TestDisableRetries(t *testing.T) {

--- a/seed/go-sdk/file-upload/v0/internal/retrier.go
+++ b/seed/go-sdk/file-upload/v0/internal/retrier.go
@@ -145,12 +145,20 @@ func (r *Retrier) run(
 	}
 
 	if r.shouldRetry(response) {
-		defer func() { _ = response.Body.Close() }()
-
 		delay, err := r.retryDelay(response, retryAttempt)
 		if err != nil {
+			_ = response.Body.Close()
 			return nil, err
 		}
+
+		// If the context's deadline would elapse before the backoff completes, return
+		// the response instead of sleeping through it. The caller then sees why the
+		// request actually failed (e.g. a 429) rather than a context deadline error.
+		if deadline, ok := request.Context().Deadline(); ok && time.Until(deadline) < delay {
+			return response, nil
+		}
+
+		defer func() { _ = response.Body.Close() }()
 
 		if err := sleepWithContext(request.Context(), delay); err != nil {
 			return nil, err

--- a/seed/go-sdk/file-upload/v0/internal/retrier_test.go
+++ b/seed/go-sdk/file-upload/v0/internal/retrier_test.go
@@ -295,7 +295,50 @@ func TestRetryWithRequestBody(t *testing.T) {
 	assert.Equal(t, expectedBody, requestBodies[1], "Second request body should match expected (retry should re-send body)")
 }
 
+// An explicit cancel (e.g. Ctrl-C wired to cancel()) must interrupt the backoff
+// wait. There is no deadline here, so the retrier cannot know the wait is futile
+// up front -- it has to be woken by the context.
 func TestRetryWaitIsInterruptedByContext(t *testing.T) {
+	var requestCount int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		w.Header().Set("Retry-After", "5")
+		w.WriteHeader(http.StatusTooManyRequests)
+	}))
+	defer server.Close()
+
+	caller := NewCaller(&CallerParams{
+		Client: server.Client(),
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		time.Sleep(100 * time.Millisecond)
+		cancel()
+	}()
+	defer cancel()
+
+	start := time.Now()
+	_, err := caller.Call(
+		ctx,
+		&CallParams{
+			URL:         server.URL,
+			Method:      http.MethodGet,
+			Request:     &InternalTestRequest{},
+			MaxAttempts: 3,
+		},
+	)
+	elapsed := time.Since(start)
+
+	assert.ErrorIs(t, err, context.Canceled)
+	assert.Equal(t, 1, requestCount, "Expected the retry to be abandoned once the context was cancelled")
+	assert.Less(t, elapsed, time.Second, "Expected the backoff to be interrupted by the context, took %v", elapsed)
+}
+
+// When the caller's deadline would elapse before the backoff finishes, sleeping
+// only guarantees a context error. Return the response instead so the caller
+// learns why the request actually failed.
+func TestRetryReturnsResponseWhenDeadlineShorterThanBackoff(t *testing.T) {
 	var requestCount int
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		requestCount++
@@ -323,9 +366,50 @@ func TestRetryWaitIsInterruptedByContext(t *testing.T) {
 	)
 	elapsed := time.Since(start)
 
-	assert.ErrorIs(t, err, context.DeadlineExceeded)
-	assert.Equal(t, 1, requestCount, "Expected the retry to be abandoned once the context expired")
-	assert.Less(t, elapsed, time.Second, "Expected the backoff to be interrupted by the context, took %v", elapsed)
+	// The caller gets the 429, not context.DeadlineExceeded.
+	var apiError *core.APIError
+	require.ErrorAs(t, err, &apiError)
+	assert.Equal(t, http.StatusTooManyRequests, apiError.StatusCode)
+	assert.NotErrorIs(t, err, context.DeadlineExceeded)
+	assert.Equal(t, 1, requestCount, "Expected no retry once the deadline was known to be too short")
+	assert.Less(t, elapsed, time.Second, "Expected to return immediately rather than sleep, took %v", elapsed)
+}
+
+// A deadline with room for the backoff must still retry as normal.
+func TestRetryProceedsWhenDeadlineLongerThanBackoff(t *testing.T) {
+	var requestCount int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		if requestCount == 1 {
+			w.Header().Set("Retry-After", "1")
+			w.WriteHeader(http.StatusTooManyRequests)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("{}"))
+	}))
+	defer server.Close()
+
+	caller := NewCaller(&CallerParams{
+		Client: server.Client(),
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	_, err := caller.Call(
+		ctx,
+		&CallParams{
+			URL:         server.URL,
+			Method:      http.MethodGet,
+			Request:     &InternalTestRequest{},
+			Response:    &InternalTestResponse{},
+			MaxAttempts: 3,
+		},
+	)
+
+	assert.NoError(t, err)
+	assert.Equal(t, 2, requestCount, "Expected the retry to proceed when the deadline allows it")
 }
 
 func TestDisableRetries(t *testing.T) {

--- a/seed/go-sdk/folders/internal/retrier.go
+++ b/seed/go-sdk/folders/internal/retrier.go
@@ -145,12 +145,20 @@ func (r *Retrier) run(
 	}
 
 	if r.shouldRetry(response) {
-		defer func() { _ = response.Body.Close() }()
-
 		delay, err := r.retryDelay(response, retryAttempt)
 		if err != nil {
+			_ = response.Body.Close()
 			return nil, err
 		}
+
+		// If the context's deadline would elapse before the backoff completes, return
+		// the response instead of sleeping through it. The caller then sees why the
+		// request actually failed (e.g. a 429) rather than a context deadline error.
+		if deadline, ok := request.Context().Deadline(); ok && time.Until(deadline) < delay {
+			return response, nil
+		}
+
+		defer func() { _ = response.Body.Close() }()
 
 		if err := sleepWithContext(request.Context(), delay); err != nil {
 			return nil, err

--- a/seed/go-sdk/folders/internal/retrier_test.go
+++ b/seed/go-sdk/folders/internal/retrier_test.go
@@ -295,7 +295,50 @@ func TestRetryWithRequestBody(t *testing.T) {
 	assert.Equal(t, expectedBody, requestBodies[1], "Second request body should match expected (retry should re-send body)")
 }
 
+// An explicit cancel (e.g. Ctrl-C wired to cancel()) must interrupt the backoff
+// wait. There is no deadline here, so the retrier cannot know the wait is futile
+// up front -- it has to be woken by the context.
 func TestRetryWaitIsInterruptedByContext(t *testing.T) {
+	var requestCount int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		w.Header().Set("Retry-After", "5")
+		w.WriteHeader(http.StatusTooManyRequests)
+	}))
+	defer server.Close()
+
+	caller := NewCaller(&CallerParams{
+		Client: server.Client(),
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		time.Sleep(100 * time.Millisecond)
+		cancel()
+	}()
+	defer cancel()
+
+	start := time.Now()
+	_, err := caller.Call(
+		ctx,
+		&CallParams{
+			URL:         server.URL,
+			Method:      http.MethodGet,
+			Request:     &InternalTestRequest{},
+			MaxAttempts: 3,
+		},
+	)
+	elapsed := time.Since(start)
+
+	assert.ErrorIs(t, err, context.Canceled)
+	assert.Equal(t, 1, requestCount, "Expected the retry to be abandoned once the context was cancelled")
+	assert.Less(t, elapsed, time.Second, "Expected the backoff to be interrupted by the context, took %v", elapsed)
+}
+
+// When the caller's deadline would elapse before the backoff finishes, sleeping
+// only guarantees a context error. Return the response instead so the caller
+// learns why the request actually failed.
+func TestRetryReturnsResponseWhenDeadlineShorterThanBackoff(t *testing.T) {
 	var requestCount int
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		requestCount++
@@ -323,9 +366,50 @@ func TestRetryWaitIsInterruptedByContext(t *testing.T) {
 	)
 	elapsed := time.Since(start)
 
-	assert.ErrorIs(t, err, context.DeadlineExceeded)
-	assert.Equal(t, 1, requestCount, "Expected the retry to be abandoned once the context expired")
-	assert.Less(t, elapsed, time.Second, "Expected the backoff to be interrupted by the context, took %v", elapsed)
+	// The caller gets the 429, not context.DeadlineExceeded.
+	var apiError *core.APIError
+	require.ErrorAs(t, err, &apiError)
+	assert.Equal(t, http.StatusTooManyRequests, apiError.StatusCode)
+	assert.NotErrorIs(t, err, context.DeadlineExceeded)
+	assert.Equal(t, 1, requestCount, "Expected no retry once the deadline was known to be too short")
+	assert.Less(t, elapsed, time.Second, "Expected to return immediately rather than sleep, took %v", elapsed)
+}
+
+// A deadline with room for the backoff must still retry as normal.
+func TestRetryProceedsWhenDeadlineLongerThanBackoff(t *testing.T) {
+	var requestCount int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		if requestCount == 1 {
+			w.Header().Set("Retry-After", "1")
+			w.WriteHeader(http.StatusTooManyRequests)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("{}"))
+	}))
+	defer server.Close()
+
+	caller := NewCaller(&CallerParams{
+		Client: server.Client(),
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	_, err := caller.Call(
+		ctx,
+		&CallParams{
+			URL:         server.URL,
+			Method:      http.MethodGet,
+			Request:     &InternalTestRequest{},
+			Response:    &InternalTestResponse{},
+			MaxAttempts: 3,
+		},
+	)
+
+	assert.NoError(t, err)
+	assert.Equal(t, 2, requestCount, "Expected the retry to proceed when the deadline allows it")
 }
 
 func TestDisableRetries(t *testing.T) {

--- a/seed/go-sdk/go-bytes-request/no-custom-config/internal/retrier.go
+++ b/seed/go-sdk/go-bytes-request/no-custom-config/internal/retrier.go
@@ -145,12 +145,20 @@ func (r *Retrier) run(
 	}
 
 	if r.shouldRetry(response) {
-		defer func() { _ = response.Body.Close() }()
-
 		delay, err := r.retryDelay(response, retryAttempt)
 		if err != nil {
+			_ = response.Body.Close()
 			return nil, err
 		}
+
+		// If the context's deadline would elapse before the backoff completes, return
+		// the response instead of sleeping through it. The caller then sees why the
+		// request actually failed (e.g. a 429) rather than a context deadline error.
+		if deadline, ok := request.Context().Deadline(); ok && time.Until(deadline) < delay {
+			return response, nil
+		}
+
+		defer func() { _ = response.Body.Close() }()
 
 		if err := sleepWithContext(request.Context(), delay); err != nil {
 			return nil, err

--- a/seed/go-sdk/go-bytes-request/no-custom-config/internal/retrier_test.go
+++ b/seed/go-sdk/go-bytes-request/no-custom-config/internal/retrier_test.go
@@ -295,7 +295,50 @@ func TestRetryWithRequestBody(t *testing.T) {
 	assert.Equal(t, expectedBody, requestBodies[1], "Second request body should match expected (retry should re-send body)")
 }
 
+// An explicit cancel (e.g. Ctrl-C wired to cancel()) must interrupt the backoff
+// wait. There is no deadline here, so the retrier cannot know the wait is futile
+// up front -- it has to be woken by the context.
 func TestRetryWaitIsInterruptedByContext(t *testing.T) {
+	var requestCount int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		w.Header().Set("Retry-After", "5")
+		w.WriteHeader(http.StatusTooManyRequests)
+	}))
+	defer server.Close()
+
+	caller := NewCaller(&CallerParams{
+		Client: server.Client(),
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		time.Sleep(100 * time.Millisecond)
+		cancel()
+	}()
+	defer cancel()
+
+	start := time.Now()
+	_, err := caller.Call(
+		ctx,
+		&CallParams{
+			URL:         server.URL,
+			Method:      http.MethodGet,
+			Request:     &InternalTestRequest{},
+			MaxAttempts: 3,
+		},
+	)
+	elapsed := time.Since(start)
+
+	assert.ErrorIs(t, err, context.Canceled)
+	assert.Equal(t, 1, requestCount, "Expected the retry to be abandoned once the context was cancelled")
+	assert.Less(t, elapsed, time.Second, "Expected the backoff to be interrupted by the context, took %v", elapsed)
+}
+
+// When the caller's deadline would elapse before the backoff finishes, sleeping
+// only guarantees a context error. Return the response instead so the caller
+// learns why the request actually failed.
+func TestRetryReturnsResponseWhenDeadlineShorterThanBackoff(t *testing.T) {
 	var requestCount int
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		requestCount++
@@ -323,9 +366,50 @@ func TestRetryWaitIsInterruptedByContext(t *testing.T) {
 	)
 	elapsed := time.Since(start)
 
-	assert.ErrorIs(t, err, context.DeadlineExceeded)
-	assert.Equal(t, 1, requestCount, "Expected the retry to be abandoned once the context expired")
-	assert.Less(t, elapsed, time.Second, "Expected the backoff to be interrupted by the context, took %v", elapsed)
+	// The caller gets the 429, not context.DeadlineExceeded.
+	var apiError *core.APIError
+	require.ErrorAs(t, err, &apiError)
+	assert.Equal(t, http.StatusTooManyRequests, apiError.StatusCode)
+	assert.NotErrorIs(t, err, context.DeadlineExceeded)
+	assert.Equal(t, 1, requestCount, "Expected no retry once the deadline was known to be too short")
+	assert.Less(t, elapsed, time.Second, "Expected to return immediately rather than sleep, took %v", elapsed)
+}
+
+// A deadline with room for the backoff must still retry as normal.
+func TestRetryProceedsWhenDeadlineLongerThanBackoff(t *testing.T) {
+	var requestCount int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		if requestCount == 1 {
+			w.Header().Set("Retry-After", "1")
+			w.WriteHeader(http.StatusTooManyRequests)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("{}"))
+	}))
+	defer server.Close()
+
+	caller := NewCaller(&CallerParams{
+		Client: server.Client(),
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	_, err := caller.Call(
+		ctx,
+		&CallParams{
+			URL:         server.URL,
+			Method:      http.MethodGet,
+			Request:     &InternalTestRequest{},
+			Response:    &InternalTestResponse{},
+			MaxAttempts: 3,
+		},
+	)
+
+	assert.NoError(t, err)
+	assert.Equal(t, 2, requestCount, "Expected the retry to proceed when the deadline allows it")
 }
 
 func TestDisableRetries(t *testing.T) {

--- a/seed/go-sdk/go-bytes-request/use-reader-for-bytes-request/internal/retrier.go
+++ b/seed/go-sdk/go-bytes-request/use-reader-for-bytes-request/internal/retrier.go
@@ -145,12 +145,20 @@ func (r *Retrier) run(
 	}
 
 	if r.shouldRetry(response) {
-		defer func() { _ = response.Body.Close() }()
-
 		delay, err := r.retryDelay(response, retryAttempt)
 		if err != nil {
+			_ = response.Body.Close()
 			return nil, err
 		}
+
+		// If the context's deadline would elapse before the backoff completes, return
+		// the response instead of sleeping through it. The caller then sees why the
+		// request actually failed (e.g. a 429) rather than a context deadline error.
+		if deadline, ok := request.Context().Deadline(); ok && time.Until(deadline) < delay {
+			return response, nil
+		}
+
+		defer func() { _ = response.Body.Close() }()
 
 		if err := sleepWithContext(request.Context(), delay); err != nil {
 			return nil, err

--- a/seed/go-sdk/go-bytes-request/use-reader-for-bytes-request/internal/retrier_test.go
+++ b/seed/go-sdk/go-bytes-request/use-reader-for-bytes-request/internal/retrier_test.go
@@ -295,7 +295,50 @@ func TestRetryWithRequestBody(t *testing.T) {
 	assert.Equal(t, expectedBody, requestBodies[1], "Second request body should match expected (retry should re-send body)")
 }
 
+// An explicit cancel (e.g. Ctrl-C wired to cancel()) must interrupt the backoff
+// wait. There is no deadline here, so the retrier cannot know the wait is futile
+// up front -- it has to be woken by the context.
 func TestRetryWaitIsInterruptedByContext(t *testing.T) {
+	var requestCount int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		w.Header().Set("Retry-After", "5")
+		w.WriteHeader(http.StatusTooManyRequests)
+	}))
+	defer server.Close()
+
+	caller := NewCaller(&CallerParams{
+		Client: server.Client(),
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		time.Sleep(100 * time.Millisecond)
+		cancel()
+	}()
+	defer cancel()
+
+	start := time.Now()
+	_, err := caller.Call(
+		ctx,
+		&CallParams{
+			URL:         server.URL,
+			Method:      http.MethodGet,
+			Request:     &InternalTestRequest{},
+			MaxAttempts: 3,
+		},
+	)
+	elapsed := time.Since(start)
+
+	assert.ErrorIs(t, err, context.Canceled)
+	assert.Equal(t, 1, requestCount, "Expected the retry to be abandoned once the context was cancelled")
+	assert.Less(t, elapsed, time.Second, "Expected the backoff to be interrupted by the context, took %v", elapsed)
+}
+
+// When the caller's deadline would elapse before the backoff finishes, sleeping
+// only guarantees a context error. Return the response instead so the caller
+// learns why the request actually failed.
+func TestRetryReturnsResponseWhenDeadlineShorterThanBackoff(t *testing.T) {
 	var requestCount int
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		requestCount++
@@ -323,9 +366,50 @@ func TestRetryWaitIsInterruptedByContext(t *testing.T) {
 	)
 	elapsed := time.Since(start)
 
-	assert.ErrorIs(t, err, context.DeadlineExceeded)
-	assert.Equal(t, 1, requestCount, "Expected the retry to be abandoned once the context expired")
-	assert.Less(t, elapsed, time.Second, "Expected the backoff to be interrupted by the context, took %v", elapsed)
+	// The caller gets the 429, not context.DeadlineExceeded.
+	var apiError *core.APIError
+	require.ErrorAs(t, err, &apiError)
+	assert.Equal(t, http.StatusTooManyRequests, apiError.StatusCode)
+	assert.NotErrorIs(t, err, context.DeadlineExceeded)
+	assert.Equal(t, 1, requestCount, "Expected no retry once the deadline was known to be too short")
+	assert.Less(t, elapsed, time.Second, "Expected to return immediately rather than sleep, took %v", elapsed)
+}
+
+// A deadline with room for the backoff must still retry as normal.
+func TestRetryProceedsWhenDeadlineLongerThanBackoff(t *testing.T) {
+	var requestCount int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		if requestCount == 1 {
+			w.Header().Set("Retry-After", "1")
+			w.WriteHeader(http.StatusTooManyRequests)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("{}"))
+	}))
+	defer server.Close()
+
+	caller := NewCaller(&CallerParams{
+		Client: server.Client(),
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	_, err := caller.Call(
+		ctx,
+		&CallParams{
+			URL:         server.URL,
+			Method:      http.MethodGet,
+			Request:     &InternalTestRequest{},
+			Response:    &InternalTestResponse{},
+			MaxAttempts: 3,
+		},
+	)
+
+	assert.NoError(t, err)
+	assert.Equal(t, 2, requestCount, "Expected the retry to proceed when the deadline allows it")
 }
 
 func TestDisableRetries(t *testing.T) {

--- a/seed/go-sdk/go-content-type/internal/retrier.go
+++ b/seed/go-sdk/go-content-type/internal/retrier.go
@@ -145,12 +145,20 @@ func (r *Retrier) run(
 	}
 
 	if r.shouldRetry(response) {
-		defer func() { _ = response.Body.Close() }()
-
 		delay, err := r.retryDelay(response, retryAttempt)
 		if err != nil {
+			_ = response.Body.Close()
 			return nil, err
 		}
+
+		// If the context's deadline would elapse before the backoff completes, return
+		// the response instead of sleeping through it. The caller then sees why the
+		// request actually failed (e.g. a 429) rather than a context deadline error.
+		if deadline, ok := request.Context().Deadline(); ok && time.Until(deadline) < delay {
+			return response, nil
+		}
+
+		defer func() { _ = response.Body.Close() }()
 
 		if err := sleepWithContext(request.Context(), delay); err != nil {
 			return nil, err

--- a/seed/go-sdk/go-content-type/internal/retrier_test.go
+++ b/seed/go-sdk/go-content-type/internal/retrier_test.go
@@ -295,7 +295,50 @@ func TestRetryWithRequestBody(t *testing.T) {
 	assert.Equal(t, expectedBody, requestBodies[1], "Second request body should match expected (retry should re-send body)")
 }
 
+// An explicit cancel (e.g. Ctrl-C wired to cancel()) must interrupt the backoff
+// wait. There is no deadline here, so the retrier cannot know the wait is futile
+// up front -- it has to be woken by the context.
 func TestRetryWaitIsInterruptedByContext(t *testing.T) {
+	var requestCount int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		w.Header().Set("Retry-After", "5")
+		w.WriteHeader(http.StatusTooManyRequests)
+	}))
+	defer server.Close()
+
+	caller := NewCaller(&CallerParams{
+		Client: server.Client(),
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		time.Sleep(100 * time.Millisecond)
+		cancel()
+	}()
+	defer cancel()
+
+	start := time.Now()
+	_, err := caller.Call(
+		ctx,
+		&CallParams{
+			URL:         server.URL,
+			Method:      http.MethodGet,
+			Request:     &InternalTestRequest{},
+			MaxAttempts: 3,
+		},
+	)
+	elapsed := time.Since(start)
+
+	assert.ErrorIs(t, err, context.Canceled)
+	assert.Equal(t, 1, requestCount, "Expected the retry to be abandoned once the context was cancelled")
+	assert.Less(t, elapsed, time.Second, "Expected the backoff to be interrupted by the context, took %v", elapsed)
+}
+
+// When the caller's deadline would elapse before the backoff finishes, sleeping
+// only guarantees a context error. Return the response instead so the caller
+// learns why the request actually failed.
+func TestRetryReturnsResponseWhenDeadlineShorterThanBackoff(t *testing.T) {
 	var requestCount int
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		requestCount++
@@ -323,9 +366,50 @@ func TestRetryWaitIsInterruptedByContext(t *testing.T) {
 	)
 	elapsed := time.Since(start)
 
-	assert.ErrorIs(t, err, context.DeadlineExceeded)
-	assert.Equal(t, 1, requestCount, "Expected the retry to be abandoned once the context expired")
-	assert.Less(t, elapsed, time.Second, "Expected the backoff to be interrupted by the context, took %v", elapsed)
+	// The caller gets the 429, not context.DeadlineExceeded.
+	var apiError *core.APIError
+	require.ErrorAs(t, err, &apiError)
+	assert.Equal(t, http.StatusTooManyRequests, apiError.StatusCode)
+	assert.NotErrorIs(t, err, context.DeadlineExceeded)
+	assert.Equal(t, 1, requestCount, "Expected no retry once the deadline was known to be too short")
+	assert.Less(t, elapsed, time.Second, "Expected to return immediately rather than sleep, took %v", elapsed)
+}
+
+// A deadline with room for the backoff must still retry as normal.
+func TestRetryProceedsWhenDeadlineLongerThanBackoff(t *testing.T) {
+	var requestCount int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		if requestCount == 1 {
+			w.Header().Set("Retry-After", "1")
+			w.WriteHeader(http.StatusTooManyRequests)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("{}"))
+	}))
+	defer server.Close()
+
+	caller := NewCaller(&CallerParams{
+		Client: server.Client(),
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	_, err := caller.Call(
+		ctx,
+		&CallParams{
+			URL:         server.URL,
+			Method:      http.MethodGet,
+			Request:     &InternalTestRequest{},
+			Response:    &InternalTestResponse{},
+			MaxAttempts: 3,
+		},
+	)
+
+	assert.NoError(t, err)
+	assert.Equal(t, 2, requestCount, "Expected the retry to proceed when the deadline allows it")
 }
 
 func TestDisableRetries(t *testing.T) {

--- a/seed/go-sdk/go-date-containers/internal/retrier.go
+++ b/seed/go-sdk/go-date-containers/internal/retrier.go
@@ -145,12 +145,20 @@ func (r *Retrier) run(
 	}
 
 	if r.shouldRetry(response) {
-		defer func() { _ = response.Body.Close() }()
-
 		delay, err := r.retryDelay(response, retryAttempt)
 		if err != nil {
+			_ = response.Body.Close()
 			return nil, err
 		}
+
+		// If the context's deadline would elapse before the backoff completes, return
+		// the response instead of sleeping through it. The caller then sees why the
+		// request actually failed (e.g. a 429) rather than a context deadline error.
+		if deadline, ok := request.Context().Deadline(); ok && time.Until(deadline) < delay {
+			return response, nil
+		}
+
+		defer func() { _ = response.Body.Close() }()
 
 		if err := sleepWithContext(request.Context(), delay); err != nil {
 			return nil, err

--- a/seed/go-sdk/go-date-containers/internal/retrier_test.go
+++ b/seed/go-sdk/go-date-containers/internal/retrier_test.go
@@ -295,7 +295,50 @@ func TestRetryWithRequestBody(t *testing.T) {
 	assert.Equal(t, expectedBody, requestBodies[1], "Second request body should match expected (retry should re-send body)")
 }
 
+// An explicit cancel (e.g. Ctrl-C wired to cancel()) must interrupt the backoff
+// wait. There is no deadline here, so the retrier cannot know the wait is futile
+// up front -- it has to be woken by the context.
 func TestRetryWaitIsInterruptedByContext(t *testing.T) {
+	var requestCount int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		w.Header().Set("Retry-After", "5")
+		w.WriteHeader(http.StatusTooManyRequests)
+	}))
+	defer server.Close()
+
+	caller := NewCaller(&CallerParams{
+		Client: server.Client(),
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		time.Sleep(100 * time.Millisecond)
+		cancel()
+	}()
+	defer cancel()
+
+	start := time.Now()
+	_, err := caller.Call(
+		ctx,
+		&CallParams{
+			URL:         server.URL,
+			Method:      http.MethodGet,
+			Request:     &InternalTestRequest{},
+			MaxAttempts: 3,
+		},
+	)
+	elapsed := time.Since(start)
+
+	assert.ErrorIs(t, err, context.Canceled)
+	assert.Equal(t, 1, requestCount, "Expected the retry to be abandoned once the context was cancelled")
+	assert.Less(t, elapsed, time.Second, "Expected the backoff to be interrupted by the context, took %v", elapsed)
+}
+
+// When the caller's deadline would elapse before the backoff finishes, sleeping
+// only guarantees a context error. Return the response instead so the caller
+// learns why the request actually failed.
+func TestRetryReturnsResponseWhenDeadlineShorterThanBackoff(t *testing.T) {
 	var requestCount int
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		requestCount++
@@ -323,9 +366,50 @@ func TestRetryWaitIsInterruptedByContext(t *testing.T) {
 	)
 	elapsed := time.Since(start)
 
-	assert.ErrorIs(t, err, context.DeadlineExceeded)
-	assert.Equal(t, 1, requestCount, "Expected the retry to be abandoned once the context expired")
-	assert.Less(t, elapsed, time.Second, "Expected the backoff to be interrupted by the context, took %v", elapsed)
+	// The caller gets the 429, not context.DeadlineExceeded.
+	var apiError *core.APIError
+	require.ErrorAs(t, err, &apiError)
+	assert.Equal(t, http.StatusTooManyRequests, apiError.StatusCode)
+	assert.NotErrorIs(t, err, context.DeadlineExceeded)
+	assert.Equal(t, 1, requestCount, "Expected no retry once the deadline was known to be too short")
+	assert.Less(t, elapsed, time.Second, "Expected to return immediately rather than sleep, took %v", elapsed)
+}
+
+// A deadline with room for the backoff must still retry as normal.
+func TestRetryProceedsWhenDeadlineLongerThanBackoff(t *testing.T) {
+	var requestCount int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		if requestCount == 1 {
+			w.Header().Set("Retry-After", "1")
+			w.WriteHeader(http.StatusTooManyRequests)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("{}"))
+	}))
+	defer server.Close()
+
+	caller := NewCaller(&CallerParams{
+		Client: server.Client(),
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	_, err := caller.Call(
+		ctx,
+		&CallParams{
+			URL:         server.URL,
+			Method:      http.MethodGet,
+			Request:     &InternalTestRequest{},
+			Response:    &InternalTestResponse{},
+			MaxAttempts: 3,
+		},
+	)
+
+	assert.NoError(t, err)
+	assert.Equal(t, 2, requestCount, "Expected the retry to proceed when the deadline allows it")
 }
 
 func TestDisableRetries(t *testing.T) {

--- a/seed/go-sdk/go-deterministic-ordering/internal/retrier.go
+++ b/seed/go-sdk/go-deterministic-ordering/internal/retrier.go
@@ -145,12 +145,20 @@ func (r *Retrier) run(
 	}
 
 	if r.shouldRetry(response) {
-		defer func() { _ = response.Body.Close() }()
-
 		delay, err := r.retryDelay(response, retryAttempt)
 		if err != nil {
+			_ = response.Body.Close()
 			return nil, err
 		}
+
+		// If the context's deadline would elapse before the backoff completes, return
+		// the response instead of sleeping through it. The caller then sees why the
+		// request actually failed (e.g. a 429) rather than a context deadline error.
+		if deadline, ok := request.Context().Deadline(); ok && time.Until(deadline) < delay {
+			return response, nil
+		}
+
+		defer func() { _ = response.Body.Close() }()
 
 		if err := sleepWithContext(request.Context(), delay); err != nil {
 			return nil, err

--- a/seed/go-sdk/go-deterministic-ordering/internal/retrier_test.go
+++ b/seed/go-sdk/go-deterministic-ordering/internal/retrier_test.go
@@ -295,7 +295,50 @@ func TestRetryWithRequestBody(t *testing.T) {
 	assert.Equal(t, expectedBody, requestBodies[1], "Second request body should match expected (retry should re-send body)")
 }
 
+// An explicit cancel (e.g. Ctrl-C wired to cancel()) must interrupt the backoff
+// wait. There is no deadline here, so the retrier cannot know the wait is futile
+// up front -- it has to be woken by the context.
 func TestRetryWaitIsInterruptedByContext(t *testing.T) {
+	var requestCount int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		w.Header().Set("Retry-After", "5")
+		w.WriteHeader(http.StatusTooManyRequests)
+	}))
+	defer server.Close()
+
+	caller := NewCaller(&CallerParams{
+		Client: server.Client(),
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		time.Sleep(100 * time.Millisecond)
+		cancel()
+	}()
+	defer cancel()
+
+	start := time.Now()
+	_, err := caller.Call(
+		ctx,
+		&CallParams{
+			URL:         server.URL,
+			Method:      http.MethodGet,
+			Request:     &InternalTestRequest{},
+			MaxAttempts: 3,
+		},
+	)
+	elapsed := time.Since(start)
+
+	assert.ErrorIs(t, err, context.Canceled)
+	assert.Equal(t, 1, requestCount, "Expected the retry to be abandoned once the context was cancelled")
+	assert.Less(t, elapsed, time.Second, "Expected the backoff to be interrupted by the context, took %v", elapsed)
+}
+
+// When the caller's deadline would elapse before the backoff finishes, sleeping
+// only guarantees a context error. Return the response instead so the caller
+// learns why the request actually failed.
+func TestRetryReturnsResponseWhenDeadlineShorterThanBackoff(t *testing.T) {
 	var requestCount int
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		requestCount++
@@ -323,9 +366,50 @@ func TestRetryWaitIsInterruptedByContext(t *testing.T) {
 	)
 	elapsed := time.Since(start)
 
-	assert.ErrorIs(t, err, context.DeadlineExceeded)
-	assert.Equal(t, 1, requestCount, "Expected the retry to be abandoned once the context expired")
-	assert.Less(t, elapsed, time.Second, "Expected the backoff to be interrupted by the context, took %v", elapsed)
+	// The caller gets the 429, not context.DeadlineExceeded.
+	var apiError *core.APIError
+	require.ErrorAs(t, err, &apiError)
+	assert.Equal(t, http.StatusTooManyRequests, apiError.StatusCode)
+	assert.NotErrorIs(t, err, context.DeadlineExceeded)
+	assert.Equal(t, 1, requestCount, "Expected no retry once the deadline was known to be too short")
+	assert.Less(t, elapsed, time.Second, "Expected to return immediately rather than sleep, took %v", elapsed)
+}
+
+// A deadline with room for the backoff must still retry as normal.
+func TestRetryProceedsWhenDeadlineLongerThanBackoff(t *testing.T) {
+	var requestCount int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		if requestCount == 1 {
+			w.Header().Set("Retry-After", "1")
+			w.WriteHeader(http.StatusTooManyRequests)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("{}"))
+	}))
+	defer server.Close()
+
+	caller := NewCaller(&CallerParams{
+		Client: server.Client(),
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	_, err := caller.Call(
+		ctx,
+		&CallParams{
+			URL:         server.URL,
+			Method:      http.MethodGet,
+			Request:     &InternalTestRequest{},
+			Response:    &InternalTestResponse{},
+			MaxAttempts: 3,
+		},
+	)
+
+	assert.NoError(t, err)
+	assert.Equal(t, 2, requestCount, "Expected the retry to proceed when the deadline allows it")
 }
 
 func TestDisableRetries(t *testing.T) {

--- a/seed/go-sdk/go-global-headers/internal/retrier.go
+++ b/seed/go-sdk/go-global-headers/internal/retrier.go
@@ -145,12 +145,20 @@ func (r *Retrier) run(
 	}
 
 	if r.shouldRetry(response) {
-		defer func() { _ = response.Body.Close() }()
-
 		delay, err := r.retryDelay(response, retryAttempt)
 		if err != nil {
+			_ = response.Body.Close()
 			return nil, err
 		}
+
+		// If the context's deadline would elapse before the backoff completes, return
+		// the response instead of sleeping through it. The caller then sees why the
+		// request actually failed (e.g. a 429) rather than a context deadline error.
+		if deadline, ok := request.Context().Deadline(); ok && time.Until(deadline) < delay {
+			return response, nil
+		}
+
+		defer func() { _ = response.Body.Close() }()
 
 		if err := sleepWithContext(request.Context(), delay); err != nil {
 			return nil, err

--- a/seed/go-sdk/go-global-headers/internal/retrier_test.go
+++ b/seed/go-sdk/go-global-headers/internal/retrier_test.go
@@ -295,7 +295,50 @@ func TestRetryWithRequestBody(t *testing.T) {
 	assert.Equal(t, expectedBody, requestBodies[1], "Second request body should match expected (retry should re-send body)")
 }
 
+// An explicit cancel (e.g. Ctrl-C wired to cancel()) must interrupt the backoff
+// wait. There is no deadline here, so the retrier cannot know the wait is futile
+// up front -- it has to be woken by the context.
 func TestRetryWaitIsInterruptedByContext(t *testing.T) {
+	var requestCount int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		w.Header().Set("Retry-After", "5")
+		w.WriteHeader(http.StatusTooManyRequests)
+	}))
+	defer server.Close()
+
+	caller := NewCaller(&CallerParams{
+		Client: server.Client(),
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		time.Sleep(100 * time.Millisecond)
+		cancel()
+	}()
+	defer cancel()
+
+	start := time.Now()
+	_, err := caller.Call(
+		ctx,
+		&CallParams{
+			URL:         server.URL,
+			Method:      http.MethodGet,
+			Request:     &InternalTestRequest{},
+			MaxAttempts: 3,
+		},
+	)
+	elapsed := time.Since(start)
+
+	assert.ErrorIs(t, err, context.Canceled)
+	assert.Equal(t, 1, requestCount, "Expected the retry to be abandoned once the context was cancelled")
+	assert.Less(t, elapsed, time.Second, "Expected the backoff to be interrupted by the context, took %v", elapsed)
+}
+
+// When the caller's deadline would elapse before the backoff finishes, sleeping
+// only guarantees a context error. Return the response instead so the caller
+// learns why the request actually failed.
+func TestRetryReturnsResponseWhenDeadlineShorterThanBackoff(t *testing.T) {
 	var requestCount int
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		requestCount++
@@ -323,9 +366,50 @@ func TestRetryWaitIsInterruptedByContext(t *testing.T) {
 	)
 	elapsed := time.Since(start)
 
-	assert.ErrorIs(t, err, context.DeadlineExceeded)
-	assert.Equal(t, 1, requestCount, "Expected the retry to be abandoned once the context expired")
-	assert.Less(t, elapsed, time.Second, "Expected the backoff to be interrupted by the context, took %v", elapsed)
+	// The caller gets the 429, not context.DeadlineExceeded.
+	var apiError *core.APIError
+	require.ErrorAs(t, err, &apiError)
+	assert.Equal(t, http.StatusTooManyRequests, apiError.StatusCode)
+	assert.NotErrorIs(t, err, context.DeadlineExceeded)
+	assert.Equal(t, 1, requestCount, "Expected no retry once the deadline was known to be too short")
+	assert.Less(t, elapsed, time.Second, "Expected to return immediately rather than sleep, took %v", elapsed)
+}
+
+// A deadline with room for the backoff must still retry as normal.
+func TestRetryProceedsWhenDeadlineLongerThanBackoff(t *testing.T) {
+	var requestCount int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		if requestCount == 1 {
+			w.Header().Set("Retry-After", "1")
+			w.WriteHeader(http.StatusTooManyRequests)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("{}"))
+	}))
+	defer server.Close()
+
+	caller := NewCaller(&CallerParams{
+		Client: server.Client(),
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	_, err := caller.Call(
+		ctx,
+		&CallParams{
+			URL:         server.URL,
+			Method:      http.MethodGet,
+			Request:     &InternalTestRequest{},
+			Response:    &InternalTestResponse{},
+			MaxAttempts: 3,
+		},
+	)
+
+	assert.NoError(t, err)
+	assert.Equal(t, 2, requestCount, "Expected the retry to proceed when the deadline allows it")
 }
 
 func TestDisableRetries(t *testing.T) {

--- a/seed/go-sdk/go-multi-env-url-templating/no-custom-config/internal/retrier.go
+++ b/seed/go-sdk/go-multi-env-url-templating/no-custom-config/internal/retrier.go
@@ -145,12 +145,20 @@ func (r *Retrier) run(
 	}
 
 	if r.shouldRetry(response) {
-		defer func() { _ = response.Body.Close() }()
-
 		delay, err := r.retryDelay(response, retryAttempt)
 		if err != nil {
+			_ = response.Body.Close()
 			return nil, err
 		}
+
+		// If the context's deadline would elapse before the backoff completes, return
+		// the response instead of sleeping through it. The caller then sees why the
+		// request actually failed (e.g. a 429) rather than a context deadline error.
+		if deadline, ok := request.Context().Deadline(); ok && time.Until(deadline) < delay {
+			return response, nil
+		}
+
+		defer func() { _ = response.Body.Close() }()
 
 		if err := sleepWithContext(request.Context(), delay); err != nil {
 			return nil, err

--- a/seed/go-sdk/go-multi-env-url-templating/no-custom-config/internal/retrier_test.go
+++ b/seed/go-sdk/go-multi-env-url-templating/no-custom-config/internal/retrier_test.go
@@ -295,7 +295,50 @@ func TestRetryWithRequestBody(t *testing.T) {
 	assert.Equal(t, expectedBody, requestBodies[1], "Second request body should match expected (retry should re-send body)")
 }
 
+// An explicit cancel (e.g. Ctrl-C wired to cancel()) must interrupt the backoff
+// wait. There is no deadline here, so the retrier cannot know the wait is futile
+// up front -- it has to be woken by the context.
 func TestRetryWaitIsInterruptedByContext(t *testing.T) {
+	var requestCount int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		w.Header().Set("Retry-After", "5")
+		w.WriteHeader(http.StatusTooManyRequests)
+	}))
+	defer server.Close()
+
+	caller := NewCaller(&CallerParams{
+		Client: server.Client(),
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		time.Sleep(100 * time.Millisecond)
+		cancel()
+	}()
+	defer cancel()
+
+	start := time.Now()
+	_, err := caller.Call(
+		ctx,
+		&CallParams{
+			URL:         server.URL,
+			Method:      http.MethodGet,
+			Request:     &InternalTestRequest{},
+			MaxAttempts: 3,
+		},
+	)
+	elapsed := time.Since(start)
+
+	assert.ErrorIs(t, err, context.Canceled)
+	assert.Equal(t, 1, requestCount, "Expected the retry to be abandoned once the context was cancelled")
+	assert.Less(t, elapsed, time.Second, "Expected the backoff to be interrupted by the context, took %v", elapsed)
+}
+
+// When the caller's deadline would elapse before the backoff finishes, sleeping
+// only guarantees a context error. Return the response instead so the caller
+// learns why the request actually failed.
+func TestRetryReturnsResponseWhenDeadlineShorterThanBackoff(t *testing.T) {
 	var requestCount int
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		requestCount++
@@ -323,9 +366,50 @@ func TestRetryWaitIsInterruptedByContext(t *testing.T) {
 	)
 	elapsed := time.Since(start)
 
-	assert.ErrorIs(t, err, context.DeadlineExceeded)
-	assert.Equal(t, 1, requestCount, "Expected the retry to be abandoned once the context expired")
-	assert.Less(t, elapsed, time.Second, "Expected the backoff to be interrupted by the context, took %v", elapsed)
+	// The caller gets the 429, not context.DeadlineExceeded.
+	var apiError *core.APIError
+	require.ErrorAs(t, err, &apiError)
+	assert.Equal(t, http.StatusTooManyRequests, apiError.StatusCode)
+	assert.NotErrorIs(t, err, context.DeadlineExceeded)
+	assert.Equal(t, 1, requestCount, "Expected no retry once the deadline was known to be too short")
+	assert.Less(t, elapsed, time.Second, "Expected to return immediately rather than sleep, took %v", elapsed)
+}
+
+// A deadline with room for the backoff must still retry as normal.
+func TestRetryProceedsWhenDeadlineLongerThanBackoff(t *testing.T) {
+	var requestCount int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		if requestCount == 1 {
+			w.Header().Set("Retry-After", "1")
+			w.WriteHeader(http.StatusTooManyRequests)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("{}"))
+	}))
+	defer server.Close()
+
+	caller := NewCaller(&CallerParams{
+		Client: server.Client(),
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	_, err := caller.Call(
+		ctx,
+		&CallParams{
+			URL:         server.URL,
+			Method:      http.MethodGet,
+			Request:     &InternalTestRequest{},
+			Response:    &InternalTestResponse{},
+			MaxAttempts: 3,
+		},
+	)
+
+	assert.NoError(t, err)
+	assert.Equal(t, 2, requestCount, "Expected the retry to proceed when the deadline allows it")
 }
 
 func TestDisableRetries(t *testing.T) {

--- a/seed/go-sdk/go-nested-cross-package/internal/retrier.go
+++ b/seed/go-sdk/go-nested-cross-package/internal/retrier.go
@@ -145,12 +145,20 @@ func (r *Retrier) run(
 	}
 
 	if r.shouldRetry(response) {
-		defer func() { _ = response.Body.Close() }()
-
 		delay, err := r.retryDelay(response, retryAttempt)
 		if err != nil {
+			_ = response.Body.Close()
 			return nil, err
 		}
+
+		// If the context's deadline would elapse before the backoff completes, return
+		// the response instead of sleeping through it. The caller then sees why the
+		// request actually failed (e.g. a 429) rather than a context deadline error.
+		if deadline, ok := request.Context().Deadline(); ok && time.Until(deadline) < delay {
+			return response, nil
+		}
+
+		defer func() { _ = response.Body.Close() }()
 
 		if err := sleepWithContext(request.Context(), delay); err != nil {
 			return nil, err

--- a/seed/go-sdk/go-nested-cross-package/internal/retrier_test.go
+++ b/seed/go-sdk/go-nested-cross-package/internal/retrier_test.go
@@ -295,7 +295,50 @@ func TestRetryWithRequestBody(t *testing.T) {
 	assert.Equal(t, expectedBody, requestBodies[1], "Second request body should match expected (retry should re-send body)")
 }
 
+// An explicit cancel (e.g. Ctrl-C wired to cancel()) must interrupt the backoff
+// wait. There is no deadline here, so the retrier cannot know the wait is futile
+// up front -- it has to be woken by the context.
 func TestRetryWaitIsInterruptedByContext(t *testing.T) {
+	var requestCount int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		w.Header().Set("Retry-After", "5")
+		w.WriteHeader(http.StatusTooManyRequests)
+	}))
+	defer server.Close()
+
+	caller := NewCaller(&CallerParams{
+		Client: server.Client(),
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		time.Sleep(100 * time.Millisecond)
+		cancel()
+	}()
+	defer cancel()
+
+	start := time.Now()
+	_, err := caller.Call(
+		ctx,
+		&CallParams{
+			URL:         server.URL,
+			Method:      http.MethodGet,
+			Request:     &InternalTestRequest{},
+			MaxAttempts: 3,
+		},
+	)
+	elapsed := time.Since(start)
+
+	assert.ErrorIs(t, err, context.Canceled)
+	assert.Equal(t, 1, requestCount, "Expected the retry to be abandoned once the context was cancelled")
+	assert.Less(t, elapsed, time.Second, "Expected the backoff to be interrupted by the context, took %v", elapsed)
+}
+
+// When the caller's deadline would elapse before the backoff finishes, sleeping
+// only guarantees a context error. Return the response instead so the caller
+// learns why the request actually failed.
+func TestRetryReturnsResponseWhenDeadlineShorterThanBackoff(t *testing.T) {
 	var requestCount int
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		requestCount++
@@ -323,9 +366,50 @@ func TestRetryWaitIsInterruptedByContext(t *testing.T) {
 	)
 	elapsed := time.Since(start)
 
-	assert.ErrorIs(t, err, context.DeadlineExceeded)
-	assert.Equal(t, 1, requestCount, "Expected the retry to be abandoned once the context expired")
-	assert.Less(t, elapsed, time.Second, "Expected the backoff to be interrupted by the context, took %v", elapsed)
+	// The caller gets the 429, not context.DeadlineExceeded.
+	var apiError *core.APIError
+	require.ErrorAs(t, err, &apiError)
+	assert.Equal(t, http.StatusTooManyRequests, apiError.StatusCode)
+	assert.NotErrorIs(t, err, context.DeadlineExceeded)
+	assert.Equal(t, 1, requestCount, "Expected no retry once the deadline was known to be too short")
+	assert.Less(t, elapsed, time.Second, "Expected to return immediately rather than sleep, took %v", elapsed)
+}
+
+// A deadline with room for the backoff must still retry as normal.
+func TestRetryProceedsWhenDeadlineLongerThanBackoff(t *testing.T) {
+	var requestCount int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		if requestCount == 1 {
+			w.Header().Set("Retry-After", "1")
+			w.WriteHeader(http.StatusTooManyRequests)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("{}"))
+	}))
+	defer server.Close()
+
+	caller := NewCaller(&CallerParams{
+		Client: server.Client(),
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	_, err := caller.Call(
+		ctx,
+		&CallParams{
+			URL:         server.URL,
+			Method:      http.MethodGet,
+			Request:     &InternalTestRequest{},
+			Response:    &InternalTestResponse{},
+			MaxAttempts: 3,
+		},
+	)
+
+	assert.NoError(t, err)
+	assert.Equal(t, 2, requestCount, "Expected the retry to proceed when the deadline allows it")
 }
 
 func TestDisableRetries(t *testing.T) {

--- a/seed/go-sdk/go-nullable-date-ref/internal/retrier.go
+++ b/seed/go-sdk/go-nullable-date-ref/internal/retrier.go
@@ -145,12 +145,20 @@ func (r *Retrier) run(
 	}
 
 	if r.shouldRetry(response) {
-		defer func() { _ = response.Body.Close() }()
-
 		delay, err := r.retryDelay(response, retryAttempt)
 		if err != nil {
+			_ = response.Body.Close()
 			return nil, err
 		}
+
+		// If the context's deadline would elapse before the backoff completes, return
+		// the response instead of sleeping through it. The caller then sees why the
+		// request actually failed (e.g. a 429) rather than a context deadline error.
+		if deadline, ok := request.Context().Deadline(); ok && time.Until(deadline) < delay {
+			return response, nil
+		}
+
+		defer func() { _ = response.Body.Close() }()
 
 		if err := sleepWithContext(request.Context(), delay); err != nil {
 			return nil, err

--- a/seed/go-sdk/go-nullable-date-ref/internal/retrier_test.go
+++ b/seed/go-sdk/go-nullable-date-ref/internal/retrier_test.go
@@ -295,7 +295,50 @@ func TestRetryWithRequestBody(t *testing.T) {
 	assert.Equal(t, expectedBody, requestBodies[1], "Second request body should match expected (retry should re-send body)")
 }
 
+// An explicit cancel (e.g. Ctrl-C wired to cancel()) must interrupt the backoff
+// wait. There is no deadline here, so the retrier cannot know the wait is futile
+// up front -- it has to be woken by the context.
 func TestRetryWaitIsInterruptedByContext(t *testing.T) {
+	var requestCount int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		w.Header().Set("Retry-After", "5")
+		w.WriteHeader(http.StatusTooManyRequests)
+	}))
+	defer server.Close()
+
+	caller := NewCaller(&CallerParams{
+		Client: server.Client(),
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		time.Sleep(100 * time.Millisecond)
+		cancel()
+	}()
+	defer cancel()
+
+	start := time.Now()
+	_, err := caller.Call(
+		ctx,
+		&CallParams{
+			URL:         server.URL,
+			Method:      http.MethodGet,
+			Request:     &InternalTestRequest{},
+			MaxAttempts: 3,
+		},
+	)
+	elapsed := time.Since(start)
+
+	assert.ErrorIs(t, err, context.Canceled)
+	assert.Equal(t, 1, requestCount, "Expected the retry to be abandoned once the context was cancelled")
+	assert.Less(t, elapsed, time.Second, "Expected the backoff to be interrupted by the context, took %v", elapsed)
+}
+
+// When the caller's deadline would elapse before the backoff finishes, sleeping
+// only guarantees a context error. Return the response instead so the caller
+// learns why the request actually failed.
+func TestRetryReturnsResponseWhenDeadlineShorterThanBackoff(t *testing.T) {
 	var requestCount int
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		requestCount++
@@ -323,9 +366,50 @@ func TestRetryWaitIsInterruptedByContext(t *testing.T) {
 	)
 	elapsed := time.Since(start)
 
-	assert.ErrorIs(t, err, context.DeadlineExceeded)
-	assert.Equal(t, 1, requestCount, "Expected the retry to be abandoned once the context expired")
-	assert.Less(t, elapsed, time.Second, "Expected the backoff to be interrupted by the context, took %v", elapsed)
+	// The caller gets the 429, not context.DeadlineExceeded.
+	var apiError *core.APIError
+	require.ErrorAs(t, err, &apiError)
+	assert.Equal(t, http.StatusTooManyRequests, apiError.StatusCode)
+	assert.NotErrorIs(t, err, context.DeadlineExceeded)
+	assert.Equal(t, 1, requestCount, "Expected no retry once the deadline was known to be too short")
+	assert.Less(t, elapsed, time.Second, "Expected to return immediately rather than sleep, took %v", elapsed)
+}
+
+// A deadline with room for the backoff must still retry as normal.
+func TestRetryProceedsWhenDeadlineLongerThanBackoff(t *testing.T) {
+	var requestCount int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		if requestCount == 1 {
+			w.Header().Set("Retry-After", "1")
+			w.WriteHeader(http.StatusTooManyRequests)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("{}"))
+	}))
+	defer server.Close()
+
+	caller := NewCaller(&CallerParams{
+		Client: server.Client(),
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	_, err := caller.Call(
+		ctx,
+		&CallParams{
+			URL:         server.URL,
+			Method:      http.MethodGet,
+			Request:     &InternalTestRequest{},
+			Response:    &InternalTestResponse{},
+			MaxAttempts: 3,
+		},
+	)
+
+	assert.NoError(t, err)
+	assert.Equal(t, 2, requestCount, "Expected the retry to proceed when the deadline allows it")
 }
 
 func TestDisableRetries(t *testing.T) {

--- a/seed/go-sdk/go-nullable-wire-tests/internal/retrier.go
+++ b/seed/go-sdk/go-nullable-wire-tests/internal/retrier.go
@@ -145,12 +145,20 @@ func (r *Retrier) run(
 	}
 
 	if r.shouldRetry(response) {
-		defer func() { _ = response.Body.Close() }()
-
 		delay, err := r.retryDelay(response, retryAttempt)
 		if err != nil {
+			_ = response.Body.Close()
 			return nil, err
 		}
+
+		// If the context's deadline would elapse before the backoff completes, return
+		// the response instead of sleeping through it. The caller then sees why the
+		// request actually failed (e.g. a 429) rather than a context deadline error.
+		if deadline, ok := request.Context().Deadline(); ok && time.Until(deadline) < delay {
+			return response, nil
+		}
+
+		defer func() { _ = response.Body.Close() }()
 
 		if err := sleepWithContext(request.Context(), delay); err != nil {
 			return nil, err

--- a/seed/go-sdk/go-nullable-wire-tests/internal/retrier_test.go
+++ b/seed/go-sdk/go-nullable-wire-tests/internal/retrier_test.go
@@ -295,7 +295,50 @@ func TestRetryWithRequestBody(t *testing.T) {
 	assert.Equal(t, expectedBody, requestBodies[1], "Second request body should match expected (retry should re-send body)")
 }
 
+// An explicit cancel (e.g. Ctrl-C wired to cancel()) must interrupt the backoff
+// wait. There is no deadline here, so the retrier cannot know the wait is futile
+// up front -- it has to be woken by the context.
 func TestRetryWaitIsInterruptedByContext(t *testing.T) {
+	var requestCount int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		w.Header().Set("Retry-After", "5")
+		w.WriteHeader(http.StatusTooManyRequests)
+	}))
+	defer server.Close()
+
+	caller := NewCaller(&CallerParams{
+		Client: server.Client(),
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		time.Sleep(100 * time.Millisecond)
+		cancel()
+	}()
+	defer cancel()
+
+	start := time.Now()
+	_, err := caller.Call(
+		ctx,
+		&CallParams{
+			URL:         server.URL,
+			Method:      http.MethodGet,
+			Request:     &InternalTestRequest{},
+			MaxAttempts: 3,
+		},
+	)
+	elapsed := time.Since(start)
+
+	assert.ErrorIs(t, err, context.Canceled)
+	assert.Equal(t, 1, requestCount, "Expected the retry to be abandoned once the context was cancelled")
+	assert.Less(t, elapsed, time.Second, "Expected the backoff to be interrupted by the context, took %v", elapsed)
+}
+
+// When the caller's deadline would elapse before the backoff finishes, sleeping
+// only guarantees a context error. Return the response instead so the caller
+// learns why the request actually failed.
+func TestRetryReturnsResponseWhenDeadlineShorterThanBackoff(t *testing.T) {
 	var requestCount int
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		requestCount++
@@ -323,9 +366,50 @@ func TestRetryWaitIsInterruptedByContext(t *testing.T) {
 	)
 	elapsed := time.Since(start)
 
-	assert.ErrorIs(t, err, context.DeadlineExceeded)
-	assert.Equal(t, 1, requestCount, "Expected the retry to be abandoned once the context expired")
-	assert.Less(t, elapsed, time.Second, "Expected the backoff to be interrupted by the context, took %v", elapsed)
+	// The caller gets the 429, not context.DeadlineExceeded.
+	var apiError *core.APIError
+	require.ErrorAs(t, err, &apiError)
+	assert.Equal(t, http.StatusTooManyRequests, apiError.StatusCode)
+	assert.NotErrorIs(t, err, context.DeadlineExceeded)
+	assert.Equal(t, 1, requestCount, "Expected no retry once the deadline was known to be too short")
+	assert.Less(t, elapsed, time.Second, "Expected to return immediately rather than sleep, took %v", elapsed)
+}
+
+// A deadline with room for the backoff must still retry as normal.
+func TestRetryProceedsWhenDeadlineLongerThanBackoff(t *testing.T) {
+	var requestCount int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		if requestCount == 1 {
+			w.Header().Set("Retry-After", "1")
+			w.WriteHeader(http.StatusTooManyRequests)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("{}"))
+	}))
+	defer server.Close()
+
+	caller := NewCaller(&CallerParams{
+		Client: server.Client(),
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	_, err := caller.Call(
+		ctx,
+		&CallParams{
+			URL:         server.URL,
+			Method:      http.MethodGet,
+			Request:     &InternalTestRequest{},
+			Response:    &InternalTestResponse{},
+			MaxAttempts: 3,
+		},
+	)
+
+	assert.NoError(t, err)
+	assert.Equal(t, 2, requestCount, "Expected the retry to proceed when the deadline allows it")
 }
 
 func TestDisableRetries(t *testing.T) {

--- a/seed/go-sdk/go-oauth-token-nullable/no-custom-config/internal/retrier.go
+++ b/seed/go-sdk/go-oauth-token-nullable/no-custom-config/internal/retrier.go
@@ -145,12 +145,20 @@ func (r *Retrier) run(
 	}
 
 	if r.shouldRetry(response) {
-		defer func() { _ = response.Body.Close() }()
-
 		delay, err := r.retryDelay(response, retryAttempt)
 		if err != nil {
+			_ = response.Body.Close()
 			return nil, err
 		}
+
+		// If the context's deadline would elapse before the backoff completes, return
+		// the response instead of sleeping through it. The caller then sees why the
+		// request actually failed (e.g. a 429) rather than a context deadline error.
+		if deadline, ok := request.Context().Deadline(); ok && time.Until(deadline) < delay {
+			return response, nil
+		}
+
+		defer func() { _ = response.Body.Close() }()
 
 		if err := sleepWithContext(request.Context(), delay); err != nil {
 			return nil, err

--- a/seed/go-sdk/go-oauth-token-nullable/no-custom-config/internal/retrier_test.go
+++ b/seed/go-sdk/go-oauth-token-nullable/no-custom-config/internal/retrier_test.go
@@ -295,7 +295,50 @@ func TestRetryWithRequestBody(t *testing.T) {
 	assert.Equal(t, expectedBody, requestBodies[1], "Second request body should match expected (retry should re-send body)")
 }
 
+// An explicit cancel (e.g. Ctrl-C wired to cancel()) must interrupt the backoff
+// wait. There is no deadline here, so the retrier cannot know the wait is futile
+// up front -- it has to be woken by the context.
 func TestRetryWaitIsInterruptedByContext(t *testing.T) {
+	var requestCount int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		w.Header().Set("Retry-After", "5")
+		w.WriteHeader(http.StatusTooManyRequests)
+	}))
+	defer server.Close()
+
+	caller := NewCaller(&CallerParams{
+		Client: server.Client(),
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		time.Sleep(100 * time.Millisecond)
+		cancel()
+	}()
+	defer cancel()
+
+	start := time.Now()
+	_, err := caller.Call(
+		ctx,
+		&CallParams{
+			URL:         server.URL,
+			Method:      http.MethodGet,
+			Request:     &InternalTestRequest{},
+			MaxAttempts: 3,
+		},
+	)
+	elapsed := time.Since(start)
+
+	assert.ErrorIs(t, err, context.Canceled)
+	assert.Equal(t, 1, requestCount, "Expected the retry to be abandoned once the context was cancelled")
+	assert.Less(t, elapsed, time.Second, "Expected the backoff to be interrupted by the context, took %v", elapsed)
+}
+
+// When the caller's deadline would elapse before the backoff finishes, sleeping
+// only guarantees a context error. Return the response instead so the caller
+// learns why the request actually failed.
+func TestRetryReturnsResponseWhenDeadlineShorterThanBackoff(t *testing.T) {
 	var requestCount int
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		requestCount++
@@ -323,9 +366,50 @@ func TestRetryWaitIsInterruptedByContext(t *testing.T) {
 	)
 	elapsed := time.Since(start)
 
-	assert.ErrorIs(t, err, context.DeadlineExceeded)
-	assert.Equal(t, 1, requestCount, "Expected the retry to be abandoned once the context expired")
-	assert.Less(t, elapsed, time.Second, "Expected the backoff to be interrupted by the context, took %v", elapsed)
+	// The caller gets the 429, not context.DeadlineExceeded.
+	var apiError *core.APIError
+	require.ErrorAs(t, err, &apiError)
+	assert.Equal(t, http.StatusTooManyRequests, apiError.StatusCode)
+	assert.NotErrorIs(t, err, context.DeadlineExceeded)
+	assert.Equal(t, 1, requestCount, "Expected no retry once the deadline was known to be too short")
+	assert.Less(t, elapsed, time.Second, "Expected to return immediately rather than sleep, took %v", elapsed)
+}
+
+// A deadline with room for the backoff must still retry as normal.
+func TestRetryProceedsWhenDeadlineLongerThanBackoff(t *testing.T) {
+	var requestCount int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		if requestCount == 1 {
+			w.Header().Set("Retry-After", "1")
+			w.WriteHeader(http.StatusTooManyRequests)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("{}"))
+	}))
+	defer server.Close()
+
+	caller := NewCaller(&CallerParams{
+		Client: server.Client(),
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	_, err := caller.Call(
+		ctx,
+		&CallParams{
+			URL:         server.URL,
+			Method:      http.MethodGet,
+			Request:     &InternalTestRequest{},
+			Response:    &InternalTestResponse{},
+			MaxAttempts: 3,
+		},
+	)
+
+	assert.NoError(t, err)
+	assert.Equal(t, 2, requestCount, "Expected the retry to proceed when the deadline allows it")
 }
 
 func TestDisableRetries(t *testing.T) {

--- a/seed/go-sdk/go-oauth-token-optional/no-custom-config/internal/retrier.go
+++ b/seed/go-sdk/go-oauth-token-optional/no-custom-config/internal/retrier.go
@@ -145,12 +145,20 @@ func (r *Retrier) run(
 	}
 
 	if r.shouldRetry(response) {
-		defer func() { _ = response.Body.Close() }()
-
 		delay, err := r.retryDelay(response, retryAttempt)
 		if err != nil {
+			_ = response.Body.Close()
 			return nil, err
 		}
+
+		// If the context's deadline would elapse before the backoff completes, return
+		// the response instead of sleeping through it. The caller then sees why the
+		// request actually failed (e.g. a 429) rather than a context deadline error.
+		if deadline, ok := request.Context().Deadline(); ok && time.Until(deadline) < delay {
+			return response, nil
+		}
+
+		defer func() { _ = response.Body.Close() }()
 
 		if err := sleepWithContext(request.Context(), delay); err != nil {
 			return nil, err

--- a/seed/go-sdk/go-oauth-token-optional/no-custom-config/internal/retrier_test.go
+++ b/seed/go-sdk/go-oauth-token-optional/no-custom-config/internal/retrier_test.go
@@ -295,7 +295,50 @@ func TestRetryWithRequestBody(t *testing.T) {
 	assert.Equal(t, expectedBody, requestBodies[1], "Second request body should match expected (retry should re-send body)")
 }
 
+// An explicit cancel (e.g. Ctrl-C wired to cancel()) must interrupt the backoff
+// wait. There is no deadline here, so the retrier cannot know the wait is futile
+// up front -- it has to be woken by the context.
 func TestRetryWaitIsInterruptedByContext(t *testing.T) {
+	var requestCount int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		w.Header().Set("Retry-After", "5")
+		w.WriteHeader(http.StatusTooManyRequests)
+	}))
+	defer server.Close()
+
+	caller := NewCaller(&CallerParams{
+		Client: server.Client(),
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		time.Sleep(100 * time.Millisecond)
+		cancel()
+	}()
+	defer cancel()
+
+	start := time.Now()
+	_, err := caller.Call(
+		ctx,
+		&CallParams{
+			URL:         server.URL,
+			Method:      http.MethodGet,
+			Request:     &InternalTestRequest{},
+			MaxAttempts: 3,
+		},
+	)
+	elapsed := time.Since(start)
+
+	assert.ErrorIs(t, err, context.Canceled)
+	assert.Equal(t, 1, requestCount, "Expected the retry to be abandoned once the context was cancelled")
+	assert.Less(t, elapsed, time.Second, "Expected the backoff to be interrupted by the context, took %v", elapsed)
+}
+
+// When the caller's deadline would elapse before the backoff finishes, sleeping
+// only guarantees a context error. Return the response instead so the caller
+// learns why the request actually failed.
+func TestRetryReturnsResponseWhenDeadlineShorterThanBackoff(t *testing.T) {
 	var requestCount int
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		requestCount++
@@ -323,9 +366,50 @@ func TestRetryWaitIsInterruptedByContext(t *testing.T) {
 	)
 	elapsed := time.Since(start)
 
-	assert.ErrorIs(t, err, context.DeadlineExceeded)
-	assert.Equal(t, 1, requestCount, "Expected the retry to be abandoned once the context expired")
-	assert.Less(t, elapsed, time.Second, "Expected the backoff to be interrupted by the context, took %v", elapsed)
+	// The caller gets the 429, not context.DeadlineExceeded.
+	var apiError *core.APIError
+	require.ErrorAs(t, err, &apiError)
+	assert.Equal(t, http.StatusTooManyRequests, apiError.StatusCode)
+	assert.NotErrorIs(t, err, context.DeadlineExceeded)
+	assert.Equal(t, 1, requestCount, "Expected no retry once the deadline was known to be too short")
+	assert.Less(t, elapsed, time.Second, "Expected to return immediately rather than sleep, took %v", elapsed)
+}
+
+// A deadline with room for the backoff must still retry as normal.
+func TestRetryProceedsWhenDeadlineLongerThanBackoff(t *testing.T) {
+	var requestCount int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		if requestCount == 1 {
+			w.Header().Set("Retry-After", "1")
+			w.WriteHeader(http.StatusTooManyRequests)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("{}"))
+	}))
+	defer server.Close()
+
+	caller := NewCaller(&CallerParams{
+		Client: server.Client(),
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	_, err := caller.Call(
+		ctx,
+		&CallParams{
+			URL:         server.URL,
+			Method:      http.MethodGet,
+			Request:     &InternalTestRequest{},
+			Response:    &InternalTestResponse{},
+			MaxAttempts: 3,
+		},
+	)
+
+	assert.NoError(t, err)
+	assert.Equal(t, 2, requestCount, "Expected the retry to proceed when the deadline allows it")
 }
 
 func TestDisableRetries(t *testing.T) {

--- a/seed/go-sdk/go-optional-header-env/internal/retrier.go
+++ b/seed/go-sdk/go-optional-header-env/internal/retrier.go
@@ -145,12 +145,20 @@ func (r *Retrier) run(
 	}
 
 	if r.shouldRetry(response) {
-		defer func() { _ = response.Body.Close() }()
-
 		delay, err := r.retryDelay(response, retryAttempt)
 		if err != nil {
+			_ = response.Body.Close()
 			return nil, err
 		}
+
+		// If the context's deadline would elapse before the backoff completes, return
+		// the response instead of sleeping through it. The caller then sees why the
+		// request actually failed (e.g. a 429) rather than a context deadline error.
+		if deadline, ok := request.Context().Deadline(); ok && time.Until(deadline) < delay {
+			return response, nil
+		}
+
+		defer func() { _ = response.Body.Close() }()
 
 		if err := sleepWithContext(request.Context(), delay); err != nil {
 			return nil, err

--- a/seed/go-sdk/go-optional-header-env/internal/retrier_test.go
+++ b/seed/go-sdk/go-optional-header-env/internal/retrier_test.go
@@ -295,7 +295,50 @@ func TestRetryWithRequestBody(t *testing.T) {
 	assert.Equal(t, expectedBody, requestBodies[1], "Second request body should match expected (retry should re-send body)")
 }
 
+// An explicit cancel (e.g. Ctrl-C wired to cancel()) must interrupt the backoff
+// wait. There is no deadline here, so the retrier cannot know the wait is futile
+// up front -- it has to be woken by the context.
 func TestRetryWaitIsInterruptedByContext(t *testing.T) {
+	var requestCount int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		w.Header().Set("Retry-After", "5")
+		w.WriteHeader(http.StatusTooManyRequests)
+	}))
+	defer server.Close()
+
+	caller := NewCaller(&CallerParams{
+		Client: server.Client(),
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		time.Sleep(100 * time.Millisecond)
+		cancel()
+	}()
+	defer cancel()
+
+	start := time.Now()
+	_, err := caller.Call(
+		ctx,
+		&CallParams{
+			URL:         server.URL,
+			Method:      http.MethodGet,
+			Request:     &InternalTestRequest{},
+			MaxAttempts: 3,
+		},
+	)
+	elapsed := time.Since(start)
+
+	assert.ErrorIs(t, err, context.Canceled)
+	assert.Equal(t, 1, requestCount, "Expected the retry to be abandoned once the context was cancelled")
+	assert.Less(t, elapsed, time.Second, "Expected the backoff to be interrupted by the context, took %v", elapsed)
+}
+
+// When the caller's deadline would elapse before the backoff finishes, sleeping
+// only guarantees a context error. Return the response instead so the caller
+// learns why the request actually failed.
+func TestRetryReturnsResponseWhenDeadlineShorterThanBackoff(t *testing.T) {
 	var requestCount int
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		requestCount++
@@ -323,9 +366,50 @@ func TestRetryWaitIsInterruptedByContext(t *testing.T) {
 	)
 	elapsed := time.Since(start)
 
-	assert.ErrorIs(t, err, context.DeadlineExceeded)
-	assert.Equal(t, 1, requestCount, "Expected the retry to be abandoned once the context expired")
-	assert.Less(t, elapsed, time.Second, "Expected the backoff to be interrupted by the context, took %v", elapsed)
+	// The caller gets the 429, not context.DeadlineExceeded.
+	var apiError *core.APIError
+	require.ErrorAs(t, err, &apiError)
+	assert.Equal(t, http.StatusTooManyRequests, apiError.StatusCode)
+	assert.NotErrorIs(t, err, context.DeadlineExceeded)
+	assert.Equal(t, 1, requestCount, "Expected no retry once the deadline was known to be too short")
+	assert.Less(t, elapsed, time.Second, "Expected to return immediately rather than sleep, took %v", elapsed)
+}
+
+// A deadline with room for the backoff must still retry as normal.
+func TestRetryProceedsWhenDeadlineLongerThanBackoff(t *testing.T) {
+	var requestCount int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		if requestCount == 1 {
+			w.Header().Set("Retry-After", "1")
+			w.WriteHeader(http.StatusTooManyRequests)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("{}"))
+	}))
+	defer server.Close()
+
+	caller := NewCaller(&CallerParams{
+		Client: server.Client(),
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	_, err := caller.Call(
+		ctx,
+		&CallParams{
+			URL:         server.URL,
+			Method:      http.MethodGet,
+			Request:     &InternalTestRequest{},
+			Response:    &InternalTestResponse{},
+			MaxAttempts: 3,
+		},
+	)
+
+	assert.NoError(t, err)
+	assert.Equal(t, 2, requestCount, "Expected the retry to proceed when the deadline allows it")
 }
 
 func TestDisableRetries(t *testing.T) {

--- a/seed/go-sdk/go-optional-literal-alias/internal/retrier.go
+++ b/seed/go-sdk/go-optional-literal-alias/internal/retrier.go
@@ -145,12 +145,20 @@ func (r *Retrier) run(
 	}
 
 	if r.shouldRetry(response) {
-		defer func() { _ = response.Body.Close() }()
-
 		delay, err := r.retryDelay(response, retryAttempt)
 		if err != nil {
+			_ = response.Body.Close()
 			return nil, err
 		}
+
+		// If the context's deadline would elapse before the backoff completes, return
+		// the response instead of sleeping through it. The caller then sees why the
+		// request actually failed (e.g. a 429) rather than a context deadline error.
+		if deadline, ok := request.Context().Deadline(); ok && time.Until(deadline) < delay {
+			return response, nil
+		}
+
+		defer func() { _ = response.Body.Close() }()
 
 		if err := sleepWithContext(request.Context(), delay); err != nil {
 			return nil, err

--- a/seed/go-sdk/go-optional-literal-alias/internal/retrier_test.go
+++ b/seed/go-sdk/go-optional-literal-alias/internal/retrier_test.go
@@ -295,7 +295,50 @@ func TestRetryWithRequestBody(t *testing.T) {
 	assert.Equal(t, expectedBody, requestBodies[1], "Second request body should match expected (retry should re-send body)")
 }
 
+// An explicit cancel (e.g. Ctrl-C wired to cancel()) must interrupt the backoff
+// wait. There is no deadline here, so the retrier cannot know the wait is futile
+// up front -- it has to be woken by the context.
 func TestRetryWaitIsInterruptedByContext(t *testing.T) {
+	var requestCount int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		w.Header().Set("Retry-After", "5")
+		w.WriteHeader(http.StatusTooManyRequests)
+	}))
+	defer server.Close()
+
+	caller := NewCaller(&CallerParams{
+		Client: server.Client(),
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		time.Sleep(100 * time.Millisecond)
+		cancel()
+	}()
+	defer cancel()
+
+	start := time.Now()
+	_, err := caller.Call(
+		ctx,
+		&CallParams{
+			URL:         server.URL,
+			Method:      http.MethodGet,
+			Request:     &InternalTestRequest{},
+			MaxAttempts: 3,
+		},
+	)
+	elapsed := time.Since(start)
+
+	assert.ErrorIs(t, err, context.Canceled)
+	assert.Equal(t, 1, requestCount, "Expected the retry to be abandoned once the context was cancelled")
+	assert.Less(t, elapsed, time.Second, "Expected the backoff to be interrupted by the context, took %v", elapsed)
+}
+
+// When the caller's deadline would elapse before the backoff finishes, sleeping
+// only guarantees a context error. Return the response instead so the caller
+// learns why the request actually failed.
+func TestRetryReturnsResponseWhenDeadlineShorterThanBackoff(t *testing.T) {
 	var requestCount int
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		requestCount++
@@ -323,9 +366,50 @@ func TestRetryWaitIsInterruptedByContext(t *testing.T) {
 	)
 	elapsed := time.Since(start)
 
-	assert.ErrorIs(t, err, context.DeadlineExceeded)
-	assert.Equal(t, 1, requestCount, "Expected the retry to be abandoned once the context expired")
-	assert.Less(t, elapsed, time.Second, "Expected the backoff to be interrupted by the context, took %v", elapsed)
+	// The caller gets the 429, not context.DeadlineExceeded.
+	var apiError *core.APIError
+	require.ErrorAs(t, err, &apiError)
+	assert.Equal(t, http.StatusTooManyRequests, apiError.StatusCode)
+	assert.NotErrorIs(t, err, context.DeadlineExceeded)
+	assert.Equal(t, 1, requestCount, "Expected no retry once the deadline was known to be too short")
+	assert.Less(t, elapsed, time.Second, "Expected to return immediately rather than sleep, took %v", elapsed)
+}
+
+// A deadline with room for the backoff must still retry as normal.
+func TestRetryProceedsWhenDeadlineLongerThanBackoff(t *testing.T) {
+	var requestCount int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		if requestCount == 1 {
+			w.Header().Set("Retry-After", "1")
+			w.WriteHeader(http.StatusTooManyRequests)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("{}"))
+	}))
+	defer server.Close()
+
+	caller := NewCaller(&CallerParams{
+		Client: server.Client(),
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	_, err := caller.Call(
+		ctx,
+		&CallParams{
+			URL:         server.URL,
+			Method:      http.MethodGet,
+			Request:     &InternalTestRequest{},
+			Response:    &InternalTestResponse{},
+			MaxAttempts: 3,
+		},
+	)
+
+	assert.NoError(t, err)
+	assert.Equal(t, 2, requestCount, "Expected the retry to proceed when the deadline allows it")
 }
 
 func TestDisableRetries(t *testing.T) {

--- a/seed/go-sdk/go-optional-request-body/no-custom-config/internal/retrier.go
+++ b/seed/go-sdk/go-optional-request-body/no-custom-config/internal/retrier.go
@@ -145,12 +145,20 @@ func (r *Retrier) run(
 	}
 
 	if r.shouldRetry(response) {
-		defer func() { _ = response.Body.Close() }()
-
 		delay, err := r.retryDelay(response, retryAttempt)
 		if err != nil {
+			_ = response.Body.Close()
 			return nil, err
 		}
+
+		// If the context's deadline would elapse before the backoff completes, return
+		// the response instead of sleeping through it. The caller then sees why the
+		// request actually failed (e.g. a 429) rather than a context deadline error.
+		if deadline, ok := request.Context().Deadline(); ok && time.Until(deadline) < delay {
+			return response, nil
+		}
+
+		defer func() { _ = response.Body.Close() }()
 
 		if err := sleepWithContext(request.Context(), delay); err != nil {
 			return nil, err

--- a/seed/go-sdk/go-optional-request-body/no-custom-config/internal/retrier_test.go
+++ b/seed/go-sdk/go-optional-request-body/no-custom-config/internal/retrier_test.go
@@ -295,7 +295,50 @@ func TestRetryWithRequestBody(t *testing.T) {
 	assert.Equal(t, expectedBody, requestBodies[1], "Second request body should match expected (retry should re-send body)")
 }
 
+// An explicit cancel (e.g. Ctrl-C wired to cancel()) must interrupt the backoff
+// wait. There is no deadline here, so the retrier cannot know the wait is futile
+// up front -- it has to be woken by the context.
 func TestRetryWaitIsInterruptedByContext(t *testing.T) {
+	var requestCount int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		w.Header().Set("Retry-After", "5")
+		w.WriteHeader(http.StatusTooManyRequests)
+	}))
+	defer server.Close()
+
+	caller := NewCaller(&CallerParams{
+		Client: server.Client(),
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		time.Sleep(100 * time.Millisecond)
+		cancel()
+	}()
+	defer cancel()
+
+	start := time.Now()
+	_, err := caller.Call(
+		ctx,
+		&CallParams{
+			URL:         server.URL,
+			Method:      http.MethodGet,
+			Request:     &InternalTestRequest{},
+			MaxAttempts: 3,
+		},
+	)
+	elapsed := time.Since(start)
+
+	assert.ErrorIs(t, err, context.Canceled)
+	assert.Equal(t, 1, requestCount, "Expected the retry to be abandoned once the context was cancelled")
+	assert.Less(t, elapsed, time.Second, "Expected the backoff to be interrupted by the context, took %v", elapsed)
+}
+
+// When the caller's deadline would elapse before the backoff finishes, sleeping
+// only guarantees a context error. Return the response instead so the caller
+// learns why the request actually failed.
+func TestRetryReturnsResponseWhenDeadlineShorterThanBackoff(t *testing.T) {
 	var requestCount int
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		requestCount++
@@ -323,9 +366,50 @@ func TestRetryWaitIsInterruptedByContext(t *testing.T) {
 	)
 	elapsed := time.Since(start)
 
-	assert.ErrorIs(t, err, context.DeadlineExceeded)
-	assert.Equal(t, 1, requestCount, "Expected the retry to be abandoned once the context expired")
-	assert.Less(t, elapsed, time.Second, "Expected the backoff to be interrupted by the context, took %v", elapsed)
+	// The caller gets the 429, not context.DeadlineExceeded.
+	var apiError *core.APIError
+	require.ErrorAs(t, err, &apiError)
+	assert.Equal(t, http.StatusTooManyRequests, apiError.StatusCode)
+	assert.NotErrorIs(t, err, context.DeadlineExceeded)
+	assert.Equal(t, 1, requestCount, "Expected no retry once the deadline was known to be too short")
+	assert.Less(t, elapsed, time.Second, "Expected to return immediately rather than sleep, took %v", elapsed)
+}
+
+// A deadline with room for the backoff must still retry as normal.
+func TestRetryProceedsWhenDeadlineLongerThanBackoff(t *testing.T) {
+	var requestCount int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		if requestCount == 1 {
+			w.Header().Set("Retry-After", "1")
+			w.WriteHeader(http.StatusTooManyRequests)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("{}"))
+	}))
+	defer server.Close()
+
+	caller := NewCaller(&CallerParams{
+		Client: server.Client(),
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	_, err := caller.Call(
+		ctx,
+		&CallParams{
+			URL:         server.URL,
+			Method:      http.MethodGet,
+			Request:     &InternalTestRequest{},
+			Response:    &InternalTestResponse{},
+			MaxAttempts: 3,
+		},
+	)
+
+	assert.NoError(t, err)
+	assert.Equal(t, 2, requestCount, "Expected the retry to proceed when the deadline allows it")
 }
 
 func TestDisableRetries(t *testing.T) {

--- a/seed/go-sdk/go-optional-request-body/respect-optional-request-body/internal/retrier.go
+++ b/seed/go-sdk/go-optional-request-body/respect-optional-request-body/internal/retrier.go
@@ -145,12 +145,20 @@ func (r *Retrier) run(
 	}
 
 	if r.shouldRetry(response) {
-		defer func() { _ = response.Body.Close() }()
-
 		delay, err := r.retryDelay(response, retryAttempt)
 		if err != nil {
+			_ = response.Body.Close()
 			return nil, err
 		}
+
+		// If the context's deadline would elapse before the backoff completes, return
+		// the response instead of sleeping through it. The caller then sees why the
+		// request actually failed (e.g. a 429) rather than a context deadline error.
+		if deadline, ok := request.Context().Deadline(); ok && time.Until(deadline) < delay {
+			return response, nil
+		}
+
+		defer func() { _ = response.Body.Close() }()
 
 		if err := sleepWithContext(request.Context(), delay); err != nil {
 			return nil, err

--- a/seed/go-sdk/go-optional-request-body/respect-optional-request-body/internal/retrier_test.go
+++ b/seed/go-sdk/go-optional-request-body/respect-optional-request-body/internal/retrier_test.go
@@ -295,7 +295,50 @@ func TestRetryWithRequestBody(t *testing.T) {
 	assert.Equal(t, expectedBody, requestBodies[1], "Second request body should match expected (retry should re-send body)")
 }
 
+// An explicit cancel (e.g. Ctrl-C wired to cancel()) must interrupt the backoff
+// wait. There is no deadline here, so the retrier cannot know the wait is futile
+// up front -- it has to be woken by the context.
 func TestRetryWaitIsInterruptedByContext(t *testing.T) {
+	var requestCount int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		w.Header().Set("Retry-After", "5")
+		w.WriteHeader(http.StatusTooManyRequests)
+	}))
+	defer server.Close()
+
+	caller := NewCaller(&CallerParams{
+		Client: server.Client(),
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		time.Sleep(100 * time.Millisecond)
+		cancel()
+	}()
+	defer cancel()
+
+	start := time.Now()
+	_, err := caller.Call(
+		ctx,
+		&CallParams{
+			URL:         server.URL,
+			Method:      http.MethodGet,
+			Request:     &InternalTestRequest{},
+			MaxAttempts: 3,
+		},
+	)
+	elapsed := time.Since(start)
+
+	assert.ErrorIs(t, err, context.Canceled)
+	assert.Equal(t, 1, requestCount, "Expected the retry to be abandoned once the context was cancelled")
+	assert.Less(t, elapsed, time.Second, "Expected the backoff to be interrupted by the context, took %v", elapsed)
+}
+
+// When the caller's deadline would elapse before the backoff finishes, sleeping
+// only guarantees a context error. Return the response instead so the caller
+// learns why the request actually failed.
+func TestRetryReturnsResponseWhenDeadlineShorterThanBackoff(t *testing.T) {
 	var requestCount int
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		requestCount++
@@ -323,9 +366,50 @@ func TestRetryWaitIsInterruptedByContext(t *testing.T) {
 	)
 	elapsed := time.Since(start)
 
-	assert.ErrorIs(t, err, context.DeadlineExceeded)
-	assert.Equal(t, 1, requestCount, "Expected the retry to be abandoned once the context expired")
-	assert.Less(t, elapsed, time.Second, "Expected the backoff to be interrupted by the context, took %v", elapsed)
+	// The caller gets the 429, not context.DeadlineExceeded.
+	var apiError *core.APIError
+	require.ErrorAs(t, err, &apiError)
+	assert.Equal(t, http.StatusTooManyRequests, apiError.StatusCode)
+	assert.NotErrorIs(t, err, context.DeadlineExceeded)
+	assert.Equal(t, 1, requestCount, "Expected no retry once the deadline was known to be too short")
+	assert.Less(t, elapsed, time.Second, "Expected to return immediately rather than sleep, took %v", elapsed)
+}
+
+// A deadline with room for the backoff must still retry as normal.
+func TestRetryProceedsWhenDeadlineLongerThanBackoff(t *testing.T) {
+	var requestCount int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		if requestCount == 1 {
+			w.Header().Set("Retry-After", "1")
+			w.WriteHeader(http.StatusTooManyRequests)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("{}"))
+	}))
+	defer server.Close()
+
+	caller := NewCaller(&CallerParams{
+		Client: server.Client(),
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	_, err := caller.Call(
+		ctx,
+		&CallParams{
+			URL:         server.URL,
+			Method:      http.MethodGet,
+			Request:     &InternalTestRequest{},
+			Response:    &InternalTestResponse{},
+			MaxAttempts: 3,
+		},
+	)
+
+	assert.NoError(t, err)
+	assert.Equal(t, 2, requestCount, "Expected the retry to proceed when the deadline allows it")
 }
 
 func TestDisableRetries(t *testing.T) {

--- a/seed/go-sdk/go-pagination-offset-item-index/internal/retrier.go
+++ b/seed/go-sdk/go-pagination-offset-item-index/internal/retrier.go
@@ -145,12 +145,20 @@ func (r *Retrier) run(
 	}
 
 	if r.shouldRetry(response) {
-		defer func() { _ = response.Body.Close() }()
-
 		delay, err := r.retryDelay(response, retryAttempt)
 		if err != nil {
+			_ = response.Body.Close()
 			return nil, err
 		}
+
+		// If the context's deadline would elapse before the backoff completes, return
+		// the response instead of sleeping through it. The caller then sees why the
+		// request actually failed (e.g. a 429) rather than a context deadline error.
+		if deadline, ok := request.Context().Deadline(); ok && time.Until(deadline) < delay {
+			return response, nil
+		}
+
+		defer func() { _ = response.Body.Close() }()
 
 		if err := sleepWithContext(request.Context(), delay); err != nil {
 			return nil, err

--- a/seed/go-sdk/go-pagination-offset-item-index/internal/retrier_test.go
+++ b/seed/go-sdk/go-pagination-offset-item-index/internal/retrier_test.go
@@ -295,7 +295,50 @@ func TestRetryWithRequestBody(t *testing.T) {
 	assert.Equal(t, expectedBody, requestBodies[1], "Second request body should match expected (retry should re-send body)")
 }
 
+// An explicit cancel (e.g. Ctrl-C wired to cancel()) must interrupt the backoff
+// wait. There is no deadline here, so the retrier cannot know the wait is futile
+// up front -- it has to be woken by the context.
 func TestRetryWaitIsInterruptedByContext(t *testing.T) {
+	var requestCount int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		w.Header().Set("Retry-After", "5")
+		w.WriteHeader(http.StatusTooManyRequests)
+	}))
+	defer server.Close()
+
+	caller := NewCaller(&CallerParams{
+		Client: server.Client(),
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		time.Sleep(100 * time.Millisecond)
+		cancel()
+	}()
+	defer cancel()
+
+	start := time.Now()
+	_, err := caller.Call(
+		ctx,
+		&CallParams{
+			URL:         server.URL,
+			Method:      http.MethodGet,
+			Request:     &InternalTestRequest{},
+			MaxAttempts: 3,
+		},
+	)
+	elapsed := time.Since(start)
+
+	assert.ErrorIs(t, err, context.Canceled)
+	assert.Equal(t, 1, requestCount, "Expected the retry to be abandoned once the context was cancelled")
+	assert.Less(t, elapsed, time.Second, "Expected the backoff to be interrupted by the context, took %v", elapsed)
+}
+
+// When the caller's deadline would elapse before the backoff finishes, sleeping
+// only guarantees a context error. Return the response instead so the caller
+// learns why the request actually failed.
+func TestRetryReturnsResponseWhenDeadlineShorterThanBackoff(t *testing.T) {
 	var requestCount int
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		requestCount++
@@ -323,9 +366,50 @@ func TestRetryWaitIsInterruptedByContext(t *testing.T) {
 	)
 	elapsed := time.Since(start)
 
-	assert.ErrorIs(t, err, context.DeadlineExceeded)
-	assert.Equal(t, 1, requestCount, "Expected the retry to be abandoned once the context expired")
-	assert.Less(t, elapsed, time.Second, "Expected the backoff to be interrupted by the context, took %v", elapsed)
+	// The caller gets the 429, not context.DeadlineExceeded.
+	var apiError *core.APIError
+	require.ErrorAs(t, err, &apiError)
+	assert.Equal(t, http.StatusTooManyRequests, apiError.StatusCode)
+	assert.NotErrorIs(t, err, context.DeadlineExceeded)
+	assert.Equal(t, 1, requestCount, "Expected no retry once the deadline was known to be too short")
+	assert.Less(t, elapsed, time.Second, "Expected to return immediately rather than sleep, took %v", elapsed)
+}
+
+// A deadline with room for the backoff must still retry as normal.
+func TestRetryProceedsWhenDeadlineLongerThanBackoff(t *testing.T) {
+	var requestCount int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		if requestCount == 1 {
+			w.Header().Set("Retry-After", "1")
+			w.WriteHeader(http.StatusTooManyRequests)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("{}"))
+	}))
+	defer server.Close()
+
+	caller := NewCaller(&CallerParams{
+		Client: server.Client(),
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	_, err := caller.Call(
+		ctx,
+		&CallParams{
+			URL:         server.URL,
+			Method:      http.MethodGet,
+			Request:     &InternalTestRequest{},
+			Response:    &InternalTestResponse{},
+			MaxAttempts: 3,
+		},
+	)
+
+	assert.NoError(t, err)
+	assert.Equal(t, 2, requestCount, "Expected the retry to proceed when the deadline allows it")
 }
 
 func TestDisableRetries(t *testing.T) {

--- a/seed/go-sdk/go-request-body-pagination/internal/retrier.go
+++ b/seed/go-sdk/go-request-body-pagination/internal/retrier.go
@@ -145,12 +145,20 @@ func (r *Retrier) run(
 	}
 
 	if r.shouldRetry(response) {
-		defer func() { _ = response.Body.Close() }()
-
 		delay, err := r.retryDelay(response, retryAttempt)
 		if err != nil {
+			_ = response.Body.Close()
 			return nil, err
 		}
+
+		// If the context's deadline would elapse before the backoff completes, return
+		// the response instead of sleeping through it. The caller then sees why the
+		// request actually failed (e.g. a 429) rather than a context deadline error.
+		if deadline, ok := request.Context().Deadline(); ok && time.Until(deadline) < delay {
+			return response, nil
+		}
+
+		defer func() { _ = response.Body.Close() }()
 
 		if err := sleepWithContext(request.Context(), delay); err != nil {
 			return nil, err

--- a/seed/go-sdk/go-request-body-pagination/internal/retrier_test.go
+++ b/seed/go-sdk/go-request-body-pagination/internal/retrier_test.go
@@ -295,7 +295,50 @@ func TestRetryWithRequestBody(t *testing.T) {
 	assert.Equal(t, expectedBody, requestBodies[1], "Second request body should match expected (retry should re-send body)")
 }
 
+// An explicit cancel (e.g. Ctrl-C wired to cancel()) must interrupt the backoff
+// wait. There is no deadline here, so the retrier cannot know the wait is futile
+// up front -- it has to be woken by the context.
 func TestRetryWaitIsInterruptedByContext(t *testing.T) {
+	var requestCount int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		w.Header().Set("Retry-After", "5")
+		w.WriteHeader(http.StatusTooManyRequests)
+	}))
+	defer server.Close()
+
+	caller := NewCaller(&CallerParams{
+		Client: server.Client(),
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		time.Sleep(100 * time.Millisecond)
+		cancel()
+	}()
+	defer cancel()
+
+	start := time.Now()
+	_, err := caller.Call(
+		ctx,
+		&CallParams{
+			URL:         server.URL,
+			Method:      http.MethodGet,
+			Request:     &InternalTestRequest{},
+			MaxAttempts: 3,
+		},
+	)
+	elapsed := time.Since(start)
+
+	assert.ErrorIs(t, err, context.Canceled)
+	assert.Equal(t, 1, requestCount, "Expected the retry to be abandoned once the context was cancelled")
+	assert.Less(t, elapsed, time.Second, "Expected the backoff to be interrupted by the context, took %v", elapsed)
+}
+
+// When the caller's deadline would elapse before the backoff finishes, sleeping
+// only guarantees a context error. Return the response instead so the caller
+// learns why the request actually failed.
+func TestRetryReturnsResponseWhenDeadlineShorterThanBackoff(t *testing.T) {
 	var requestCount int
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		requestCount++
@@ -323,9 +366,50 @@ func TestRetryWaitIsInterruptedByContext(t *testing.T) {
 	)
 	elapsed := time.Since(start)
 
-	assert.ErrorIs(t, err, context.DeadlineExceeded)
-	assert.Equal(t, 1, requestCount, "Expected the retry to be abandoned once the context expired")
-	assert.Less(t, elapsed, time.Second, "Expected the backoff to be interrupted by the context, took %v", elapsed)
+	// The caller gets the 429, not context.DeadlineExceeded.
+	var apiError *core.APIError
+	require.ErrorAs(t, err, &apiError)
+	assert.Equal(t, http.StatusTooManyRequests, apiError.StatusCode)
+	assert.NotErrorIs(t, err, context.DeadlineExceeded)
+	assert.Equal(t, 1, requestCount, "Expected no retry once the deadline was known to be too short")
+	assert.Less(t, elapsed, time.Second, "Expected to return immediately rather than sleep, took %v", elapsed)
+}
+
+// A deadline with room for the backoff must still retry as normal.
+func TestRetryProceedsWhenDeadlineLongerThanBackoff(t *testing.T) {
+	var requestCount int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		if requestCount == 1 {
+			w.Header().Set("Retry-After", "1")
+			w.WriteHeader(http.StatusTooManyRequests)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("{}"))
+	}))
+	defer server.Close()
+
+	caller := NewCaller(&CallerParams{
+		Client: server.Client(),
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	_, err := caller.Call(
+		ctx,
+		&CallParams{
+			URL:         server.URL,
+			Method:      http.MethodGet,
+			Request:     &InternalTestRequest{},
+			Response:    &InternalTestResponse{},
+			MaxAttempts: 3,
+		},
+	)
+
+	assert.NoError(t, err)
+	assert.Equal(t, 2, requestCount, "Expected the retry to proceed when the deadline allows it")
 }
 
 func TestDisableRetries(t *testing.T) {

--- a/seed/go-sdk/go-subpackage-collision/internal/retrier.go
+++ b/seed/go-sdk/go-subpackage-collision/internal/retrier.go
@@ -145,12 +145,20 @@ func (r *Retrier) run(
 	}
 
 	if r.shouldRetry(response) {
-		defer func() { _ = response.Body.Close() }()
-
 		delay, err := r.retryDelay(response, retryAttempt)
 		if err != nil {
+			_ = response.Body.Close()
 			return nil, err
 		}
+
+		// If the context's deadline would elapse before the backoff completes, return
+		// the response instead of sleeping through it. The caller then sees why the
+		// request actually failed (e.g. a 429) rather than a context deadline error.
+		if deadline, ok := request.Context().Deadline(); ok && time.Until(deadline) < delay {
+			return response, nil
+		}
+
+		defer func() { _ = response.Body.Close() }()
 
 		if err := sleepWithContext(request.Context(), delay); err != nil {
 			return nil, err

--- a/seed/go-sdk/go-subpackage-collision/internal/retrier_test.go
+++ b/seed/go-sdk/go-subpackage-collision/internal/retrier_test.go
@@ -295,7 +295,50 @@ func TestRetryWithRequestBody(t *testing.T) {
 	assert.Equal(t, expectedBody, requestBodies[1], "Second request body should match expected (retry should re-send body)")
 }
 
+// An explicit cancel (e.g. Ctrl-C wired to cancel()) must interrupt the backoff
+// wait. There is no deadline here, so the retrier cannot know the wait is futile
+// up front -- it has to be woken by the context.
 func TestRetryWaitIsInterruptedByContext(t *testing.T) {
+	var requestCount int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		w.Header().Set("Retry-After", "5")
+		w.WriteHeader(http.StatusTooManyRequests)
+	}))
+	defer server.Close()
+
+	caller := NewCaller(&CallerParams{
+		Client: server.Client(),
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		time.Sleep(100 * time.Millisecond)
+		cancel()
+	}()
+	defer cancel()
+
+	start := time.Now()
+	_, err := caller.Call(
+		ctx,
+		&CallParams{
+			URL:         server.URL,
+			Method:      http.MethodGet,
+			Request:     &InternalTestRequest{},
+			MaxAttempts: 3,
+		},
+	)
+	elapsed := time.Since(start)
+
+	assert.ErrorIs(t, err, context.Canceled)
+	assert.Equal(t, 1, requestCount, "Expected the retry to be abandoned once the context was cancelled")
+	assert.Less(t, elapsed, time.Second, "Expected the backoff to be interrupted by the context, took %v", elapsed)
+}
+
+// When the caller's deadline would elapse before the backoff finishes, sleeping
+// only guarantees a context error. Return the response instead so the caller
+// learns why the request actually failed.
+func TestRetryReturnsResponseWhenDeadlineShorterThanBackoff(t *testing.T) {
 	var requestCount int
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		requestCount++
@@ -323,9 +366,50 @@ func TestRetryWaitIsInterruptedByContext(t *testing.T) {
 	)
 	elapsed := time.Since(start)
 
-	assert.ErrorIs(t, err, context.DeadlineExceeded)
-	assert.Equal(t, 1, requestCount, "Expected the retry to be abandoned once the context expired")
-	assert.Less(t, elapsed, time.Second, "Expected the backoff to be interrupted by the context, took %v", elapsed)
+	// The caller gets the 429, not context.DeadlineExceeded.
+	var apiError *core.APIError
+	require.ErrorAs(t, err, &apiError)
+	assert.Equal(t, http.StatusTooManyRequests, apiError.StatusCode)
+	assert.NotErrorIs(t, err, context.DeadlineExceeded)
+	assert.Equal(t, 1, requestCount, "Expected no retry once the deadline was known to be too short")
+	assert.Less(t, elapsed, time.Second, "Expected to return immediately rather than sleep, took %v", elapsed)
+}
+
+// A deadline with room for the backoff must still retry as normal.
+func TestRetryProceedsWhenDeadlineLongerThanBackoff(t *testing.T) {
+	var requestCount int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		if requestCount == 1 {
+			w.Header().Set("Retry-After", "1")
+			w.WriteHeader(http.StatusTooManyRequests)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("{}"))
+	}))
+	defer server.Close()
+
+	caller := NewCaller(&CallerParams{
+		Client: server.Client(),
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	_, err := caller.Call(
+		ctx,
+		&CallParams{
+			URL:         server.URL,
+			Method:      http.MethodGet,
+			Request:     &InternalTestRequest{},
+			Response:    &InternalTestResponse{},
+			MaxAttempts: 3,
+		},
+	)
+
+	assert.NoError(t, err)
+	assert.Equal(t, 2, requestCount, "Expected the retry to proceed when the deadline allows it")
 }
 
 func TestDisableRetries(t *testing.T) {

--- a/seed/go-sdk/go-undiscriminated-union-wire-tests/internal/retrier.go
+++ b/seed/go-sdk/go-undiscriminated-union-wire-tests/internal/retrier.go
@@ -145,12 +145,20 @@ func (r *Retrier) run(
 	}
 
 	if r.shouldRetry(response) {
-		defer func() { _ = response.Body.Close() }()
-
 		delay, err := r.retryDelay(response, retryAttempt)
 		if err != nil {
+			_ = response.Body.Close()
 			return nil, err
 		}
+
+		// If the context's deadline would elapse before the backoff completes, return
+		// the response instead of sleeping through it. The caller then sees why the
+		// request actually failed (e.g. a 429) rather than a context deadline error.
+		if deadline, ok := request.Context().Deadline(); ok && time.Until(deadline) < delay {
+			return response, nil
+		}
+
+		defer func() { _ = response.Body.Close() }()
 
 		if err := sleepWithContext(request.Context(), delay); err != nil {
 			return nil, err

--- a/seed/go-sdk/go-undiscriminated-union-wire-tests/internal/retrier_test.go
+++ b/seed/go-sdk/go-undiscriminated-union-wire-tests/internal/retrier_test.go
@@ -295,7 +295,50 @@ func TestRetryWithRequestBody(t *testing.T) {
 	assert.Equal(t, expectedBody, requestBodies[1], "Second request body should match expected (retry should re-send body)")
 }
 
+// An explicit cancel (e.g. Ctrl-C wired to cancel()) must interrupt the backoff
+// wait. There is no deadline here, so the retrier cannot know the wait is futile
+// up front -- it has to be woken by the context.
 func TestRetryWaitIsInterruptedByContext(t *testing.T) {
+	var requestCount int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		w.Header().Set("Retry-After", "5")
+		w.WriteHeader(http.StatusTooManyRequests)
+	}))
+	defer server.Close()
+
+	caller := NewCaller(&CallerParams{
+		Client: server.Client(),
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		time.Sleep(100 * time.Millisecond)
+		cancel()
+	}()
+	defer cancel()
+
+	start := time.Now()
+	_, err := caller.Call(
+		ctx,
+		&CallParams{
+			URL:         server.URL,
+			Method:      http.MethodGet,
+			Request:     &InternalTestRequest{},
+			MaxAttempts: 3,
+		},
+	)
+	elapsed := time.Since(start)
+
+	assert.ErrorIs(t, err, context.Canceled)
+	assert.Equal(t, 1, requestCount, "Expected the retry to be abandoned once the context was cancelled")
+	assert.Less(t, elapsed, time.Second, "Expected the backoff to be interrupted by the context, took %v", elapsed)
+}
+
+// When the caller's deadline would elapse before the backoff finishes, sleeping
+// only guarantees a context error. Return the response instead so the caller
+// learns why the request actually failed.
+func TestRetryReturnsResponseWhenDeadlineShorterThanBackoff(t *testing.T) {
 	var requestCount int
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		requestCount++
@@ -323,9 +366,50 @@ func TestRetryWaitIsInterruptedByContext(t *testing.T) {
 	)
 	elapsed := time.Since(start)
 
-	assert.ErrorIs(t, err, context.DeadlineExceeded)
-	assert.Equal(t, 1, requestCount, "Expected the retry to be abandoned once the context expired")
-	assert.Less(t, elapsed, time.Second, "Expected the backoff to be interrupted by the context, took %v", elapsed)
+	// The caller gets the 429, not context.DeadlineExceeded.
+	var apiError *core.APIError
+	require.ErrorAs(t, err, &apiError)
+	assert.Equal(t, http.StatusTooManyRequests, apiError.StatusCode)
+	assert.NotErrorIs(t, err, context.DeadlineExceeded)
+	assert.Equal(t, 1, requestCount, "Expected no retry once the deadline was known to be too short")
+	assert.Less(t, elapsed, time.Second, "Expected to return immediately rather than sleep, took %v", elapsed)
+}
+
+// A deadline with room for the backoff must still retry as normal.
+func TestRetryProceedsWhenDeadlineLongerThanBackoff(t *testing.T) {
+	var requestCount int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		if requestCount == 1 {
+			w.Header().Set("Retry-After", "1")
+			w.WriteHeader(http.StatusTooManyRequests)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("{}"))
+	}))
+	defer server.Close()
+
+	caller := NewCaller(&CallerParams{
+		Client: server.Client(),
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	_, err := caller.Call(
+		ctx,
+		&CallParams{
+			URL:         server.URL,
+			Method:      http.MethodGet,
+			Request:     &InternalTestRequest{},
+			Response:    &InternalTestResponse{},
+			MaxAttempts: 3,
+		},
+	)
+
+	assert.NoError(t, err)
+	assert.Equal(t, 2, requestCount, "Expected the retry to proceed when the deadline allows it")
 }
 
 func TestDisableRetries(t *testing.T) {

--- a/seed/go-sdk/go-union-base-properties/dedupe-union-base-properties/internal/retrier.go
+++ b/seed/go-sdk/go-union-base-properties/dedupe-union-base-properties/internal/retrier.go
@@ -145,12 +145,20 @@ func (r *Retrier) run(
 	}
 
 	if r.shouldRetry(response) {
-		defer func() { _ = response.Body.Close() }()
-
 		delay, err := r.retryDelay(response, retryAttempt)
 		if err != nil {
+			_ = response.Body.Close()
 			return nil, err
 		}
+
+		// If the context's deadline would elapse before the backoff completes, return
+		// the response instead of sleeping through it. The caller then sees why the
+		// request actually failed (e.g. a 429) rather than a context deadline error.
+		if deadline, ok := request.Context().Deadline(); ok && time.Until(deadline) < delay {
+			return response, nil
+		}
+
+		defer func() { _ = response.Body.Close() }()
 
 		if err := sleepWithContext(request.Context(), delay); err != nil {
 			return nil, err

--- a/seed/go-sdk/go-union-base-properties/dedupe-union-base-properties/internal/retrier_test.go
+++ b/seed/go-sdk/go-union-base-properties/dedupe-union-base-properties/internal/retrier_test.go
@@ -295,7 +295,50 @@ func TestRetryWithRequestBody(t *testing.T) {
 	assert.Equal(t, expectedBody, requestBodies[1], "Second request body should match expected (retry should re-send body)")
 }
 
+// An explicit cancel (e.g. Ctrl-C wired to cancel()) must interrupt the backoff
+// wait. There is no deadline here, so the retrier cannot know the wait is futile
+// up front -- it has to be woken by the context.
 func TestRetryWaitIsInterruptedByContext(t *testing.T) {
+	var requestCount int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		w.Header().Set("Retry-After", "5")
+		w.WriteHeader(http.StatusTooManyRequests)
+	}))
+	defer server.Close()
+
+	caller := NewCaller(&CallerParams{
+		Client: server.Client(),
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		time.Sleep(100 * time.Millisecond)
+		cancel()
+	}()
+	defer cancel()
+
+	start := time.Now()
+	_, err := caller.Call(
+		ctx,
+		&CallParams{
+			URL:         server.URL,
+			Method:      http.MethodGet,
+			Request:     &InternalTestRequest{},
+			MaxAttempts: 3,
+		},
+	)
+	elapsed := time.Since(start)
+
+	assert.ErrorIs(t, err, context.Canceled)
+	assert.Equal(t, 1, requestCount, "Expected the retry to be abandoned once the context was cancelled")
+	assert.Less(t, elapsed, time.Second, "Expected the backoff to be interrupted by the context, took %v", elapsed)
+}
+
+// When the caller's deadline would elapse before the backoff finishes, sleeping
+// only guarantees a context error. Return the response instead so the caller
+// learns why the request actually failed.
+func TestRetryReturnsResponseWhenDeadlineShorterThanBackoff(t *testing.T) {
 	var requestCount int
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		requestCount++
@@ -323,9 +366,50 @@ func TestRetryWaitIsInterruptedByContext(t *testing.T) {
 	)
 	elapsed := time.Since(start)
 
-	assert.ErrorIs(t, err, context.DeadlineExceeded)
-	assert.Equal(t, 1, requestCount, "Expected the retry to be abandoned once the context expired")
-	assert.Less(t, elapsed, time.Second, "Expected the backoff to be interrupted by the context, took %v", elapsed)
+	// The caller gets the 429, not context.DeadlineExceeded.
+	var apiError *core.APIError
+	require.ErrorAs(t, err, &apiError)
+	assert.Equal(t, http.StatusTooManyRequests, apiError.StatusCode)
+	assert.NotErrorIs(t, err, context.DeadlineExceeded)
+	assert.Equal(t, 1, requestCount, "Expected no retry once the deadline was known to be too short")
+	assert.Less(t, elapsed, time.Second, "Expected to return immediately rather than sleep, took %v", elapsed)
+}
+
+// A deadline with room for the backoff must still retry as normal.
+func TestRetryProceedsWhenDeadlineLongerThanBackoff(t *testing.T) {
+	var requestCount int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		if requestCount == 1 {
+			w.Header().Set("Retry-After", "1")
+			w.WriteHeader(http.StatusTooManyRequests)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("{}"))
+	}))
+	defer server.Close()
+
+	caller := NewCaller(&CallerParams{
+		Client: server.Client(),
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	_, err := caller.Call(
+		ctx,
+		&CallParams{
+			URL:         server.URL,
+			Method:      http.MethodGet,
+			Request:     &InternalTestRequest{},
+			Response:    &InternalTestResponse{},
+			MaxAttempts: 3,
+		},
+	)
+
+	assert.NoError(t, err)
+	assert.Equal(t, 2, requestCount, "Expected the retry to proceed when the deadline allows it")
 }
 
 func TestDisableRetries(t *testing.T) {

--- a/seed/go-sdk/go-union-base-properties/no-custom-config/internal/retrier.go
+++ b/seed/go-sdk/go-union-base-properties/no-custom-config/internal/retrier.go
@@ -145,12 +145,20 @@ func (r *Retrier) run(
 	}
 
 	if r.shouldRetry(response) {
-		defer func() { _ = response.Body.Close() }()
-
 		delay, err := r.retryDelay(response, retryAttempt)
 		if err != nil {
+			_ = response.Body.Close()
 			return nil, err
 		}
+
+		// If the context's deadline would elapse before the backoff completes, return
+		// the response instead of sleeping through it. The caller then sees why the
+		// request actually failed (e.g. a 429) rather than a context deadline error.
+		if deadline, ok := request.Context().Deadline(); ok && time.Until(deadline) < delay {
+			return response, nil
+		}
+
+		defer func() { _ = response.Body.Close() }()
 
 		if err := sleepWithContext(request.Context(), delay); err != nil {
 			return nil, err

--- a/seed/go-sdk/go-union-base-properties/no-custom-config/internal/retrier_test.go
+++ b/seed/go-sdk/go-union-base-properties/no-custom-config/internal/retrier_test.go
@@ -295,7 +295,50 @@ func TestRetryWithRequestBody(t *testing.T) {
 	assert.Equal(t, expectedBody, requestBodies[1], "Second request body should match expected (retry should re-send body)")
 }
 
+// An explicit cancel (e.g. Ctrl-C wired to cancel()) must interrupt the backoff
+// wait. There is no deadline here, so the retrier cannot know the wait is futile
+// up front -- it has to be woken by the context.
 func TestRetryWaitIsInterruptedByContext(t *testing.T) {
+	var requestCount int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		w.Header().Set("Retry-After", "5")
+		w.WriteHeader(http.StatusTooManyRequests)
+	}))
+	defer server.Close()
+
+	caller := NewCaller(&CallerParams{
+		Client: server.Client(),
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		time.Sleep(100 * time.Millisecond)
+		cancel()
+	}()
+	defer cancel()
+
+	start := time.Now()
+	_, err := caller.Call(
+		ctx,
+		&CallParams{
+			URL:         server.URL,
+			Method:      http.MethodGet,
+			Request:     &InternalTestRequest{},
+			MaxAttempts: 3,
+		},
+	)
+	elapsed := time.Since(start)
+
+	assert.ErrorIs(t, err, context.Canceled)
+	assert.Equal(t, 1, requestCount, "Expected the retry to be abandoned once the context was cancelled")
+	assert.Less(t, elapsed, time.Second, "Expected the backoff to be interrupted by the context, took %v", elapsed)
+}
+
+// When the caller's deadline would elapse before the backoff finishes, sleeping
+// only guarantees a context error. Return the response instead so the caller
+// learns why the request actually failed.
+func TestRetryReturnsResponseWhenDeadlineShorterThanBackoff(t *testing.T) {
 	var requestCount int
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		requestCount++
@@ -323,9 +366,50 @@ func TestRetryWaitIsInterruptedByContext(t *testing.T) {
 	)
 	elapsed := time.Since(start)
 
-	assert.ErrorIs(t, err, context.DeadlineExceeded)
-	assert.Equal(t, 1, requestCount, "Expected the retry to be abandoned once the context expired")
-	assert.Less(t, elapsed, time.Second, "Expected the backoff to be interrupted by the context, took %v", elapsed)
+	// The caller gets the 429, not context.DeadlineExceeded.
+	var apiError *core.APIError
+	require.ErrorAs(t, err, &apiError)
+	assert.Equal(t, http.StatusTooManyRequests, apiError.StatusCode)
+	assert.NotErrorIs(t, err, context.DeadlineExceeded)
+	assert.Equal(t, 1, requestCount, "Expected no retry once the deadline was known to be too short")
+	assert.Less(t, elapsed, time.Second, "Expected to return immediately rather than sleep, took %v", elapsed)
+}
+
+// A deadline with room for the backoff must still retry as normal.
+func TestRetryProceedsWhenDeadlineLongerThanBackoff(t *testing.T) {
+	var requestCount int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		if requestCount == 1 {
+			w.Header().Set("Retry-After", "1")
+			w.WriteHeader(http.StatusTooManyRequests)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("{}"))
+	}))
+	defer server.Close()
+
+	caller := NewCaller(&CallerParams{
+		Client: server.Client(),
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	_, err := caller.Call(
+		ctx,
+		&CallParams{
+			URL:         server.URL,
+			Method:      http.MethodGet,
+			Request:     &InternalTestRequest{},
+			Response:    &InternalTestResponse{},
+			MaxAttempts: 3,
+		},
+	)
+
+	assert.NoError(t, err)
+	assert.Equal(t, 2, requestCount, "Expected the retry to proceed when the deadline allows it")
 }
 
 func TestDisableRetries(t *testing.T) {

--- a/seed/go-sdk/header-auth-environment-variable/internal/retrier.go
+++ b/seed/go-sdk/header-auth-environment-variable/internal/retrier.go
@@ -145,12 +145,20 @@ func (r *Retrier) run(
 	}
 
 	if r.shouldRetry(response) {
-		defer func() { _ = response.Body.Close() }()
-
 		delay, err := r.retryDelay(response, retryAttempt)
 		if err != nil {
+			_ = response.Body.Close()
 			return nil, err
 		}
+
+		// If the context's deadline would elapse before the backoff completes, return
+		// the response instead of sleeping through it. The caller then sees why the
+		// request actually failed (e.g. a 429) rather than a context deadline error.
+		if deadline, ok := request.Context().Deadline(); ok && time.Until(deadline) < delay {
+			return response, nil
+		}
+
+		defer func() { _ = response.Body.Close() }()
 
 		if err := sleepWithContext(request.Context(), delay); err != nil {
 			return nil, err

--- a/seed/go-sdk/header-auth-environment-variable/internal/retrier_test.go
+++ b/seed/go-sdk/header-auth-environment-variable/internal/retrier_test.go
@@ -295,7 +295,50 @@ func TestRetryWithRequestBody(t *testing.T) {
 	assert.Equal(t, expectedBody, requestBodies[1], "Second request body should match expected (retry should re-send body)")
 }
 
+// An explicit cancel (e.g. Ctrl-C wired to cancel()) must interrupt the backoff
+// wait. There is no deadline here, so the retrier cannot know the wait is futile
+// up front -- it has to be woken by the context.
 func TestRetryWaitIsInterruptedByContext(t *testing.T) {
+	var requestCount int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		w.Header().Set("Retry-After", "5")
+		w.WriteHeader(http.StatusTooManyRequests)
+	}))
+	defer server.Close()
+
+	caller := NewCaller(&CallerParams{
+		Client: server.Client(),
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		time.Sleep(100 * time.Millisecond)
+		cancel()
+	}()
+	defer cancel()
+
+	start := time.Now()
+	_, err := caller.Call(
+		ctx,
+		&CallParams{
+			URL:         server.URL,
+			Method:      http.MethodGet,
+			Request:     &InternalTestRequest{},
+			MaxAttempts: 3,
+		},
+	)
+	elapsed := time.Since(start)
+
+	assert.ErrorIs(t, err, context.Canceled)
+	assert.Equal(t, 1, requestCount, "Expected the retry to be abandoned once the context was cancelled")
+	assert.Less(t, elapsed, time.Second, "Expected the backoff to be interrupted by the context, took %v", elapsed)
+}
+
+// When the caller's deadline would elapse before the backoff finishes, sleeping
+// only guarantees a context error. Return the response instead so the caller
+// learns why the request actually failed.
+func TestRetryReturnsResponseWhenDeadlineShorterThanBackoff(t *testing.T) {
 	var requestCount int
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		requestCount++
@@ -323,9 +366,50 @@ func TestRetryWaitIsInterruptedByContext(t *testing.T) {
 	)
 	elapsed := time.Since(start)
 
-	assert.ErrorIs(t, err, context.DeadlineExceeded)
-	assert.Equal(t, 1, requestCount, "Expected the retry to be abandoned once the context expired")
-	assert.Less(t, elapsed, time.Second, "Expected the backoff to be interrupted by the context, took %v", elapsed)
+	// The caller gets the 429, not context.DeadlineExceeded.
+	var apiError *core.APIError
+	require.ErrorAs(t, err, &apiError)
+	assert.Equal(t, http.StatusTooManyRequests, apiError.StatusCode)
+	assert.NotErrorIs(t, err, context.DeadlineExceeded)
+	assert.Equal(t, 1, requestCount, "Expected no retry once the deadline was known to be too short")
+	assert.Less(t, elapsed, time.Second, "Expected to return immediately rather than sleep, took %v", elapsed)
+}
+
+// A deadline with room for the backoff must still retry as normal.
+func TestRetryProceedsWhenDeadlineLongerThanBackoff(t *testing.T) {
+	var requestCount int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		if requestCount == 1 {
+			w.Header().Set("Retry-After", "1")
+			w.WriteHeader(http.StatusTooManyRequests)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("{}"))
+	}))
+	defer server.Close()
+
+	caller := NewCaller(&CallerParams{
+		Client: server.Client(),
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	_, err := caller.Call(
+		ctx,
+		&CallParams{
+			URL:         server.URL,
+			Method:      http.MethodGet,
+			Request:     &InternalTestRequest{},
+			Response:    &InternalTestResponse{},
+			MaxAttempts: 3,
+		},
+	)
+
+	assert.NoError(t, err)
+	assert.Equal(t, 2, requestCount, "Expected the retry to proceed when the deadline allows it")
 }
 
 func TestDisableRetries(t *testing.T) {

--- a/seed/go-sdk/header-auth/internal/retrier.go
+++ b/seed/go-sdk/header-auth/internal/retrier.go
@@ -145,12 +145,20 @@ func (r *Retrier) run(
 	}
 
 	if r.shouldRetry(response) {
-		defer func() { _ = response.Body.Close() }()
-
 		delay, err := r.retryDelay(response, retryAttempt)
 		if err != nil {
+			_ = response.Body.Close()
 			return nil, err
 		}
+
+		// If the context's deadline would elapse before the backoff completes, return
+		// the response instead of sleeping through it. The caller then sees why the
+		// request actually failed (e.g. a 429) rather than a context deadline error.
+		if deadline, ok := request.Context().Deadline(); ok && time.Until(deadline) < delay {
+			return response, nil
+		}
+
+		defer func() { _ = response.Body.Close() }()
 
 		if err := sleepWithContext(request.Context(), delay); err != nil {
 			return nil, err

--- a/seed/go-sdk/header-auth/internal/retrier_test.go
+++ b/seed/go-sdk/header-auth/internal/retrier_test.go
@@ -295,7 +295,50 @@ func TestRetryWithRequestBody(t *testing.T) {
 	assert.Equal(t, expectedBody, requestBodies[1], "Second request body should match expected (retry should re-send body)")
 }
 
+// An explicit cancel (e.g. Ctrl-C wired to cancel()) must interrupt the backoff
+// wait. There is no deadline here, so the retrier cannot know the wait is futile
+// up front -- it has to be woken by the context.
 func TestRetryWaitIsInterruptedByContext(t *testing.T) {
+	var requestCount int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		w.Header().Set("Retry-After", "5")
+		w.WriteHeader(http.StatusTooManyRequests)
+	}))
+	defer server.Close()
+
+	caller := NewCaller(&CallerParams{
+		Client: server.Client(),
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		time.Sleep(100 * time.Millisecond)
+		cancel()
+	}()
+	defer cancel()
+
+	start := time.Now()
+	_, err := caller.Call(
+		ctx,
+		&CallParams{
+			URL:         server.URL,
+			Method:      http.MethodGet,
+			Request:     &InternalTestRequest{},
+			MaxAttempts: 3,
+		},
+	)
+	elapsed := time.Since(start)
+
+	assert.ErrorIs(t, err, context.Canceled)
+	assert.Equal(t, 1, requestCount, "Expected the retry to be abandoned once the context was cancelled")
+	assert.Less(t, elapsed, time.Second, "Expected the backoff to be interrupted by the context, took %v", elapsed)
+}
+
+// When the caller's deadline would elapse before the backoff finishes, sleeping
+// only guarantees a context error. Return the response instead so the caller
+// learns why the request actually failed.
+func TestRetryReturnsResponseWhenDeadlineShorterThanBackoff(t *testing.T) {
 	var requestCount int
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		requestCount++
@@ -323,9 +366,50 @@ func TestRetryWaitIsInterruptedByContext(t *testing.T) {
 	)
 	elapsed := time.Since(start)
 
-	assert.ErrorIs(t, err, context.DeadlineExceeded)
-	assert.Equal(t, 1, requestCount, "Expected the retry to be abandoned once the context expired")
-	assert.Less(t, elapsed, time.Second, "Expected the backoff to be interrupted by the context, took %v", elapsed)
+	// The caller gets the 429, not context.DeadlineExceeded.
+	var apiError *core.APIError
+	require.ErrorAs(t, err, &apiError)
+	assert.Equal(t, http.StatusTooManyRequests, apiError.StatusCode)
+	assert.NotErrorIs(t, err, context.DeadlineExceeded)
+	assert.Equal(t, 1, requestCount, "Expected no retry once the deadline was known to be too short")
+	assert.Less(t, elapsed, time.Second, "Expected to return immediately rather than sleep, took %v", elapsed)
+}
+
+// A deadline with room for the backoff must still retry as normal.
+func TestRetryProceedsWhenDeadlineLongerThanBackoff(t *testing.T) {
+	var requestCount int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		if requestCount == 1 {
+			w.Header().Set("Retry-After", "1")
+			w.WriteHeader(http.StatusTooManyRequests)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("{}"))
+	}))
+	defer server.Close()
+
+	caller := NewCaller(&CallerParams{
+		Client: server.Client(),
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	_, err := caller.Call(
+		ctx,
+		&CallParams{
+			URL:         server.URL,
+			Method:      http.MethodGet,
+			Request:     &InternalTestRequest{},
+			Response:    &InternalTestResponse{},
+			MaxAttempts: 3,
+		},
+	)
+
+	assert.NoError(t, err)
+	assert.Equal(t, 2, requestCount, "Expected the retry to proceed when the deadline allows it")
 }
 
 func TestDisableRetries(t *testing.T) {

--- a/seed/go-sdk/http-head/internal/retrier.go
+++ b/seed/go-sdk/http-head/internal/retrier.go
@@ -145,12 +145,20 @@ func (r *Retrier) run(
 	}
 
 	if r.shouldRetry(response) {
-		defer func() { _ = response.Body.Close() }()
-
 		delay, err := r.retryDelay(response, retryAttempt)
 		if err != nil {
+			_ = response.Body.Close()
 			return nil, err
 		}
+
+		// If the context's deadline would elapse before the backoff completes, return
+		// the response instead of sleeping through it. The caller then sees why the
+		// request actually failed (e.g. a 429) rather than a context deadline error.
+		if deadline, ok := request.Context().Deadline(); ok && time.Until(deadline) < delay {
+			return response, nil
+		}
+
+		defer func() { _ = response.Body.Close() }()
 
 		if err := sleepWithContext(request.Context(), delay); err != nil {
 			return nil, err

--- a/seed/go-sdk/http-head/internal/retrier_test.go
+++ b/seed/go-sdk/http-head/internal/retrier_test.go
@@ -295,7 +295,50 @@ func TestRetryWithRequestBody(t *testing.T) {
 	assert.Equal(t, expectedBody, requestBodies[1], "Second request body should match expected (retry should re-send body)")
 }
 
+// An explicit cancel (e.g. Ctrl-C wired to cancel()) must interrupt the backoff
+// wait. There is no deadline here, so the retrier cannot know the wait is futile
+// up front -- it has to be woken by the context.
 func TestRetryWaitIsInterruptedByContext(t *testing.T) {
+	var requestCount int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		w.Header().Set("Retry-After", "5")
+		w.WriteHeader(http.StatusTooManyRequests)
+	}))
+	defer server.Close()
+
+	caller := NewCaller(&CallerParams{
+		Client: server.Client(),
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		time.Sleep(100 * time.Millisecond)
+		cancel()
+	}()
+	defer cancel()
+
+	start := time.Now()
+	_, err := caller.Call(
+		ctx,
+		&CallParams{
+			URL:         server.URL,
+			Method:      http.MethodGet,
+			Request:     &InternalTestRequest{},
+			MaxAttempts: 3,
+		},
+	)
+	elapsed := time.Since(start)
+
+	assert.ErrorIs(t, err, context.Canceled)
+	assert.Equal(t, 1, requestCount, "Expected the retry to be abandoned once the context was cancelled")
+	assert.Less(t, elapsed, time.Second, "Expected the backoff to be interrupted by the context, took %v", elapsed)
+}
+
+// When the caller's deadline would elapse before the backoff finishes, sleeping
+// only guarantees a context error. Return the response instead so the caller
+// learns why the request actually failed.
+func TestRetryReturnsResponseWhenDeadlineShorterThanBackoff(t *testing.T) {
 	var requestCount int
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		requestCount++
@@ -323,9 +366,50 @@ func TestRetryWaitIsInterruptedByContext(t *testing.T) {
 	)
 	elapsed := time.Since(start)
 
-	assert.ErrorIs(t, err, context.DeadlineExceeded)
-	assert.Equal(t, 1, requestCount, "Expected the retry to be abandoned once the context expired")
-	assert.Less(t, elapsed, time.Second, "Expected the backoff to be interrupted by the context, took %v", elapsed)
+	// The caller gets the 429, not context.DeadlineExceeded.
+	var apiError *core.APIError
+	require.ErrorAs(t, err, &apiError)
+	assert.Equal(t, http.StatusTooManyRequests, apiError.StatusCode)
+	assert.NotErrorIs(t, err, context.DeadlineExceeded)
+	assert.Equal(t, 1, requestCount, "Expected no retry once the deadline was known to be too short")
+	assert.Less(t, elapsed, time.Second, "Expected to return immediately rather than sleep, took %v", elapsed)
+}
+
+// A deadline with room for the backoff must still retry as normal.
+func TestRetryProceedsWhenDeadlineLongerThanBackoff(t *testing.T) {
+	var requestCount int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		if requestCount == 1 {
+			w.Header().Set("Retry-After", "1")
+			w.WriteHeader(http.StatusTooManyRequests)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("{}"))
+	}))
+	defer server.Close()
+
+	caller := NewCaller(&CallerParams{
+		Client: server.Client(),
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	_, err := caller.Call(
+		ctx,
+		&CallParams{
+			URL:         server.URL,
+			Method:      http.MethodGet,
+			Request:     &InternalTestRequest{},
+			Response:    &InternalTestResponse{},
+			MaxAttempts: 3,
+		},
+	)
+
+	assert.NoError(t, err)
+	assert.Equal(t, 2, requestCount, "Expected the retry to proceed when the deadline allows it")
 }
 
 func TestDisableRetries(t *testing.T) {

--- a/seed/go-sdk/idempotency-headers/auto-generate-idempotency-key/internal/retrier.go
+++ b/seed/go-sdk/idempotency-headers/auto-generate-idempotency-key/internal/retrier.go
@@ -145,12 +145,20 @@ func (r *Retrier) run(
 	}
 
 	if r.shouldRetry(response) {
-		defer func() { _ = response.Body.Close() }()
-
 		delay, err := r.retryDelay(response, retryAttempt)
 		if err != nil {
+			_ = response.Body.Close()
 			return nil, err
 		}
+
+		// If the context's deadline would elapse before the backoff completes, return
+		// the response instead of sleeping through it. The caller then sees why the
+		// request actually failed (e.g. a 429) rather than a context deadline error.
+		if deadline, ok := request.Context().Deadline(); ok && time.Until(deadline) < delay {
+			return response, nil
+		}
+
+		defer func() { _ = response.Body.Close() }()
 
 		if err := sleepWithContext(request.Context(), delay); err != nil {
 			return nil, err

--- a/seed/go-sdk/idempotency-headers/auto-generate-idempotency-key/internal/retrier_test.go
+++ b/seed/go-sdk/idempotency-headers/auto-generate-idempotency-key/internal/retrier_test.go
@@ -295,7 +295,50 @@ func TestRetryWithRequestBody(t *testing.T) {
 	assert.Equal(t, expectedBody, requestBodies[1], "Second request body should match expected (retry should re-send body)")
 }
 
+// An explicit cancel (e.g. Ctrl-C wired to cancel()) must interrupt the backoff
+// wait. There is no deadline here, so the retrier cannot know the wait is futile
+// up front -- it has to be woken by the context.
 func TestRetryWaitIsInterruptedByContext(t *testing.T) {
+	var requestCount int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		w.Header().Set("Retry-After", "5")
+		w.WriteHeader(http.StatusTooManyRequests)
+	}))
+	defer server.Close()
+
+	caller := NewCaller(&CallerParams{
+		Client: server.Client(),
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		time.Sleep(100 * time.Millisecond)
+		cancel()
+	}()
+	defer cancel()
+
+	start := time.Now()
+	_, err := caller.Call(
+		ctx,
+		&CallParams{
+			URL:         server.URL,
+			Method:      http.MethodGet,
+			Request:     &InternalTestRequest{},
+			MaxAttempts: 3,
+		},
+	)
+	elapsed := time.Since(start)
+
+	assert.ErrorIs(t, err, context.Canceled)
+	assert.Equal(t, 1, requestCount, "Expected the retry to be abandoned once the context was cancelled")
+	assert.Less(t, elapsed, time.Second, "Expected the backoff to be interrupted by the context, took %v", elapsed)
+}
+
+// When the caller's deadline would elapse before the backoff finishes, sleeping
+// only guarantees a context error. Return the response instead so the caller
+// learns why the request actually failed.
+func TestRetryReturnsResponseWhenDeadlineShorterThanBackoff(t *testing.T) {
 	var requestCount int
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		requestCount++
@@ -323,9 +366,50 @@ func TestRetryWaitIsInterruptedByContext(t *testing.T) {
 	)
 	elapsed := time.Since(start)
 
-	assert.ErrorIs(t, err, context.DeadlineExceeded)
-	assert.Equal(t, 1, requestCount, "Expected the retry to be abandoned once the context expired")
-	assert.Less(t, elapsed, time.Second, "Expected the backoff to be interrupted by the context, took %v", elapsed)
+	// The caller gets the 429, not context.DeadlineExceeded.
+	var apiError *core.APIError
+	require.ErrorAs(t, err, &apiError)
+	assert.Equal(t, http.StatusTooManyRequests, apiError.StatusCode)
+	assert.NotErrorIs(t, err, context.DeadlineExceeded)
+	assert.Equal(t, 1, requestCount, "Expected no retry once the deadline was known to be too short")
+	assert.Less(t, elapsed, time.Second, "Expected to return immediately rather than sleep, took %v", elapsed)
+}
+
+// A deadline with room for the backoff must still retry as normal.
+func TestRetryProceedsWhenDeadlineLongerThanBackoff(t *testing.T) {
+	var requestCount int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		if requestCount == 1 {
+			w.Header().Set("Retry-After", "1")
+			w.WriteHeader(http.StatusTooManyRequests)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("{}"))
+	}))
+	defer server.Close()
+
+	caller := NewCaller(&CallerParams{
+		Client: server.Client(),
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	_, err := caller.Call(
+		ctx,
+		&CallParams{
+			URL:         server.URL,
+			Method:      http.MethodGet,
+			Request:     &InternalTestRequest{},
+			Response:    &InternalTestResponse{},
+			MaxAttempts: 3,
+		},
+	)
+
+	assert.NoError(t, err)
+	assert.Equal(t, 2, requestCount, "Expected the retry to proceed when the deadline allows it")
 }
 
 func TestDisableRetries(t *testing.T) {

--- a/seed/go-sdk/idempotency-headers/internal/retrier.go
+++ b/seed/go-sdk/idempotency-headers/internal/retrier.go
@@ -145,12 +145,20 @@ func (r *Retrier) run(
 	}
 
 	if r.shouldRetry(response) {
-		defer func() { _ = response.Body.Close() }()
-
 		delay, err := r.retryDelay(response, retryAttempt)
 		if err != nil {
+			_ = response.Body.Close()
 			return nil, err
 		}
+
+		// If the context's deadline would elapse before the backoff completes, return
+		// the response instead of sleeping through it. The caller then sees why the
+		// request actually failed (e.g. a 429) rather than a context deadline error.
+		if deadline, ok := request.Context().Deadline(); ok && time.Until(deadline) < delay {
+			return response, nil
+		}
+
+		defer func() { _ = response.Body.Close() }()
 
 		if err := sleepWithContext(request.Context(), delay); err != nil {
 			return nil, err

--- a/seed/go-sdk/idempotency-headers/internal/retrier_test.go
+++ b/seed/go-sdk/idempotency-headers/internal/retrier_test.go
@@ -295,7 +295,50 @@ func TestRetryWithRequestBody(t *testing.T) {
 	assert.Equal(t, expectedBody, requestBodies[1], "Second request body should match expected (retry should re-send body)")
 }
 
+// An explicit cancel (e.g. Ctrl-C wired to cancel()) must interrupt the backoff
+// wait. There is no deadline here, so the retrier cannot know the wait is futile
+// up front -- it has to be woken by the context.
 func TestRetryWaitIsInterruptedByContext(t *testing.T) {
+	var requestCount int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		w.Header().Set("Retry-After", "5")
+		w.WriteHeader(http.StatusTooManyRequests)
+	}))
+	defer server.Close()
+
+	caller := NewCaller(&CallerParams{
+		Client: server.Client(),
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		time.Sleep(100 * time.Millisecond)
+		cancel()
+	}()
+	defer cancel()
+
+	start := time.Now()
+	_, err := caller.Call(
+		ctx,
+		&CallParams{
+			URL:         server.URL,
+			Method:      http.MethodGet,
+			Request:     &InternalTestRequest{},
+			MaxAttempts: 3,
+		},
+	)
+	elapsed := time.Since(start)
+
+	assert.ErrorIs(t, err, context.Canceled)
+	assert.Equal(t, 1, requestCount, "Expected the retry to be abandoned once the context was cancelled")
+	assert.Less(t, elapsed, time.Second, "Expected the backoff to be interrupted by the context, took %v", elapsed)
+}
+
+// When the caller's deadline would elapse before the backoff finishes, sleeping
+// only guarantees a context error. Return the response instead so the caller
+// learns why the request actually failed.
+func TestRetryReturnsResponseWhenDeadlineShorterThanBackoff(t *testing.T) {
 	var requestCount int
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		requestCount++
@@ -323,9 +366,50 @@ func TestRetryWaitIsInterruptedByContext(t *testing.T) {
 	)
 	elapsed := time.Since(start)
 
-	assert.ErrorIs(t, err, context.DeadlineExceeded)
-	assert.Equal(t, 1, requestCount, "Expected the retry to be abandoned once the context expired")
-	assert.Less(t, elapsed, time.Second, "Expected the backoff to be interrupted by the context, took %v", elapsed)
+	// The caller gets the 429, not context.DeadlineExceeded.
+	var apiError *core.APIError
+	require.ErrorAs(t, err, &apiError)
+	assert.Equal(t, http.StatusTooManyRequests, apiError.StatusCode)
+	assert.NotErrorIs(t, err, context.DeadlineExceeded)
+	assert.Equal(t, 1, requestCount, "Expected no retry once the deadline was known to be too short")
+	assert.Less(t, elapsed, time.Second, "Expected to return immediately rather than sleep, took %v", elapsed)
+}
+
+// A deadline with room for the backoff must still retry as normal.
+func TestRetryProceedsWhenDeadlineLongerThanBackoff(t *testing.T) {
+	var requestCount int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		if requestCount == 1 {
+			w.Header().Set("Retry-After", "1")
+			w.WriteHeader(http.StatusTooManyRequests)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("{}"))
+	}))
+	defer server.Close()
+
+	caller := NewCaller(&CallerParams{
+		Client: server.Client(),
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	_, err := caller.Call(
+		ctx,
+		&CallParams{
+			URL:         server.URL,
+			Method:      http.MethodGet,
+			Request:     &InternalTestRequest{},
+			Response:    &InternalTestResponse{},
+			MaxAttempts: 3,
+		},
+	)
+
+	assert.NoError(t, err)
+	assert.Equal(t, 2, requestCount, "Expected the retry to proceed when the deadline allows it")
 }
 
 func TestDisableRetries(t *testing.T) {

--- a/seed/go-sdk/imdb/allow-user-agent-app-info/internal/retrier.go
+++ b/seed/go-sdk/imdb/allow-user-agent-app-info/internal/retrier.go
@@ -145,12 +145,20 @@ func (r *Retrier) run(
 	}
 
 	if r.shouldRetry(response) {
-		defer func() { _ = response.Body.Close() }()
-
 		delay, err := r.retryDelay(response, retryAttempt)
 		if err != nil {
+			_ = response.Body.Close()
 			return nil, err
 		}
+
+		// If the context's deadline would elapse before the backoff completes, return
+		// the response instead of sleeping through it. The caller then sees why the
+		// request actually failed (e.g. a 429) rather than a context deadline error.
+		if deadline, ok := request.Context().Deadline(); ok && time.Until(deadline) < delay {
+			return response, nil
+		}
+
+		defer func() { _ = response.Body.Close() }()
 
 		if err := sleepWithContext(request.Context(), delay); err != nil {
 			return nil, err

--- a/seed/go-sdk/imdb/allow-user-agent-app-info/internal/retrier_test.go
+++ b/seed/go-sdk/imdb/allow-user-agent-app-info/internal/retrier_test.go
@@ -295,7 +295,50 @@ func TestRetryWithRequestBody(t *testing.T) {
 	assert.Equal(t, expectedBody, requestBodies[1], "Second request body should match expected (retry should re-send body)")
 }
 
+// An explicit cancel (e.g. Ctrl-C wired to cancel()) must interrupt the backoff
+// wait. There is no deadline here, so the retrier cannot know the wait is futile
+// up front -- it has to be woken by the context.
 func TestRetryWaitIsInterruptedByContext(t *testing.T) {
+	var requestCount int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		w.Header().Set("Retry-After", "5")
+		w.WriteHeader(http.StatusTooManyRequests)
+	}))
+	defer server.Close()
+
+	caller := NewCaller(&CallerParams{
+		Client: server.Client(),
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		time.Sleep(100 * time.Millisecond)
+		cancel()
+	}()
+	defer cancel()
+
+	start := time.Now()
+	_, err := caller.Call(
+		ctx,
+		&CallParams{
+			URL:         server.URL,
+			Method:      http.MethodGet,
+			Request:     &InternalTestRequest{},
+			MaxAttempts: 3,
+		},
+	)
+	elapsed := time.Since(start)
+
+	assert.ErrorIs(t, err, context.Canceled)
+	assert.Equal(t, 1, requestCount, "Expected the retry to be abandoned once the context was cancelled")
+	assert.Less(t, elapsed, time.Second, "Expected the backoff to be interrupted by the context, took %v", elapsed)
+}
+
+// When the caller's deadline would elapse before the backoff finishes, sleeping
+// only guarantees a context error. Return the response instead so the caller
+// learns why the request actually failed.
+func TestRetryReturnsResponseWhenDeadlineShorterThanBackoff(t *testing.T) {
 	var requestCount int
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		requestCount++
@@ -323,9 +366,50 @@ func TestRetryWaitIsInterruptedByContext(t *testing.T) {
 	)
 	elapsed := time.Since(start)
 
-	assert.ErrorIs(t, err, context.DeadlineExceeded)
-	assert.Equal(t, 1, requestCount, "Expected the retry to be abandoned once the context expired")
-	assert.Less(t, elapsed, time.Second, "Expected the backoff to be interrupted by the context, took %v", elapsed)
+	// The caller gets the 429, not context.DeadlineExceeded.
+	var apiError *core.APIError
+	require.ErrorAs(t, err, &apiError)
+	assert.Equal(t, http.StatusTooManyRequests, apiError.StatusCode)
+	assert.NotErrorIs(t, err, context.DeadlineExceeded)
+	assert.Equal(t, 1, requestCount, "Expected no retry once the deadline was known to be too short")
+	assert.Less(t, elapsed, time.Second, "Expected to return immediately rather than sleep, took %v", elapsed)
+}
+
+// A deadline with room for the backoff must still retry as normal.
+func TestRetryProceedsWhenDeadlineLongerThanBackoff(t *testing.T) {
+	var requestCount int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		if requestCount == 1 {
+			w.Header().Set("Retry-After", "1")
+			w.WriteHeader(http.StatusTooManyRequests)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("{}"))
+	}))
+	defer server.Close()
+
+	caller := NewCaller(&CallerParams{
+		Client: server.Client(),
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	_, err := caller.Call(
+		ctx,
+		&CallParams{
+			URL:         server.URL,
+			Method:      http.MethodGet,
+			Request:     &InternalTestRequest{},
+			Response:    &InternalTestResponse{},
+			MaxAttempts: 3,
+		},
+	)
+
+	assert.NoError(t, err)
+	assert.Equal(t, 2, requestCount, "Expected the retry to proceed when the deadline allows it")
 }
 
 func TestDisableRetries(t *testing.T) {

--- a/seed/go-sdk/imdb/deep-package-path/all/the/way/in/here/please/internal/retrier.go
+++ b/seed/go-sdk/imdb/deep-package-path/all/the/way/in/here/please/internal/retrier.go
@@ -145,12 +145,20 @@ func (r *Retrier) run(
 	}
 
 	if r.shouldRetry(response) {
-		defer func() { _ = response.Body.Close() }()
-
 		delay, err := r.retryDelay(response, retryAttempt)
 		if err != nil {
+			_ = response.Body.Close()
 			return nil, err
 		}
+
+		// If the context's deadline would elapse before the backoff completes, return
+		// the response instead of sleeping through it. The caller then sees why the
+		// request actually failed (e.g. a 429) rather than a context deadline error.
+		if deadline, ok := request.Context().Deadline(); ok && time.Until(deadline) < delay {
+			return response, nil
+		}
+
+		defer func() { _ = response.Body.Close() }()
 
 		if err := sleepWithContext(request.Context(), delay); err != nil {
 			return nil, err

--- a/seed/go-sdk/imdb/deep-package-path/all/the/way/in/here/please/internal/retrier_test.go
+++ b/seed/go-sdk/imdb/deep-package-path/all/the/way/in/here/please/internal/retrier_test.go
@@ -295,7 +295,50 @@ func TestRetryWithRequestBody(t *testing.T) {
 	assert.Equal(t, expectedBody, requestBodies[1], "Second request body should match expected (retry should re-send body)")
 }
 
+// An explicit cancel (e.g. Ctrl-C wired to cancel()) must interrupt the backoff
+// wait. There is no deadline here, so the retrier cannot know the wait is futile
+// up front -- it has to be woken by the context.
 func TestRetryWaitIsInterruptedByContext(t *testing.T) {
+	var requestCount int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		w.Header().Set("Retry-After", "5")
+		w.WriteHeader(http.StatusTooManyRequests)
+	}))
+	defer server.Close()
+
+	caller := NewCaller(&CallerParams{
+		Client: server.Client(),
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		time.Sleep(100 * time.Millisecond)
+		cancel()
+	}()
+	defer cancel()
+
+	start := time.Now()
+	_, err := caller.Call(
+		ctx,
+		&CallParams{
+			URL:         server.URL,
+			Method:      http.MethodGet,
+			Request:     &InternalTestRequest{},
+			MaxAttempts: 3,
+		},
+	)
+	elapsed := time.Since(start)
+
+	assert.ErrorIs(t, err, context.Canceled)
+	assert.Equal(t, 1, requestCount, "Expected the retry to be abandoned once the context was cancelled")
+	assert.Less(t, elapsed, time.Second, "Expected the backoff to be interrupted by the context, took %v", elapsed)
+}
+
+// When the caller's deadline would elapse before the backoff finishes, sleeping
+// only guarantees a context error. Return the response instead so the caller
+// learns why the request actually failed.
+func TestRetryReturnsResponseWhenDeadlineShorterThanBackoff(t *testing.T) {
 	var requestCount int
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		requestCount++
@@ -323,9 +366,50 @@ func TestRetryWaitIsInterruptedByContext(t *testing.T) {
 	)
 	elapsed := time.Since(start)
 
-	assert.ErrorIs(t, err, context.DeadlineExceeded)
-	assert.Equal(t, 1, requestCount, "Expected the retry to be abandoned once the context expired")
-	assert.Less(t, elapsed, time.Second, "Expected the backoff to be interrupted by the context, took %v", elapsed)
+	// The caller gets the 429, not context.DeadlineExceeded.
+	var apiError *core.APIError
+	require.ErrorAs(t, err, &apiError)
+	assert.Equal(t, http.StatusTooManyRequests, apiError.StatusCode)
+	assert.NotErrorIs(t, err, context.DeadlineExceeded)
+	assert.Equal(t, 1, requestCount, "Expected no retry once the deadline was known to be too short")
+	assert.Less(t, elapsed, time.Second, "Expected to return immediately rather than sleep, took %v", elapsed)
+}
+
+// A deadline with room for the backoff must still retry as normal.
+func TestRetryProceedsWhenDeadlineLongerThanBackoff(t *testing.T) {
+	var requestCount int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		if requestCount == 1 {
+			w.Header().Set("Retry-After", "1")
+			w.WriteHeader(http.StatusTooManyRequests)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("{}"))
+	}))
+	defer server.Close()
+
+	caller := NewCaller(&CallerParams{
+		Client: server.Client(),
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	_, err := caller.Call(
+		ctx,
+		&CallParams{
+			URL:         server.URL,
+			Method:      http.MethodGet,
+			Request:     &InternalTestRequest{},
+			Response:    &InternalTestResponse{},
+			MaxAttempts: 3,
+		},
+	)
+
+	assert.NoError(t, err)
+	assert.Equal(t, 2, requestCount, "Expected the retry to proceed when the deadline allows it")
 }
 
 func TestDisableRetries(t *testing.T) {

--- a/seed/go-sdk/imdb/include-platform-headers-app-info/internal/retrier.go
+++ b/seed/go-sdk/imdb/include-platform-headers-app-info/internal/retrier.go
@@ -145,12 +145,20 @@ func (r *Retrier) run(
 	}
 
 	if r.shouldRetry(response) {
-		defer func() { _ = response.Body.Close() }()
-
 		delay, err := r.retryDelay(response, retryAttempt)
 		if err != nil {
+			_ = response.Body.Close()
 			return nil, err
 		}
+
+		// If the context's deadline would elapse before the backoff completes, return
+		// the response instead of sleeping through it. The caller then sees why the
+		// request actually failed (e.g. a 429) rather than a context deadline error.
+		if deadline, ok := request.Context().Deadline(); ok && time.Until(deadline) < delay {
+			return response, nil
+		}
+
+		defer func() { _ = response.Body.Close() }()
 
 		if err := sleepWithContext(request.Context(), delay); err != nil {
 			return nil, err

--- a/seed/go-sdk/imdb/include-platform-headers-app-info/internal/retrier_test.go
+++ b/seed/go-sdk/imdb/include-platform-headers-app-info/internal/retrier_test.go
@@ -295,7 +295,50 @@ func TestRetryWithRequestBody(t *testing.T) {
 	assert.Equal(t, expectedBody, requestBodies[1], "Second request body should match expected (retry should re-send body)")
 }
 
+// An explicit cancel (e.g. Ctrl-C wired to cancel()) must interrupt the backoff
+// wait. There is no deadline here, so the retrier cannot know the wait is futile
+// up front -- it has to be woken by the context.
 func TestRetryWaitIsInterruptedByContext(t *testing.T) {
+	var requestCount int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		w.Header().Set("Retry-After", "5")
+		w.WriteHeader(http.StatusTooManyRequests)
+	}))
+	defer server.Close()
+
+	caller := NewCaller(&CallerParams{
+		Client: server.Client(),
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		time.Sleep(100 * time.Millisecond)
+		cancel()
+	}()
+	defer cancel()
+
+	start := time.Now()
+	_, err := caller.Call(
+		ctx,
+		&CallParams{
+			URL:         server.URL,
+			Method:      http.MethodGet,
+			Request:     &InternalTestRequest{},
+			MaxAttempts: 3,
+		},
+	)
+	elapsed := time.Since(start)
+
+	assert.ErrorIs(t, err, context.Canceled)
+	assert.Equal(t, 1, requestCount, "Expected the retry to be abandoned once the context was cancelled")
+	assert.Less(t, elapsed, time.Second, "Expected the backoff to be interrupted by the context, took %v", elapsed)
+}
+
+// When the caller's deadline would elapse before the backoff finishes, sleeping
+// only guarantees a context error. Return the response instead so the caller
+// learns why the request actually failed.
+func TestRetryReturnsResponseWhenDeadlineShorterThanBackoff(t *testing.T) {
 	var requestCount int
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		requestCount++
@@ -323,9 +366,50 @@ func TestRetryWaitIsInterruptedByContext(t *testing.T) {
 	)
 	elapsed := time.Since(start)
 
-	assert.ErrorIs(t, err, context.DeadlineExceeded)
-	assert.Equal(t, 1, requestCount, "Expected the retry to be abandoned once the context expired")
-	assert.Less(t, elapsed, time.Second, "Expected the backoff to be interrupted by the context, took %v", elapsed)
+	// The caller gets the 429, not context.DeadlineExceeded.
+	var apiError *core.APIError
+	require.ErrorAs(t, err, &apiError)
+	assert.Equal(t, http.StatusTooManyRequests, apiError.StatusCode)
+	assert.NotErrorIs(t, err, context.DeadlineExceeded)
+	assert.Equal(t, 1, requestCount, "Expected no retry once the deadline was known to be too short")
+	assert.Less(t, elapsed, time.Second, "Expected to return immediately rather than sleep, took %v", elapsed)
+}
+
+// A deadline with room for the backoff must still retry as normal.
+func TestRetryProceedsWhenDeadlineLongerThanBackoff(t *testing.T) {
+	var requestCount int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		if requestCount == 1 {
+			w.Header().Set("Retry-After", "1")
+			w.WriteHeader(http.StatusTooManyRequests)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("{}"))
+	}))
+	defer server.Close()
+
+	caller := NewCaller(&CallerParams{
+		Client: server.Client(),
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	_, err := caller.Call(
+		ctx,
+		&CallParams{
+			URL:         server.URL,
+			Method:      http.MethodGet,
+			Request:     &InternalTestRequest{},
+			Response:    &InternalTestResponse{},
+			MaxAttempts: 3,
+		},
+	)
+
+	assert.NoError(t, err)
+	assert.Equal(t, 2, requestCount, "Expected the retry to proceed when the deadline allows it")
 }
 
 func TestDisableRetries(t *testing.T) {

--- a/seed/go-sdk/imdb/include-platform-headers/internal/retrier.go
+++ b/seed/go-sdk/imdb/include-platform-headers/internal/retrier.go
@@ -145,12 +145,20 @@ func (r *Retrier) run(
 	}
 
 	if r.shouldRetry(response) {
-		defer func() { _ = response.Body.Close() }()
-
 		delay, err := r.retryDelay(response, retryAttempt)
 		if err != nil {
+			_ = response.Body.Close()
 			return nil, err
 		}
+
+		// If the context's deadline would elapse before the backoff completes, return
+		// the response instead of sleeping through it. The caller then sees why the
+		// request actually failed (e.g. a 429) rather than a context deadline error.
+		if deadline, ok := request.Context().Deadline(); ok && time.Until(deadline) < delay {
+			return response, nil
+		}
+
+		defer func() { _ = response.Body.Close() }()
 
 		if err := sleepWithContext(request.Context(), delay); err != nil {
 			return nil, err

--- a/seed/go-sdk/imdb/include-platform-headers/internal/retrier_test.go
+++ b/seed/go-sdk/imdb/include-platform-headers/internal/retrier_test.go
@@ -295,7 +295,50 @@ func TestRetryWithRequestBody(t *testing.T) {
 	assert.Equal(t, expectedBody, requestBodies[1], "Second request body should match expected (retry should re-send body)")
 }
 
+// An explicit cancel (e.g. Ctrl-C wired to cancel()) must interrupt the backoff
+// wait. There is no deadline here, so the retrier cannot know the wait is futile
+// up front -- it has to be woken by the context.
 func TestRetryWaitIsInterruptedByContext(t *testing.T) {
+	var requestCount int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		w.Header().Set("Retry-After", "5")
+		w.WriteHeader(http.StatusTooManyRequests)
+	}))
+	defer server.Close()
+
+	caller := NewCaller(&CallerParams{
+		Client: server.Client(),
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		time.Sleep(100 * time.Millisecond)
+		cancel()
+	}()
+	defer cancel()
+
+	start := time.Now()
+	_, err := caller.Call(
+		ctx,
+		&CallParams{
+			URL:         server.URL,
+			Method:      http.MethodGet,
+			Request:     &InternalTestRequest{},
+			MaxAttempts: 3,
+		},
+	)
+	elapsed := time.Since(start)
+
+	assert.ErrorIs(t, err, context.Canceled)
+	assert.Equal(t, 1, requestCount, "Expected the retry to be abandoned once the context was cancelled")
+	assert.Less(t, elapsed, time.Second, "Expected the backoff to be interrupted by the context, took %v", elapsed)
+}
+
+// When the caller's deadline would elapse before the backoff finishes, sleeping
+// only guarantees a context error. Return the response instead so the caller
+// learns why the request actually failed.
+func TestRetryReturnsResponseWhenDeadlineShorterThanBackoff(t *testing.T) {
 	var requestCount int
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		requestCount++
@@ -323,9 +366,50 @@ func TestRetryWaitIsInterruptedByContext(t *testing.T) {
 	)
 	elapsed := time.Since(start)
 
-	assert.ErrorIs(t, err, context.DeadlineExceeded)
-	assert.Equal(t, 1, requestCount, "Expected the retry to be abandoned once the context expired")
-	assert.Less(t, elapsed, time.Second, "Expected the backoff to be interrupted by the context, took %v", elapsed)
+	// The caller gets the 429, not context.DeadlineExceeded.
+	var apiError *core.APIError
+	require.ErrorAs(t, err, &apiError)
+	assert.Equal(t, http.StatusTooManyRequests, apiError.StatusCode)
+	assert.NotErrorIs(t, err, context.DeadlineExceeded)
+	assert.Equal(t, 1, requestCount, "Expected no retry once the deadline was known to be too short")
+	assert.Less(t, elapsed, time.Second, "Expected to return immediately rather than sleep, took %v", elapsed)
+}
+
+// A deadline with room for the backoff must still retry as normal.
+func TestRetryProceedsWhenDeadlineLongerThanBackoff(t *testing.T) {
+	var requestCount int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		if requestCount == 1 {
+			w.Header().Set("Retry-After", "1")
+			w.WriteHeader(http.StatusTooManyRequests)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("{}"))
+	}))
+	defer server.Close()
+
+	caller := NewCaller(&CallerParams{
+		Client: server.Client(),
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	_, err := caller.Call(
+		ctx,
+		&CallParams{
+			URL:         server.URL,
+			Method:      http.MethodGet,
+			Request:     &InternalTestRequest{},
+			Response:    &InternalTestResponse{},
+			MaxAttempts: 3,
+		},
+	)
+
+	assert.NoError(t, err)
+	assert.Equal(t, 2, requestCount, "Expected the retry to proceed when the deadline allows it")
 }
 
 func TestDisableRetries(t *testing.T) {

--- a/seed/go-sdk/imdb/no-custom-config/internal/retrier.go
+++ b/seed/go-sdk/imdb/no-custom-config/internal/retrier.go
@@ -145,12 +145,20 @@ func (r *Retrier) run(
 	}
 
 	if r.shouldRetry(response) {
-		defer func() { _ = response.Body.Close() }()
-
 		delay, err := r.retryDelay(response, retryAttempt)
 		if err != nil {
+			_ = response.Body.Close()
 			return nil, err
 		}
+
+		// If the context's deadline would elapse before the backoff completes, return
+		// the response instead of sleeping through it. The caller then sees why the
+		// request actually failed (e.g. a 429) rather than a context deadline error.
+		if deadline, ok := request.Context().Deadline(); ok && time.Until(deadline) < delay {
+			return response, nil
+		}
+
+		defer func() { _ = response.Body.Close() }()
 
 		if err := sleepWithContext(request.Context(), delay); err != nil {
 			return nil, err

--- a/seed/go-sdk/imdb/no-custom-config/internal/retrier_test.go
+++ b/seed/go-sdk/imdb/no-custom-config/internal/retrier_test.go
@@ -295,7 +295,50 @@ func TestRetryWithRequestBody(t *testing.T) {
 	assert.Equal(t, expectedBody, requestBodies[1], "Second request body should match expected (retry should re-send body)")
 }
 
+// An explicit cancel (e.g. Ctrl-C wired to cancel()) must interrupt the backoff
+// wait. There is no deadline here, so the retrier cannot know the wait is futile
+// up front -- it has to be woken by the context.
 func TestRetryWaitIsInterruptedByContext(t *testing.T) {
+	var requestCount int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		w.Header().Set("Retry-After", "5")
+		w.WriteHeader(http.StatusTooManyRequests)
+	}))
+	defer server.Close()
+
+	caller := NewCaller(&CallerParams{
+		Client: server.Client(),
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		time.Sleep(100 * time.Millisecond)
+		cancel()
+	}()
+	defer cancel()
+
+	start := time.Now()
+	_, err := caller.Call(
+		ctx,
+		&CallParams{
+			URL:         server.URL,
+			Method:      http.MethodGet,
+			Request:     &InternalTestRequest{},
+			MaxAttempts: 3,
+		},
+	)
+	elapsed := time.Since(start)
+
+	assert.ErrorIs(t, err, context.Canceled)
+	assert.Equal(t, 1, requestCount, "Expected the retry to be abandoned once the context was cancelled")
+	assert.Less(t, elapsed, time.Second, "Expected the backoff to be interrupted by the context, took %v", elapsed)
+}
+
+// When the caller's deadline would elapse before the backoff finishes, sleeping
+// only guarantees a context error. Return the response instead so the caller
+// learns why the request actually failed.
+func TestRetryReturnsResponseWhenDeadlineShorterThanBackoff(t *testing.T) {
 	var requestCount int
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		requestCount++
@@ -323,9 +366,50 @@ func TestRetryWaitIsInterruptedByContext(t *testing.T) {
 	)
 	elapsed := time.Since(start)
 
-	assert.ErrorIs(t, err, context.DeadlineExceeded)
-	assert.Equal(t, 1, requestCount, "Expected the retry to be abandoned once the context expired")
-	assert.Less(t, elapsed, time.Second, "Expected the backoff to be interrupted by the context, took %v", elapsed)
+	// The caller gets the 429, not context.DeadlineExceeded.
+	var apiError *core.APIError
+	require.ErrorAs(t, err, &apiError)
+	assert.Equal(t, http.StatusTooManyRequests, apiError.StatusCode)
+	assert.NotErrorIs(t, err, context.DeadlineExceeded)
+	assert.Equal(t, 1, requestCount, "Expected no retry once the deadline was known to be too short")
+	assert.Less(t, elapsed, time.Second, "Expected to return immediately rather than sleep, took %v", elapsed)
+}
+
+// A deadline with room for the backoff must still retry as normal.
+func TestRetryProceedsWhenDeadlineLongerThanBackoff(t *testing.T) {
+	var requestCount int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		if requestCount == 1 {
+			w.Header().Set("Retry-After", "1")
+			w.WriteHeader(http.StatusTooManyRequests)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("{}"))
+	}))
+	defer server.Close()
+
+	caller := NewCaller(&CallerParams{
+		Client: server.Client(),
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	_, err := caller.Call(
+		ctx,
+		&CallParams{
+			URL:         server.URL,
+			Method:      http.MethodGet,
+			Request:     &InternalTestRequest{},
+			Response:    &InternalTestResponse{},
+			MaxAttempts: 3,
+		},
+	)
+
+	assert.NoError(t, err)
+	assert.Equal(t, 2, requestCount, "Expected the retry to proceed when the deadline allows it")
 }
 
 func TestDisableRetries(t *testing.T) {

--- a/seed/go-sdk/imdb/omit-fern-headers/internal/retrier.go
+++ b/seed/go-sdk/imdb/omit-fern-headers/internal/retrier.go
@@ -145,12 +145,20 @@ func (r *Retrier) run(
 	}
 
 	if r.shouldRetry(response) {
-		defer func() { _ = response.Body.Close() }()
-
 		delay, err := r.retryDelay(response, retryAttempt)
 		if err != nil {
+			_ = response.Body.Close()
 			return nil, err
 		}
+
+		// If the context's deadline would elapse before the backoff completes, return
+		// the response instead of sleeping through it. The caller then sees why the
+		// request actually failed (e.g. a 429) rather than a context deadline error.
+		if deadline, ok := request.Context().Deadline(); ok && time.Until(deadline) < delay {
+			return response, nil
+		}
+
+		defer func() { _ = response.Body.Close() }()
 
 		if err := sleepWithContext(request.Context(), delay); err != nil {
 			return nil, err

--- a/seed/go-sdk/imdb/omit-fern-headers/internal/retrier_test.go
+++ b/seed/go-sdk/imdb/omit-fern-headers/internal/retrier_test.go
@@ -295,7 +295,50 @@ func TestRetryWithRequestBody(t *testing.T) {
 	assert.Equal(t, expectedBody, requestBodies[1], "Second request body should match expected (retry should re-send body)")
 }
 
+// An explicit cancel (e.g. Ctrl-C wired to cancel()) must interrupt the backoff
+// wait. There is no deadline here, so the retrier cannot know the wait is futile
+// up front -- it has to be woken by the context.
 func TestRetryWaitIsInterruptedByContext(t *testing.T) {
+	var requestCount int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		w.Header().Set("Retry-After", "5")
+		w.WriteHeader(http.StatusTooManyRequests)
+	}))
+	defer server.Close()
+
+	caller := NewCaller(&CallerParams{
+		Client: server.Client(),
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		time.Sleep(100 * time.Millisecond)
+		cancel()
+	}()
+	defer cancel()
+
+	start := time.Now()
+	_, err := caller.Call(
+		ctx,
+		&CallParams{
+			URL:         server.URL,
+			Method:      http.MethodGet,
+			Request:     &InternalTestRequest{},
+			MaxAttempts: 3,
+		},
+	)
+	elapsed := time.Since(start)
+
+	assert.ErrorIs(t, err, context.Canceled)
+	assert.Equal(t, 1, requestCount, "Expected the retry to be abandoned once the context was cancelled")
+	assert.Less(t, elapsed, time.Second, "Expected the backoff to be interrupted by the context, took %v", elapsed)
+}
+
+// When the caller's deadline would elapse before the backoff finishes, sleeping
+// only guarantees a context error. Return the response instead so the caller
+// learns why the request actually failed.
+func TestRetryReturnsResponseWhenDeadlineShorterThanBackoff(t *testing.T) {
 	var requestCount int
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		requestCount++
@@ -323,9 +366,50 @@ func TestRetryWaitIsInterruptedByContext(t *testing.T) {
 	)
 	elapsed := time.Since(start)
 
-	assert.ErrorIs(t, err, context.DeadlineExceeded)
-	assert.Equal(t, 1, requestCount, "Expected the retry to be abandoned once the context expired")
-	assert.Less(t, elapsed, time.Second, "Expected the backoff to be interrupted by the context, took %v", elapsed)
+	// The caller gets the 429, not context.DeadlineExceeded.
+	var apiError *core.APIError
+	require.ErrorAs(t, err, &apiError)
+	assert.Equal(t, http.StatusTooManyRequests, apiError.StatusCode)
+	assert.NotErrorIs(t, err, context.DeadlineExceeded)
+	assert.Equal(t, 1, requestCount, "Expected no retry once the deadline was known to be too short")
+	assert.Less(t, elapsed, time.Second, "Expected to return immediately rather than sleep, took %v", elapsed)
+}
+
+// A deadline with room for the backoff must still retry as normal.
+func TestRetryProceedsWhenDeadlineLongerThanBackoff(t *testing.T) {
+	var requestCount int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		if requestCount == 1 {
+			w.Header().Set("Retry-After", "1")
+			w.WriteHeader(http.StatusTooManyRequests)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("{}"))
+	}))
+	defer server.Close()
+
+	caller := NewCaller(&CallerParams{
+		Client: server.Client(),
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	_, err := caller.Call(
+		ctx,
+		&CallParams{
+			URL:         server.URL,
+			Method:      http.MethodGet,
+			Request:     &InternalTestRequest{},
+			Response:    &InternalTestResponse{},
+			MaxAttempts: 3,
+		},
+	)
+
+	assert.NoError(t, err)
+	assert.Equal(t, 2, requestCount, "Expected the retry to proceed when the deadline allows it")
 }
 
 func TestDisableRetries(t *testing.T) {

--- a/seed/go-sdk/imdb/package-path/inhereplease/internal/retrier.go
+++ b/seed/go-sdk/imdb/package-path/inhereplease/internal/retrier.go
@@ -145,12 +145,20 @@ func (r *Retrier) run(
 	}
 
 	if r.shouldRetry(response) {
-		defer func() { _ = response.Body.Close() }()
-
 		delay, err := r.retryDelay(response, retryAttempt)
 		if err != nil {
+			_ = response.Body.Close()
 			return nil, err
 		}
+
+		// If the context's deadline would elapse before the backoff completes, return
+		// the response instead of sleeping through it. The caller then sees why the
+		// request actually failed (e.g. a 429) rather than a context deadline error.
+		if deadline, ok := request.Context().Deadline(); ok && time.Until(deadline) < delay {
+			return response, nil
+		}
+
+		defer func() { _ = response.Body.Close() }()
 
 		if err := sleepWithContext(request.Context(), delay); err != nil {
 			return nil, err

--- a/seed/go-sdk/imdb/package-path/inhereplease/internal/retrier_test.go
+++ b/seed/go-sdk/imdb/package-path/inhereplease/internal/retrier_test.go
@@ -295,7 +295,50 @@ func TestRetryWithRequestBody(t *testing.T) {
 	assert.Equal(t, expectedBody, requestBodies[1], "Second request body should match expected (retry should re-send body)")
 }
 
+// An explicit cancel (e.g. Ctrl-C wired to cancel()) must interrupt the backoff
+// wait. There is no deadline here, so the retrier cannot know the wait is futile
+// up front -- it has to be woken by the context.
 func TestRetryWaitIsInterruptedByContext(t *testing.T) {
+	var requestCount int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		w.Header().Set("Retry-After", "5")
+		w.WriteHeader(http.StatusTooManyRequests)
+	}))
+	defer server.Close()
+
+	caller := NewCaller(&CallerParams{
+		Client: server.Client(),
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		time.Sleep(100 * time.Millisecond)
+		cancel()
+	}()
+	defer cancel()
+
+	start := time.Now()
+	_, err := caller.Call(
+		ctx,
+		&CallParams{
+			URL:         server.URL,
+			Method:      http.MethodGet,
+			Request:     &InternalTestRequest{},
+			MaxAttempts: 3,
+		},
+	)
+	elapsed := time.Since(start)
+
+	assert.ErrorIs(t, err, context.Canceled)
+	assert.Equal(t, 1, requestCount, "Expected the retry to be abandoned once the context was cancelled")
+	assert.Less(t, elapsed, time.Second, "Expected the backoff to be interrupted by the context, took %v", elapsed)
+}
+
+// When the caller's deadline would elapse before the backoff finishes, sleeping
+// only guarantees a context error. Return the response instead so the caller
+// learns why the request actually failed.
+func TestRetryReturnsResponseWhenDeadlineShorterThanBackoff(t *testing.T) {
 	var requestCount int
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		requestCount++
@@ -323,9 +366,50 @@ func TestRetryWaitIsInterruptedByContext(t *testing.T) {
 	)
 	elapsed := time.Since(start)
 
-	assert.ErrorIs(t, err, context.DeadlineExceeded)
-	assert.Equal(t, 1, requestCount, "Expected the retry to be abandoned once the context expired")
-	assert.Less(t, elapsed, time.Second, "Expected the backoff to be interrupted by the context, took %v", elapsed)
+	// The caller gets the 429, not context.DeadlineExceeded.
+	var apiError *core.APIError
+	require.ErrorAs(t, err, &apiError)
+	assert.Equal(t, http.StatusTooManyRequests, apiError.StatusCode)
+	assert.NotErrorIs(t, err, context.DeadlineExceeded)
+	assert.Equal(t, 1, requestCount, "Expected no retry once the deadline was known to be too short")
+	assert.Less(t, elapsed, time.Second, "Expected to return immediately rather than sleep, took %v", elapsed)
+}
+
+// A deadline with room for the backoff must still retry as normal.
+func TestRetryProceedsWhenDeadlineLongerThanBackoff(t *testing.T) {
+	var requestCount int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		if requestCount == 1 {
+			w.Header().Set("Retry-After", "1")
+			w.WriteHeader(http.StatusTooManyRequests)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("{}"))
+	}))
+	defer server.Close()
+
+	caller := NewCaller(&CallerParams{
+		Client: server.Client(),
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	_, err := caller.Call(
+		ctx,
+		&CallParams{
+			URL:         server.URL,
+			Method:      http.MethodGet,
+			Request:     &InternalTestRequest{},
+			Response:    &InternalTestResponse{},
+			MaxAttempts: 3,
+		},
+	)
+
+	assert.NoError(t, err)
+	assert.Equal(t, 2, requestCount, "Expected the retry to proceed when the deadline allows it")
 }
 
 func TestDisableRetries(t *testing.T) {

--- a/seed/go-sdk/imdb/with-wiremock-tests/internal/retrier.go
+++ b/seed/go-sdk/imdb/with-wiremock-tests/internal/retrier.go
@@ -145,12 +145,20 @@ func (r *Retrier) run(
 	}
 
 	if r.shouldRetry(response) {
-		defer func() { _ = response.Body.Close() }()
-
 		delay, err := r.retryDelay(response, retryAttempt)
 		if err != nil {
+			_ = response.Body.Close()
 			return nil, err
 		}
+
+		// If the context's deadline would elapse before the backoff completes, return
+		// the response instead of sleeping through it. The caller then sees why the
+		// request actually failed (e.g. a 429) rather than a context deadline error.
+		if deadline, ok := request.Context().Deadline(); ok && time.Until(deadline) < delay {
+			return response, nil
+		}
+
+		defer func() { _ = response.Body.Close() }()
 
 		if err := sleepWithContext(request.Context(), delay); err != nil {
 			return nil, err

--- a/seed/go-sdk/imdb/with-wiremock-tests/internal/retrier_test.go
+++ b/seed/go-sdk/imdb/with-wiremock-tests/internal/retrier_test.go
@@ -295,7 +295,50 @@ func TestRetryWithRequestBody(t *testing.T) {
 	assert.Equal(t, expectedBody, requestBodies[1], "Second request body should match expected (retry should re-send body)")
 }
 
+// An explicit cancel (e.g. Ctrl-C wired to cancel()) must interrupt the backoff
+// wait. There is no deadline here, so the retrier cannot know the wait is futile
+// up front -- it has to be woken by the context.
 func TestRetryWaitIsInterruptedByContext(t *testing.T) {
+	var requestCount int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		w.Header().Set("Retry-After", "5")
+		w.WriteHeader(http.StatusTooManyRequests)
+	}))
+	defer server.Close()
+
+	caller := NewCaller(&CallerParams{
+		Client: server.Client(),
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		time.Sleep(100 * time.Millisecond)
+		cancel()
+	}()
+	defer cancel()
+
+	start := time.Now()
+	_, err := caller.Call(
+		ctx,
+		&CallParams{
+			URL:         server.URL,
+			Method:      http.MethodGet,
+			Request:     &InternalTestRequest{},
+			MaxAttempts: 3,
+		},
+	)
+	elapsed := time.Since(start)
+
+	assert.ErrorIs(t, err, context.Canceled)
+	assert.Equal(t, 1, requestCount, "Expected the retry to be abandoned once the context was cancelled")
+	assert.Less(t, elapsed, time.Second, "Expected the backoff to be interrupted by the context, took %v", elapsed)
+}
+
+// When the caller's deadline would elapse before the backoff finishes, sleeping
+// only guarantees a context error. Return the response instead so the caller
+// learns why the request actually failed.
+func TestRetryReturnsResponseWhenDeadlineShorterThanBackoff(t *testing.T) {
 	var requestCount int
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		requestCount++
@@ -323,9 +366,50 @@ func TestRetryWaitIsInterruptedByContext(t *testing.T) {
 	)
 	elapsed := time.Since(start)
 
-	assert.ErrorIs(t, err, context.DeadlineExceeded)
-	assert.Equal(t, 1, requestCount, "Expected the retry to be abandoned once the context expired")
-	assert.Less(t, elapsed, time.Second, "Expected the backoff to be interrupted by the context, took %v", elapsed)
+	// The caller gets the 429, not context.DeadlineExceeded.
+	var apiError *core.APIError
+	require.ErrorAs(t, err, &apiError)
+	assert.Equal(t, http.StatusTooManyRequests, apiError.StatusCode)
+	assert.NotErrorIs(t, err, context.DeadlineExceeded)
+	assert.Equal(t, 1, requestCount, "Expected no retry once the deadline was known to be too short")
+	assert.Less(t, elapsed, time.Second, "Expected to return immediately rather than sleep, took %v", elapsed)
+}
+
+// A deadline with room for the backoff must still retry as normal.
+func TestRetryProceedsWhenDeadlineLongerThanBackoff(t *testing.T) {
+	var requestCount int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		if requestCount == 1 {
+			w.Header().Set("Retry-After", "1")
+			w.WriteHeader(http.StatusTooManyRequests)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("{}"))
+	}))
+	defer server.Close()
+
+	caller := NewCaller(&CallerParams{
+		Client: server.Client(),
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	_, err := caller.Call(
+		ctx,
+		&CallParams{
+			URL:         server.URL,
+			Method:      http.MethodGet,
+			Request:     &InternalTestRequest{},
+			Response:    &InternalTestResponse{},
+			MaxAttempts: 3,
+		},
+	)
+
+	assert.NoError(t, err)
+	assert.Equal(t, 2, requestCount, "Expected the retry to proceed when the deadline allows it")
 }
 
 func TestDisableRetries(t *testing.T) {

--- a/seed/go-sdk/inferred-auth-explicit/internal/retrier.go
+++ b/seed/go-sdk/inferred-auth-explicit/internal/retrier.go
@@ -145,12 +145,20 @@ func (r *Retrier) run(
 	}
 
 	if r.shouldRetry(response) {
-		defer func() { _ = response.Body.Close() }()
-
 		delay, err := r.retryDelay(response, retryAttempt)
 		if err != nil {
+			_ = response.Body.Close()
 			return nil, err
 		}
+
+		// If the context's deadline would elapse before the backoff completes, return
+		// the response instead of sleeping through it. The caller then sees why the
+		// request actually failed (e.g. a 429) rather than a context deadline error.
+		if deadline, ok := request.Context().Deadline(); ok && time.Until(deadline) < delay {
+			return response, nil
+		}
+
+		defer func() { _ = response.Body.Close() }()
 
 		if err := sleepWithContext(request.Context(), delay); err != nil {
 			return nil, err

--- a/seed/go-sdk/inferred-auth-explicit/internal/retrier_test.go
+++ b/seed/go-sdk/inferred-auth-explicit/internal/retrier_test.go
@@ -295,7 +295,50 @@ func TestRetryWithRequestBody(t *testing.T) {
 	assert.Equal(t, expectedBody, requestBodies[1], "Second request body should match expected (retry should re-send body)")
 }
 
+// An explicit cancel (e.g. Ctrl-C wired to cancel()) must interrupt the backoff
+// wait. There is no deadline here, so the retrier cannot know the wait is futile
+// up front -- it has to be woken by the context.
 func TestRetryWaitIsInterruptedByContext(t *testing.T) {
+	var requestCount int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		w.Header().Set("Retry-After", "5")
+		w.WriteHeader(http.StatusTooManyRequests)
+	}))
+	defer server.Close()
+
+	caller := NewCaller(&CallerParams{
+		Client: server.Client(),
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		time.Sleep(100 * time.Millisecond)
+		cancel()
+	}()
+	defer cancel()
+
+	start := time.Now()
+	_, err := caller.Call(
+		ctx,
+		&CallParams{
+			URL:         server.URL,
+			Method:      http.MethodGet,
+			Request:     &InternalTestRequest{},
+			MaxAttempts: 3,
+		},
+	)
+	elapsed := time.Since(start)
+
+	assert.ErrorIs(t, err, context.Canceled)
+	assert.Equal(t, 1, requestCount, "Expected the retry to be abandoned once the context was cancelled")
+	assert.Less(t, elapsed, time.Second, "Expected the backoff to be interrupted by the context, took %v", elapsed)
+}
+
+// When the caller's deadline would elapse before the backoff finishes, sleeping
+// only guarantees a context error. Return the response instead so the caller
+// learns why the request actually failed.
+func TestRetryReturnsResponseWhenDeadlineShorterThanBackoff(t *testing.T) {
 	var requestCount int
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		requestCount++
@@ -323,9 +366,50 @@ func TestRetryWaitIsInterruptedByContext(t *testing.T) {
 	)
 	elapsed := time.Since(start)
 
-	assert.ErrorIs(t, err, context.DeadlineExceeded)
-	assert.Equal(t, 1, requestCount, "Expected the retry to be abandoned once the context expired")
-	assert.Less(t, elapsed, time.Second, "Expected the backoff to be interrupted by the context, took %v", elapsed)
+	// The caller gets the 429, not context.DeadlineExceeded.
+	var apiError *core.APIError
+	require.ErrorAs(t, err, &apiError)
+	assert.Equal(t, http.StatusTooManyRequests, apiError.StatusCode)
+	assert.NotErrorIs(t, err, context.DeadlineExceeded)
+	assert.Equal(t, 1, requestCount, "Expected no retry once the deadline was known to be too short")
+	assert.Less(t, elapsed, time.Second, "Expected to return immediately rather than sleep, took %v", elapsed)
+}
+
+// A deadline with room for the backoff must still retry as normal.
+func TestRetryProceedsWhenDeadlineLongerThanBackoff(t *testing.T) {
+	var requestCount int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		if requestCount == 1 {
+			w.Header().Set("Retry-After", "1")
+			w.WriteHeader(http.StatusTooManyRequests)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("{}"))
+	}))
+	defer server.Close()
+
+	caller := NewCaller(&CallerParams{
+		Client: server.Client(),
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	_, err := caller.Call(
+		ctx,
+		&CallParams{
+			URL:         server.URL,
+			Method:      http.MethodGet,
+			Request:     &InternalTestRequest{},
+			Response:    &InternalTestResponse{},
+			MaxAttempts: 3,
+		},
+	)
+
+	assert.NoError(t, err)
+	assert.Equal(t, 2, requestCount, "Expected the retry to proceed when the deadline allows it")
 }
 
 func TestDisableRetries(t *testing.T) {

--- a/seed/go-sdk/inferred-auth-implicit-api-key/internal/retrier.go
+++ b/seed/go-sdk/inferred-auth-implicit-api-key/internal/retrier.go
@@ -145,12 +145,20 @@ func (r *Retrier) run(
 	}
 
 	if r.shouldRetry(response) {
-		defer func() { _ = response.Body.Close() }()
-
 		delay, err := r.retryDelay(response, retryAttempt)
 		if err != nil {
+			_ = response.Body.Close()
 			return nil, err
 		}
+
+		// If the context's deadline would elapse before the backoff completes, return
+		// the response instead of sleeping through it. The caller then sees why the
+		// request actually failed (e.g. a 429) rather than a context deadline error.
+		if deadline, ok := request.Context().Deadline(); ok && time.Until(deadline) < delay {
+			return response, nil
+		}
+
+		defer func() { _ = response.Body.Close() }()
 
 		if err := sleepWithContext(request.Context(), delay); err != nil {
 			return nil, err

--- a/seed/go-sdk/inferred-auth-implicit-api-key/internal/retrier_test.go
+++ b/seed/go-sdk/inferred-auth-implicit-api-key/internal/retrier_test.go
@@ -295,7 +295,50 @@ func TestRetryWithRequestBody(t *testing.T) {
 	assert.Equal(t, expectedBody, requestBodies[1], "Second request body should match expected (retry should re-send body)")
 }
 
+// An explicit cancel (e.g. Ctrl-C wired to cancel()) must interrupt the backoff
+// wait. There is no deadline here, so the retrier cannot know the wait is futile
+// up front -- it has to be woken by the context.
 func TestRetryWaitIsInterruptedByContext(t *testing.T) {
+	var requestCount int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		w.Header().Set("Retry-After", "5")
+		w.WriteHeader(http.StatusTooManyRequests)
+	}))
+	defer server.Close()
+
+	caller := NewCaller(&CallerParams{
+		Client: server.Client(),
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		time.Sleep(100 * time.Millisecond)
+		cancel()
+	}()
+	defer cancel()
+
+	start := time.Now()
+	_, err := caller.Call(
+		ctx,
+		&CallParams{
+			URL:         server.URL,
+			Method:      http.MethodGet,
+			Request:     &InternalTestRequest{},
+			MaxAttempts: 3,
+		},
+	)
+	elapsed := time.Since(start)
+
+	assert.ErrorIs(t, err, context.Canceled)
+	assert.Equal(t, 1, requestCount, "Expected the retry to be abandoned once the context was cancelled")
+	assert.Less(t, elapsed, time.Second, "Expected the backoff to be interrupted by the context, took %v", elapsed)
+}
+
+// When the caller's deadline would elapse before the backoff finishes, sleeping
+// only guarantees a context error. Return the response instead so the caller
+// learns why the request actually failed.
+func TestRetryReturnsResponseWhenDeadlineShorterThanBackoff(t *testing.T) {
 	var requestCount int
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		requestCount++
@@ -323,9 +366,50 @@ func TestRetryWaitIsInterruptedByContext(t *testing.T) {
 	)
 	elapsed := time.Since(start)
 
-	assert.ErrorIs(t, err, context.DeadlineExceeded)
-	assert.Equal(t, 1, requestCount, "Expected the retry to be abandoned once the context expired")
-	assert.Less(t, elapsed, time.Second, "Expected the backoff to be interrupted by the context, took %v", elapsed)
+	// The caller gets the 429, not context.DeadlineExceeded.
+	var apiError *core.APIError
+	require.ErrorAs(t, err, &apiError)
+	assert.Equal(t, http.StatusTooManyRequests, apiError.StatusCode)
+	assert.NotErrorIs(t, err, context.DeadlineExceeded)
+	assert.Equal(t, 1, requestCount, "Expected no retry once the deadline was known to be too short")
+	assert.Less(t, elapsed, time.Second, "Expected to return immediately rather than sleep, took %v", elapsed)
+}
+
+// A deadline with room for the backoff must still retry as normal.
+func TestRetryProceedsWhenDeadlineLongerThanBackoff(t *testing.T) {
+	var requestCount int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		if requestCount == 1 {
+			w.Header().Set("Retry-After", "1")
+			w.WriteHeader(http.StatusTooManyRequests)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("{}"))
+	}))
+	defer server.Close()
+
+	caller := NewCaller(&CallerParams{
+		Client: server.Client(),
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	_, err := caller.Call(
+		ctx,
+		&CallParams{
+			URL:         server.URL,
+			Method:      http.MethodGet,
+			Request:     &InternalTestRequest{},
+			Response:    &InternalTestResponse{},
+			MaxAttempts: 3,
+		},
+	)
+
+	assert.NoError(t, err)
+	assert.Equal(t, 2, requestCount, "Expected the retry to proceed when the deadline allows it")
 }
 
 func TestDisableRetries(t *testing.T) {

--- a/seed/go-sdk/inferred-auth-implicit-no-expiry/internal/retrier.go
+++ b/seed/go-sdk/inferred-auth-implicit-no-expiry/internal/retrier.go
@@ -145,12 +145,20 @@ func (r *Retrier) run(
 	}
 
 	if r.shouldRetry(response) {
-		defer func() { _ = response.Body.Close() }()
-
 		delay, err := r.retryDelay(response, retryAttempt)
 		if err != nil {
+			_ = response.Body.Close()
 			return nil, err
 		}
+
+		// If the context's deadline would elapse before the backoff completes, return
+		// the response instead of sleeping through it. The caller then sees why the
+		// request actually failed (e.g. a 429) rather than a context deadline error.
+		if deadline, ok := request.Context().Deadline(); ok && time.Until(deadline) < delay {
+			return response, nil
+		}
+
+		defer func() { _ = response.Body.Close() }()
 
 		if err := sleepWithContext(request.Context(), delay); err != nil {
 			return nil, err

--- a/seed/go-sdk/inferred-auth-implicit-no-expiry/internal/retrier_test.go
+++ b/seed/go-sdk/inferred-auth-implicit-no-expiry/internal/retrier_test.go
@@ -295,7 +295,50 @@ func TestRetryWithRequestBody(t *testing.T) {
 	assert.Equal(t, expectedBody, requestBodies[1], "Second request body should match expected (retry should re-send body)")
 }
 
+// An explicit cancel (e.g. Ctrl-C wired to cancel()) must interrupt the backoff
+// wait. There is no deadline here, so the retrier cannot know the wait is futile
+// up front -- it has to be woken by the context.
 func TestRetryWaitIsInterruptedByContext(t *testing.T) {
+	var requestCount int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		w.Header().Set("Retry-After", "5")
+		w.WriteHeader(http.StatusTooManyRequests)
+	}))
+	defer server.Close()
+
+	caller := NewCaller(&CallerParams{
+		Client: server.Client(),
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		time.Sleep(100 * time.Millisecond)
+		cancel()
+	}()
+	defer cancel()
+
+	start := time.Now()
+	_, err := caller.Call(
+		ctx,
+		&CallParams{
+			URL:         server.URL,
+			Method:      http.MethodGet,
+			Request:     &InternalTestRequest{},
+			MaxAttempts: 3,
+		},
+	)
+	elapsed := time.Since(start)
+
+	assert.ErrorIs(t, err, context.Canceled)
+	assert.Equal(t, 1, requestCount, "Expected the retry to be abandoned once the context was cancelled")
+	assert.Less(t, elapsed, time.Second, "Expected the backoff to be interrupted by the context, took %v", elapsed)
+}
+
+// When the caller's deadline would elapse before the backoff finishes, sleeping
+// only guarantees a context error. Return the response instead so the caller
+// learns why the request actually failed.
+func TestRetryReturnsResponseWhenDeadlineShorterThanBackoff(t *testing.T) {
 	var requestCount int
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		requestCount++
@@ -323,9 +366,50 @@ func TestRetryWaitIsInterruptedByContext(t *testing.T) {
 	)
 	elapsed := time.Since(start)
 
-	assert.ErrorIs(t, err, context.DeadlineExceeded)
-	assert.Equal(t, 1, requestCount, "Expected the retry to be abandoned once the context expired")
-	assert.Less(t, elapsed, time.Second, "Expected the backoff to be interrupted by the context, took %v", elapsed)
+	// The caller gets the 429, not context.DeadlineExceeded.
+	var apiError *core.APIError
+	require.ErrorAs(t, err, &apiError)
+	assert.Equal(t, http.StatusTooManyRequests, apiError.StatusCode)
+	assert.NotErrorIs(t, err, context.DeadlineExceeded)
+	assert.Equal(t, 1, requestCount, "Expected no retry once the deadline was known to be too short")
+	assert.Less(t, elapsed, time.Second, "Expected to return immediately rather than sleep, took %v", elapsed)
+}
+
+// A deadline with room for the backoff must still retry as normal.
+func TestRetryProceedsWhenDeadlineLongerThanBackoff(t *testing.T) {
+	var requestCount int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		if requestCount == 1 {
+			w.Header().Set("Retry-After", "1")
+			w.WriteHeader(http.StatusTooManyRequests)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("{}"))
+	}))
+	defer server.Close()
+
+	caller := NewCaller(&CallerParams{
+		Client: server.Client(),
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	_, err := caller.Call(
+		ctx,
+		&CallParams{
+			URL:         server.URL,
+			Method:      http.MethodGet,
+			Request:     &InternalTestRequest{},
+			Response:    &InternalTestResponse{},
+			MaxAttempts: 3,
+		},
+	)
+
+	assert.NoError(t, err)
+	assert.Equal(t, 2, requestCount, "Expected the retry to proceed when the deadline allows it")
 }
 
 func TestDisableRetries(t *testing.T) {

--- a/seed/go-sdk/inferred-auth-implicit-reference/internal/retrier.go
+++ b/seed/go-sdk/inferred-auth-implicit-reference/internal/retrier.go
@@ -145,12 +145,20 @@ func (r *Retrier) run(
 	}
 
 	if r.shouldRetry(response) {
-		defer func() { _ = response.Body.Close() }()
-
 		delay, err := r.retryDelay(response, retryAttempt)
 		if err != nil {
+			_ = response.Body.Close()
 			return nil, err
 		}
+
+		// If the context's deadline would elapse before the backoff completes, return
+		// the response instead of sleeping through it. The caller then sees why the
+		// request actually failed (e.g. a 429) rather than a context deadline error.
+		if deadline, ok := request.Context().Deadline(); ok && time.Until(deadline) < delay {
+			return response, nil
+		}
+
+		defer func() { _ = response.Body.Close() }()
 
 		if err := sleepWithContext(request.Context(), delay); err != nil {
 			return nil, err

--- a/seed/go-sdk/inferred-auth-implicit-reference/internal/retrier_test.go
+++ b/seed/go-sdk/inferred-auth-implicit-reference/internal/retrier_test.go
@@ -295,7 +295,50 @@ func TestRetryWithRequestBody(t *testing.T) {
 	assert.Equal(t, expectedBody, requestBodies[1], "Second request body should match expected (retry should re-send body)")
 }
 
+// An explicit cancel (e.g. Ctrl-C wired to cancel()) must interrupt the backoff
+// wait. There is no deadline here, so the retrier cannot know the wait is futile
+// up front -- it has to be woken by the context.
 func TestRetryWaitIsInterruptedByContext(t *testing.T) {
+	var requestCount int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		w.Header().Set("Retry-After", "5")
+		w.WriteHeader(http.StatusTooManyRequests)
+	}))
+	defer server.Close()
+
+	caller := NewCaller(&CallerParams{
+		Client: server.Client(),
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		time.Sleep(100 * time.Millisecond)
+		cancel()
+	}()
+	defer cancel()
+
+	start := time.Now()
+	_, err := caller.Call(
+		ctx,
+		&CallParams{
+			URL:         server.URL,
+			Method:      http.MethodGet,
+			Request:     &InternalTestRequest{},
+			MaxAttempts: 3,
+		},
+	)
+	elapsed := time.Since(start)
+
+	assert.ErrorIs(t, err, context.Canceled)
+	assert.Equal(t, 1, requestCount, "Expected the retry to be abandoned once the context was cancelled")
+	assert.Less(t, elapsed, time.Second, "Expected the backoff to be interrupted by the context, took %v", elapsed)
+}
+
+// When the caller's deadline would elapse before the backoff finishes, sleeping
+// only guarantees a context error. Return the response instead so the caller
+// learns why the request actually failed.
+func TestRetryReturnsResponseWhenDeadlineShorterThanBackoff(t *testing.T) {
 	var requestCount int
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		requestCount++
@@ -323,9 +366,50 @@ func TestRetryWaitIsInterruptedByContext(t *testing.T) {
 	)
 	elapsed := time.Since(start)
 
-	assert.ErrorIs(t, err, context.DeadlineExceeded)
-	assert.Equal(t, 1, requestCount, "Expected the retry to be abandoned once the context expired")
-	assert.Less(t, elapsed, time.Second, "Expected the backoff to be interrupted by the context, took %v", elapsed)
+	// The caller gets the 429, not context.DeadlineExceeded.
+	var apiError *core.APIError
+	require.ErrorAs(t, err, &apiError)
+	assert.Equal(t, http.StatusTooManyRequests, apiError.StatusCode)
+	assert.NotErrorIs(t, err, context.DeadlineExceeded)
+	assert.Equal(t, 1, requestCount, "Expected no retry once the deadline was known to be too short")
+	assert.Less(t, elapsed, time.Second, "Expected to return immediately rather than sleep, took %v", elapsed)
+}
+
+// A deadline with room for the backoff must still retry as normal.
+func TestRetryProceedsWhenDeadlineLongerThanBackoff(t *testing.T) {
+	var requestCount int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		if requestCount == 1 {
+			w.Header().Set("Retry-After", "1")
+			w.WriteHeader(http.StatusTooManyRequests)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("{}"))
+	}))
+	defer server.Close()
+
+	caller := NewCaller(&CallerParams{
+		Client: server.Client(),
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	_, err := caller.Call(
+		ctx,
+		&CallParams{
+			URL:         server.URL,
+			Method:      http.MethodGet,
+			Request:     &InternalTestRequest{},
+			Response:    &InternalTestResponse{},
+			MaxAttempts: 3,
+		},
+	)
+
+	assert.NoError(t, err)
+	assert.Equal(t, 2, requestCount, "Expected the retry to proceed when the deadline allows it")
 }
 
 func TestDisableRetries(t *testing.T) {

--- a/seed/go-sdk/inferred-auth-implicit/internal/retrier.go
+++ b/seed/go-sdk/inferred-auth-implicit/internal/retrier.go
@@ -145,12 +145,20 @@ func (r *Retrier) run(
 	}
 
 	if r.shouldRetry(response) {
-		defer func() { _ = response.Body.Close() }()
-
 		delay, err := r.retryDelay(response, retryAttempt)
 		if err != nil {
+			_ = response.Body.Close()
 			return nil, err
 		}
+
+		// If the context's deadline would elapse before the backoff completes, return
+		// the response instead of sleeping through it. The caller then sees why the
+		// request actually failed (e.g. a 429) rather than a context deadline error.
+		if deadline, ok := request.Context().Deadline(); ok && time.Until(deadline) < delay {
+			return response, nil
+		}
+
+		defer func() { _ = response.Body.Close() }()
 
 		if err := sleepWithContext(request.Context(), delay); err != nil {
 			return nil, err

--- a/seed/go-sdk/inferred-auth-implicit/internal/retrier_test.go
+++ b/seed/go-sdk/inferred-auth-implicit/internal/retrier_test.go
@@ -295,7 +295,50 @@ func TestRetryWithRequestBody(t *testing.T) {
 	assert.Equal(t, expectedBody, requestBodies[1], "Second request body should match expected (retry should re-send body)")
 }
 
+// An explicit cancel (e.g. Ctrl-C wired to cancel()) must interrupt the backoff
+// wait. There is no deadline here, so the retrier cannot know the wait is futile
+// up front -- it has to be woken by the context.
 func TestRetryWaitIsInterruptedByContext(t *testing.T) {
+	var requestCount int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		w.Header().Set("Retry-After", "5")
+		w.WriteHeader(http.StatusTooManyRequests)
+	}))
+	defer server.Close()
+
+	caller := NewCaller(&CallerParams{
+		Client: server.Client(),
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		time.Sleep(100 * time.Millisecond)
+		cancel()
+	}()
+	defer cancel()
+
+	start := time.Now()
+	_, err := caller.Call(
+		ctx,
+		&CallParams{
+			URL:         server.URL,
+			Method:      http.MethodGet,
+			Request:     &InternalTestRequest{},
+			MaxAttempts: 3,
+		},
+	)
+	elapsed := time.Since(start)
+
+	assert.ErrorIs(t, err, context.Canceled)
+	assert.Equal(t, 1, requestCount, "Expected the retry to be abandoned once the context was cancelled")
+	assert.Less(t, elapsed, time.Second, "Expected the backoff to be interrupted by the context, took %v", elapsed)
+}
+
+// When the caller's deadline would elapse before the backoff finishes, sleeping
+// only guarantees a context error. Return the response instead so the caller
+// learns why the request actually failed.
+func TestRetryReturnsResponseWhenDeadlineShorterThanBackoff(t *testing.T) {
 	var requestCount int
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		requestCount++
@@ -323,9 +366,50 @@ func TestRetryWaitIsInterruptedByContext(t *testing.T) {
 	)
 	elapsed := time.Since(start)
 
-	assert.ErrorIs(t, err, context.DeadlineExceeded)
-	assert.Equal(t, 1, requestCount, "Expected the retry to be abandoned once the context expired")
-	assert.Less(t, elapsed, time.Second, "Expected the backoff to be interrupted by the context, took %v", elapsed)
+	// The caller gets the 429, not context.DeadlineExceeded.
+	var apiError *core.APIError
+	require.ErrorAs(t, err, &apiError)
+	assert.Equal(t, http.StatusTooManyRequests, apiError.StatusCode)
+	assert.NotErrorIs(t, err, context.DeadlineExceeded)
+	assert.Equal(t, 1, requestCount, "Expected no retry once the deadline was known to be too short")
+	assert.Less(t, elapsed, time.Second, "Expected to return immediately rather than sleep, took %v", elapsed)
+}
+
+// A deadline with room for the backoff must still retry as normal.
+func TestRetryProceedsWhenDeadlineLongerThanBackoff(t *testing.T) {
+	var requestCount int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		if requestCount == 1 {
+			w.Header().Set("Retry-After", "1")
+			w.WriteHeader(http.StatusTooManyRequests)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("{}"))
+	}))
+	defer server.Close()
+
+	caller := NewCaller(&CallerParams{
+		Client: server.Client(),
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	_, err := caller.Call(
+		ctx,
+		&CallParams{
+			URL:         server.URL,
+			Method:      http.MethodGet,
+			Request:     &InternalTestRequest{},
+			Response:    &InternalTestResponse{},
+			MaxAttempts: 3,
+		},
+	)
+
+	assert.NoError(t, err)
+	assert.Equal(t, 2, requestCount, "Expected the retry to proceed when the deadline allows it")
 }
 
 func TestDisableRetries(t *testing.T) {

--- a/seed/go-sdk/inline-enum-type-name-override/internal/retrier.go
+++ b/seed/go-sdk/inline-enum-type-name-override/internal/retrier.go
@@ -145,12 +145,20 @@ func (r *Retrier) run(
 	}
 
 	if r.shouldRetry(response) {
-		defer func() { _ = response.Body.Close() }()
-
 		delay, err := r.retryDelay(response, retryAttempt)
 		if err != nil {
+			_ = response.Body.Close()
 			return nil, err
 		}
+
+		// If the context's deadline would elapse before the backoff completes, return
+		// the response instead of sleeping through it. The caller then sees why the
+		// request actually failed (e.g. a 429) rather than a context deadline error.
+		if deadline, ok := request.Context().Deadline(); ok && time.Until(deadline) < delay {
+			return response, nil
+		}
+
+		defer func() { _ = response.Body.Close() }()
 
 		if err := sleepWithContext(request.Context(), delay); err != nil {
 			return nil, err

--- a/seed/go-sdk/inline-enum-type-name-override/internal/retrier_test.go
+++ b/seed/go-sdk/inline-enum-type-name-override/internal/retrier_test.go
@@ -295,7 +295,50 @@ func TestRetryWithRequestBody(t *testing.T) {
 	assert.Equal(t, expectedBody, requestBodies[1], "Second request body should match expected (retry should re-send body)")
 }
 
+// An explicit cancel (e.g. Ctrl-C wired to cancel()) must interrupt the backoff
+// wait. There is no deadline here, so the retrier cannot know the wait is futile
+// up front -- it has to be woken by the context.
 func TestRetryWaitIsInterruptedByContext(t *testing.T) {
+	var requestCount int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		w.Header().Set("Retry-After", "5")
+		w.WriteHeader(http.StatusTooManyRequests)
+	}))
+	defer server.Close()
+
+	caller := NewCaller(&CallerParams{
+		Client: server.Client(),
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		time.Sleep(100 * time.Millisecond)
+		cancel()
+	}()
+	defer cancel()
+
+	start := time.Now()
+	_, err := caller.Call(
+		ctx,
+		&CallParams{
+			URL:         server.URL,
+			Method:      http.MethodGet,
+			Request:     &InternalTestRequest{},
+			MaxAttempts: 3,
+		},
+	)
+	elapsed := time.Since(start)
+
+	assert.ErrorIs(t, err, context.Canceled)
+	assert.Equal(t, 1, requestCount, "Expected the retry to be abandoned once the context was cancelled")
+	assert.Less(t, elapsed, time.Second, "Expected the backoff to be interrupted by the context, took %v", elapsed)
+}
+
+// When the caller's deadline would elapse before the backoff finishes, sleeping
+// only guarantees a context error. Return the response instead so the caller
+// learns why the request actually failed.
+func TestRetryReturnsResponseWhenDeadlineShorterThanBackoff(t *testing.T) {
 	var requestCount int
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		requestCount++
@@ -323,9 +366,50 @@ func TestRetryWaitIsInterruptedByContext(t *testing.T) {
 	)
 	elapsed := time.Since(start)
 
-	assert.ErrorIs(t, err, context.DeadlineExceeded)
-	assert.Equal(t, 1, requestCount, "Expected the retry to be abandoned once the context expired")
-	assert.Less(t, elapsed, time.Second, "Expected the backoff to be interrupted by the context, took %v", elapsed)
+	// The caller gets the 429, not context.DeadlineExceeded.
+	var apiError *core.APIError
+	require.ErrorAs(t, err, &apiError)
+	assert.Equal(t, http.StatusTooManyRequests, apiError.StatusCode)
+	assert.NotErrorIs(t, err, context.DeadlineExceeded)
+	assert.Equal(t, 1, requestCount, "Expected no retry once the deadline was known to be too short")
+	assert.Less(t, elapsed, time.Second, "Expected to return immediately rather than sleep, took %v", elapsed)
+}
+
+// A deadline with room for the backoff must still retry as normal.
+func TestRetryProceedsWhenDeadlineLongerThanBackoff(t *testing.T) {
+	var requestCount int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		if requestCount == 1 {
+			w.Header().Set("Retry-After", "1")
+			w.WriteHeader(http.StatusTooManyRequests)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("{}"))
+	}))
+	defer server.Close()
+
+	caller := NewCaller(&CallerParams{
+		Client: server.Client(),
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	_, err := caller.Call(
+		ctx,
+		&CallParams{
+			URL:         server.URL,
+			Method:      http.MethodGet,
+			Request:     &InternalTestRequest{},
+			Response:    &InternalTestResponse{},
+			MaxAttempts: 3,
+		},
+	)
+
+	assert.NoError(t, err)
+	assert.Equal(t, 2, requestCount, "Expected the retry to proceed when the deadline allows it")
 }
 
 func TestDisableRetries(t *testing.T) {

--- a/seed/go-sdk/license/internal/retrier.go
+++ b/seed/go-sdk/license/internal/retrier.go
@@ -145,12 +145,20 @@ func (r *Retrier) run(
 	}
 
 	if r.shouldRetry(response) {
-		defer func() { _ = response.Body.Close() }()
-
 		delay, err := r.retryDelay(response, retryAttempt)
 		if err != nil {
+			_ = response.Body.Close()
 			return nil, err
 		}
+
+		// If the context's deadline would elapse before the backoff completes, return
+		// the response instead of sleeping through it. The caller then sees why the
+		// request actually failed (e.g. a 429) rather than a context deadline error.
+		if deadline, ok := request.Context().Deadline(); ok && time.Until(deadline) < delay {
+			return response, nil
+		}
+
+		defer func() { _ = response.Body.Close() }()
 
 		if err := sleepWithContext(request.Context(), delay); err != nil {
 			return nil, err

--- a/seed/go-sdk/license/internal/retrier_test.go
+++ b/seed/go-sdk/license/internal/retrier_test.go
@@ -295,7 +295,50 @@ func TestRetryWithRequestBody(t *testing.T) {
 	assert.Equal(t, expectedBody, requestBodies[1], "Second request body should match expected (retry should re-send body)")
 }
 
+// An explicit cancel (e.g. Ctrl-C wired to cancel()) must interrupt the backoff
+// wait. There is no deadline here, so the retrier cannot know the wait is futile
+// up front -- it has to be woken by the context.
 func TestRetryWaitIsInterruptedByContext(t *testing.T) {
+	var requestCount int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		w.Header().Set("Retry-After", "5")
+		w.WriteHeader(http.StatusTooManyRequests)
+	}))
+	defer server.Close()
+
+	caller := NewCaller(&CallerParams{
+		Client: server.Client(),
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		time.Sleep(100 * time.Millisecond)
+		cancel()
+	}()
+	defer cancel()
+
+	start := time.Now()
+	_, err := caller.Call(
+		ctx,
+		&CallParams{
+			URL:         server.URL,
+			Method:      http.MethodGet,
+			Request:     &InternalTestRequest{},
+			MaxAttempts: 3,
+		},
+	)
+	elapsed := time.Since(start)
+
+	assert.ErrorIs(t, err, context.Canceled)
+	assert.Equal(t, 1, requestCount, "Expected the retry to be abandoned once the context was cancelled")
+	assert.Less(t, elapsed, time.Second, "Expected the backoff to be interrupted by the context, took %v", elapsed)
+}
+
+// When the caller's deadline would elapse before the backoff finishes, sleeping
+// only guarantees a context error. Return the response instead so the caller
+// learns why the request actually failed.
+func TestRetryReturnsResponseWhenDeadlineShorterThanBackoff(t *testing.T) {
 	var requestCount int
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		requestCount++
@@ -323,9 +366,50 @@ func TestRetryWaitIsInterruptedByContext(t *testing.T) {
 	)
 	elapsed := time.Since(start)
 
-	assert.ErrorIs(t, err, context.DeadlineExceeded)
-	assert.Equal(t, 1, requestCount, "Expected the retry to be abandoned once the context expired")
-	assert.Less(t, elapsed, time.Second, "Expected the backoff to be interrupted by the context, took %v", elapsed)
+	// The caller gets the 429, not context.DeadlineExceeded.
+	var apiError *core.APIError
+	require.ErrorAs(t, err, &apiError)
+	assert.Equal(t, http.StatusTooManyRequests, apiError.StatusCode)
+	assert.NotErrorIs(t, err, context.DeadlineExceeded)
+	assert.Equal(t, 1, requestCount, "Expected no retry once the deadline was known to be too short")
+	assert.Less(t, elapsed, time.Second, "Expected to return immediately rather than sleep, took %v", elapsed)
+}
+
+// A deadline with room for the backoff must still retry as normal.
+func TestRetryProceedsWhenDeadlineLongerThanBackoff(t *testing.T) {
+	var requestCount int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		if requestCount == 1 {
+			w.Header().Set("Retry-After", "1")
+			w.WriteHeader(http.StatusTooManyRequests)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("{}"))
+	}))
+	defer server.Close()
+
+	caller := NewCaller(&CallerParams{
+		Client: server.Client(),
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	_, err := caller.Call(
+		ctx,
+		&CallParams{
+			URL:         server.URL,
+			Method:      http.MethodGet,
+			Request:     &InternalTestRequest{},
+			Response:    &InternalTestResponse{},
+			MaxAttempts: 3,
+		},
+	)
+
+	assert.NoError(t, err)
+	assert.Equal(t, 2, requestCount, "Expected the retry to proceed when the deadline allows it")
 }
 
 func TestDisableRetries(t *testing.T) {

--- a/seed/go-sdk/literal-user-agent/internal/retrier.go
+++ b/seed/go-sdk/literal-user-agent/internal/retrier.go
@@ -145,12 +145,20 @@ func (r *Retrier) run(
 	}
 
 	if r.shouldRetry(response) {
-		defer func() { _ = response.Body.Close() }()
-
 		delay, err := r.retryDelay(response, retryAttempt)
 		if err != nil {
+			_ = response.Body.Close()
 			return nil, err
 		}
+
+		// If the context's deadline would elapse before the backoff completes, return
+		// the response instead of sleeping through it. The caller then sees why the
+		// request actually failed (e.g. a 429) rather than a context deadline error.
+		if deadline, ok := request.Context().Deadline(); ok && time.Until(deadline) < delay {
+			return response, nil
+		}
+
+		defer func() { _ = response.Body.Close() }()
 
 		if err := sleepWithContext(request.Context(), delay); err != nil {
 			return nil, err

--- a/seed/go-sdk/literal-user-agent/internal/retrier_test.go
+++ b/seed/go-sdk/literal-user-agent/internal/retrier_test.go
@@ -295,7 +295,50 @@ func TestRetryWithRequestBody(t *testing.T) {
 	assert.Equal(t, expectedBody, requestBodies[1], "Second request body should match expected (retry should re-send body)")
 }
 
+// An explicit cancel (e.g. Ctrl-C wired to cancel()) must interrupt the backoff
+// wait. There is no deadline here, so the retrier cannot know the wait is futile
+// up front -- it has to be woken by the context.
 func TestRetryWaitIsInterruptedByContext(t *testing.T) {
+	var requestCount int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		w.Header().Set("Retry-After", "5")
+		w.WriteHeader(http.StatusTooManyRequests)
+	}))
+	defer server.Close()
+
+	caller := NewCaller(&CallerParams{
+		Client: server.Client(),
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		time.Sleep(100 * time.Millisecond)
+		cancel()
+	}()
+	defer cancel()
+
+	start := time.Now()
+	_, err := caller.Call(
+		ctx,
+		&CallParams{
+			URL:         server.URL,
+			Method:      http.MethodGet,
+			Request:     &InternalTestRequest{},
+			MaxAttempts: 3,
+		},
+	)
+	elapsed := time.Since(start)
+
+	assert.ErrorIs(t, err, context.Canceled)
+	assert.Equal(t, 1, requestCount, "Expected the retry to be abandoned once the context was cancelled")
+	assert.Less(t, elapsed, time.Second, "Expected the backoff to be interrupted by the context, took %v", elapsed)
+}
+
+// When the caller's deadline would elapse before the backoff finishes, sleeping
+// only guarantees a context error. Return the response instead so the caller
+// learns why the request actually failed.
+func TestRetryReturnsResponseWhenDeadlineShorterThanBackoff(t *testing.T) {
 	var requestCount int
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		requestCount++
@@ -323,9 +366,50 @@ func TestRetryWaitIsInterruptedByContext(t *testing.T) {
 	)
 	elapsed := time.Since(start)
 
-	assert.ErrorIs(t, err, context.DeadlineExceeded)
-	assert.Equal(t, 1, requestCount, "Expected the retry to be abandoned once the context expired")
-	assert.Less(t, elapsed, time.Second, "Expected the backoff to be interrupted by the context, took %v", elapsed)
+	// The caller gets the 429, not context.DeadlineExceeded.
+	var apiError *core.APIError
+	require.ErrorAs(t, err, &apiError)
+	assert.Equal(t, http.StatusTooManyRequests, apiError.StatusCode)
+	assert.NotErrorIs(t, err, context.DeadlineExceeded)
+	assert.Equal(t, 1, requestCount, "Expected no retry once the deadline was known to be too short")
+	assert.Less(t, elapsed, time.Second, "Expected to return immediately rather than sleep, took %v", elapsed)
+}
+
+// A deadline with room for the backoff must still retry as normal.
+func TestRetryProceedsWhenDeadlineLongerThanBackoff(t *testing.T) {
+	var requestCount int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		if requestCount == 1 {
+			w.Header().Set("Retry-After", "1")
+			w.WriteHeader(http.StatusTooManyRequests)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("{}"))
+	}))
+	defer server.Close()
+
+	caller := NewCaller(&CallerParams{
+		Client: server.Client(),
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	_, err := caller.Call(
+		ctx,
+		&CallParams{
+			URL:         server.URL,
+			Method:      http.MethodGet,
+			Request:     &InternalTestRequest{},
+			Response:    &InternalTestResponse{},
+			MaxAttempts: 3,
+		},
+	)
+
+	assert.NoError(t, err)
+	assert.Equal(t, 2, requestCount, "Expected the retry to proceed when the deadline allows it")
 }
 
 func TestDisableRetries(t *testing.T) {

--- a/seed/go-sdk/literal/internal/retrier.go
+++ b/seed/go-sdk/literal/internal/retrier.go
@@ -145,12 +145,20 @@ func (r *Retrier) run(
 	}
 
 	if r.shouldRetry(response) {
-		defer func() { _ = response.Body.Close() }()
-
 		delay, err := r.retryDelay(response, retryAttempt)
 		if err != nil {
+			_ = response.Body.Close()
 			return nil, err
 		}
+
+		// If the context's deadline would elapse before the backoff completes, return
+		// the response instead of sleeping through it. The caller then sees why the
+		// request actually failed (e.g. a 429) rather than a context deadline error.
+		if deadline, ok := request.Context().Deadline(); ok && time.Until(deadline) < delay {
+			return response, nil
+		}
+
+		defer func() { _ = response.Body.Close() }()
 
 		if err := sleepWithContext(request.Context(), delay); err != nil {
 			return nil, err

--- a/seed/go-sdk/literal/internal/retrier_test.go
+++ b/seed/go-sdk/literal/internal/retrier_test.go
@@ -295,7 +295,50 @@ func TestRetryWithRequestBody(t *testing.T) {
 	assert.Equal(t, expectedBody, requestBodies[1], "Second request body should match expected (retry should re-send body)")
 }
 
+// An explicit cancel (e.g. Ctrl-C wired to cancel()) must interrupt the backoff
+// wait. There is no deadline here, so the retrier cannot know the wait is futile
+// up front -- it has to be woken by the context.
 func TestRetryWaitIsInterruptedByContext(t *testing.T) {
+	var requestCount int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		w.Header().Set("Retry-After", "5")
+		w.WriteHeader(http.StatusTooManyRequests)
+	}))
+	defer server.Close()
+
+	caller := NewCaller(&CallerParams{
+		Client: server.Client(),
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		time.Sleep(100 * time.Millisecond)
+		cancel()
+	}()
+	defer cancel()
+
+	start := time.Now()
+	_, err := caller.Call(
+		ctx,
+		&CallParams{
+			URL:         server.URL,
+			Method:      http.MethodGet,
+			Request:     &InternalTestRequest{},
+			MaxAttempts: 3,
+		},
+	)
+	elapsed := time.Since(start)
+
+	assert.ErrorIs(t, err, context.Canceled)
+	assert.Equal(t, 1, requestCount, "Expected the retry to be abandoned once the context was cancelled")
+	assert.Less(t, elapsed, time.Second, "Expected the backoff to be interrupted by the context, took %v", elapsed)
+}
+
+// When the caller's deadline would elapse before the backoff finishes, sleeping
+// only guarantees a context error. Return the response instead so the caller
+// learns why the request actually failed.
+func TestRetryReturnsResponseWhenDeadlineShorterThanBackoff(t *testing.T) {
 	var requestCount int
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		requestCount++
@@ -323,9 +366,50 @@ func TestRetryWaitIsInterruptedByContext(t *testing.T) {
 	)
 	elapsed := time.Since(start)
 
-	assert.ErrorIs(t, err, context.DeadlineExceeded)
-	assert.Equal(t, 1, requestCount, "Expected the retry to be abandoned once the context expired")
-	assert.Less(t, elapsed, time.Second, "Expected the backoff to be interrupted by the context, took %v", elapsed)
+	// The caller gets the 429, not context.DeadlineExceeded.
+	var apiError *core.APIError
+	require.ErrorAs(t, err, &apiError)
+	assert.Equal(t, http.StatusTooManyRequests, apiError.StatusCode)
+	assert.NotErrorIs(t, err, context.DeadlineExceeded)
+	assert.Equal(t, 1, requestCount, "Expected no retry once the deadline was known to be too short")
+	assert.Less(t, elapsed, time.Second, "Expected to return immediately rather than sleep, took %v", elapsed)
+}
+
+// A deadline with room for the backoff must still retry as normal.
+func TestRetryProceedsWhenDeadlineLongerThanBackoff(t *testing.T) {
+	var requestCount int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		if requestCount == 1 {
+			w.Header().Set("Retry-After", "1")
+			w.WriteHeader(http.StatusTooManyRequests)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("{}"))
+	}))
+	defer server.Close()
+
+	caller := NewCaller(&CallerParams{
+		Client: server.Client(),
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	_, err := caller.Call(
+		ctx,
+		&CallParams{
+			URL:         server.URL,
+			Method:      http.MethodGet,
+			Request:     &InternalTestRequest{},
+			Response:    &InternalTestResponse{},
+			MaxAttempts: 3,
+		},
+	)
+
+	assert.NoError(t, err)
+	assert.Equal(t, 2, requestCount, "Expected the retry to proceed when the deadline allows it")
 }
 
 func TestDisableRetries(t *testing.T) {

--- a/seed/go-sdk/literals-unions/no-custom-config/internal/retrier.go
+++ b/seed/go-sdk/literals-unions/no-custom-config/internal/retrier.go
@@ -145,12 +145,20 @@ func (r *Retrier) run(
 	}
 
 	if r.shouldRetry(response) {
-		defer func() { _ = response.Body.Close() }()
-
 		delay, err := r.retryDelay(response, retryAttempt)
 		if err != nil {
+			_ = response.Body.Close()
 			return nil, err
 		}
+
+		// If the context's deadline would elapse before the backoff completes, return
+		// the response instead of sleeping through it. The caller then sees why the
+		// request actually failed (e.g. a 429) rather than a context deadline error.
+		if deadline, ok := request.Context().Deadline(); ok && time.Until(deadline) < delay {
+			return response, nil
+		}
+
+		defer func() { _ = response.Body.Close() }()
 
 		if err := sleepWithContext(request.Context(), delay); err != nil {
 			return nil, err

--- a/seed/go-sdk/literals-unions/no-custom-config/internal/retrier_test.go
+++ b/seed/go-sdk/literals-unions/no-custom-config/internal/retrier_test.go
@@ -295,7 +295,50 @@ func TestRetryWithRequestBody(t *testing.T) {
 	assert.Equal(t, expectedBody, requestBodies[1], "Second request body should match expected (retry should re-send body)")
 }
 
+// An explicit cancel (e.g. Ctrl-C wired to cancel()) must interrupt the backoff
+// wait. There is no deadline here, so the retrier cannot know the wait is futile
+// up front -- it has to be woken by the context.
 func TestRetryWaitIsInterruptedByContext(t *testing.T) {
+	var requestCount int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		w.Header().Set("Retry-After", "5")
+		w.WriteHeader(http.StatusTooManyRequests)
+	}))
+	defer server.Close()
+
+	caller := NewCaller(&CallerParams{
+		Client: server.Client(),
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		time.Sleep(100 * time.Millisecond)
+		cancel()
+	}()
+	defer cancel()
+
+	start := time.Now()
+	_, err := caller.Call(
+		ctx,
+		&CallParams{
+			URL:         server.URL,
+			Method:      http.MethodGet,
+			Request:     &InternalTestRequest{},
+			MaxAttempts: 3,
+		},
+	)
+	elapsed := time.Since(start)
+
+	assert.ErrorIs(t, err, context.Canceled)
+	assert.Equal(t, 1, requestCount, "Expected the retry to be abandoned once the context was cancelled")
+	assert.Less(t, elapsed, time.Second, "Expected the backoff to be interrupted by the context, took %v", elapsed)
+}
+
+// When the caller's deadline would elapse before the backoff finishes, sleeping
+// only guarantees a context error. Return the response instead so the caller
+// learns why the request actually failed.
+func TestRetryReturnsResponseWhenDeadlineShorterThanBackoff(t *testing.T) {
 	var requestCount int
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		requestCount++
@@ -323,9 +366,50 @@ func TestRetryWaitIsInterruptedByContext(t *testing.T) {
 	)
 	elapsed := time.Since(start)
 
-	assert.ErrorIs(t, err, context.DeadlineExceeded)
-	assert.Equal(t, 1, requestCount, "Expected the retry to be abandoned once the context expired")
-	assert.Less(t, elapsed, time.Second, "Expected the backoff to be interrupted by the context, took %v", elapsed)
+	// The caller gets the 429, not context.DeadlineExceeded.
+	var apiError *core.APIError
+	require.ErrorAs(t, err, &apiError)
+	assert.Equal(t, http.StatusTooManyRequests, apiError.StatusCode)
+	assert.NotErrorIs(t, err, context.DeadlineExceeded)
+	assert.Equal(t, 1, requestCount, "Expected no retry once the deadline was known to be too short")
+	assert.Less(t, elapsed, time.Second, "Expected to return immediately rather than sleep, took %v", elapsed)
+}
+
+// A deadline with room for the backoff must still retry as normal.
+func TestRetryProceedsWhenDeadlineLongerThanBackoff(t *testing.T) {
+	var requestCount int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		if requestCount == 1 {
+			w.Header().Set("Retry-After", "1")
+			w.WriteHeader(http.StatusTooManyRequests)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("{}"))
+	}))
+	defer server.Close()
+
+	caller := NewCaller(&CallerParams{
+		Client: server.Client(),
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	_, err := caller.Call(
+		ctx,
+		&CallParams{
+			URL:         server.URL,
+			Method:      http.MethodGet,
+			Request:     &InternalTestRequest{},
+			Response:    &InternalTestResponse{},
+			MaxAttempts: 3,
+		},
+	)
+
+	assert.NoError(t, err)
+	assert.Equal(t, 2, requestCount, "Expected the retry to proceed when the deadline allows it")
 }
 
 func TestDisableRetries(t *testing.T) {

--- a/seed/go-sdk/mixed-case/default-values/internal/retrier.go
+++ b/seed/go-sdk/mixed-case/default-values/internal/retrier.go
@@ -145,12 +145,20 @@ func (r *Retrier) run(
 	}
 
 	if r.shouldRetry(response) {
-		defer func() { _ = response.Body.Close() }()
-
 		delay, err := r.retryDelay(response, retryAttempt)
 		if err != nil {
+			_ = response.Body.Close()
 			return nil, err
 		}
+
+		// If the context's deadline would elapse before the backoff completes, return
+		// the response instead of sleeping through it. The caller then sees why the
+		// request actually failed (e.g. a 429) rather than a context deadline error.
+		if deadline, ok := request.Context().Deadline(); ok && time.Until(deadline) < delay {
+			return response, nil
+		}
+
+		defer func() { _ = response.Body.Close() }()
 
 		if err := sleepWithContext(request.Context(), delay); err != nil {
 			return nil, err

--- a/seed/go-sdk/mixed-case/default-values/internal/retrier_test.go
+++ b/seed/go-sdk/mixed-case/default-values/internal/retrier_test.go
@@ -295,7 +295,50 @@ func TestRetryWithRequestBody(t *testing.T) {
 	assert.Equal(t, expectedBody, requestBodies[1], "Second request body should match expected (retry should re-send body)")
 }
 
+// An explicit cancel (e.g. Ctrl-C wired to cancel()) must interrupt the backoff
+// wait. There is no deadline here, so the retrier cannot know the wait is futile
+// up front -- it has to be woken by the context.
 func TestRetryWaitIsInterruptedByContext(t *testing.T) {
+	var requestCount int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		w.Header().Set("Retry-After", "5")
+		w.WriteHeader(http.StatusTooManyRequests)
+	}))
+	defer server.Close()
+
+	caller := NewCaller(&CallerParams{
+		Client: server.Client(),
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		time.Sleep(100 * time.Millisecond)
+		cancel()
+	}()
+	defer cancel()
+
+	start := time.Now()
+	_, err := caller.Call(
+		ctx,
+		&CallParams{
+			URL:         server.URL,
+			Method:      http.MethodGet,
+			Request:     &InternalTestRequest{},
+			MaxAttempts: 3,
+		},
+	)
+	elapsed := time.Since(start)
+
+	assert.ErrorIs(t, err, context.Canceled)
+	assert.Equal(t, 1, requestCount, "Expected the retry to be abandoned once the context was cancelled")
+	assert.Less(t, elapsed, time.Second, "Expected the backoff to be interrupted by the context, took %v", elapsed)
+}
+
+// When the caller's deadline would elapse before the backoff finishes, sleeping
+// only guarantees a context error. Return the response instead so the caller
+// learns why the request actually failed.
+func TestRetryReturnsResponseWhenDeadlineShorterThanBackoff(t *testing.T) {
 	var requestCount int
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		requestCount++
@@ -323,9 +366,50 @@ func TestRetryWaitIsInterruptedByContext(t *testing.T) {
 	)
 	elapsed := time.Since(start)
 
-	assert.ErrorIs(t, err, context.DeadlineExceeded)
-	assert.Equal(t, 1, requestCount, "Expected the retry to be abandoned once the context expired")
-	assert.Less(t, elapsed, time.Second, "Expected the backoff to be interrupted by the context, took %v", elapsed)
+	// The caller gets the 429, not context.DeadlineExceeded.
+	var apiError *core.APIError
+	require.ErrorAs(t, err, &apiError)
+	assert.Equal(t, http.StatusTooManyRequests, apiError.StatusCode)
+	assert.NotErrorIs(t, err, context.DeadlineExceeded)
+	assert.Equal(t, 1, requestCount, "Expected no retry once the deadline was known to be too short")
+	assert.Less(t, elapsed, time.Second, "Expected to return immediately rather than sleep, took %v", elapsed)
+}
+
+// A deadline with room for the backoff must still retry as normal.
+func TestRetryProceedsWhenDeadlineLongerThanBackoff(t *testing.T) {
+	var requestCount int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		if requestCount == 1 {
+			w.Header().Set("Retry-After", "1")
+			w.WriteHeader(http.StatusTooManyRequests)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("{}"))
+	}))
+	defer server.Close()
+
+	caller := NewCaller(&CallerParams{
+		Client: server.Client(),
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	_, err := caller.Call(
+		ctx,
+		&CallParams{
+			URL:         server.URL,
+			Method:      http.MethodGet,
+			Request:     &InternalTestRequest{},
+			Response:    &InternalTestResponse{},
+			MaxAttempts: 3,
+		},
+	)
+
+	assert.NoError(t, err)
+	assert.Equal(t, 2, requestCount, "Expected the retry to proceed when the deadline allows it")
 }
 
 func TestDisableRetries(t *testing.T) {

--- a/seed/go-sdk/mixed-case/no-custom-config/internal/retrier.go
+++ b/seed/go-sdk/mixed-case/no-custom-config/internal/retrier.go
@@ -145,12 +145,20 @@ func (r *Retrier) run(
 	}
 
 	if r.shouldRetry(response) {
-		defer func() { _ = response.Body.Close() }()
-
 		delay, err := r.retryDelay(response, retryAttempt)
 		if err != nil {
+			_ = response.Body.Close()
 			return nil, err
 		}
+
+		// If the context's deadline would elapse before the backoff completes, return
+		// the response instead of sleeping through it. The caller then sees why the
+		// request actually failed (e.g. a 429) rather than a context deadline error.
+		if deadline, ok := request.Context().Deadline(); ok && time.Until(deadline) < delay {
+			return response, nil
+		}
+
+		defer func() { _ = response.Body.Close() }()
 
 		if err := sleepWithContext(request.Context(), delay); err != nil {
 			return nil, err

--- a/seed/go-sdk/mixed-case/no-custom-config/internal/retrier_test.go
+++ b/seed/go-sdk/mixed-case/no-custom-config/internal/retrier_test.go
@@ -295,7 +295,50 @@ func TestRetryWithRequestBody(t *testing.T) {
 	assert.Equal(t, expectedBody, requestBodies[1], "Second request body should match expected (retry should re-send body)")
 }
 
+// An explicit cancel (e.g. Ctrl-C wired to cancel()) must interrupt the backoff
+// wait. There is no deadline here, so the retrier cannot know the wait is futile
+// up front -- it has to be woken by the context.
 func TestRetryWaitIsInterruptedByContext(t *testing.T) {
+	var requestCount int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		w.Header().Set("Retry-After", "5")
+		w.WriteHeader(http.StatusTooManyRequests)
+	}))
+	defer server.Close()
+
+	caller := NewCaller(&CallerParams{
+		Client: server.Client(),
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		time.Sleep(100 * time.Millisecond)
+		cancel()
+	}()
+	defer cancel()
+
+	start := time.Now()
+	_, err := caller.Call(
+		ctx,
+		&CallParams{
+			URL:         server.URL,
+			Method:      http.MethodGet,
+			Request:     &InternalTestRequest{},
+			MaxAttempts: 3,
+		},
+	)
+	elapsed := time.Since(start)
+
+	assert.ErrorIs(t, err, context.Canceled)
+	assert.Equal(t, 1, requestCount, "Expected the retry to be abandoned once the context was cancelled")
+	assert.Less(t, elapsed, time.Second, "Expected the backoff to be interrupted by the context, took %v", elapsed)
+}
+
+// When the caller's deadline would elapse before the backoff finishes, sleeping
+// only guarantees a context error. Return the response instead so the caller
+// learns why the request actually failed.
+func TestRetryReturnsResponseWhenDeadlineShorterThanBackoff(t *testing.T) {
 	var requestCount int
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		requestCount++
@@ -323,9 +366,50 @@ func TestRetryWaitIsInterruptedByContext(t *testing.T) {
 	)
 	elapsed := time.Since(start)
 
-	assert.ErrorIs(t, err, context.DeadlineExceeded)
-	assert.Equal(t, 1, requestCount, "Expected the retry to be abandoned once the context expired")
-	assert.Less(t, elapsed, time.Second, "Expected the backoff to be interrupted by the context, took %v", elapsed)
+	// The caller gets the 429, not context.DeadlineExceeded.
+	var apiError *core.APIError
+	require.ErrorAs(t, err, &apiError)
+	assert.Equal(t, http.StatusTooManyRequests, apiError.StatusCode)
+	assert.NotErrorIs(t, err, context.DeadlineExceeded)
+	assert.Equal(t, 1, requestCount, "Expected no retry once the deadline was known to be too short")
+	assert.Less(t, elapsed, time.Second, "Expected to return immediately rather than sleep, took %v", elapsed)
+}
+
+// A deadline with room for the backoff must still retry as normal.
+func TestRetryProceedsWhenDeadlineLongerThanBackoff(t *testing.T) {
+	var requestCount int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		if requestCount == 1 {
+			w.Header().Set("Retry-After", "1")
+			w.WriteHeader(http.StatusTooManyRequests)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("{}"))
+	}))
+	defer server.Close()
+
+	caller := NewCaller(&CallerParams{
+		Client: server.Client(),
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	_, err := caller.Call(
+		ctx,
+		&CallParams{
+			URL:         server.URL,
+			Method:      http.MethodGet,
+			Request:     &InternalTestRequest{},
+			Response:    &InternalTestResponse{},
+			MaxAttempts: 3,
+		},
+	)
+
+	assert.NoError(t, err)
+	assert.Equal(t, 2, requestCount, "Expected the retry to proceed when the deadline allows it")
 }
 
 func TestDisableRetries(t *testing.T) {

--- a/seed/go-sdk/mixed-file-directory/internal/retrier.go
+++ b/seed/go-sdk/mixed-file-directory/internal/retrier.go
@@ -145,12 +145,20 @@ func (r *Retrier) run(
 	}
 
 	if r.shouldRetry(response) {
-		defer func() { _ = response.Body.Close() }()
-
 		delay, err := r.retryDelay(response, retryAttempt)
 		if err != nil {
+			_ = response.Body.Close()
 			return nil, err
 		}
+
+		// If the context's deadline would elapse before the backoff completes, return
+		// the response instead of sleeping through it. The caller then sees why the
+		// request actually failed (e.g. a 429) rather than a context deadline error.
+		if deadline, ok := request.Context().Deadline(); ok && time.Until(deadline) < delay {
+			return response, nil
+		}
+
+		defer func() { _ = response.Body.Close() }()
 
 		if err := sleepWithContext(request.Context(), delay); err != nil {
 			return nil, err

--- a/seed/go-sdk/mixed-file-directory/internal/retrier_test.go
+++ b/seed/go-sdk/mixed-file-directory/internal/retrier_test.go
@@ -295,7 +295,50 @@ func TestRetryWithRequestBody(t *testing.T) {
 	assert.Equal(t, expectedBody, requestBodies[1], "Second request body should match expected (retry should re-send body)")
 }
 
+// An explicit cancel (e.g. Ctrl-C wired to cancel()) must interrupt the backoff
+// wait. There is no deadline here, so the retrier cannot know the wait is futile
+// up front -- it has to be woken by the context.
 func TestRetryWaitIsInterruptedByContext(t *testing.T) {
+	var requestCount int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		w.Header().Set("Retry-After", "5")
+		w.WriteHeader(http.StatusTooManyRequests)
+	}))
+	defer server.Close()
+
+	caller := NewCaller(&CallerParams{
+		Client: server.Client(),
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		time.Sleep(100 * time.Millisecond)
+		cancel()
+	}()
+	defer cancel()
+
+	start := time.Now()
+	_, err := caller.Call(
+		ctx,
+		&CallParams{
+			URL:         server.URL,
+			Method:      http.MethodGet,
+			Request:     &InternalTestRequest{},
+			MaxAttempts: 3,
+		},
+	)
+	elapsed := time.Since(start)
+
+	assert.ErrorIs(t, err, context.Canceled)
+	assert.Equal(t, 1, requestCount, "Expected the retry to be abandoned once the context was cancelled")
+	assert.Less(t, elapsed, time.Second, "Expected the backoff to be interrupted by the context, took %v", elapsed)
+}
+
+// When the caller's deadline would elapse before the backoff finishes, sleeping
+// only guarantees a context error. Return the response instead so the caller
+// learns why the request actually failed.
+func TestRetryReturnsResponseWhenDeadlineShorterThanBackoff(t *testing.T) {
 	var requestCount int
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		requestCount++
@@ -323,9 +366,50 @@ func TestRetryWaitIsInterruptedByContext(t *testing.T) {
 	)
 	elapsed := time.Since(start)
 
-	assert.ErrorIs(t, err, context.DeadlineExceeded)
-	assert.Equal(t, 1, requestCount, "Expected the retry to be abandoned once the context expired")
-	assert.Less(t, elapsed, time.Second, "Expected the backoff to be interrupted by the context, took %v", elapsed)
+	// The caller gets the 429, not context.DeadlineExceeded.
+	var apiError *core.APIError
+	require.ErrorAs(t, err, &apiError)
+	assert.Equal(t, http.StatusTooManyRequests, apiError.StatusCode)
+	assert.NotErrorIs(t, err, context.DeadlineExceeded)
+	assert.Equal(t, 1, requestCount, "Expected no retry once the deadline was known to be too short")
+	assert.Less(t, elapsed, time.Second, "Expected to return immediately rather than sleep, took %v", elapsed)
+}
+
+// A deadline with room for the backoff must still retry as normal.
+func TestRetryProceedsWhenDeadlineLongerThanBackoff(t *testing.T) {
+	var requestCount int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		if requestCount == 1 {
+			w.Header().Set("Retry-After", "1")
+			w.WriteHeader(http.StatusTooManyRequests)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("{}"))
+	}))
+	defer server.Close()
+
+	caller := NewCaller(&CallerParams{
+		Client: server.Client(),
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	_, err := caller.Call(
+		ctx,
+		&CallParams{
+			URL:         server.URL,
+			Method:      http.MethodGet,
+			Request:     &InternalTestRequest{},
+			Response:    &InternalTestResponse{},
+			MaxAttempts: 3,
+		},
+	)
+
+	assert.NoError(t, err)
+	assert.Equal(t, 2, requestCount, "Expected the retry to proceed when the deadline allows it")
 }
 
 func TestDisableRetries(t *testing.T) {

--- a/seed/go-sdk/multi-content-type-examples/internal/retrier.go
+++ b/seed/go-sdk/multi-content-type-examples/internal/retrier.go
@@ -145,12 +145,20 @@ func (r *Retrier) run(
 	}
 
 	if r.shouldRetry(response) {
-		defer func() { _ = response.Body.Close() }()
-
 		delay, err := r.retryDelay(response, retryAttempt)
 		if err != nil {
+			_ = response.Body.Close()
 			return nil, err
 		}
+
+		// If the context's deadline would elapse before the backoff completes, return
+		// the response instead of sleeping through it. The caller then sees why the
+		// request actually failed (e.g. a 429) rather than a context deadline error.
+		if deadline, ok := request.Context().Deadline(); ok && time.Until(deadline) < delay {
+			return response, nil
+		}
+
+		defer func() { _ = response.Body.Close() }()
 
 		if err := sleepWithContext(request.Context(), delay); err != nil {
 			return nil, err

--- a/seed/go-sdk/multi-content-type-examples/internal/retrier_test.go
+++ b/seed/go-sdk/multi-content-type-examples/internal/retrier_test.go
@@ -295,7 +295,50 @@ func TestRetryWithRequestBody(t *testing.T) {
 	assert.Equal(t, expectedBody, requestBodies[1], "Second request body should match expected (retry should re-send body)")
 }
 
+// An explicit cancel (e.g. Ctrl-C wired to cancel()) must interrupt the backoff
+// wait. There is no deadline here, so the retrier cannot know the wait is futile
+// up front -- it has to be woken by the context.
 func TestRetryWaitIsInterruptedByContext(t *testing.T) {
+	var requestCount int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		w.Header().Set("Retry-After", "5")
+		w.WriteHeader(http.StatusTooManyRequests)
+	}))
+	defer server.Close()
+
+	caller := NewCaller(&CallerParams{
+		Client: server.Client(),
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		time.Sleep(100 * time.Millisecond)
+		cancel()
+	}()
+	defer cancel()
+
+	start := time.Now()
+	_, err := caller.Call(
+		ctx,
+		&CallParams{
+			URL:         server.URL,
+			Method:      http.MethodGet,
+			Request:     &InternalTestRequest{},
+			MaxAttempts: 3,
+		},
+	)
+	elapsed := time.Since(start)
+
+	assert.ErrorIs(t, err, context.Canceled)
+	assert.Equal(t, 1, requestCount, "Expected the retry to be abandoned once the context was cancelled")
+	assert.Less(t, elapsed, time.Second, "Expected the backoff to be interrupted by the context, took %v", elapsed)
+}
+
+// When the caller's deadline would elapse before the backoff finishes, sleeping
+// only guarantees a context error. Return the response instead so the caller
+// learns why the request actually failed.
+func TestRetryReturnsResponseWhenDeadlineShorterThanBackoff(t *testing.T) {
 	var requestCount int
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		requestCount++
@@ -323,9 +366,50 @@ func TestRetryWaitIsInterruptedByContext(t *testing.T) {
 	)
 	elapsed := time.Since(start)
 
-	assert.ErrorIs(t, err, context.DeadlineExceeded)
-	assert.Equal(t, 1, requestCount, "Expected the retry to be abandoned once the context expired")
-	assert.Less(t, elapsed, time.Second, "Expected the backoff to be interrupted by the context, took %v", elapsed)
+	// The caller gets the 429, not context.DeadlineExceeded.
+	var apiError *core.APIError
+	require.ErrorAs(t, err, &apiError)
+	assert.Equal(t, http.StatusTooManyRequests, apiError.StatusCode)
+	assert.NotErrorIs(t, err, context.DeadlineExceeded)
+	assert.Equal(t, 1, requestCount, "Expected no retry once the deadline was known to be too short")
+	assert.Less(t, elapsed, time.Second, "Expected to return immediately rather than sleep, took %v", elapsed)
+}
+
+// A deadline with room for the backoff must still retry as normal.
+func TestRetryProceedsWhenDeadlineLongerThanBackoff(t *testing.T) {
+	var requestCount int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		if requestCount == 1 {
+			w.Header().Set("Retry-After", "1")
+			w.WriteHeader(http.StatusTooManyRequests)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("{}"))
+	}))
+	defer server.Close()
+
+	caller := NewCaller(&CallerParams{
+		Client: server.Client(),
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	_, err := caller.Call(
+		ctx,
+		&CallParams{
+			URL:         server.URL,
+			Method:      http.MethodGet,
+			Request:     &InternalTestRequest{},
+			Response:    &InternalTestResponse{},
+			MaxAttempts: 3,
+		},
+	)
+
+	assert.NoError(t, err)
+	assert.Equal(t, 2, requestCount, "Expected the retry to proceed when the deadline allows it")
 }
 
 func TestDisableRetries(t *testing.T) {

--- a/seed/go-sdk/multi-line-docs/internal/retrier.go
+++ b/seed/go-sdk/multi-line-docs/internal/retrier.go
@@ -145,12 +145,20 @@ func (r *Retrier) run(
 	}
 
 	if r.shouldRetry(response) {
-		defer func() { _ = response.Body.Close() }()
-
 		delay, err := r.retryDelay(response, retryAttempt)
 		if err != nil {
+			_ = response.Body.Close()
 			return nil, err
 		}
+
+		// If the context's deadline would elapse before the backoff completes, return
+		// the response instead of sleeping through it. The caller then sees why the
+		// request actually failed (e.g. a 429) rather than a context deadline error.
+		if deadline, ok := request.Context().Deadline(); ok && time.Until(deadline) < delay {
+			return response, nil
+		}
+
+		defer func() { _ = response.Body.Close() }()
 
 		if err := sleepWithContext(request.Context(), delay); err != nil {
 			return nil, err

--- a/seed/go-sdk/multi-line-docs/internal/retrier_test.go
+++ b/seed/go-sdk/multi-line-docs/internal/retrier_test.go
@@ -295,7 +295,50 @@ func TestRetryWithRequestBody(t *testing.T) {
 	assert.Equal(t, expectedBody, requestBodies[1], "Second request body should match expected (retry should re-send body)")
 }
 
+// An explicit cancel (e.g. Ctrl-C wired to cancel()) must interrupt the backoff
+// wait. There is no deadline here, so the retrier cannot know the wait is futile
+// up front -- it has to be woken by the context.
 func TestRetryWaitIsInterruptedByContext(t *testing.T) {
+	var requestCount int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		w.Header().Set("Retry-After", "5")
+		w.WriteHeader(http.StatusTooManyRequests)
+	}))
+	defer server.Close()
+
+	caller := NewCaller(&CallerParams{
+		Client: server.Client(),
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		time.Sleep(100 * time.Millisecond)
+		cancel()
+	}()
+	defer cancel()
+
+	start := time.Now()
+	_, err := caller.Call(
+		ctx,
+		&CallParams{
+			URL:         server.URL,
+			Method:      http.MethodGet,
+			Request:     &InternalTestRequest{},
+			MaxAttempts: 3,
+		},
+	)
+	elapsed := time.Since(start)
+
+	assert.ErrorIs(t, err, context.Canceled)
+	assert.Equal(t, 1, requestCount, "Expected the retry to be abandoned once the context was cancelled")
+	assert.Less(t, elapsed, time.Second, "Expected the backoff to be interrupted by the context, took %v", elapsed)
+}
+
+// When the caller's deadline would elapse before the backoff finishes, sleeping
+// only guarantees a context error. Return the response instead so the caller
+// learns why the request actually failed.
+func TestRetryReturnsResponseWhenDeadlineShorterThanBackoff(t *testing.T) {
 	var requestCount int
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		requestCount++
@@ -323,9 +366,50 @@ func TestRetryWaitIsInterruptedByContext(t *testing.T) {
 	)
 	elapsed := time.Since(start)
 
-	assert.ErrorIs(t, err, context.DeadlineExceeded)
-	assert.Equal(t, 1, requestCount, "Expected the retry to be abandoned once the context expired")
-	assert.Less(t, elapsed, time.Second, "Expected the backoff to be interrupted by the context, took %v", elapsed)
+	// The caller gets the 429, not context.DeadlineExceeded.
+	var apiError *core.APIError
+	require.ErrorAs(t, err, &apiError)
+	assert.Equal(t, http.StatusTooManyRequests, apiError.StatusCode)
+	assert.NotErrorIs(t, err, context.DeadlineExceeded)
+	assert.Equal(t, 1, requestCount, "Expected no retry once the deadline was known to be too short")
+	assert.Less(t, elapsed, time.Second, "Expected to return immediately rather than sleep, took %v", elapsed)
+}
+
+// A deadline with room for the backoff must still retry as normal.
+func TestRetryProceedsWhenDeadlineLongerThanBackoff(t *testing.T) {
+	var requestCount int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		if requestCount == 1 {
+			w.Header().Set("Retry-After", "1")
+			w.WriteHeader(http.StatusTooManyRequests)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("{}"))
+	}))
+	defer server.Close()
+
+	caller := NewCaller(&CallerParams{
+		Client: server.Client(),
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	_, err := caller.Call(
+		ctx,
+		&CallParams{
+			URL:         server.URL,
+			Method:      http.MethodGet,
+			Request:     &InternalTestRequest{},
+			Response:    &InternalTestResponse{},
+			MaxAttempts: 3,
+		},
+	)
+
+	assert.NoError(t, err)
+	assert.Equal(t, 2, requestCount, "Expected the retry to proceed when the deadline allows it")
 }
 
 func TestDisableRetries(t *testing.T) {

--- a/seed/go-sdk/multi-url-environment-no-default/internal/retrier.go
+++ b/seed/go-sdk/multi-url-environment-no-default/internal/retrier.go
@@ -145,12 +145,20 @@ func (r *Retrier) run(
 	}
 
 	if r.shouldRetry(response) {
-		defer func() { _ = response.Body.Close() }()
-
 		delay, err := r.retryDelay(response, retryAttempt)
 		if err != nil {
+			_ = response.Body.Close()
 			return nil, err
 		}
+
+		// If the context's deadline would elapse before the backoff completes, return
+		// the response instead of sleeping through it. The caller then sees why the
+		// request actually failed (e.g. a 429) rather than a context deadline error.
+		if deadline, ok := request.Context().Deadline(); ok && time.Until(deadline) < delay {
+			return response, nil
+		}
+
+		defer func() { _ = response.Body.Close() }()
 
 		if err := sleepWithContext(request.Context(), delay); err != nil {
 			return nil, err

--- a/seed/go-sdk/multi-url-environment-no-default/internal/retrier_test.go
+++ b/seed/go-sdk/multi-url-environment-no-default/internal/retrier_test.go
@@ -295,7 +295,50 @@ func TestRetryWithRequestBody(t *testing.T) {
 	assert.Equal(t, expectedBody, requestBodies[1], "Second request body should match expected (retry should re-send body)")
 }
 
+// An explicit cancel (e.g. Ctrl-C wired to cancel()) must interrupt the backoff
+// wait. There is no deadline here, so the retrier cannot know the wait is futile
+// up front -- it has to be woken by the context.
 func TestRetryWaitIsInterruptedByContext(t *testing.T) {
+	var requestCount int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		w.Header().Set("Retry-After", "5")
+		w.WriteHeader(http.StatusTooManyRequests)
+	}))
+	defer server.Close()
+
+	caller := NewCaller(&CallerParams{
+		Client: server.Client(),
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		time.Sleep(100 * time.Millisecond)
+		cancel()
+	}()
+	defer cancel()
+
+	start := time.Now()
+	_, err := caller.Call(
+		ctx,
+		&CallParams{
+			URL:         server.URL,
+			Method:      http.MethodGet,
+			Request:     &InternalTestRequest{},
+			MaxAttempts: 3,
+		},
+	)
+	elapsed := time.Since(start)
+
+	assert.ErrorIs(t, err, context.Canceled)
+	assert.Equal(t, 1, requestCount, "Expected the retry to be abandoned once the context was cancelled")
+	assert.Less(t, elapsed, time.Second, "Expected the backoff to be interrupted by the context, took %v", elapsed)
+}
+
+// When the caller's deadline would elapse before the backoff finishes, sleeping
+// only guarantees a context error. Return the response instead so the caller
+// learns why the request actually failed.
+func TestRetryReturnsResponseWhenDeadlineShorterThanBackoff(t *testing.T) {
 	var requestCount int
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		requestCount++
@@ -323,9 +366,50 @@ func TestRetryWaitIsInterruptedByContext(t *testing.T) {
 	)
 	elapsed := time.Since(start)
 
-	assert.ErrorIs(t, err, context.DeadlineExceeded)
-	assert.Equal(t, 1, requestCount, "Expected the retry to be abandoned once the context expired")
-	assert.Less(t, elapsed, time.Second, "Expected the backoff to be interrupted by the context, took %v", elapsed)
+	// The caller gets the 429, not context.DeadlineExceeded.
+	var apiError *core.APIError
+	require.ErrorAs(t, err, &apiError)
+	assert.Equal(t, http.StatusTooManyRequests, apiError.StatusCode)
+	assert.NotErrorIs(t, err, context.DeadlineExceeded)
+	assert.Equal(t, 1, requestCount, "Expected no retry once the deadline was known to be too short")
+	assert.Less(t, elapsed, time.Second, "Expected to return immediately rather than sleep, took %v", elapsed)
+}
+
+// A deadline with room for the backoff must still retry as normal.
+func TestRetryProceedsWhenDeadlineLongerThanBackoff(t *testing.T) {
+	var requestCount int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		if requestCount == 1 {
+			w.Header().Set("Retry-After", "1")
+			w.WriteHeader(http.StatusTooManyRequests)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("{}"))
+	}))
+	defer server.Close()
+
+	caller := NewCaller(&CallerParams{
+		Client: server.Client(),
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	_, err := caller.Call(
+		ctx,
+		&CallParams{
+			URL:         server.URL,
+			Method:      http.MethodGet,
+			Request:     &InternalTestRequest{},
+			Response:    &InternalTestResponse{},
+			MaxAttempts: 3,
+		},
+	)
+
+	assert.NoError(t, err)
+	assert.Equal(t, 2, requestCount, "Expected the retry to proceed when the deadline allows it")
 }
 
 func TestDisableRetries(t *testing.T) {

--- a/seed/go-sdk/multi-url-environment-reference/internal/retrier.go
+++ b/seed/go-sdk/multi-url-environment-reference/internal/retrier.go
@@ -145,12 +145,20 @@ func (r *Retrier) run(
 	}
 
 	if r.shouldRetry(response) {
-		defer func() { _ = response.Body.Close() }()
-
 		delay, err := r.retryDelay(response, retryAttempt)
 		if err != nil {
+			_ = response.Body.Close()
 			return nil, err
 		}
+
+		// If the context's deadline would elapse before the backoff completes, return
+		// the response instead of sleeping through it. The caller then sees why the
+		// request actually failed (e.g. a 429) rather than a context deadline error.
+		if deadline, ok := request.Context().Deadline(); ok && time.Until(deadline) < delay {
+			return response, nil
+		}
+
+		defer func() { _ = response.Body.Close() }()
 
 		if err := sleepWithContext(request.Context(), delay); err != nil {
 			return nil, err

--- a/seed/go-sdk/multi-url-environment-reference/internal/retrier_test.go
+++ b/seed/go-sdk/multi-url-environment-reference/internal/retrier_test.go
@@ -295,7 +295,50 @@ func TestRetryWithRequestBody(t *testing.T) {
 	assert.Equal(t, expectedBody, requestBodies[1], "Second request body should match expected (retry should re-send body)")
 }
 
+// An explicit cancel (e.g. Ctrl-C wired to cancel()) must interrupt the backoff
+// wait. There is no deadline here, so the retrier cannot know the wait is futile
+// up front -- it has to be woken by the context.
 func TestRetryWaitIsInterruptedByContext(t *testing.T) {
+	var requestCount int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		w.Header().Set("Retry-After", "5")
+		w.WriteHeader(http.StatusTooManyRequests)
+	}))
+	defer server.Close()
+
+	caller := NewCaller(&CallerParams{
+		Client: server.Client(),
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		time.Sleep(100 * time.Millisecond)
+		cancel()
+	}()
+	defer cancel()
+
+	start := time.Now()
+	_, err := caller.Call(
+		ctx,
+		&CallParams{
+			URL:         server.URL,
+			Method:      http.MethodGet,
+			Request:     &InternalTestRequest{},
+			MaxAttempts: 3,
+		},
+	)
+	elapsed := time.Since(start)
+
+	assert.ErrorIs(t, err, context.Canceled)
+	assert.Equal(t, 1, requestCount, "Expected the retry to be abandoned once the context was cancelled")
+	assert.Less(t, elapsed, time.Second, "Expected the backoff to be interrupted by the context, took %v", elapsed)
+}
+
+// When the caller's deadline would elapse before the backoff finishes, sleeping
+// only guarantees a context error. Return the response instead so the caller
+// learns why the request actually failed.
+func TestRetryReturnsResponseWhenDeadlineShorterThanBackoff(t *testing.T) {
 	var requestCount int
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		requestCount++
@@ -323,9 +366,50 @@ func TestRetryWaitIsInterruptedByContext(t *testing.T) {
 	)
 	elapsed := time.Since(start)
 
-	assert.ErrorIs(t, err, context.DeadlineExceeded)
-	assert.Equal(t, 1, requestCount, "Expected the retry to be abandoned once the context expired")
-	assert.Less(t, elapsed, time.Second, "Expected the backoff to be interrupted by the context, took %v", elapsed)
+	// The caller gets the 429, not context.DeadlineExceeded.
+	var apiError *core.APIError
+	require.ErrorAs(t, err, &apiError)
+	assert.Equal(t, http.StatusTooManyRequests, apiError.StatusCode)
+	assert.NotErrorIs(t, err, context.DeadlineExceeded)
+	assert.Equal(t, 1, requestCount, "Expected no retry once the deadline was known to be too short")
+	assert.Less(t, elapsed, time.Second, "Expected to return immediately rather than sleep, took %v", elapsed)
+}
+
+// A deadline with room for the backoff must still retry as normal.
+func TestRetryProceedsWhenDeadlineLongerThanBackoff(t *testing.T) {
+	var requestCount int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		if requestCount == 1 {
+			w.Header().Set("Retry-After", "1")
+			w.WriteHeader(http.StatusTooManyRequests)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("{}"))
+	}))
+	defer server.Close()
+
+	caller := NewCaller(&CallerParams{
+		Client: server.Client(),
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	_, err := caller.Call(
+		ctx,
+		&CallParams{
+			URL:         server.URL,
+			Method:      http.MethodGet,
+			Request:     &InternalTestRequest{},
+			Response:    &InternalTestResponse{},
+			MaxAttempts: 3,
+		},
+	)
+
+	assert.NoError(t, err)
+	assert.Equal(t, 2, requestCount, "Expected the retry to proceed when the deadline allows it")
 }
 
 func TestDisableRetries(t *testing.T) {

--- a/seed/go-sdk/multi-url-environment/internal/retrier.go
+++ b/seed/go-sdk/multi-url-environment/internal/retrier.go
@@ -145,12 +145,20 @@ func (r *Retrier) run(
 	}
 
 	if r.shouldRetry(response) {
-		defer func() { _ = response.Body.Close() }()
-
 		delay, err := r.retryDelay(response, retryAttempt)
 		if err != nil {
+			_ = response.Body.Close()
 			return nil, err
 		}
+
+		// If the context's deadline would elapse before the backoff completes, return
+		// the response instead of sleeping through it. The caller then sees why the
+		// request actually failed (e.g. a 429) rather than a context deadline error.
+		if deadline, ok := request.Context().Deadline(); ok && time.Until(deadline) < delay {
+			return response, nil
+		}
+
+		defer func() { _ = response.Body.Close() }()
 
 		if err := sleepWithContext(request.Context(), delay); err != nil {
 			return nil, err

--- a/seed/go-sdk/multi-url-environment/internal/retrier_test.go
+++ b/seed/go-sdk/multi-url-environment/internal/retrier_test.go
@@ -295,7 +295,50 @@ func TestRetryWithRequestBody(t *testing.T) {
 	assert.Equal(t, expectedBody, requestBodies[1], "Second request body should match expected (retry should re-send body)")
 }
 
+// An explicit cancel (e.g. Ctrl-C wired to cancel()) must interrupt the backoff
+// wait. There is no deadline here, so the retrier cannot know the wait is futile
+// up front -- it has to be woken by the context.
 func TestRetryWaitIsInterruptedByContext(t *testing.T) {
+	var requestCount int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		w.Header().Set("Retry-After", "5")
+		w.WriteHeader(http.StatusTooManyRequests)
+	}))
+	defer server.Close()
+
+	caller := NewCaller(&CallerParams{
+		Client: server.Client(),
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		time.Sleep(100 * time.Millisecond)
+		cancel()
+	}()
+	defer cancel()
+
+	start := time.Now()
+	_, err := caller.Call(
+		ctx,
+		&CallParams{
+			URL:         server.URL,
+			Method:      http.MethodGet,
+			Request:     &InternalTestRequest{},
+			MaxAttempts: 3,
+		},
+	)
+	elapsed := time.Since(start)
+
+	assert.ErrorIs(t, err, context.Canceled)
+	assert.Equal(t, 1, requestCount, "Expected the retry to be abandoned once the context was cancelled")
+	assert.Less(t, elapsed, time.Second, "Expected the backoff to be interrupted by the context, took %v", elapsed)
+}
+
+// When the caller's deadline would elapse before the backoff finishes, sleeping
+// only guarantees a context error. Return the response instead so the caller
+// learns why the request actually failed.
+func TestRetryReturnsResponseWhenDeadlineShorterThanBackoff(t *testing.T) {
 	var requestCount int
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		requestCount++
@@ -323,9 +366,50 @@ func TestRetryWaitIsInterruptedByContext(t *testing.T) {
 	)
 	elapsed := time.Since(start)
 
-	assert.ErrorIs(t, err, context.DeadlineExceeded)
-	assert.Equal(t, 1, requestCount, "Expected the retry to be abandoned once the context expired")
-	assert.Less(t, elapsed, time.Second, "Expected the backoff to be interrupted by the context, took %v", elapsed)
+	// The caller gets the 429, not context.DeadlineExceeded.
+	var apiError *core.APIError
+	require.ErrorAs(t, err, &apiError)
+	assert.Equal(t, http.StatusTooManyRequests, apiError.StatusCode)
+	assert.NotErrorIs(t, err, context.DeadlineExceeded)
+	assert.Equal(t, 1, requestCount, "Expected no retry once the deadline was known to be too short")
+	assert.Less(t, elapsed, time.Second, "Expected to return immediately rather than sleep, took %v", elapsed)
+}
+
+// A deadline with room for the backoff must still retry as normal.
+func TestRetryProceedsWhenDeadlineLongerThanBackoff(t *testing.T) {
+	var requestCount int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		if requestCount == 1 {
+			w.Header().Set("Retry-After", "1")
+			w.WriteHeader(http.StatusTooManyRequests)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("{}"))
+	}))
+	defer server.Close()
+
+	caller := NewCaller(&CallerParams{
+		Client: server.Client(),
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	_, err := caller.Call(
+		ctx,
+		&CallParams{
+			URL:         server.URL,
+			Method:      http.MethodGet,
+			Request:     &InternalTestRequest{},
+			Response:    &InternalTestResponse{},
+			MaxAttempts: 3,
+		},
+	)
+
+	assert.NoError(t, err)
+	assert.Equal(t, 2, requestCount, "Expected the retry to proceed when the deadline allows it")
 }
 
 func TestDisableRetries(t *testing.T) {

--- a/seed/go-sdk/multiple-request-bodies/internal/retrier.go
+++ b/seed/go-sdk/multiple-request-bodies/internal/retrier.go
@@ -145,12 +145,20 @@ func (r *Retrier) run(
 	}
 
 	if r.shouldRetry(response) {
-		defer func() { _ = response.Body.Close() }()
-
 		delay, err := r.retryDelay(response, retryAttempt)
 		if err != nil {
+			_ = response.Body.Close()
 			return nil, err
 		}
+
+		// If the context's deadline would elapse before the backoff completes, return
+		// the response instead of sleeping through it. The caller then sees why the
+		// request actually failed (e.g. a 429) rather than a context deadline error.
+		if deadline, ok := request.Context().Deadline(); ok && time.Until(deadline) < delay {
+			return response, nil
+		}
+
+		defer func() { _ = response.Body.Close() }()
 
 		if err := sleepWithContext(request.Context(), delay); err != nil {
 			return nil, err

--- a/seed/go-sdk/multiple-request-bodies/internal/retrier_test.go
+++ b/seed/go-sdk/multiple-request-bodies/internal/retrier_test.go
@@ -295,7 +295,50 @@ func TestRetryWithRequestBody(t *testing.T) {
 	assert.Equal(t, expectedBody, requestBodies[1], "Second request body should match expected (retry should re-send body)")
 }
 
+// An explicit cancel (e.g. Ctrl-C wired to cancel()) must interrupt the backoff
+// wait. There is no deadline here, so the retrier cannot know the wait is futile
+// up front -- it has to be woken by the context.
 func TestRetryWaitIsInterruptedByContext(t *testing.T) {
+	var requestCount int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		w.Header().Set("Retry-After", "5")
+		w.WriteHeader(http.StatusTooManyRequests)
+	}))
+	defer server.Close()
+
+	caller := NewCaller(&CallerParams{
+		Client: server.Client(),
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		time.Sleep(100 * time.Millisecond)
+		cancel()
+	}()
+	defer cancel()
+
+	start := time.Now()
+	_, err := caller.Call(
+		ctx,
+		&CallParams{
+			URL:         server.URL,
+			Method:      http.MethodGet,
+			Request:     &InternalTestRequest{},
+			MaxAttempts: 3,
+		},
+	)
+	elapsed := time.Since(start)
+
+	assert.ErrorIs(t, err, context.Canceled)
+	assert.Equal(t, 1, requestCount, "Expected the retry to be abandoned once the context was cancelled")
+	assert.Less(t, elapsed, time.Second, "Expected the backoff to be interrupted by the context, took %v", elapsed)
+}
+
+// When the caller's deadline would elapse before the backoff finishes, sleeping
+// only guarantees a context error. Return the response instead so the caller
+// learns why the request actually failed.
+func TestRetryReturnsResponseWhenDeadlineShorterThanBackoff(t *testing.T) {
 	var requestCount int
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		requestCount++
@@ -323,9 +366,50 @@ func TestRetryWaitIsInterruptedByContext(t *testing.T) {
 	)
 	elapsed := time.Since(start)
 
-	assert.ErrorIs(t, err, context.DeadlineExceeded)
-	assert.Equal(t, 1, requestCount, "Expected the retry to be abandoned once the context expired")
-	assert.Less(t, elapsed, time.Second, "Expected the backoff to be interrupted by the context, took %v", elapsed)
+	// The caller gets the 429, not context.DeadlineExceeded.
+	var apiError *core.APIError
+	require.ErrorAs(t, err, &apiError)
+	assert.Equal(t, http.StatusTooManyRequests, apiError.StatusCode)
+	assert.NotErrorIs(t, err, context.DeadlineExceeded)
+	assert.Equal(t, 1, requestCount, "Expected no retry once the deadline was known to be too short")
+	assert.Less(t, elapsed, time.Second, "Expected to return immediately rather than sleep, took %v", elapsed)
+}
+
+// A deadline with room for the backoff must still retry as normal.
+func TestRetryProceedsWhenDeadlineLongerThanBackoff(t *testing.T) {
+	var requestCount int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		if requestCount == 1 {
+			w.Header().Set("Retry-After", "1")
+			w.WriteHeader(http.StatusTooManyRequests)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("{}"))
+	}))
+	defer server.Close()
+
+	caller := NewCaller(&CallerParams{
+		Client: server.Client(),
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	_, err := caller.Call(
+		ctx,
+		&CallParams{
+			URL:         server.URL,
+			Method:      http.MethodGet,
+			Request:     &InternalTestRequest{},
+			Response:    &InternalTestResponse{},
+			MaxAttempts: 3,
+		},
+	)
+
+	assert.NoError(t, err)
+	assert.Equal(t, 2, requestCount, "Expected the retry to proceed when the deadline allows it")
 }
 
 func TestDisableRetries(t *testing.T) {

--- a/seed/go-sdk/no-content-response/internal/retrier.go
+++ b/seed/go-sdk/no-content-response/internal/retrier.go
@@ -145,12 +145,20 @@ func (r *Retrier) run(
 	}
 
 	if r.shouldRetry(response) {
-		defer func() { _ = response.Body.Close() }()
-
 		delay, err := r.retryDelay(response, retryAttempt)
 		if err != nil {
+			_ = response.Body.Close()
 			return nil, err
 		}
+
+		// If the context's deadline would elapse before the backoff completes, return
+		// the response instead of sleeping through it. The caller then sees why the
+		// request actually failed (e.g. a 429) rather than a context deadline error.
+		if deadline, ok := request.Context().Deadline(); ok && time.Until(deadline) < delay {
+			return response, nil
+		}
+
+		defer func() { _ = response.Body.Close() }()
 
 		if err := sleepWithContext(request.Context(), delay); err != nil {
 			return nil, err

--- a/seed/go-sdk/no-content-response/internal/retrier_test.go
+++ b/seed/go-sdk/no-content-response/internal/retrier_test.go
@@ -295,7 +295,50 @@ func TestRetryWithRequestBody(t *testing.T) {
 	assert.Equal(t, expectedBody, requestBodies[1], "Second request body should match expected (retry should re-send body)")
 }
 
+// An explicit cancel (e.g. Ctrl-C wired to cancel()) must interrupt the backoff
+// wait. There is no deadline here, so the retrier cannot know the wait is futile
+// up front -- it has to be woken by the context.
 func TestRetryWaitIsInterruptedByContext(t *testing.T) {
+	var requestCount int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		w.Header().Set("Retry-After", "5")
+		w.WriteHeader(http.StatusTooManyRequests)
+	}))
+	defer server.Close()
+
+	caller := NewCaller(&CallerParams{
+		Client: server.Client(),
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		time.Sleep(100 * time.Millisecond)
+		cancel()
+	}()
+	defer cancel()
+
+	start := time.Now()
+	_, err := caller.Call(
+		ctx,
+		&CallParams{
+			URL:         server.URL,
+			Method:      http.MethodGet,
+			Request:     &InternalTestRequest{},
+			MaxAttempts: 3,
+		},
+	)
+	elapsed := time.Since(start)
+
+	assert.ErrorIs(t, err, context.Canceled)
+	assert.Equal(t, 1, requestCount, "Expected the retry to be abandoned once the context was cancelled")
+	assert.Less(t, elapsed, time.Second, "Expected the backoff to be interrupted by the context, took %v", elapsed)
+}
+
+// When the caller's deadline would elapse before the backoff finishes, sleeping
+// only guarantees a context error. Return the response instead so the caller
+// learns why the request actually failed.
+func TestRetryReturnsResponseWhenDeadlineShorterThanBackoff(t *testing.T) {
 	var requestCount int
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		requestCount++
@@ -323,9 +366,50 @@ func TestRetryWaitIsInterruptedByContext(t *testing.T) {
 	)
 	elapsed := time.Since(start)
 
-	assert.ErrorIs(t, err, context.DeadlineExceeded)
-	assert.Equal(t, 1, requestCount, "Expected the retry to be abandoned once the context expired")
-	assert.Less(t, elapsed, time.Second, "Expected the backoff to be interrupted by the context, took %v", elapsed)
+	// The caller gets the 429, not context.DeadlineExceeded.
+	var apiError *core.APIError
+	require.ErrorAs(t, err, &apiError)
+	assert.Equal(t, http.StatusTooManyRequests, apiError.StatusCode)
+	assert.NotErrorIs(t, err, context.DeadlineExceeded)
+	assert.Equal(t, 1, requestCount, "Expected no retry once the deadline was known to be too short")
+	assert.Less(t, elapsed, time.Second, "Expected to return immediately rather than sleep, took %v", elapsed)
+}
+
+// A deadline with room for the backoff must still retry as normal.
+func TestRetryProceedsWhenDeadlineLongerThanBackoff(t *testing.T) {
+	var requestCount int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		if requestCount == 1 {
+			w.Header().Set("Retry-After", "1")
+			w.WriteHeader(http.StatusTooManyRequests)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("{}"))
+	}))
+	defer server.Close()
+
+	caller := NewCaller(&CallerParams{
+		Client: server.Client(),
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	_, err := caller.Call(
+		ctx,
+		&CallParams{
+			URL:         server.URL,
+			Method:      http.MethodGet,
+			Request:     &InternalTestRequest{},
+			Response:    &InternalTestResponse{},
+			MaxAttempts: 3,
+		},
+	)
+
+	assert.NoError(t, err)
+	assert.Equal(t, 2, requestCount, "Expected the retry to proceed when the deadline allows it")
 }
 
 func TestDisableRetries(t *testing.T) {

--- a/seed/go-sdk/no-environment/internal/retrier.go
+++ b/seed/go-sdk/no-environment/internal/retrier.go
@@ -145,12 +145,20 @@ func (r *Retrier) run(
 	}
 
 	if r.shouldRetry(response) {
-		defer func() { _ = response.Body.Close() }()
-
 		delay, err := r.retryDelay(response, retryAttempt)
 		if err != nil {
+			_ = response.Body.Close()
 			return nil, err
 		}
+
+		// If the context's deadline would elapse before the backoff completes, return
+		// the response instead of sleeping through it. The caller then sees why the
+		// request actually failed (e.g. a 429) rather than a context deadline error.
+		if deadline, ok := request.Context().Deadline(); ok && time.Until(deadline) < delay {
+			return response, nil
+		}
+
+		defer func() { _ = response.Body.Close() }()
 
 		if err := sleepWithContext(request.Context(), delay); err != nil {
 			return nil, err

--- a/seed/go-sdk/no-environment/internal/retrier_test.go
+++ b/seed/go-sdk/no-environment/internal/retrier_test.go
@@ -295,7 +295,50 @@ func TestRetryWithRequestBody(t *testing.T) {
 	assert.Equal(t, expectedBody, requestBodies[1], "Second request body should match expected (retry should re-send body)")
 }
 
+// An explicit cancel (e.g. Ctrl-C wired to cancel()) must interrupt the backoff
+// wait. There is no deadline here, so the retrier cannot know the wait is futile
+// up front -- it has to be woken by the context.
 func TestRetryWaitIsInterruptedByContext(t *testing.T) {
+	var requestCount int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		w.Header().Set("Retry-After", "5")
+		w.WriteHeader(http.StatusTooManyRequests)
+	}))
+	defer server.Close()
+
+	caller := NewCaller(&CallerParams{
+		Client: server.Client(),
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		time.Sleep(100 * time.Millisecond)
+		cancel()
+	}()
+	defer cancel()
+
+	start := time.Now()
+	_, err := caller.Call(
+		ctx,
+		&CallParams{
+			URL:         server.URL,
+			Method:      http.MethodGet,
+			Request:     &InternalTestRequest{},
+			MaxAttempts: 3,
+		},
+	)
+	elapsed := time.Since(start)
+
+	assert.ErrorIs(t, err, context.Canceled)
+	assert.Equal(t, 1, requestCount, "Expected the retry to be abandoned once the context was cancelled")
+	assert.Less(t, elapsed, time.Second, "Expected the backoff to be interrupted by the context, took %v", elapsed)
+}
+
+// When the caller's deadline would elapse before the backoff finishes, sleeping
+// only guarantees a context error. Return the response instead so the caller
+// learns why the request actually failed.
+func TestRetryReturnsResponseWhenDeadlineShorterThanBackoff(t *testing.T) {
 	var requestCount int
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		requestCount++
@@ -323,9 +366,50 @@ func TestRetryWaitIsInterruptedByContext(t *testing.T) {
 	)
 	elapsed := time.Since(start)
 
-	assert.ErrorIs(t, err, context.DeadlineExceeded)
-	assert.Equal(t, 1, requestCount, "Expected the retry to be abandoned once the context expired")
-	assert.Less(t, elapsed, time.Second, "Expected the backoff to be interrupted by the context, took %v", elapsed)
+	// The caller gets the 429, not context.DeadlineExceeded.
+	var apiError *core.APIError
+	require.ErrorAs(t, err, &apiError)
+	assert.Equal(t, http.StatusTooManyRequests, apiError.StatusCode)
+	assert.NotErrorIs(t, err, context.DeadlineExceeded)
+	assert.Equal(t, 1, requestCount, "Expected no retry once the deadline was known to be too short")
+	assert.Less(t, elapsed, time.Second, "Expected to return immediately rather than sleep, took %v", elapsed)
+}
+
+// A deadline with room for the backoff must still retry as normal.
+func TestRetryProceedsWhenDeadlineLongerThanBackoff(t *testing.T) {
+	var requestCount int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		if requestCount == 1 {
+			w.Header().Set("Retry-After", "1")
+			w.WriteHeader(http.StatusTooManyRequests)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("{}"))
+	}))
+	defer server.Close()
+
+	caller := NewCaller(&CallerParams{
+		Client: server.Client(),
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	_, err := caller.Call(
+		ctx,
+		&CallParams{
+			URL:         server.URL,
+			Method:      http.MethodGet,
+			Request:     &InternalTestRequest{},
+			Response:    &InternalTestResponse{},
+			MaxAttempts: 3,
+		},
+	)
+
+	assert.NoError(t, err)
+	assert.Equal(t, 2, requestCount, "Expected the retry to proceed when the deadline allows it")
 }
 
 func TestDisableRetries(t *testing.T) {

--- a/seed/go-sdk/no-retries/internal/retrier.go
+++ b/seed/go-sdk/no-retries/internal/retrier.go
@@ -145,12 +145,20 @@ func (r *Retrier) run(
 	}
 
 	if r.shouldRetry(response) {
-		defer func() { _ = response.Body.Close() }()
-
 		delay, err := r.retryDelay(response, retryAttempt)
 		if err != nil {
+			_ = response.Body.Close()
 			return nil, err
 		}
+
+		// If the context's deadline would elapse before the backoff completes, return
+		// the response instead of sleeping through it. The caller then sees why the
+		// request actually failed (e.g. a 429) rather than a context deadline error.
+		if deadline, ok := request.Context().Deadline(); ok && time.Until(deadline) < delay {
+			return response, nil
+		}
+
+		defer func() { _ = response.Body.Close() }()
 
 		if err := sleepWithContext(request.Context(), delay); err != nil {
 			return nil, err

--- a/seed/go-sdk/no-retries/internal/retrier_test.go
+++ b/seed/go-sdk/no-retries/internal/retrier_test.go
@@ -295,7 +295,50 @@ func TestRetryWithRequestBody(t *testing.T) {
 	assert.Equal(t, expectedBody, requestBodies[1], "Second request body should match expected (retry should re-send body)")
 }
 
+// An explicit cancel (e.g. Ctrl-C wired to cancel()) must interrupt the backoff
+// wait. There is no deadline here, so the retrier cannot know the wait is futile
+// up front -- it has to be woken by the context.
 func TestRetryWaitIsInterruptedByContext(t *testing.T) {
+	var requestCount int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		w.Header().Set("Retry-After", "5")
+		w.WriteHeader(http.StatusTooManyRequests)
+	}))
+	defer server.Close()
+
+	caller := NewCaller(&CallerParams{
+		Client: server.Client(),
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		time.Sleep(100 * time.Millisecond)
+		cancel()
+	}()
+	defer cancel()
+
+	start := time.Now()
+	_, err := caller.Call(
+		ctx,
+		&CallParams{
+			URL:         server.URL,
+			Method:      http.MethodGet,
+			Request:     &InternalTestRequest{},
+			MaxAttempts: 3,
+		},
+	)
+	elapsed := time.Since(start)
+
+	assert.ErrorIs(t, err, context.Canceled)
+	assert.Equal(t, 1, requestCount, "Expected the retry to be abandoned once the context was cancelled")
+	assert.Less(t, elapsed, time.Second, "Expected the backoff to be interrupted by the context, took %v", elapsed)
+}
+
+// When the caller's deadline would elapse before the backoff finishes, sleeping
+// only guarantees a context error. Return the response instead so the caller
+// learns why the request actually failed.
+func TestRetryReturnsResponseWhenDeadlineShorterThanBackoff(t *testing.T) {
 	var requestCount int
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		requestCount++
@@ -323,9 +366,50 @@ func TestRetryWaitIsInterruptedByContext(t *testing.T) {
 	)
 	elapsed := time.Since(start)
 
-	assert.ErrorIs(t, err, context.DeadlineExceeded)
-	assert.Equal(t, 1, requestCount, "Expected the retry to be abandoned once the context expired")
-	assert.Less(t, elapsed, time.Second, "Expected the backoff to be interrupted by the context, took %v", elapsed)
+	// The caller gets the 429, not context.DeadlineExceeded.
+	var apiError *core.APIError
+	require.ErrorAs(t, err, &apiError)
+	assert.Equal(t, http.StatusTooManyRequests, apiError.StatusCode)
+	assert.NotErrorIs(t, err, context.DeadlineExceeded)
+	assert.Equal(t, 1, requestCount, "Expected no retry once the deadline was known to be too short")
+	assert.Less(t, elapsed, time.Second, "Expected to return immediately rather than sleep, took %v", elapsed)
+}
+
+// A deadline with room for the backoff must still retry as normal.
+func TestRetryProceedsWhenDeadlineLongerThanBackoff(t *testing.T) {
+	var requestCount int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		if requestCount == 1 {
+			w.Header().Set("Retry-After", "1")
+			w.WriteHeader(http.StatusTooManyRequests)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("{}"))
+	}))
+	defer server.Close()
+
+	caller := NewCaller(&CallerParams{
+		Client: server.Client(),
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	_, err := caller.Call(
+		ctx,
+		&CallParams{
+			URL:         server.URL,
+			Method:      http.MethodGet,
+			Request:     &InternalTestRequest{},
+			Response:    &InternalTestResponse{},
+			MaxAttempts: 3,
+		},
+	)
+
+	assert.NoError(t, err)
+	assert.Equal(t, 2, requestCount, "Expected the retry to proceed when the deadline allows it")
 }
 
 func TestDisableRetries(t *testing.T) {

--- a/seed/go-sdk/null-type/internal/retrier.go
+++ b/seed/go-sdk/null-type/internal/retrier.go
@@ -145,12 +145,20 @@ func (r *Retrier) run(
 	}
 
 	if r.shouldRetry(response) {
-		defer func() { _ = response.Body.Close() }()
-
 		delay, err := r.retryDelay(response, retryAttempt)
 		if err != nil {
+			_ = response.Body.Close()
 			return nil, err
 		}
+
+		// If the context's deadline would elapse before the backoff completes, return
+		// the response instead of sleeping through it. The caller then sees why the
+		// request actually failed (e.g. a 429) rather than a context deadline error.
+		if deadline, ok := request.Context().Deadline(); ok && time.Until(deadline) < delay {
+			return response, nil
+		}
+
+		defer func() { _ = response.Body.Close() }()
 
 		if err := sleepWithContext(request.Context(), delay); err != nil {
 			return nil, err

--- a/seed/go-sdk/null-type/internal/retrier_test.go
+++ b/seed/go-sdk/null-type/internal/retrier_test.go
@@ -295,7 +295,50 @@ func TestRetryWithRequestBody(t *testing.T) {
 	assert.Equal(t, expectedBody, requestBodies[1], "Second request body should match expected (retry should re-send body)")
 }
 
+// An explicit cancel (e.g. Ctrl-C wired to cancel()) must interrupt the backoff
+// wait. There is no deadline here, so the retrier cannot know the wait is futile
+// up front -- it has to be woken by the context.
 func TestRetryWaitIsInterruptedByContext(t *testing.T) {
+	var requestCount int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		w.Header().Set("Retry-After", "5")
+		w.WriteHeader(http.StatusTooManyRequests)
+	}))
+	defer server.Close()
+
+	caller := NewCaller(&CallerParams{
+		Client: server.Client(),
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		time.Sleep(100 * time.Millisecond)
+		cancel()
+	}()
+	defer cancel()
+
+	start := time.Now()
+	_, err := caller.Call(
+		ctx,
+		&CallParams{
+			URL:         server.URL,
+			Method:      http.MethodGet,
+			Request:     &InternalTestRequest{},
+			MaxAttempts: 3,
+		},
+	)
+	elapsed := time.Since(start)
+
+	assert.ErrorIs(t, err, context.Canceled)
+	assert.Equal(t, 1, requestCount, "Expected the retry to be abandoned once the context was cancelled")
+	assert.Less(t, elapsed, time.Second, "Expected the backoff to be interrupted by the context, took %v", elapsed)
+}
+
+// When the caller's deadline would elapse before the backoff finishes, sleeping
+// only guarantees a context error. Return the response instead so the caller
+// learns why the request actually failed.
+func TestRetryReturnsResponseWhenDeadlineShorterThanBackoff(t *testing.T) {
 	var requestCount int
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		requestCount++
@@ -323,9 +366,50 @@ func TestRetryWaitIsInterruptedByContext(t *testing.T) {
 	)
 	elapsed := time.Since(start)
 
-	assert.ErrorIs(t, err, context.DeadlineExceeded)
-	assert.Equal(t, 1, requestCount, "Expected the retry to be abandoned once the context expired")
-	assert.Less(t, elapsed, time.Second, "Expected the backoff to be interrupted by the context, took %v", elapsed)
+	// The caller gets the 429, not context.DeadlineExceeded.
+	var apiError *core.APIError
+	require.ErrorAs(t, err, &apiError)
+	assert.Equal(t, http.StatusTooManyRequests, apiError.StatusCode)
+	assert.NotErrorIs(t, err, context.DeadlineExceeded)
+	assert.Equal(t, 1, requestCount, "Expected no retry once the deadline was known to be too short")
+	assert.Less(t, elapsed, time.Second, "Expected to return immediately rather than sleep, took %v", elapsed)
+}
+
+// A deadline with room for the backoff must still retry as normal.
+func TestRetryProceedsWhenDeadlineLongerThanBackoff(t *testing.T) {
+	var requestCount int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		if requestCount == 1 {
+			w.Header().Set("Retry-After", "1")
+			w.WriteHeader(http.StatusTooManyRequests)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("{}"))
+	}))
+	defer server.Close()
+
+	caller := NewCaller(&CallerParams{
+		Client: server.Client(),
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	_, err := caller.Call(
+		ctx,
+		&CallParams{
+			URL:         server.URL,
+			Method:      http.MethodGet,
+			Request:     &InternalTestRequest{},
+			Response:    &InternalTestResponse{},
+			MaxAttempts: 3,
+		},
+	)
+
+	assert.NoError(t, err)
+	assert.Equal(t, 2, requestCount, "Expected the retry to proceed when the deadline allows it")
 }
 
 func TestDisableRetries(t *testing.T) {

--- a/seed/go-sdk/nullable-allof-extends/internal/retrier.go
+++ b/seed/go-sdk/nullable-allof-extends/internal/retrier.go
@@ -145,12 +145,20 @@ func (r *Retrier) run(
 	}
 
 	if r.shouldRetry(response) {
-		defer func() { _ = response.Body.Close() }()
-
 		delay, err := r.retryDelay(response, retryAttempt)
 		if err != nil {
+			_ = response.Body.Close()
 			return nil, err
 		}
+
+		// If the context's deadline would elapse before the backoff completes, return
+		// the response instead of sleeping through it. The caller then sees why the
+		// request actually failed (e.g. a 429) rather than a context deadline error.
+		if deadline, ok := request.Context().Deadline(); ok && time.Until(deadline) < delay {
+			return response, nil
+		}
+
+		defer func() { _ = response.Body.Close() }()
 
 		if err := sleepWithContext(request.Context(), delay); err != nil {
 			return nil, err

--- a/seed/go-sdk/nullable-allof-extends/internal/retrier_test.go
+++ b/seed/go-sdk/nullable-allof-extends/internal/retrier_test.go
@@ -295,7 +295,50 @@ func TestRetryWithRequestBody(t *testing.T) {
 	assert.Equal(t, expectedBody, requestBodies[1], "Second request body should match expected (retry should re-send body)")
 }
 
+// An explicit cancel (e.g. Ctrl-C wired to cancel()) must interrupt the backoff
+// wait. There is no deadline here, so the retrier cannot know the wait is futile
+// up front -- it has to be woken by the context.
 func TestRetryWaitIsInterruptedByContext(t *testing.T) {
+	var requestCount int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		w.Header().Set("Retry-After", "5")
+		w.WriteHeader(http.StatusTooManyRequests)
+	}))
+	defer server.Close()
+
+	caller := NewCaller(&CallerParams{
+		Client: server.Client(),
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		time.Sleep(100 * time.Millisecond)
+		cancel()
+	}()
+	defer cancel()
+
+	start := time.Now()
+	_, err := caller.Call(
+		ctx,
+		&CallParams{
+			URL:         server.URL,
+			Method:      http.MethodGet,
+			Request:     &InternalTestRequest{},
+			MaxAttempts: 3,
+		},
+	)
+	elapsed := time.Since(start)
+
+	assert.ErrorIs(t, err, context.Canceled)
+	assert.Equal(t, 1, requestCount, "Expected the retry to be abandoned once the context was cancelled")
+	assert.Less(t, elapsed, time.Second, "Expected the backoff to be interrupted by the context, took %v", elapsed)
+}
+
+// When the caller's deadline would elapse before the backoff finishes, sleeping
+// only guarantees a context error. Return the response instead so the caller
+// learns why the request actually failed.
+func TestRetryReturnsResponseWhenDeadlineShorterThanBackoff(t *testing.T) {
 	var requestCount int
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		requestCount++
@@ -323,9 +366,50 @@ func TestRetryWaitIsInterruptedByContext(t *testing.T) {
 	)
 	elapsed := time.Since(start)
 
-	assert.ErrorIs(t, err, context.DeadlineExceeded)
-	assert.Equal(t, 1, requestCount, "Expected the retry to be abandoned once the context expired")
-	assert.Less(t, elapsed, time.Second, "Expected the backoff to be interrupted by the context, took %v", elapsed)
+	// The caller gets the 429, not context.DeadlineExceeded.
+	var apiError *core.APIError
+	require.ErrorAs(t, err, &apiError)
+	assert.Equal(t, http.StatusTooManyRequests, apiError.StatusCode)
+	assert.NotErrorIs(t, err, context.DeadlineExceeded)
+	assert.Equal(t, 1, requestCount, "Expected no retry once the deadline was known to be too short")
+	assert.Less(t, elapsed, time.Second, "Expected to return immediately rather than sleep, took %v", elapsed)
+}
+
+// A deadline with room for the backoff must still retry as normal.
+func TestRetryProceedsWhenDeadlineLongerThanBackoff(t *testing.T) {
+	var requestCount int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		if requestCount == 1 {
+			w.Header().Set("Retry-After", "1")
+			w.WriteHeader(http.StatusTooManyRequests)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("{}"))
+	}))
+	defer server.Close()
+
+	caller := NewCaller(&CallerParams{
+		Client: server.Client(),
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	_, err := caller.Call(
+		ctx,
+		&CallParams{
+			URL:         server.URL,
+			Method:      http.MethodGet,
+			Request:     &InternalTestRequest{},
+			Response:    &InternalTestResponse{},
+			MaxAttempts: 3,
+		},
+	)
+
+	assert.NoError(t, err)
+	assert.Equal(t, 2, requestCount, "Expected the retry to proceed when the deadline allows it")
 }
 
 func TestDisableRetries(t *testing.T) {

--- a/seed/go-sdk/nullable-optional/internal/retrier.go
+++ b/seed/go-sdk/nullable-optional/internal/retrier.go
@@ -145,12 +145,20 @@ func (r *Retrier) run(
 	}
 
 	if r.shouldRetry(response) {
-		defer func() { _ = response.Body.Close() }()
-
 		delay, err := r.retryDelay(response, retryAttempt)
 		if err != nil {
+			_ = response.Body.Close()
 			return nil, err
 		}
+
+		// If the context's deadline would elapse before the backoff completes, return
+		// the response instead of sleeping through it. The caller then sees why the
+		// request actually failed (e.g. a 429) rather than a context deadline error.
+		if deadline, ok := request.Context().Deadline(); ok && time.Until(deadline) < delay {
+			return response, nil
+		}
+
+		defer func() { _ = response.Body.Close() }()
 
 		if err := sleepWithContext(request.Context(), delay); err != nil {
 			return nil, err

--- a/seed/go-sdk/nullable-optional/internal/retrier_test.go
+++ b/seed/go-sdk/nullable-optional/internal/retrier_test.go
@@ -295,7 +295,50 @@ func TestRetryWithRequestBody(t *testing.T) {
 	assert.Equal(t, expectedBody, requestBodies[1], "Second request body should match expected (retry should re-send body)")
 }
 
+// An explicit cancel (e.g. Ctrl-C wired to cancel()) must interrupt the backoff
+// wait. There is no deadline here, so the retrier cannot know the wait is futile
+// up front -- it has to be woken by the context.
 func TestRetryWaitIsInterruptedByContext(t *testing.T) {
+	var requestCount int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		w.Header().Set("Retry-After", "5")
+		w.WriteHeader(http.StatusTooManyRequests)
+	}))
+	defer server.Close()
+
+	caller := NewCaller(&CallerParams{
+		Client: server.Client(),
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		time.Sleep(100 * time.Millisecond)
+		cancel()
+	}()
+	defer cancel()
+
+	start := time.Now()
+	_, err := caller.Call(
+		ctx,
+		&CallParams{
+			URL:         server.URL,
+			Method:      http.MethodGet,
+			Request:     &InternalTestRequest{},
+			MaxAttempts: 3,
+		},
+	)
+	elapsed := time.Since(start)
+
+	assert.ErrorIs(t, err, context.Canceled)
+	assert.Equal(t, 1, requestCount, "Expected the retry to be abandoned once the context was cancelled")
+	assert.Less(t, elapsed, time.Second, "Expected the backoff to be interrupted by the context, took %v", elapsed)
+}
+
+// When the caller's deadline would elapse before the backoff finishes, sleeping
+// only guarantees a context error. Return the response instead so the caller
+// learns why the request actually failed.
+func TestRetryReturnsResponseWhenDeadlineShorterThanBackoff(t *testing.T) {
 	var requestCount int
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		requestCount++
@@ -323,9 +366,50 @@ func TestRetryWaitIsInterruptedByContext(t *testing.T) {
 	)
 	elapsed := time.Since(start)
 
-	assert.ErrorIs(t, err, context.DeadlineExceeded)
-	assert.Equal(t, 1, requestCount, "Expected the retry to be abandoned once the context expired")
-	assert.Less(t, elapsed, time.Second, "Expected the backoff to be interrupted by the context, took %v", elapsed)
+	// The caller gets the 429, not context.DeadlineExceeded.
+	var apiError *core.APIError
+	require.ErrorAs(t, err, &apiError)
+	assert.Equal(t, http.StatusTooManyRequests, apiError.StatusCode)
+	assert.NotErrorIs(t, err, context.DeadlineExceeded)
+	assert.Equal(t, 1, requestCount, "Expected no retry once the deadline was known to be too short")
+	assert.Less(t, elapsed, time.Second, "Expected to return immediately rather than sleep, took %v", elapsed)
+}
+
+// A deadline with room for the backoff must still retry as normal.
+func TestRetryProceedsWhenDeadlineLongerThanBackoff(t *testing.T) {
+	var requestCount int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		if requestCount == 1 {
+			w.Header().Set("Retry-After", "1")
+			w.WriteHeader(http.StatusTooManyRequests)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("{}"))
+	}))
+	defer server.Close()
+
+	caller := NewCaller(&CallerParams{
+		Client: server.Client(),
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	_, err := caller.Call(
+		ctx,
+		&CallParams{
+			URL:         server.URL,
+			Method:      http.MethodGet,
+			Request:     &InternalTestRequest{},
+			Response:    &InternalTestResponse{},
+			MaxAttempts: 3,
+		},
+	)
+
+	assert.NoError(t, err)
+	assert.Equal(t, 2, requestCount, "Expected the retry to proceed when the deadline allows it")
 }
 
 func TestDisableRetries(t *testing.T) {

--- a/seed/go-sdk/nullable-request-body/dynamic-snippets-disabled/internal/retrier.go
+++ b/seed/go-sdk/nullable-request-body/dynamic-snippets-disabled/internal/retrier.go
@@ -145,12 +145,20 @@ func (r *Retrier) run(
 	}
 
 	if r.shouldRetry(response) {
-		defer func() { _ = response.Body.Close() }()
-
 		delay, err := r.retryDelay(response, retryAttempt)
 		if err != nil {
+			_ = response.Body.Close()
 			return nil, err
 		}
+
+		// If the context's deadline would elapse before the backoff completes, return
+		// the response instead of sleeping through it. The caller then sees why the
+		// request actually failed (e.g. a 429) rather than a context deadline error.
+		if deadline, ok := request.Context().Deadline(); ok && time.Until(deadline) < delay {
+			return response, nil
+		}
+
+		defer func() { _ = response.Body.Close() }()
 
 		if err := sleepWithContext(request.Context(), delay); err != nil {
 			return nil, err

--- a/seed/go-sdk/nullable-request-body/dynamic-snippets-disabled/internal/retrier_test.go
+++ b/seed/go-sdk/nullable-request-body/dynamic-snippets-disabled/internal/retrier_test.go
@@ -295,7 +295,50 @@ func TestRetryWithRequestBody(t *testing.T) {
 	assert.Equal(t, expectedBody, requestBodies[1], "Second request body should match expected (retry should re-send body)")
 }
 
+// An explicit cancel (e.g. Ctrl-C wired to cancel()) must interrupt the backoff
+// wait. There is no deadline here, so the retrier cannot know the wait is futile
+// up front -- it has to be woken by the context.
 func TestRetryWaitIsInterruptedByContext(t *testing.T) {
+	var requestCount int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		w.Header().Set("Retry-After", "5")
+		w.WriteHeader(http.StatusTooManyRequests)
+	}))
+	defer server.Close()
+
+	caller := NewCaller(&CallerParams{
+		Client: server.Client(),
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		time.Sleep(100 * time.Millisecond)
+		cancel()
+	}()
+	defer cancel()
+
+	start := time.Now()
+	_, err := caller.Call(
+		ctx,
+		&CallParams{
+			URL:         server.URL,
+			Method:      http.MethodGet,
+			Request:     &InternalTestRequest{},
+			MaxAttempts: 3,
+		},
+	)
+	elapsed := time.Since(start)
+
+	assert.ErrorIs(t, err, context.Canceled)
+	assert.Equal(t, 1, requestCount, "Expected the retry to be abandoned once the context was cancelled")
+	assert.Less(t, elapsed, time.Second, "Expected the backoff to be interrupted by the context, took %v", elapsed)
+}
+
+// When the caller's deadline would elapse before the backoff finishes, sleeping
+// only guarantees a context error. Return the response instead so the caller
+// learns why the request actually failed.
+func TestRetryReturnsResponseWhenDeadlineShorterThanBackoff(t *testing.T) {
 	var requestCount int
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		requestCount++
@@ -323,9 +366,50 @@ func TestRetryWaitIsInterruptedByContext(t *testing.T) {
 	)
 	elapsed := time.Since(start)
 
-	assert.ErrorIs(t, err, context.DeadlineExceeded)
-	assert.Equal(t, 1, requestCount, "Expected the retry to be abandoned once the context expired")
-	assert.Less(t, elapsed, time.Second, "Expected the backoff to be interrupted by the context, took %v", elapsed)
+	// The caller gets the 429, not context.DeadlineExceeded.
+	var apiError *core.APIError
+	require.ErrorAs(t, err, &apiError)
+	assert.Equal(t, http.StatusTooManyRequests, apiError.StatusCode)
+	assert.NotErrorIs(t, err, context.DeadlineExceeded)
+	assert.Equal(t, 1, requestCount, "Expected no retry once the deadline was known to be too short")
+	assert.Less(t, elapsed, time.Second, "Expected to return immediately rather than sleep, took %v", elapsed)
+}
+
+// A deadline with room for the backoff must still retry as normal.
+func TestRetryProceedsWhenDeadlineLongerThanBackoff(t *testing.T) {
+	var requestCount int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		if requestCount == 1 {
+			w.Header().Set("Retry-After", "1")
+			w.WriteHeader(http.StatusTooManyRequests)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("{}"))
+	}))
+	defer server.Close()
+
+	caller := NewCaller(&CallerParams{
+		Client: server.Client(),
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	_, err := caller.Call(
+		ctx,
+		&CallParams{
+			URL:         server.URL,
+			Method:      http.MethodGet,
+			Request:     &InternalTestRequest{},
+			Response:    &InternalTestResponse{},
+			MaxAttempts: 3,
+		},
+	)
+
+	assert.NoError(t, err)
+	assert.Equal(t, 2, requestCount, "Expected the retry to proceed when the deadline allows it")
 }
 
 func TestDisableRetries(t *testing.T) {

--- a/seed/go-sdk/nullable/internal/retrier.go
+++ b/seed/go-sdk/nullable/internal/retrier.go
@@ -145,12 +145,20 @@ func (r *Retrier) run(
 	}
 
 	if r.shouldRetry(response) {
-		defer func() { _ = response.Body.Close() }()
-
 		delay, err := r.retryDelay(response, retryAttempt)
 		if err != nil {
+			_ = response.Body.Close()
 			return nil, err
 		}
+
+		// If the context's deadline would elapse before the backoff completes, return
+		// the response instead of sleeping through it. The caller then sees why the
+		// request actually failed (e.g. a 429) rather than a context deadline error.
+		if deadline, ok := request.Context().Deadline(); ok && time.Until(deadline) < delay {
+			return response, nil
+		}
+
+		defer func() { _ = response.Body.Close() }()
 
 		if err := sleepWithContext(request.Context(), delay); err != nil {
 			return nil, err

--- a/seed/go-sdk/nullable/internal/retrier_test.go
+++ b/seed/go-sdk/nullable/internal/retrier_test.go
@@ -295,7 +295,50 @@ func TestRetryWithRequestBody(t *testing.T) {
 	assert.Equal(t, expectedBody, requestBodies[1], "Second request body should match expected (retry should re-send body)")
 }
 
+// An explicit cancel (e.g. Ctrl-C wired to cancel()) must interrupt the backoff
+// wait. There is no deadline here, so the retrier cannot know the wait is futile
+// up front -- it has to be woken by the context.
 func TestRetryWaitIsInterruptedByContext(t *testing.T) {
+	var requestCount int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		w.Header().Set("Retry-After", "5")
+		w.WriteHeader(http.StatusTooManyRequests)
+	}))
+	defer server.Close()
+
+	caller := NewCaller(&CallerParams{
+		Client: server.Client(),
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		time.Sleep(100 * time.Millisecond)
+		cancel()
+	}()
+	defer cancel()
+
+	start := time.Now()
+	_, err := caller.Call(
+		ctx,
+		&CallParams{
+			URL:         server.URL,
+			Method:      http.MethodGet,
+			Request:     &InternalTestRequest{},
+			MaxAttempts: 3,
+		},
+	)
+	elapsed := time.Since(start)
+
+	assert.ErrorIs(t, err, context.Canceled)
+	assert.Equal(t, 1, requestCount, "Expected the retry to be abandoned once the context was cancelled")
+	assert.Less(t, elapsed, time.Second, "Expected the backoff to be interrupted by the context, took %v", elapsed)
+}
+
+// When the caller's deadline would elapse before the backoff finishes, sleeping
+// only guarantees a context error. Return the response instead so the caller
+// learns why the request actually failed.
+func TestRetryReturnsResponseWhenDeadlineShorterThanBackoff(t *testing.T) {
 	var requestCount int
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		requestCount++
@@ -323,9 +366,50 @@ func TestRetryWaitIsInterruptedByContext(t *testing.T) {
 	)
 	elapsed := time.Since(start)
 
-	assert.ErrorIs(t, err, context.DeadlineExceeded)
-	assert.Equal(t, 1, requestCount, "Expected the retry to be abandoned once the context expired")
-	assert.Less(t, elapsed, time.Second, "Expected the backoff to be interrupted by the context, took %v", elapsed)
+	// The caller gets the 429, not context.DeadlineExceeded.
+	var apiError *core.APIError
+	require.ErrorAs(t, err, &apiError)
+	assert.Equal(t, http.StatusTooManyRequests, apiError.StatusCode)
+	assert.NotErrorIs(t, err, context.DeadlineExceeded)
+	assert.Equal(t, 1, requestCount, "Expected no retry once the deadline was known to be too short")
+	assert.Less(t, elapsed, time.Second, "Expected to return immediately rather than sleep, took %v", elapsed)
+}
+
+// A deadline with room for the backoff must still retry as normal.
+func TestRetryProceedsWhenDeadlineLongerThanBackoff(t *testing.T) {
+	var requestCount int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		if requestCount == 1 {
+			w.Header().Set("Retry-After", "1")
+			w.WriteHeader(http.StatusTooManyRequests)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("{}"))
+	}))
+	defer server.Close()
+
+	caller := NewCaller(&CallerParams{
+		Client: server.Client(),
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	_, err := caller.Call(
+		ctx,
+		&CallParams{
+			URL:         server.URL,
+			Method:      http.MethodGet,
+			Request:     &InternalTestRequest{},
+			Response:    &InternalTestResponse{},
+			MaxAttempts: 3,
+		},
+	)
+
+	assert.NoError(t, err)
+	assert.Equal(t, 2, requestCount, "Expected the retry to proceed when the deadline allows it")
 }
 
 func TestDisableRetries(t *testing.T) {

--- a/seed/go-sdk/oauth-client-credentials-custom/internal/retrier.go
+++ b/seed/go-sdk/oauth-client-credentials-custom/internal/retrier.go
@@ -145,12 +145,20 @@ func (r *Retrier) run(
 	}
 
 	if r.shouldRetry(response) {
-		defer func() { _ = response.Body.Close() }()
-
 		delay, err := r.retryDelay(response, retryAttempt)
 		if err != nil {
+			_ = response.Body.Close()
 			return nil, err
 		}
+
+		// If the context's deadline would elapse before the backoff completes, return
+		// the response instead of sleeping through it. The caller then sees why the
+		// request actually failed (e.g. a 429) rather than a context deadline error.
+		if deadline, ok := request.Context().Deadline(); ok && time.Until(deadline) < delay {
+			return response, nil
+		}
+
+		defer func() { _ = response.Body.Close() }()
 
 		if err := sleepWithContext(request.Context(), delay); err != nil {
 			return nil, err

--- a/seed/go-sdk/oauth-client-credentials-custom/internal/retrier_test.go
+++ b/seed/go-sdk/oauth-client-credentials-custom/internal/retrier_test.go
@@ -295,7 +295,50 @@ func TestRetryWithRequestBody(t *testing.T) {
 	assert.Equal(t, expectedBody, requestBodies[1], "Second request body should match expected (retry should re-send body)")
 }
 
+// An explicit cancel (e.g. Ctrl-C wired to cancel()) must interrupt the backoff
+// wait. There is no deadline here, so the retrier cannot know the wait is futile
+// up front -- it has to be woken by the context.
 func TestRetryWaitIsInterruptedByContext(t *testing.T) {
+	var requestCount int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		w.Header().Set("Retry-After", "5")
+		w.WriteHeader(http.StatusTooManyRequests)
+	}))
+	defer server.Close()
+
+	caller := NewCaller(&CallerParams{
+		Client: server.Client(),
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		time.Sleep(100 * time.Millisecond)
+		cancel()
+	}()
+	defer cancel()
+
+	start := time.Now()
+	_, err := caller.Call(
+		ctx,
+		&CallParams{
+			URL:         server.URL,
+			Method:      http.MethodGet,
+			Request:     &InternalTestRequest{},
+			MaxAttempts: 3,
+		},
+	)
+	elapsed := time.Since(start)
+
+	assert.ErrorIs(t, err, context.Canceled)
+	assert.Equal(t, 1, requestCount, "Expected the retry to be abandoned once the context was cancelled")
+	assert.Less(t, elapsed, time.Second, "Expected the backoff to be interrupted by the context, took %v", elapsed)
+}
+
+// When the caller's deadline would elapse before the backoff finishes, sleeping
+// only guarantees a context error. Return the response instead so the caller
+// learns why the request actually failed.
+func TestRetryReturnsResponseWhenDeadlineShorterThanBackoff(t *testing.T) {
 	var requestCount int
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		requestCount++
@@ -323,9 +366,50 @@ func TestRetryWaitIsInterruptedByContext(t *testing.T) {
 	)
 	elapsed := time.Since(start)
 
-	assert.ErrorIs(t, err, context.DeadlineExceeded)
-	assert.Equal(t, 1, requestCount, "Expected the retry to be abandoned once the context expired")
-	assert.Less(t, elapsed, time.Second, "Expected the backoff to be interrupted by the context, took %v", elapsed)
+	// The caller gets the 429, not context.DeadlineExceeded.
+	var apiError *core.APIError
+	require.ErrorAs(t, err, &apiError)
+	assert.Equal(t, http.StatusTooManyRequests, apiError.StatusCode)
+	assert.NotErrorIs(t, err, context.DeadlineExceeded)
+	assert.Equal(t, 1, requestCount, "Expected no retry once the deadline was known to be too short")
+	assert.Less(t, elapsed, time.Second, "Expected to return immediately rather than sleep, took %v", elapsed)
+}
+
+// A deadline with room for the backoff must still retry as normal.
+func TestRetryProceedsWhenDeadlineLongerThanBackoff(t *testing.T) {
+	var requestCount int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		if requestCount == 1 {
+			w.Header().Set("Retry-After", "1")
+			w.WriteHeader(http.StatusTooManyRequests)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("{}"))
+	}))
+	defer server.Close()
+
+	caller := NewCaller(&CallerParams{
+		Client: server.Client(),
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	_, err := caller.Call(
+		ctx,
+		&CallParams{
+			URL:         server.URL,
+			Method:      http.MethodGet,
+			Request:     &InternalTestRequest{},
+			Response:    &InternalTestResponse{},
+			MaxAttempts: 3,
+		},
+	)
+
+	assert.NoError(t, err)
+	assert.Equal(t, 2, requestCount, "Expected the retry to proceed when the deadline allows it")
 }
 
 func TestDisableRetries(t *testing.T) {

--- a/seed/go-sdk/oauth-client-credentials-default/internal/retrier.go
+++ b/seed/go-sdk/oauth-client-credentials-default/internal/retrier.go
@@ -145,12 +145,20 @@ func (r *Retrier) run(
 	}
 
 	if r.shouldRetry(response) {
-		defer func() { _ = response.Body.Close() }()
-
 		delay, err := r.retryDelay(response, retryAttempt)
 		if err != nil {
+			_ = response.Body.Close()
 			return nil, err
 		}
+
+		// If the context's deadline would elapse before the backoff completes, return
+		// the response instead of sleeping through it. The caller then sees why the
+		// request actually failed (e.g. a 429) rather than a context deadline error.
+		if deadline, ok := request.Context().Deadline(); ok && time.Until(deadline) < delay {
+			return response, nil
+		}
+
+		defer func() { _ = response.Body.Close() }()
 
 		if err := sleepWithContext(request.Context(), delay); err != nil {
 			return nil, err

--- a/seed/go-sdk/oauth-client-credentials-default/internal/retrier_test.go
+++ b/seed/go-sdk/oauth-client-credentials-default/internal/retrier_test.go
@@ -295,7 +295,50 @@ func TestRetryWithRequestBody(t *testing.T) {
 	assert.Equal(t, expectedBody, requestBodies[1], "Second request body should match expected (retry should re-send body)")
 }
 
+// An explicit cancel (e.g. Ctrl-C wired to cancel()) must interrupt the backoff
+// wait. There is no deadline here, so the retrier cannot know the wait is futile
+// up front -- it has to be woken by the context.
 func TestRetryWaitIsInterruptedByContext(t *testing.T) {
+	var requestCount int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		w.Header().Set("Retry-After", "5")
+		w.WriteHeader(http.StatusTooManyRequests)
+	}))
+	defer server.Close()
+
+	caller := NewCaller(&CallerParams{
+		Client: server.Client(),
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		time.Sleep(100 * time.Millisecond)
+		cancel()
+	}()
+	defer cancel()
+
+	start := time.Now()
+	_, err := caller.Call(
+		ctx,
+		&CallParams{
+			URL:         server.URL,
+			Method:      http.MethodGet,
+			Request:     &InternalTestRequest{},
+			MaxAttempts: 3,
+		},
+	)
+	elapsed := time.Since(start)
+
+	assert.ErrorIs(t, err, context.Canceled)
+	assert.Equal(t, 1, requestCount, "Expected the retry to be abandoned once the context was cancelled")
+	assert.Less(t, elapsed, time.Second, "Expected the backoff to be interrupted by the context, took %v", elapsed)
+}
+
+// When the caller's deadline would elapse before the backoff finishes, sleeping
+// only guarantees a context error. Return the response instead so the caller
+// learns why the request actually failed.
+func TestRetryReturnsResponseWhenDeadlineShorterThanBackoff(t *testing.T) {
 	var requestCount int
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		requestCount++
@@ -323,9 +366,50 @@ func TestRetryWaitIsInterruptedByContext(t *testing.T) {
 	)
 	elapsed := time.Since(start)
 
-	assert.ErrorIs(t, err, context.DeadlineExceeded)
-	assert.Equal(t, 1, requestCount, "Expected the retry to be abandoned once the context expired")
-	assert.Less(t, elapsed, time.Second, "Expected the backoff to be interrupted by the context, took %v", elapsed)
+	// The caller gets the 429, not context.DeadlineExceeded.
+	var apiError *core.APIError
+	require.ErrorAs(t, err, &apiError)
+	assert.Equal(t, http.StatusTooManyRequests, apiError.StatusCode)
+	assert.NotErrorIs(t, err, context.DeadlineExceeded)
+	assert.Equal(t, 1, requestCount, "Expected no retry once the deadline was known to be too short")
+	assert.Less(t, elapsed, time.Second, "Expected to return immediately rather than sleep, took %v", elapsed)
+}
+
+// A deadline with room for the backoff must still retry as normal.
+func TestRetryProceedsWhenDeadlineLongerThanBackoff(t *testing.T) {
+	var requestCount int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		if requestCount == 1 {
+			w.Header().Set("Retry-After", "1")
+			w.WriteHeader(http.StatusTooManyRequests)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("{}"))
+	}))
+	defer server.Close()
+
+	caller := NewCaller(&CallerParams{
+		Client: server.Client(),
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	_, err := caller.Call(
+		ctx,
+		&CallParams{
+			URL:         server.URL,
+			Method:      http.MethodGet,
+			Request:     &InternalTestRequest{},
+			Response:    &InternalTestResponse{},
+			MaxAttempts: 3,
+		},
+	)
+
+	assert.NoError(t, err)
+	assert.Equal(t, 2, requestCount, "Expected the retry to proceed when the deadline allows it")
 }
 
 func TestDisableRetries(t *testing.T) {

--- a/seed/go-sdk/oauth-client-credentials-environment-variables/internal/retrier.go
+++ b/seed/go-sdk/oauth-client-credentials-environment-variables/internal/retrier.go
@@ -145,12 +145,20 @@ func (r *Retrier) run(
 	}
 
 	if r.shouldRetry(response) {
-		defer func() { _ = response.Body.Close() }()
-
 		delay, err := r.retryDelay(response, retryAttempt)
 		if err != nil {
+			_ = response.Body.Close()
 			return nil, err
 		}
+
+		// If the context's deadline would elapse before the backoff completes, return
+		// the response instead of sleeping through it. The caller then sees why the
+		// request actually failed (e.g. a 429) rather than a context deadline error.
+		if deadline, ok := request.Context().Deadline(); ok && time.Until(deadline) < delay {
+			return response, nil
+		}
+
+		defer func() { _ = response.Body.Close() }()
 
 		if err := sleepWithContext(request.Context(), delay); err != nil {
 			return nil, err

--- a/seed/go-sdk/oauth-client-credentials-environment-variables/internal/retrier_test.go
+++ b/seed/go-sdk/oauth-client-credentials-environment-variables/internal/retrier_test.go
@@ -295,7 +295,50 @@ func TestRetryWithRequestBody(t *testing.T) {
 	assert.Equal(t, expectedBody, requestBodies[1], "Second request body should match expected (retry should re-send body)")
 }
 
+// An explicit cancel (e.g. Ctrl-C wired to cancel()) must interrupt the backoff
+// wait. There is no deadline here, so the retrier cannot know the wait is futile
+// up front -- it has to be woken by the context.
 func TestRetryWaitIsInterruptedByContext(t *testing.T) {
+	var requestCount int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		w.Header().Set("Retry-After", "5")
+		w.WriteHeader(http.StatusTooManyRequests)
+	}))
+	defer server.Close()
+
+	caller := NewCaller(&CallerParams{
+		Client: server.Client(),
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		time.Sleep(100 * time.Millisecond)
+		cancel()
+	}()
+	defer cancel()
+
+	start := time.Now()
+	_, err := caller.Call(
+		ctx,
+		&CallParams{
+			URL:         server.URL,
+			Method:      http.MethodGet,
+			Request:     &InternalTestRequest{},
+			MaxAttempts: 3,
+		},
+	)
+	elapsed := time.Since(start)
+
+	assert.ErrorIs(t, err, context.Canceled)
+	assert.Equal(t, 1, requestCount, "Expected the retry to be abandoned once the context was cancelled")
+	assert.Less(t, elapsed, time.Second, "Expected the backoff to be interrupted by the context, took %v", elapsed)
+}
+
+// When the caller's deadline would elapse before the backoff finishes, sleeping
+// only guarantees a context error. Return the response instead so the caller
+// learns why the request actually failed.
+func TestRetryReturnsResponseWhenDeadlineShorterThanBackoff(t *testing.T) {
 	var requestCount int
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		requestCount++
@@ -323,9 +366,50 @@ func TestRetryWaitIsInterruptedByContext(t *testing.T) {
 	)
 	elapsed := time.Since(start)
 
-	assert.ErrorIs(t, err, context.DeadlineExceeded)
-	assert.Equal(t, 1, requestCount, "Expected the retry to be abandoned once the context expired")
-	assert.Less(t, elapsed, time.Second, "Expected the backoff to be interrupted by the context, took %v", elapsed)
+	// The caller gets the 429, not context.DeadlineExceeded.
+	var apiError *core.APIError
+	require.ErrorAs(t, err, &apiError)
+	assert.Equal(t, http.StatusTooManyRequests, apiError.StatusCode)
+	assert.NotErrorIs(t, err, context.DeadlineExceeded)
+	assert.Equal(t, 1, requestCount, "Expected no retry once the deadline was known to be too short")
+	assert.Less(t, elapsed, time.Second, "Expected to return immediately rather than sleep, took %v", elapsed)
+}
+
+// A deadline with room for the backoff must still retry as normal.
+func TestRetryProceedsWhenDeadlineLongerThanBackoff(t *testing.T) {
+	var requestCount int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		if requestCount == 1 {
+			w.Header().Set("Retry-After", "1")
+			w.WriteHeader(http.StatusTooManyRequests)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("{}"))
+	}))
+	defer server.Close()
+
+	caller := NewCaller(&CallerParams{
+		Client: server.Client(),
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	_, err := caller.Call(
+		ctx,
+		&CallParams{
+			URL:         server.URL,
+			Method:      http.MethodGet,
+			Request:     &InternalTestRequest{},
+			Response:    &InternalTestResponse{},
+			MaxAttempts: 3,
+		},
+	)
+
+	assert.NoError(t, err)
+	assert.Equal(t, 2, requestCount, "Expected the retry to proceed when the deadline allows it")
 }
 
 func TestDisableRetries(t *testing.T) {

--- a/seed/go-sdk/oauth-client-credentials-mandatory-auth/no-custom-config/internal/retrier.go
+++ b/seed/go-sdk/oauth-client-credentials-mandatory-auth/no-custom-config/internal/retrier.go
@@ -145,12 +145,20 @@ func (r *Retrier) run(
 	}
 
 	if r.shouldRetry(response) {
-		defer func() { _ = response.Body.Close() }()
-
 		delay, err := r.retryDelay(response, retryAttempt)
 		if err != nil {
+			_ = response.Body.Close()
 			return nil, err
 		}
+
+		// If the context's deadline would elapse before the backoff completes, return
+		// the response instead of sleeping through it. The caller then sees why the
+		// request actually failed (e.g. a 429) rather than a context deadline error.
+		if deadline, ok := request.Context().Deadline(); ok && time.Until(deadline) < delay {
+			return response, nil
+		}
+
+		defer func() { _ = response.Body.Close() }()
 
 		if err := sleepWithContext(request.Context(), delay); err != nil {
 			return nil, err

--- a/seed/go-sdk/oauth-client-credentials-mandatory-auth/no-custom-config/internal/retrier_test.go
+++ b/seed/go-sdk/oauth-client-credentials-mandatory-auth/no-custom-config/internal/retrier_test.go
@@ -295,7 +295,50 @@ func TestRetryWithRequestBody(t *testing.T) {
 	assert.Equal(t, expectedBody, requestBodies[1], "Second request body should match expected (retry should re-send body)")
 }
 
+// An explicit cancel (e.g. Ctrl-C wired to cancel()) must interrupt the backoff
+// wait. There is no deadline here, so the retrier cannot know the wait is futile
+// up front -- it has to be woken by the context.
 func TestRetryWaitIsInterruptedByContext(t *testing.T) {
+	var requestCount int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		w.Header().Set("Retry-After", "5")
+		w.WriteHeader(http.StatusTooManyRequests)
+	}))
+	defer server.Close()
+
+	caller := NewCaller(&CallerParams{
+		Client: server.Client(),
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		time.Sleep(100 * time.Millisecond)
+		cancel()
+	}()
+	defer cancel()
+
+	start := time.Now()
+	_, err := caller.Call(
+		ctx,
+		&CallParams{
+			URL:         server.URL,
+			Method:      http.MethodGet,
+			Request:     &InternalTestRequest{},
+			MaxAttempts: 3,
+		},
+	)
+	elapsed := time.Since(start)
+
+	assert.ErrorIs(t, err, context.Canceled)
+	assert.Equal(t, 1, requestCount, "Expected the retry to be abandoned once the context was cancelled")
+	assert.Less(t, elapsed, time.Second, "Expected the backoff to be interrupted by the context, took %v", elapsed)
+}
+
+// When the caller's deadline would elapse before the backoff finishes, sleeping
+// only guarantees a context error. Return the response instead so the caller
+// learns why the request actually failed.
+func TestRetryReturnsResponseWhenDeadlineShorterThanBackoff(t *testing.T) {
 	var requestCount int
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		requestCount++
@@ -323,9 +366,50 @@ func TestRetryWaitIsInterruptedByContext(t *testing.T) {
 	)
 	elapsed := time.Since(start)
 
-	assert.ErrorIs(t, err, context.DeadlineExceeded)
-	assert.Equal(t, 1, requestCount, "Expected the retry to be abandoned once the context expired")
-	assert.Less(t, elapsed, time.Second, "Expected the backoff to be interrupted by the context, took %v", elapsed)
+	// The caller gets the 429, not context.DeadlineExceeded.
+	var apiError *core.APIError
+	require.ErrorAs(t, err, &apiError)
+	assert.Equal(t, http.StatusTooManyRequests, apiError.StatusCode)
+	assert.NotErrorIs(t, err, context.DeadlineExceeded)
+	assert.Equal(t, 1, requestCount, "Expected no retry once the deadline was known to be too short")
+	assert.Less(t, elapsed, time.Second, "Expected to return immediately rather than sleep, took %v", elapsed)
+}
+
+// A deadline with room for the backoff must still retry as normal.
+func TestRetryProceedsWhenDeadlineLongerThanBackoff(t *testing.T) {
+	var requestCount int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		if requestCount == 1 {
+			w.Header().Set("Retry-After", "1")
+			w.WriteHeader(http.StatusTooManyRequests)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("{}"))
+	}))
+	defer server.Close()
+
+	caller := NewCaller(&CallerParams{
+		Client: server.Client(),
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	_, err := caller.Call(
+		ctx,
+		&CallParams{
+			URL:         server.URL,
+			Method:      http.MethodGet,
+			Request:     &InternalTestRequest{},
+			Response:    &InternalTestResponse{},
+			MaxAttempts: 3,
+		},
+	)
+
+	assert.NoError(t, err)
+	assert.Equal(t, 2, requestCount, "Expected the retry to proceed when the deadline allows it")
 }
 
 func TestDisableRetries(t *testing.T) {

--- a/seed/go-sdk/oauth-client-credentials-nested-root/internal/retrier.go
+++ b/seed/go-sdk/oauth-client-credentials-nested-root/internal/retrier.go
@@ -145,12 +145,20 @@ func (r *Retrier) run(
 	}
 
 	if r.shouldRetry(response) {
-		defer func() { _ = response.Body.Close() }()
-
 		delay, err := r.retryDelay(response, retryAttempt)
 		if err != nil {
+			_ = response.Body.Close()
 			return nil, err
 		}
+
+		// If the context's deadline would elapse before the backoff completes, return
+		// the response instead of sleeping through it. The caller then sees why the
+		// request actually failed (e.g. a 429) rather than a context deadline error.
+		if deadline, ok := request.Context().Deadline(); ok && time.Until(deadline) < delay {
+			return response, nil
+		}
+
+		defer func() { _ = response.Body.Close() }()
 
 		if err := sleepWithContext(request.Context(), delay); err != nil {
 			return nil, err

--- a/seed/go-sdk/oauth-client-credentials-nested-root/internal/retrier_test.go
+++ b/seed/go-sdk/oauth-client-credentials-nested-root/internal/retrier_test.go
@@ -295,7 +295,50 @@ func TestRetryWithRequestBody(t *testing.T) {
 	assert.Equal(t, expectedBody, requestBodies[1], "Second request body should match expected (retry should re-send body)")
 }
 
+// An explicit cancel (e.g. Ctrl-C wired to cancel()) must interrupt the backoff
+// wait. There is no deadline here, so the retrier cannot know the wait is futile
+// up front -- it has to be woken by the context.
 func TestRetryWaitIsInterruptedByContext(t *testing.T) {
+	var requestCount int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		w.Header().Set("Retry-After", "5")
+		w.WriteHeader(http.StatusTooManyRequests)
+	}))
+	defer server.Close()
+
+	caller := NewCaller(&CallerParams{
+		Client: server.Client(),
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		time.Sleep(100 * time.Millisecond)
+		cancel()
+	}()
+	defer cancel()
+
+	start := time.Now()
+	_, err := caller.Call(
+		ctx,
+		&CallParams{
+			URL:         server.URL,
+			Method:      http.MethodGet,
+			Request:     &InternalTestRequest{},
+			MaxAttempts: 3,
+		},
+	)
+	elapsed := time.Since(start)
+
+	assert.ErrorIs(t, err, context.Canceled)
+	assert.Equal(t, 1, requestCount, "Expected the retry to be abandoned once the context was cancelled")
+	assert.Less(t, elapsed, time.Second, "Expected the backoff to be interrupted by the context, took %v", elapsed)
+}
+
+// When the caller's deadline would elapse before the backoff finishes, sleeping
+// only guarantees a context error. Return the response instead so the caller
+// learns why the request actually failed.
+func TestRetryReturnsResponseWhenDeadlineShorterThanBackoff(t *testing.T) {
 	var requestCount int
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		requestCount++
@@ -323,9 +366,50 @@ func TestRetryWaitIsInterruptedByContext(t *testing.T) {
 	)
 	elapsed := time.Since(start)
 
-	assert.ErrorIs(t, err, context.DeadlineExceeded)
-	assert.Equal(t, 1, requestCount, "Expected the retry to be abandoned once the context expired")
-	assert.Less(t, elapsed, time.Second, "Expected the backoff to be interrupted by the context, took %v", elapsed)
+	// The caller gets the 429, not context.DeadlineExceeded.
+	var apiError *core.APIError
+	require.ErrorAs(t, err, &apiError)
+	assert.Equal(t, http.StatusTooManyRequests, apiError.StatusCode)
+	assert.NotErrorIs(t, err, context.DeadlineExceeded)
+	assert.Equal(t, 1, requestCount, "Expected no retry once the deadline was known to be too short")
+	assert.Less(t, elapsed, time.Second, "Expected to return immediately rather than sleep, took %v", elapsed)
+}
+
+// A deadline with room for the backoff must still retry as normal.
+func TestRetryProceedsWhenDeadlineLongerThanBackoff(t *testing.T) {
+	var requestCount int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		if requestCount == 1 {
+			w.Header().Set("Retry-After", "1")
+			w.WriteHeader(http.StatusTooManyRequests)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("{}"))
+	}))
+	defer server.Close()
+
+	caller := NewCaller(&CallerParams{
+		Client: server.Client(),
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	_, err := caller.Call(
+		ctx,
+		&CallParams{
+			URL:         server.URL,
+			Method:      http.MethodGet,
+			Request:     &InternalTestRequest{},
+			Response:    &InternalTestResponse{},
+			MaxAttempts: 3,
+		},
+	)
+
+	assert.NoError(t, err)
+	assert.Equal(t, 2, requestCount, "Expected the retry to proceed when the deadline allows it")
 }
 
 func TestDisableRetries(t *testing.T) {

--- a/seed/go-sdk/oauth-client-credentials-openapi/internal/retrier.go
+++ b/seed/go-sdk/oauth-client-credentials-openapi/internal/retrier.go
@@ -145,12 +145,20 @@ func (r *Retrier) run(
 	}
 
 	if r.shouldRetry(response) {
-		defer func() { _ = response.Body.Close() }()
-
 		delay, err := r.retryDelay(response, retryAttempt)
 		if err != nil {
+			_ = response.Body.Close()
 			return nil, err
 		}
+
+		// If the context's deadline would elapse before the backoff completes, return
+		// the response instead of sleeping through it. The caller then sees why the
+		// request actually failed (e.g. a 429) rather than a context deadline error.
+		if deadline, ok := request.Context().Deadline(); ok && time.Until(deadline) < delay {
+			return response, nil
+		}
+
+		defer func() { _ = response.Body.Close() }()
 
 		if err := sleepWithContext(request.Context(), delay); err != nil {
 			return nil, err

--- a/seed/go-sdk/oauth-client-credentials-openapi/internal/retrier_test.go
+++ b/seed/go-sdk/oauth-client-credentials-openapi/internal/retrier_test.go
@@ -295,7 +295,50 @@ func TestRetryWithRequestBody(t *testing.T) {
 	assert.Equal(t, expectedBody, requestBodies[1], "Second request body should match expected (retry should re-send body)")
 }
 
+// An explicit cancel (e.g. Ctrl-C wired to cancel()) must interrupt the backoff
+// wait. There is no deadline here, so the retrier cannot know the wait is futile
+// up front -- it has to be woken by the context.
 func TestRetryWaitIsInterruptedByContext(t *testing.T) {
+	var requestCount int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		w.Header().Set("Retry-After", "5")
+		w.WriteHeader(http.StatusTooManyRequests)
+	}))
+	defer server.Close()
+
+	caller := NewCaller(&CallerParams{
+		Client: server.Client(),
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		time.Sleep(100 * time.Millisecond)
+		cancel()
+	}()
+	defer cancel()
+
+	start := time.Now()
+	_, err := caller.Call(
+		ctx,
+		&CallParams{
+			URL:         server.URL,
+			Method:      http.MethodGet,
+			Request:     &InternalTestRequest{},
+			MaxAttempts: 3,
+		},
+	)
+	elapsed := time.Since(start)
+
+	assert.ErrorIs(t, err, context.Canceled)
+	assert.Equal(t, 1, requestCount, "Expected the retry to be abandoned once the context was cancelled")
+	assert.Less(t, elapsed, time.Second, "Expected the backoff to be interrupted by the context, took %v", elapsed)
+}
+
+// When the caller's deadline would elapse before the backoff finishes, sleeping
+// only guarantees a context error. Return the response instead so the caller
+// learns why the request actually failed.
+func TestRetryReturnsResponseWhenDeadlineShorterThanBackoff(t *testing.T) {
 	var requestCount int
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		requestCount++
@@ -323,9 +366,50 @@ func TestRetryWaitIsInterruptedByContext(t *testing.T) {
 	)
 	elapsed := time.Since(start)
 
-	assert.ErrorIs(t, err, context.DeadlineExceeded)
-	assert.Equal(t, 1, requestCount, "Expected the retry to be abandoned once the context expired")
-	assert.Less(t, elapsed, time.Second, "Expected the backoff to be interrupted by the context, took %v", elapsed)
+	// The caller gets the 429, not context.DeadlineExceeded.
+	var apiError *core.APIError
+	require.ErrorAs(t, err, &apiError)
+	assert.Equal(t, http.StatusTooManyRequests, apiError.StatusCode)
+	assert.NotErrorIs(t, err, context.DeadlineExceeded)
+	assert.Equal(t, 1, requestCount, "Expected no retry once the deadline was known to be too short")
+	assert.Less(t, elapsed, time.Second, "Expected to return immediately rather than sleep, took %v", elapsed)
+}
+
+// A deadline with room for the backoff must still retry as normal.
+func TestRetryProceedsWhenDeadlineLongerThanBackoff(t *testing.T) {
+	var requestCount int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		if requestCount == 1 {
+			w.Header().Set("Retry-After", "1")
+			w.WriteHeader(http.StatusTooManyRequests)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("{}"))
+	}))
+	defer server.Close()
+
+	caller := NewCaller(&CallerParams{
+		Client: server.Client(),
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	_, err := caller.Call(
+		ctx,
+		&CallParams{
+			URL:         server.URL,
+			Method:      http.MethodGet,
+			Request:     &InternalTestRequest{},
+			Response:    &InternalTestResponse{},
+			MaxAttempts: 3,
+		},
+	)
+
+	assert.NoError(t, err)
+	assert.Equal(t, 2, requestCount, "Expected the retry to proceed when the deadline allows it")
 }
 
 func TestDisableRetries(t *testing.T) {

--- a/seed/go-sdk/oauth-client-credentials-reference/internal/retrier.go
+++ b/seed/go-sdk/oauth-client-credentials-reference/internal/retrier.go
@@ -145,12 +145,20 @@ func (r *Retrier) run(
 	}
 
 	if r.shouldRetry(response) {
-		defer func() { _ = response.Body.Close() }()
-
 		delay, err := r.retryDelay(response, retryAttempt)
 		if err != nil {
+			_ = response.Body.Close()
 			return nil, err
 		}
+
+		// If the context's deadline would elapse before the backoff completes, return
+		// the response instead of sleeping through it. The caller then sees why the
+		// request actually failed (e.g. a 429) rather than a context deadline error.
+		if deadline, ok := request.Context().Deadline(); ok && time.Until(deadline) < delay {
+			return response, nil
+		}
+
+		defer func() { _ = response.Body.Close() }()
 
 		if err := sleepWithContext(request.Context(), delay); err != nil {
 			return nil, err

--- a/seed/go-sdk/oauth-client-credentials-reference/internal/retrier_test.go
+++ b/seed/go-sdk/oauth-client-credentials-reference/internal/retrier_test.go
@@ -295,7 +295,50 @@ func TestRetryWithRequestBody(t *testing.T) {
 	assert.Equal(t, expectedBody, requestBodies[1], "Second request body should match expected (retry should re-send body)")
 }
 
+// An explicit cancel (e.g. Ctrl-C wired to cancel()) must interrupt the backoff
+// wait. There is no deadline here, so the retrier cannot know the wait is futile
+// up front -- it has to be woken by the context.
 func TestRetryWaitIsInterruptedByContext(t *testing.T) {
+	var requestCount int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		w.Header().Set("Retry-After", "5")
+		w.WriteHeader(http.StatusTooManyRequests)
+	}))
+	defer server.Close()
+
+	caller := NewCaller(&CallerParams{
+		Client: server.Client(),
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		time.Sleep(100 * time.Millisecond)
+		cancel()
+	}()
+	defer cancel()
+
+	start := time.Now()
+	_, err := caller.Call(
+		ctx,
+		&CallParams{
+			URL:         server.URL,
+			Method:      http.MethodGet,
+			Request:     &InternalTestRequest{},
+			MaxAttempts: 3,
+		},
+	)
+	elapsed := time.Since(start)
+
+	assert.ErrorIs(t, err, context.Canceled)
+	assert.Equal(t, 1, requestCount, "Expected the retry to be abandoned once the context was cancelled")
+	assert.Less(t, elapsed, time.Second, "Expected the backoff to be interrupted by the context, took %v", elapsed)
+}
+
+// When the caller's deadline would elapse before the backoff finishes, sleeping
+// only guarantees a context error. Return the response instead so the caller
+// learns why the request actually failed.
+func TestRetryReturnsResponseWhenDeadlineShorterThanBackoff(t *testing.T) {
 	var requestCount int
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		requestCount++
@@ -323,9 +366,50 @@ func TestRetryWaitIsInterruptedByContext(t *testing.T) {
 	)
 	elapsed := time.Since(start)
 
-	assert.ErrorIs(t, err, context.DeadlineExceeded)
-	assert.Equal(t, 1, requestCount, "Expected the retry to be abandoned once the context expired")
-	assert.Less(t, elapsed, time.Second, "Expected the backoff to be interrupted by the context, took %v", elapsed)
+	// The caller gets the 429, not context.DeadlineExceeded.
+	var apiError *core.APIError
+	require.ErrorAs(t, err, &apiError)
+	assert.Equal(t, http.StatusTooManyRequests, apiError.StatusCode)
+	assert.NotErrorIs(t, err, context.DeadlineExceeded)
+	assert.Equal(t, 1, requestCount, "Expected no retry once the deadline was known to be too short")
+	assert.Less(t, elapsed, time.Second, "Expected to return immediately rather than sleep, took %v", elapsed)
+}
+
+// A deadline with room for the backoff must still retry as normal.
+func TestRetryProceedsWhenDeadlineLongerThanBackoff(t *testing.T) {
+	var requestCount int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		if requestCount == 1 {
+			w.Header().Set("Retry-After", "1")
+			w.WriteHeader(http.StatusTooManyRequests)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("{}"))
+	}))
+	defer server.Close()
+
+	caller := NewCaller(&CallerParams{
+		Client: server.Client(),
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	_, err := caller.Call(
+		ctx,
+		&CallParams{
+			URL:         server.URL,
+			Method:      http.MethodGet,
+			Request:     &InternalTestRequest{},
+			Response:    &InternalTestResponse{},
+			MaxAttempts: 3,
+		},
+	)
+
+	assert.NoError(t, err)
+	assert.Equal(t, 2, requestCount, "Expected the retry to proceed when the deadline allows it")
 }
 
 func TestDisableRetries(t *testing.T) {

--- a/seed/go-sdk/oauth-client-credentials-with-variables/internal/retrier.go
+++ b/seed/go-sdk/oauth-client-credentials-with-variables/internal/retrier.go
@@ -145,12 +145,20 @@ func (r *Retrier) run(
 	}
 
 	if r.shouldRetry(response) {
-		defer func() { _ = response.Body.Close() }()
-
 		delay, err := r.retryDelay(response, retryAttempt)
 		if err != nil {
+			_ = response.Body.Close()
 			return nil, err
 		}
+
+		// If the context's deadline would elapse before the backoff completes, return
+		// the response instead of sleeping through it. The caller then sees why the
+		// request actually failed (e.g. a 429) rather than a context deadline error.
+		if deadline, ok := request.Context().Deadline(); ok && time.Until(deadline) < delay {
+			return response, nil
+		}
+
+		defer func() { _ = response.Body.Close() }()
 
 		if err := sleepWithContext(request.Context(), delay); err != nil {
 			return nil, err

--- a/seed/go-sdk/oauth-client-credentials-with-variables/internal/retrier_test.go
+++ b/seed/go-sdk/oauth-client-credentials-with-variables/internal/retrier_test.go
@@ -295,7 +295,50 @@ func TestRetryWithRequestBody(t *testing.T) {
 	assert.Equal(t, expectedBody, requestBodies[1], "Second request body should match expected (retry should re-send body)")
 }
 
+// An explicit cancel (e.g. Ctrl-C wired to cancel()) must interrupt the backoff
+// wait. There is no deadline here, so the retrier cannot know the wait is futile
+// up front -- it has to be woken by the context.
 func TestRetryWaitIsInterruptedByContext(t *testing.T) {
+	var requestCount int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		w.Header().Set("Retry-After", "5")
+		w.WriteHeader(http.StatusTooManyRequests)
+	}))
+	defer server.Close()
+
+	caller := NewCaller(&CallerParams{
+		Client: server.Client(),
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		time.Sleep(100 * time.Millisecond)
+		cancel()
+	}()
+	defer cancel()
+
+	start := time.Now()
+	_, err := caller.Call(
+		ctx,
+		&CallParams{
+			URL:         server.URL,
+			Method:      http.MethodGet,
+			Request:     &InternalTestRequest{},
+			MaxAttempts: 3,
+		},
+	)
+	elapsed := time.Since(start)
+
+	assert.ErrorIs(t, err, context.Canceled)
+	assert.Equal(t, 1, requestCount, "Expected the retry to be abandoned once the context was cancelled")
+	assert.Less(t, elapsed, time.Second, "Expected the backoff to be interrupted by the context, took %v", elapsed)
+}
+
+// When the caller's deadline would elapse before the backoff finishes, sleeping
+// only guarantees a context error. Return the response instead so the caller
+// learns why the request actually failed.
+func TestRetryReturnsResponseWhenDeadlineShorterThanBackoff(t *testing.T) {
 	var requestCount int
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		requestCount++
@@ -323,9 +366,50 @@ func TestRetryWaitIsInterruptedByContext(t *testing.T) {
 	)
 	elapsed := time.Since(start)
 
-	assert.ErrorIs(t, err, context.DeadlineExceeded)
-	assert.Equal(t, 1, requestCount, "Expected the retry to be abandoned once the context expired")
-	assert.Less(t, elapsed, time.Second, "Expected the backoff to be interrupted by the context, took %v", elapsed)
+	// The caller gets the 429, not context.DeadlineExceeded.
+	var apiError *core.APIError
+	require.ErrorAs(t, err, &apiError)
+	assert.Equal(t, http.StatusTooManyRequests, apiError.StatusCode)
+	assert.NotErrorIs(t, err, context.DeadlineExceeded)
+	assert.Equal(t, 1, requestCount, "Expected no retry once the deadline was known to be too short")
+	assert.Less(t, elapsed, time.Second, "Expected to return immediately rather than sleep, took %v", elapsed)
+}
+
+// A deadline with room for the backoff must still retry as normal.
+func TestRetryProceedsWhenDeadlineLongerThanBackoff(t *testing.T) {
+	var requestCount int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		if requestCount == 1 {
+			w.Header().Set("Retry-After", "1")
+			w.WriteHeader(http.StatusTooManyRequests)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("{}"))
+	}))
+	defer server.Close()
+
+	caller := NewCaller(&CallerParams{
+		Client: server.Client(),
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	_, err := caller.Call(
+		ctx,
+		&CallParams{
+			URL:         server.URL,
+			Method:      http.MethodGet,
+			Request:     &InternalTestRequest{},
+			Response:    &InternalTestResponse{},
+			MaxAttempts: 3,
+		},
+	)
+
+	assert.NoError(t, err)
+	assert.Equal(t, 2, requestCount, "Expected the retry to proceed when the deadline allows it")
 }
 
 func TestDisableRetries(t *testing.T) {

--- a/seed/go-sdk/oauth-client-credentials/internal/retrier.go
+++ b/seed/go-sdk/oauth-client-credentials/internal/retrier.go
@@ -145,12 +145,20 @@ func (r *Retrier) run(
 	}
 
 	if r.shouldRetry(response) {
-		defer func() { _ = response.Body.Close() }()
-
 		delay, err := r.retryDelay(response, retryAttempt)
 		if err != nil {
+			_ = response.Body.Close()
 			return nil, err
 		}
+
+		// If the context's deadline would elapse before the backoff completes, return
+		// the response instead of sleeping through it. The caller then sees why the
+		// request actually failed (e.g. a 429) rather than a context deadline error.
+		if deadline, ok := request.Context().Deadline(); ok && time.Until(deadline) < delay {
+			return response, nil
+		}
+
+		defer func() { _ = response.Body.Close() }()
 
 		if err := sleepWithContext(request.Context(), delay); err != nil {
 			return nil, err

--- a/seed/go-sdk/oauth-client-credentials/internal/retrier_test.go
+++ b/seed/go-sdk/oauth-client-credentials/internal/retrier_test.go
@@ -295,7 +295,50 @@ func TestRetryWithRequestBody(t *testing.T) {
 	assert.Equal(t, expectedBody, requestBodies[1], "Second request body should match expected (retry should re-send body)")
 }
 
+// An explicit cancel (e.g. Ctrl-C wired to cancel()) must interrupt the backoff
+// wait. There is no deadline here, so the retrier cannot know the wait is futile
+// up front -- it has to be woken by the context.
 func TestRetryWaitIsInterruptedByContext(t *testing.T) {
+	var requestCount int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		w.Header().Set("Retry-After", "5")
+		w.WriteHeader(http.StatusTooManyRequests)
+	}))
+	defer server.Close()
+
+	caller := NewCaller(&CallerParams{
+		Client: server.Client(),
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		time.Sleep(100 * time.Millisecond)
+		cancel()
+	}()
+	defer cancel()
+
+	start := time.Now()
+	_, err := caller.Call(
+		ctx,
+		&CallParams{
+			URL:         server.URL,
+			Method:      http.MethodGet,
+			Request:     &InternalTestRequest{},
+			MaxAttempts: 3,
+		},
+	)
+	elapsed := time.Since(start)
+
+	assert.ErrorIs(t, err, context.Canceled)
+	assert.Equal(t, 1, requestCount, "Expected the retry to be abandoned once the context was cancelled")
+	assert.Less(t, elapsed, time.Second, "Expected the backoff to be interrupted by the context, took %v", elapsed)
+}
+
+// When the caller's deadline would elapse before the backoff finishes, sleeping
+// only guarantees a context error. Return the response instead so the caller
+// learns why the request actually failed.
+func TestRetryReturnsResponseWhenDeadlineShorterThanBackoff(t *testing.T) {
 	var requestCount int
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		requestCount++
@@ -323,9 +366,50 @@ func TestRetryWaitIsInterruptedByContext(t *testing.T) {
 	)
 	elapsed := time.Since(start)
 
-	assert.ErrorIs(t, err, context.DeadlineExceeded)
-	assert.Equal(t, 1, requestCount, "Expected the retry to be abandoned once the context expired")
-	assert.Less(t, elapsed, time.Second, "Expected the backoff to be interrupted by the context, took %v", elapsed)
+	// The caller gets the 429, not context.DeadlineExceeded.
+	var apiError *core.APIError
+	require.ErrorAs(t, err, &apiError)
+	assert.Equal(t, http.StatusTooManyRequests, apiError.StatusCode)
+	assert.NotErrorIs(t, err, context.DeadlineExceeded)
+	assert.Equal(t, 1, requestCount, "Expected no retry once the deadline was known to be too short")
+	assert.Less(t, elapsed, time.Second, "Expected to return immediately rather than sleep, took %v", elapsed)
+}
+
+// A deadline with room for the backoff must still retry as normal.
+func TestRetryProceedsWhenDeadlineLongerThanBackoff(t *testing.T) {
+	var requestCount int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		if requestCount == 1 {
+			w.Header().Set("Retry-After", "1")
+			w.WriteHeader(http.StatusTooManyRequests)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("{}"))
+	}))
+	defer server.Close()
+
+	caller := NewCaller(&CallerParams{
+		Client: server.Client(),
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	_, err := caller.Call(
+		ctx,
+		&CallParams{
+			URL:         server.URL,
+			Method:      http.MethodGet,
+			Request:     &InternalTestRequest{},
+			Response:    &InternalTestResponse{},
+			MaxAttempts: 3,
+		},
+	)
+
+	assert.NoError(t, err)
+	assert.Equal(t, 2, requestCount, "Expected the retry to proceed when the deadline allows it")
 }
 
 func TestDisableRetries(t *testing.T) {

--- a/seed/go-sdk/oauth-pkce/internal/retrier.go
+++ b/seed/go-sdk/oauth-pkce/internal/retrier.go
@@ -145,12 +145,20 @@ func (r *Retrier) run(
 	}
 
 	if r.shouldRetry(response) {
-		defer func() { _ = response.Body.Close() }()
-
 		delay, err := r.retryDelay(response, retryAttempt)
 		if err != nil {
+			_ = response.Body.Close()
 			return nil, err
 		}
+
+		// If the context's deadline would elapse before the backoff completes, return
+		// the response instead of sleeping through it. The caller then sees why the
+		// request actually failed (e.g. a 429) rather than a context deadline error.
+		if deadline, ok := request.Context().Deadline(); ok && time.Until(deadline) < delay {
+			return response, nil
+		}
+
+		defer func() { _ = response.Body.Close() }()
 
 		if err := sleepWithContext(request.Context(), delay); err != nil {
 			return nil, err

--- a/seed/go-sdk/oauth-pkce/internal/retrier_test.go
+++ b/seed/go-sdk/oauth-pkce/internal/retrier_test.go
@@ -295,7 +295,50 @@ func TestRetryWithRequestBody(t *testing.T) {
 	assert.Equal(t, expectedBody, requestBodies[1], "Second request body should match expected (retry should re-send body)")
 }
 
+// An explicit cancel (e.g. Ctrl-C wired to cancel()) must interrupt the backoff
+// wait. There is no deadline here, so the retrier cannot know the wait is futile
+// up front -- it has to be woken by the context.
 func TestRetryWaitIsInterruptedByContext(t *testing.T) {
+	var requestCount int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		w.Header().Set("Retry-After", "5")
+		w.WriteHeader(http.StatusTooManyRequests)
+	}))
+	defer server.Close()
+
+	caller := NewCaller(&CallerParams{
+		Client: server.Client(),
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		time.Sleep(100 * time.Millisecond)
+		cancel()
+	}()
+	defer cancel()
+
+	start := time.Now()
+	_, err := caller.Call(
+		ctx,
+		&CallParams{
+			URL:         server.URL,
+			Method:      http.MethodGet,
+			Request:     &InternalTestRequest{},
+			MaxAttempts: 3,
+		},
+	)
+	elapsed := time.Since(start)
+
+	assert.ErrorIs(t, err, context.Canceled)
+	assert.Equal(t, 1, requestCount, "Expected the retry to be abandoned once the context was cancelled")
+	assert.Less(t, elapsed, time.Second, "Expected the backoff to be interrupted by the context, took %v", elapsed)
+}
+
+// When the caller's deadline would elapse before the backoff finishes, sleeping
+// only guarantees a context error. Return the response instead so the caller
+// learns why the request actually failed.
+func TestRetryReturnsResponseWhenDeadlineShorterThanBackoff(t *testing.T) {
 	var requestCount int
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		requestCount++
@@ -323,9 +366,50 @@ func TestRetryWaitIsInterruptedByContext(t *testing.T) {
 	)
 	elapsed := time.Since(start)
 
-	assert.ErrorIs(t, err, context.DeadlineExceeded)
-	assert.Equal(t, 1, requestCount, "Expected the retry to be abandoned once the context expired")
-	assert.Less(t, elapsed, time.Second, "Expected the backoff to be interrupted by the context, took %v", elapsed)
+	// The caller gets the 429, not context.DeadlineExceeded.
+	var apiError *core.APIError
+	require.ErrorAs(t, err, &apiError)
+	assert.Equal(t, http.StatusTooManyRequests, apiError.StatusCode)
+	assert.NotErrorIs(t, err, context.DeadlineExceeded)
+	assert.Equal(t, 1, requestCount, "Expected no retry once the deadline was known to be too short")
+	assert.Less(t, elapsed, time.Second, "Expected to return immediately rather than sleep, took %v", elapsed)
+}
+
+// A deadline with room for the backoff must still retry as normal.
+func TestRetryProceedsWhenDeadlineLongerThanBackoff(t *testing.T) {
+	var requestCount int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		if requestCount == 1 {
+			w.Header().Set("Retry-After", "1")
+			w.WriteHeader(http.StatusTooManyRequests)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("{}"))
+	}))
+	defer server.Close()
+
+	caller := NewCaller(&CallerParams{
+		Client: server.Client(),
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	_, err := caller.Call(
+		ctx,
+		&CallParams{
+			URL:         server.URL,
+			Method:      http.MethodGet,
+			Request:     &InternalTestRequest{},
+			Response:    &InternalTestResponse{},
+			MaxAttempts: 3,
+		},
+	)
+
+	assert.NoError(t, err)
+	assert.Equal(t, 2, requestCount, "Expected the retry to proceed when the deadline allows it")
 }
 
 func TestDisableRetries(t *testing.T) {

--- a/seed/go-sdk/object/internal/retrier.go
+++ b/seed/go-sdk/object/internal/retrier.go
@@ -145,12 +145,20 @@ func (r *Retrier) run(
 	}
 
 	if r.shouldRetry(response) {
-		defer func() { _ = response.Body.Close() }()
-
 		delay, err := r.retryDelay(response, retryAttempt)
 		if err != nil {
+			_ = response.Body.Close()
 			return nil, err
 		}
+
+		// If the context's deadline would elapse before the backoff completes, return
+		// the response instead of sleeping through it. The caller then sees why the
+		// request actually failed (e.g. a 429) rather than a context deadline error.
+		if deadline, ok := request.Context().Deadline(); ok && time.Until(deadline) < delay {
+			return response, nil
+		}
+
+		defer func() { _ = response.Body.Close() }()
 
 		if err := sleepWithContext(request.Context(), delay); err != nil {
 			return nil, err

--- a/seed/go-sdk/object/internal/retrier_test.go
+++ b/seed/go-sdk/object/internal/retrier_test.go
@@ -295,7 +295,50 @@ func TestRetryWithRequestBody(t *testing.T) {
 	assert.Equal(t, expectedBody, requestBodies[1], "Second request body should match expected (retry should re-send body)")
 }
 
+// An explicit cancel (e.g. Ctrl-C wired to cancel()) must interrupt the backoff
+// wait. There is no deadline here, so the retrier cannot know the wait is futile
+// up front -- it has to be woken by the context.
 func TestRetryWaitIsInterruptedByContext(t *testing.T) {
+	var requestCount int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		w.Header().Set("Retry-After", "5")
+		w.WriteHeader(http.StatusTooManyRequests)
+	}))
+	defer server.Close()
+
+	caller := NewCaller(&CallerParams{
+		Client: server.Client(),
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		time.Sleep(100 * time.Millisecond)
+		cancel()
+	}()
+	defer cancel()
+
+	start := time.Now()
+	_, err := caller.Call(
+		ctx,
+		&CallParams{
+			URL:         server.URL,
+			Method:      http.MethodGet,
+			Request:     &InternalTestRequest{},
+			MaxAttempts: 3,
+		},
+	)
+	elapsed := time.Since(start)
+
+	assert.ErrorIs(t, err, context.Canceled)
+	assert.Equal(t, 1, requestCount, "Expected the retry to be abandoned once the context was cancelled")
+	assert.Less(t, elapsed, time.Second, "Expected the backoff to be interrupted by the context, took %v", elapsed)
+}
+
+// When the caller's deadline would elapse before the backoff finishes, sleeping
+// only guarantees a context error. Return the response instead so the caller
+// learns why the request actually failed.
+func TestRetryReturnsResponseWhenDeadlineShorterThanBackoff(t *testing.T) {
 	var requestCount int
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		requestCount++
@@ -323,9 +366,50 @@ func TestRetryWaitIsInterruptedByContext(t *testing.T) {
 	)
 	elapsed := time.Since(start)
 
-	assert.ErrorIs(t, err, context.DeadlineExceeded)
-	assert.Equal(t, 1, requestCount, "Expected the retry to be abandoned once the context expired")
-	assert.Less(t, elapsed, time.Second, "Expected the backoff to be interrupted by the context, took %v", elapsed)
+	// The caller gets the 429, not context.DeadlineExceeded.
+	var apiError *core.APIError
+	require.ErrorAs(t, err, &apiError)
+	assert.Equal(t, http.StatusTooManyRequests, apiError.StatusCode)
+	assert.NotErrorIs(t, err, context.DeadlineExceeded)
+	assert.Equal(t, 1, requestCount, "Expected no retry once the deadline was known to be too short")
+	assert.Less(t, elapsed, time.Second, "Expected to return immediately rather than sleep, took %v", elapsed)
+}
+
+// A deadline with room for the backoff must still retry as normal.
+func TestRetryProceedsWhenDeadlineLongerThanBackoff(t *testing.T) {
+	var requestCount int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		if requestCount == 1 {
+			w.Header().Set("Retry-After", "1")
+			w.WriteHeader(http.StatusTooManyRequests)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("{}"))
+	}))
+	defer server.Close()
+
+	caller := NewCaller(&CallerParams{
+		Client: server.Client(),
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	_, err := caller.Call(
+		ctx,
+		&CallParams{
+			URL:         server.URL,
+			Method:      http.MethodGet,
+			Request:     &InternalTestRequest{},
+			Response:    &InternalTestResponse{},
+			MaxAttempts: 3,
+		},
+	)
+
+	assert.NoError(t, err)
+	assert.Equal(t, 2, requestCount, "Expected the retry to proceed when the deadline allows it")
 }
 
 func TestDisableRetries(t *testing.T) {

--- a/seed/go-sdk/objects-with-imports/internal/retrier.go
+++ b/seed/go-sdk/objects-with-imports/internal/retrier.go
@@ -145,12 +145,20 @@ func (r *Retrier) run(
 	}
 
 	if r.shouldRetry(response) {
-		defer func() { _ = response.Body.Close() }()
-
 		delay, err := r.retryDelay(response, retryAttempt)
 		if err != nil {
+			_ = response.Body.Close()
 			return nil, err
 		}
+
+		// If the context's deadline would elapse before the backoff completes, return
+		// the response instead of sleeping through it. The caller then sees why the
+		// request actually failed (e.g. a 429) rather than a context deadline error.
+		if deadline, ok := request.Context().Deadline(); ok && time.Until(deadline) < delay {
+			return response, nil
+		}
+
+		defer func() { _ = response.Body.Close() }()
 
 		if err := sleepWithContext(request.Context(), delay); err != nil {
 			return nil, err

--- a/seed/go-sdk/objects-with-imports/internal/retrier_test.go
+++ b/seed/go-sdk/objects-with-imports/internal/retrier_test.go
@@ -295,7 +295,50 @@ func TestRetryWithRequestBody(t *testing.T) {
 	assert.Equal(t, expectedBody, requestBodies[1], "Second request body should match expected (retry should re-send body)")
 }
 
+// An explicit cancel (e.g. Ctrl-C wired to cancel()) must interrupt the backoff
+// wait. There is no deadline here, so the retrier cannot know the wait is futile
+// up front -- it has to be woken by the context.
 func TestRetryWaitIsInterruptedByContext(t *testing.T) {
+	var requestCount int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		w.Header().Set("Retry-After", "5")
+		w.WriteHeader(http.StatusTooManyRequests)
+	}))
+	defer server.Close()
+
+	caller := NewCaller(&CallerParams{
+		Client: server.Client(),
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		time.Sleep(100 * time.Millisecond)
+		cancel()
+	}()
+	defer cancel()
+
+	start := time.Now()
+	_, err := caller.Call(
+		ctx,
+		&CallParams{
+			URL:         server.URL,
+			Method:      http.MethodGet,
+			Request:     &InternalTestRequest{},
+			MaxAttempts: 3,
+		},
+	)
+	elapsed := time.Since(start)
+
+	assert.ErrorIs(t, err, context.Canceled)
+	assert.Equal(t, 1, requestCount, "Expected the retry to be abandoned once the context was cancelled")
+	assert.Less(t, elapsed, time.Second, "Expected the backoff to be interrupted by the context, took %v", elapsed)
+}
+
+// When the caller's deadline would elapse before the backoff finishes, sleeping
+// only guarantees a context error. Return the response instead so the caller
+// learns why the request actually failed.
+func TestRetryReturnsResponseWhenDeadlineShorterThanBackoff(t *testing.T) {
 	var requestCount int
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		requestCount++
@@ -323,9 +366,50 @@ func TestRetryWaitIsInterruptedByContext(t *testing.T) {
 	)
 	elapsed := time.Since(start)
 
-	assert.ErrorIs(t, err, context.DeadlineExceeded)
-	assert.Equal(t, 1, requestCount, "Expected the retry to be abandoned once the context expired")
-	assert.Less(t, elapsed, time.Second, "Expected the backoff to be interrupted by the context, took %v", elapsed)
+	// The caller gets the 429, not context.DeadlineExceeded.
+	var apiError *core.APIError
+	require.ErrorAs(t, err, &apiError)
+	assert.Equal(t, http.StatusTooManyRequests, apiError.StatusCode)
+	assert.NotErrorIs(t, err, context.DeadlineExceeded)
+	assert.Equal(t, 1, requestCount, "Expected no retry once the deadline was known to be too short")
+	assert.Less(t, elapsed, time.Second, "Expected to return immediately rather than sleep, took %v", elapsed)
+}
+
+// A deadline with room for the backoff must still retry as normal.
+func TestRetryProceedsWhenDeadlineLongerThanBackoff(t *testing.T) {
+	var requestCount int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		if requestCount == 1 {
+			w.Header().Set("Retry-After", "1")
+			w.WriteHeader(http.StatusTooManyRequests)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("{}"))
+	}))
+	defer server.Close()
+
+	caller := NewCaller(&CallerParams{
+		Client: server.Client(),
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	_, err := caller.Call(
+		ctx,
+		&CallParams{
+			URL:         server.URL,
+			Method:      http.MethodGet,
+			Request:     &InternalTestRequest{},
+			Response:    &InternalTestResponse{},
+			MaxAttempts: 3,
+		},
+	)
+
+	assert.NoError(t, err)
+	assert.Equal(t, 2, requestCount, "Expected the retry to proceed when the deadline allows it")
 }
 
 func TestDisableRetries(t *testing.T) {

--- a/seed/go-sdk/openapi-path-param-body-collision/internal/retrier.go
+++ b/seed/go-sdk/openapi-path-param-body-collision/internal/retrier.go
@@ -145,12 +145,20 @@ func (r *Retrier) run(
 	}
 
 	if r.shouldRetry(response) {
-		defer func() { _ = response.Body.Close() }()
-
 		delay, err := r.retryDelay(response, retryAttempt)
 		if err != nil {
+			_ = response.Body.Close()
 			return nil, err
 		}
+
+		// If the context's deadline would elapse before the backoff completes, return
+		// the response instead of sleeping through it. The caller then sees why the
+		// request actually failed (e.g. a 429) rather than a context deadline error.
+		if deadline, ok := request.Context().Deadline(); ok && time.Until(deadline) < delay {
+			return response, nil
+		}
+
+		defer func() { _ = response.Body.Close() }()
 
 		if err := sleepWithContext(request.Context(), delay); err != nil {
 			return nil, err

--- a/seed/go-sdk/openapi-path-param-body-collision/internal/retrier_test.go
+++ b/seed/go-sdk/openapi-path-param-body-collision/internal/retrier_test.go
@@ -295,7 +295,50 @@ func TestRetryWithRequestBody(t *testing.T) {
 	assert.Equal(t, expectedBody, requestBodies[1], "Second request body should match expected (retry should re-send body)")
 }
 
+// An explicit cancel (e.g. Ctrl-C wired to cancel()) must interrupt the backoff
+// wait. There is no deadline here, so the retrier cannot know the wait is futile
+// up front -- it has to be woken by the context.
 func TestRetryWaitIsInterruptedByContext(t *testing.T) {
+	var requestCount int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		w.Header().Set("Retry-After", "5")
+		w.WriteHeader(http.StatusTooManyRequests)
+	}))
+	defer server.Close()
+
+	caller := NewCaller(&CallerParams{
+		Client: server.Client(),
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		time.Sleep(100 * time.Millisecond)
+		cancel()
+	}()
+	defer cancel()
+
+	start := time.Now()
+	_, err := caller.Call(
+		ctx,
+		&CallParams{
+			URL:         server.URL,
+			Method:      http.MethodGet,
+			Request:     &InternalTestRequest{},
+			MaxAttempts: 3,
+		},
+	)
+	elapsed := time.Since(start)
+
+	assert.ErrorIs(t, err, context.Canceled)
+	assert.Equal(t, 1, requestCount, "Expected the retry to be abandoned once the context was cancelled")
+	assert.Less(t, elapsed, time.Second, "Expected the backoff to be interrupted by the context, took %v", elapsed)
+}
+
+// When the caller's deadline would elapse before the backoff finishes, sleeping
+// only guarantees a context error. Return the response instead so the caller
+// learns why the request actually failed.
+func TestRetryReturnsResponseWhenDeadlineShorterThanBackoff(t *testing.T) {
 	var requestCount int
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		requestCount++
@@ -323,9 +366,50 @@ func TestRetryWaitIsInterruptedByContext(t *testing.T) {
 	)
 	elapsed := time.Since(start)
 
-	assert.ErrorIs(t, err, context.DeadlineExceeded)
-	assert.Equal(t, 1, requestCount, "Expected the retry to be abandoned once the context expired")
-	assert.Less(t, elapsed, time.Second, "Expected the backoff to be interrupted by the context, took %v", elapsed)
+	// The caller gets the 429, not context.DeadlineExceeded.
+	var apiError *core.APIError
+	require.ErrorAs(t, err, &apiError)
+	assert.Equal(t, http.StatusTooManyRequests, apiError.StatusCode)
+	assert.NotErrorIs(t, err, context.DeadlineExceeded)
+	assert.Equal(t, 1, requestCount, "Expected no retry once the deadline was known to be too short")
+	assert.Less(t, elapsed, time.Second, "Expected to return immediately rather than sleep, took %v", elapsed)
+}
+
+// A deadline with room for the backoff must still retry as normal.
+func TestRetryProceedsWhenDeadlineLongerThanBackoff(t *testing.T) {
+	var requestCount int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		if requestCount == 1 {
+			w.Header().Set("Retry-After", "1")
+			w.WriteHeader(http.StatusTooManyRequests)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("{}"))
+	}))
+	defer server.Close()
+
+	caller := NewCaller(&CallerParams{
+		Client: server.Client(),
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	_, err := caller.Call(
+		ctx,
+		&CallParams{
+			URL:         server.URL,
+			Method:      http.MethodGet,
+			Request:     &InternalTestRequest{},
+			Response:    &InternalTestResponse{},
+			MaxAttempts: 3,
+		},
+	)
+
+	assert.NoError(t, err)
+	assert.Equal(t, 2, requestCount, "Expected the retry to proceed when the deadline allows it")
 }
 
 func TestDisableRetries(t *testing.T) {

--- a/seed/go-sdk/openapi-request-body-ref/no-custom-config/internal/retrier.go
+++ b/seed/go-sdk/openapi-request-body-ref/no-custom-config/internal/retrier.go
@@ -145,12 +145,20 @@ func (r *Retrier) run(
 	}
 
 	if r.shouldRetry(response) {
-		defer func() { _ = response.Body.Close() }()
-
 		delay, err := r.retryDelay(response, retryAttempt)
 		if err != nil {
+			_ = response.Body.Close()
 			return nil, err
 		}
+
+		// If the context's deadline would elapse before the backoff completes, return
+		// the response instead of sleeping through it. The caller then sees why the
+		// request actually failed (e.g. a 429) rather than a context deadline error.
+		if deadline, ok := request.Context().Deadline(); ok && time.Until(deadline) < delay {
+			return response, nil
+		}
+
+		defer func() { _ = response.Body.Close() }()
 
 		if err := sleepWithContext(request.Context(), delay); err != nil {
 			return nil, err

--- a/seed/go-sdk/openapi-request-body-ref/no-custom-config/internal/retrier_test.go
+++ b/seed/go-sdk/openapi-request-body-ref/no-custom-config/internal/retrier_test.go
@@ -295,7 +295,50 @@ func TestRetryWithRequestBody(t *testing.T) {
 	assert.Equal(t, expectedBody, requestBodies[1], "Second request body should match expected (retry should re-send body)")
 }
 
+// An explicit cancel (e.g. Ctrl-C wired to cancel()) must interrupt the backoff
+// wait. There is no deadline here, so the retrier cannot know the wait is futile
+// up front -- it has to be woken by the context.
 func TestRetryWaitIsInterruptedByContext(t *testing.T) {
+	var requestCount int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		w.Header().Set("Retry-After", "5")
+		w.WriteHeader(http.StatusTooManyRequests)
+	}))
+	defer server.Close()
+
+	caller := NewCaller(&CallerParams{
+		Client: server.Client(),
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		time.Sleep(100 * time.Millisecond)
+		cancel()
+	}()
+	defer cancel()
+
+	start := time.Now()
+	_, err := caller.Call(
+		ctx,
+		&CallParams{
+			URL:         server.URL,
+			Method:      http.MethodGet,
+			Request:     &InternalTestRequest{},
+			MaxAttempts: 3,
+		},
+	)
+	elapsed := time.Since(start)
+
+	assert.ErrorIs(t, err, context.Canceled)
+	assert.Equal(t, 1, requestCount, "Expected the retry to be abandoned once the context was cancelled")
+	assert.Less(t, elapsed, time.Second, "Expected the backoff to be interrupted by the context, took %v", elapsed)
+}
+
+// When the caller's deadline would elapse before the backoff finishes, sleeping
+// only guarantees a context error. Return the response instead so the caller
+// learns why the request actually failed.
+func TestRetryReturnsResponseWhenDeadlineShorterThanBackoff(t *testing.T) {
 	var requestCount int
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		requestCount++
@@ -323,9 +366,50 @@ func TestRetryWaitIsInterruptedByContext(t *testing.T) {
 	)
 	elapsed := time.Since(start)
 
-	assert.ErrorIs(t, err, context.DeadlineExceeded)
-	assert.Equal(t, 1, requestCount, "Expected the retry to be abandoned once the context expired")
-	assert.Less(t, elapsed, time.Second, "Expected the backoff to be interrupted by the context, took %v", elapsed)
+	// The caller gets the 429, not context.DeadlineExceeded.
+	var apiError *core.APIError
+	require.ErrorAs(t, err, &apiError)
+	assert.Equal(t, http.StatusTooManyRequests, apiError.StatusCode)
+	assert.NotErrorIs(t, err, context.DeadlineExceeded)
+	assert.Equal(t, 1, requestCount, "Expected no retry once the deadline was known to be too short")
+	assert.Less(t, elapsed, time.Second, "Expected to return immediately rather than sleep, took %v", elapsed)
+}
+
+// A deadline with room for the backoff must still retry as normal.
+func TestRetryProceedsWhenDeadlineLongerThanBackoff(t *testing.T) {
+	var requestCount int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		if requestCount == 1 {
+			w.Header().Set("Retry-After", "1")
+			w.WriteHeader(http.StatusTooManyRequests)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("{}"))
+	}))
+	defer server.Close()
+
+	caller := NewCaller(&CallerParams{
+		Client: server.Client(),
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	_, err := caller.Call(
+		ctx,
+		&CallParams{
+			URL:         server.URL,
+			Method:      http.MethodGet,
+			Request:     &InternalTestRequest{},
+			Response:    &InternalTestResponse{},
+			MaxAttempts: 3,
+		},
+	)
+
+	assert.NoError(t, err)
+	assert.Equal(t, 2, requestCount, "Expected the retry to proceed when the deadline allows it")
 }
 
 func TestDisableRetries(t *testing.T) {

--- a/seed/go-sdk/openapi-subtitle/internal/retrier.go
+++ b/seed/go-sdk/openapi-subtitle/internal/retrier.go
@@ -145,12 +145,20 @@ func (r *Retrier) run(
 	}
 
 	if r.shouldRetry(response) {
-		defer func() { _ = response.Body.Close() }()
-
 		delay, err := r.retryDelay(response, retryAttempt)
 		if err != nil {
+			_ = response.Body.Close()
 			return nil, err
 		}
+
+		// If the context's deadline would elapse before the backoff completes, return
+		// the response instead of sleeping through it. The caller then sees why the
+		// request actually failed (e.g. a 429) rather than a context deadline error.
+		if deadline, ok := request.Context().Deadline(); ok && time.Until(deadline) < delay {
+			return response, nil
+		}
+
+		defer func() { _ = response.Body.Close() }()
 
 		if err := sleepWithContext(request.Context(), delay); err != nil {
 			return nil, err

--- a/seed/go-sdk/openapi-subtitle/internal/retrier_test.go
+++ b/seed/go-sdk/openapi-subtitle/internal/retrier_test.go
@@ -295,7 +295,50 @@ func TestRetryWithRequestBody(t *testing.T) {
 	assert.Equal(t, expectedBody, requestBodies[1], "Second request body should match expected (retry should re-send body)")
 }
 
+// An explicit cancel (e.g. Ctrl-C wired to cancel()) must interrupt the backoff
+// wait. There is no deadline here, so the retrier cannot know the wait is futile
+// up front -- it has to be woken by the context.
 func TestRetryWaitIsInterruptedByContext(t *testing.T) {
+	var requestCount int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		w.Header().Set("Retry-After", "5")
+		w.WriteHeader(http.StatusTooManyRequests)
+	}))
+	defer server.Close()
+
+	caller := NewCaller(&CallerParams{
+		Client: server.Client(),
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		time.Sleep(100 * time.Millisecond)
+		cancel()
+	}()
+	defer cancel()
+
+	start := time.Now()
+	_, err := caller.Call(
+		ctx,
+		&CallParams{
+			URL:         server.URL,
+			Method:      http.MethodGet,
+			Request:     &InternalTestRequest{},
+			MaxAttempts: 3,
+		},
+	)
+	elapsed := time.Since(start)
+
+	assert.ErrorIs(t, err, context.Canceled)
+	assert.Equal(t, 1, requestCount, "Expected the retry to be abandoned once the context was cancelled")
+	assert.Less(t, elapsed, time.Second, "Expected the backoff to be interrupted by the context, took %v", elapsed)
+}
+
+// When the caller's deadline would elapse before the backoff finishes, sleeping
+// only guarantees a context error. Return the response instead so the caller
+// learns why the request actually failed.
+func TestRetryReturnsResponseWhenDeadlineShorterThanBackoff(t *testing.T) {
 	var requestCount int
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		requestCount++
@@ -323,9 +366,50 @@ func TestRetryWaitIsInterruptedByContext(t *testing.T) {
 	)
 	elapsed := time.Since(start)
 
-	assert.ErrorIs(t, err, context.DeadlineExceeded)
-	assert.Equal(t, 1, requestCount, "Expected the retry to be abandoned once the context expired")
-	assert.Less(t, elapsed, time.Second, "Expected the backoff to be interrupted by the context, took %v", elapsed)
+	// The caller gets the 429, not context.DeadlineExceeded.
+	var apiError *core.APIError
+	require.ErrorAs(t, err, &apiError)
+	assert.Equal(t, http.StatusTooManyRequests, apiError.StatusCode)
+	assert.NotErrorIs(t, err, context.DeadlineExceeded)
+	assert.Equal(t, 1, requestCount, "Expected no retry once the deadline was known to be too short")
+	assert.Less(t, elapsed, time.Second, "Expected to return immediately rather than sleep, took %v", elapsed)
+}
+
+// A deadline with room for the backoff must still retry as normal.
+func TestRetryProceedsWhenDeadlineLongerThanBackoff(t *testing.T) {
+	var requestCount int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		if requestCount == 1 {
+			w.Header().Set("Retry-After", "1")
+			w.WriteHeader(http.StatusTooManyRequests)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("{}"))
+	}))
+	defer server.Close()
+
+	caller := NewCaller(&CallerParams{
+		Client: server.Client(),
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	_, err := caller.Call(
+		ctx,
+		&CallParams{
+			URL:         server.URL,
+			Method:      http.MethodGet,
+			Request:     &InternalTestRequest{},
+			Response:    &InternalTestResponse{},
+			MaxAttempts: 3,
+		},
+	)
+
+	assert.NoError(t, err)
+	assert.Equal(t, 2, requestCount, "Expected the retry to proceed when the deadline allows it")
 }
 
 func TestDisableRetries(t *testing.T) {

--- a/seed/go-sdk/optional/internal/retrier.go
+++ b/seed/go-sdk/optional/internal/retrier.go
@@ -145,12 +145,20 @@ func (r *Retrier) run(
 	}
 
 	if r.shouldRetry(response) {
-		defer func() { _ = response.Body.Close() }()
-
 		delay, err := r.retryDelay(response, retryAttempt)
 		if err != nil {
+			_ = response.Body.Close()
 			return nil, err
 		}
+
+		// If the context's deadline would elapse before the backoff completes, return
+		// the response instead of sleeping through it. The caller then sees why the
+		// request actually failed (e.g. a 429) rather than a context deadline error.
+		if deadline, ok := request.Context().Deadline(); ok && time.Until(deadline) < delay {
+			return response, nil
+		}
+
+		defer func() { _ = response.Body.Close() }()
 
 		if err := sleepWithContext(request.Context(), delay); err != nil {
 			return nil, err

--- a/seed/go-sdk/optional/internal/retrier_test.go
+++ b/seed/go-sdk/optional/internal/retrier_test.go
@@ -295,7 +295,50 @@ func TestRetryWithRequestBody(t *testing.T) {
 	assert.Equal(t, expectedBody, requestBodies[1], "Second request body should match expected (retry should re-send body)")
 }
 
+// An explicit cancel (e.g. Ctrl-C wired to cancel()) must interrupt the backoff
+// wait. There is no deadline here, so the retrier cannot know the wait is futile
+// up front -- it has to be woken by the context.
 func TestRetryWaitIsInterruptedByContext(t *testing.T) {
+	var requestCount int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		w.Header().Set("Retry-After", "5")
+		w.WriteHeader(http.StatusTooManyRequests)
+	}))
+	defer server.Close()
+
+	caller := NewCaller(&CallerParams{
+		Client: server.Client(),
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		time.Sleep(100 * time.Millisecond)
+		cancel()
+	}()
+	defer cancel()
+
+	start := time.Now()
+	_, err := caller.Call(
+		ctx,
+		&CallParams{
+			URL:         server.URL,
+			Method:      http.MethodGet,
+			Request:     &InternalTestRequest{},
+			MaxAttempts: 3,
+		},
+	)
+	elapsed := time.Since(start)
+
+	assert.ErrorIs(t, err, context.Canceled)
+	assert.Equal(t, 1, requestCount, "Expected the retry to be abandoned once the context was cancelled")
+	assert.Less(t, elapsed, time.Second, "Expected the backoff to be interrupted by the context, took %v", elapsed)
+}
+
+// When the caller's deadline would elapse before the backoff finishes, sleeping
+// only guarantees a context error. Return the response instead so the caller
+// learns why the request actually failed.
+func TestRetryReturnsResponseWhenDeadlineShorterThanBackoff(t *testing.T) {
 	var requestCount int
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		requestCount++
@@ -323,9 +366,50 @@ func TestRetryWaitIsInterruptedByContext(t *testing.T) {
 	)
 	elapsed := time.Since(start)
 
-	assert.ErrorIs(t, err, context.DeadlineExceeded)
-	assert.Equal(t, 1, requestCount, "Expected the retry to be abandoned once the context expired")
-	assert.Less(t, elapsed, time.Second, "Expected the backoff to be interrupted by the context, took %v", elapsed)
+	// The caller gets the 429, not context.DeadlineExceeded.
+	var apiError *core.APIError
+	require.ErrorAs(t, err, &apiError)
+	assert.Equal(t, http.StatusTooManyRequests, apiError.StatusCode)
+	assert.NotErrorIs(t, err, context.DeadlineExceeded)
+	assert.Equal(t, 1, requestCount, "Expected no retry once the deadline was known to be too short")
+	assert.Less(t, elapsed, time.Second, "Expected to return immediately rather than sleep, took %v", elapsed)
+}
+
+// A deadline with room for the backoff must still retry as normal.
+func TestRetryProceedsWhenDeadlineLongerThanBackoff(t *testing.T) {
+	var requestCount int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		if requestCount == 1 {
+			w.Header().Set("Retry-After", "1")
+			w.WriteHeader(http.StatusTooManyRequests)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("{}"))
+	}))
+	defer server.Close()
+
+	caller := NewCaller(&CallerParams{
+		Client: server.Client(),
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	_, err := caller.Call(
+		ctx,
+		&CallParams{
+			URL:         server.URL,
+			Method:      http.MethodGet,
+			Request:     &InternalTestRequest{},
+			Response:    &InternalTestResponse{},
+			MaxAttempts: 3,
+		},
+	)
+
+	assert.NoError(t, err)
+	assert.Equal(t, 2, requestCount, "Expected the retry to proceed when the deadline allows it")
 }
 
 func TestDisableRetries(t *testing.T) {

--- a/seed/go-sdk/package-yml/no-custom-config/internal/retrier.go
+++ b/seed/go-sdk/package-yml/no-custom-config/internal/retrier.go
@@ -145,12 +145,20 @@ func (r *Retrier) run(
 	}
 
 	if r.shouldRetry(response) {
-		defer func() { _ = response.Body.Close() }()
-
 		delay, err := r.retryDelay(response, retryAttempt)
 		if err != nil {
+			_ = response.Body.Close()
 			return nil, err
 		}
+
+		// If the context's deadline would elapse before the backoff completes, return
+		// the response instead of sleeping through it. The caller then sees why the
+		// request actually failed (e.g. a 429) rather than a context deadline error.
+		if deadline, ok := request.Context().Deadline(); ok && time.Until(deadline) < delay {
+			return response, nil
+		}
+
+		defer func() { _ = response.Body.Close() }()
 
 		if err := sleepWithContext(request.Context(), delay); err != nil {
 			return nil, err

--- a/seed/go-sdk/package-yml/no-custom-config/internal/retrier_test.go
+++ b/seed/go-sdk/package-yml/no-custom-config/internal/retrier_test.go
@@ -295,7 +295,50 @@ func TestRetryWithRequestBody(t *testing.T) {
 	assert.Equal(t, expectedBody, requestBodies[1], "Second request body should match expected (retry should re-send body)")
 }
 
+// An explicit cancel (e.g. Ctrl-C wired to cancel()) must interrupt the backoff
+// wait. There is no deadline here, so the retrier cannot know the wait is futile
+// up front -- it has to be woken by the context.
 func TestRetryWaitIsInterruptedByContext(t *testing.T) {
+	var requestCount int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		w.Header().Set("Retry-After", "5")
+		w.WriteHeader(http.StatusTooManyRequests)
+	}))
+	defer server.Close()
+
+	caller := NewCaller(&CallerParams{
+		Client: server.Client(),
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		time.Sleep(100 * time.Millisecond)
+		cancel()
+	}()
+	defer cancel()
+
+	start := time.Now()
+	_, err := caller.Call(
+		ctx,
+		&CallParams{
+			URL:         server.URL,
+			Method:      http.MethodGet,
+			Request:     &InternalTestRequest{},
+			MaxAttempts: 3,
+		},
+	)
+	elapsed := time.Since(start)
+
+	assert.ErrorIs(t, err, context.Canceled)
+	assert.Equal(t, 1, requestCount, "Expected the retry to be abandoned once the context was cancelled")
+	assert.Less(t, elapsed, time.Second, "Expected the backoff to be interrupted by the context, took %v", elapsed)
+}
+
+// When the caller's deadline would elapse before the backoff finishes, sleeping
+// only guarantees a context error. Return the response instead so the caller
+// learns why the request actually failed.
+func TestRetryReturnsResponseWhenDeadlineShorterThanBackoff(t *testing.T) {
 	var requestCount int
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		requestCount++
@@ -323,9 +366,50 @@ func TestRetryWaitIsInterruptedByContext(t *testing.T) {
 	)
 	elapsed := time.Since(start)
 
-	assert.ErrorIs(t, err, context.DeadlineExceeded)
-	assert.Equal(t, 1, requestCount, "Expected the retry to be abandoned once the context expired")
-	assert.Less(t, elapsed, time.Second, "Expected the backoff to be interrupted by the context, took %v", elapsed)
+	// The caller gets the 429, not context.DeadlineExceeded.
+	var apiError *core.APIError
+	require.ErrorAs(t, err, &apiError)
+	assert.Equal(t, http.StatusTooManyRequests, apiError.StatusCode)
+	assert.NotErrorIs(t, err, context.DeadlineExceeded)
+	assert.Equal(t, 1, requestCount, "Expected no retry once the deadline was known to be too short")
+	assert.Less(t, elapsed, time.Second, "Expected to return immediately rather than sleep, took %v", elapsed)
+}
+
+// A deadline with room for the backoff must still retry as normal.
+func TestRetryProceedsWhenDeadlineLongerThanBackoff(t *testing.T) {
+	var requestCount int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		if requestCount == 1 {
+			w.Header().Set("Retry-After", "1")
+			w.WriteHeader(http.StatusTooManyRequests)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("{}"))
+	}))
+	defer server.Close()
+
+	caller := NewCaller(&CallerParams{
+		Client: server.Client(),
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	_, err := caller.Call(
+		ctx,
+		&CallParams{
+			URL:         server.URL,
+			Method:      http.MethodGet,
+			Request:     &InternalTestRequest{},
+			Response:    &InternalTestResponse{},
+			MaxAttempts: 3,
+		},
+	)
+
+	assert.NoError(t, err)
+	assert.Equal(t, 2, requestCount, "Expected the retry to proceed when the deadline allows it")
 }
 
 func TestDisableRetries(t *testing.T) {

--- a/seed/go-sdk/pagination-custom/internal/retrier.go
+++ b/seed/go-sdk/pagination-custom/internal/retrier.go
@@ -145,12 +145,20 @@ func (r *Retrier) run(
 	}
 
 	if r.shouldRetry(response) {
-		defer func() { _ = response.Body.Close() }()
-
 		delay, err := r.retryDelay(response, retryAttempt)
 		if err != nil {
+			_ = response.Body.Close()
 			return nil, err
 		}
+
+		// If the context's deadline would elapse before the backoff completes, return
+		// the response instead of sleeping through it. The caller then sees why the
+		// request actually failed (e.g. a 429) rather than a context deadline error.
+		if deadline, ok := request.Context().Deadline(); ok && time.Until(deadline) < delay {
+			return response, nil
+		}
+
+		defer func() { _ = response.Body.Close() }()
 
 		if err := sleepWithContext(request.Context(), delay); err != nil {
 			return nil, err

--- a/seed/go-sdk/pagination-custom/internal/retrier_test.go
+++ b/seed/go-sdk/pagination-custom/internal/retrier_test.go
@@ -295,7 +295,50 @@ func TestRetryWithRequestBody(t *testing.T) {
 	assert.Equal(t, expectedBody, requestBodies[1], "Second request body should match expected (retry should re-send body)")
 }
 
+// An explicit cancel (e.g. Ctrl-C wired to cancel()) must interrupt the backoff
+// wait. There is no deadline here, so the retrier cannot know the wait is futile
+// up front -- it has to be woken by the context.
 func TestRetryWaitIsInterruptedByContext(t *testing.T) {
+	var requestCount int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		w.Header().Set("Retry-After", "5")
+		w.WriteHeader(http.StatusTooManyRequests)
+	}))
+	defer server.Close()
+
+	caller := NewCaller(&CallerParams{
+		Client: server.Client(),
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		time.Sleep(100 * time.Millisecond)
+		cancel()
+	}()
+	defer cancel()
+
+	start := time.Now()
+	_, err := caller.Call(
+		ctx,
+		&CallParams{
+			URL:         server.URL,
+			Method:      http.MethodGet,
+			Request:     &InternalTestRequest{},
+			MaxAttempts: 3,
+		},
+	)
+	elapsed := time.Since(start)
+
+	assert.ErrorIs(t, err, context.Canceled)
+	assert.Equal(t, 1, requestCount, "Expected the retry to be abandoned once the context was cancelled")
+	assert.Less(t, elapsed, time.Second, "Expected the backoff to be interrupted by the context, took %v", elapsed)
+}
+
+// When the caller's deadline would elapse before the backoff finishes, sleeping
+// only guarantees a context error. Return the response instead so the caller
+// learns why the request actually failed.
+func TestRetryReturnsResponseWhenDeadlineShorterThanBackoff(t *testing.T) {
 	var requestCount int
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		requestCount++
@@ -323,9 +366,50 @@ func TestRetryWaitIsInterruptedByContext(t *testing.T) {
 	)
 	elapsed := time.Since(start)
 
-	assert.ErrorIs(t, err, context.DeadlineExceeded)
-	assert.Equal(t, 1, requestCount, "Expected the retry to be abandoned once the context expired")
-	assert.Less(t, elapsed, time.Second, "Expected the backoff to be interrupted by the context, took %v", elapsed)
+	// The caller gets the 429, not context.DeadlineExceeded.
+	var apiError *core.APIError
+	require.ErrorAs(t, err, &apiError)
+	assert.Equal(t, http.StatusTooManyRequests, apiError.StatusCode)
+	assert.NotErrorIs(t, err, context.DeadlineExceeded)
+	assert.Equal(t, 1, requestCount, "Expected no retry once the deadline was known to be too short")
+	assert.Less(t, elapsed, time.Second, "Expected to return immediately rather than sleep, took %v", elapsed)
+}
+
+// A deadline with room for the backoff must still retry as normal.
+func TestRetryProceedsWhenDeadlineLongerThanBackoff(t *testing.T) {
+	var requestCount int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		if requestCount == 1 {
+			w.Header().Set("Retry-After", "1")
+			w.WriteHeader(http.StatusTooManyRequests)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("{}"))
+	}))
+	defer server.Close()
+
+	caller := NewCaller(&CallerParams{
+		Client: server.Client(),
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	_, err := caller.Call(
+		ctx,
+		&CallParams{
+			URL:         server.URL,
+			Method:      http.MethodGet,
+			Request:     &InternalTestRequest{},
+			Response:    &InternalTestResponse{},
+			MaxAttempts: 3,
+		},
+	)
+
+	assert.NoError(t, err)
+	assert.Equal(t, 2, requestCount, "Expected the retry to proceed when the deadline allows it")
 }
 
 func TestDisableRetries(t *testing.T) {

--- a/seed/go-sdk/pagination-uri-path/internal/retrier.go
+++ b/seed/go-sdk/pagination-uri-path/internal/retrier.go
@@ -145,12 +145,20 @@ func (r *Retrier) run(
 	}
 
 	if r.shouldRetry(response) {
-		defer func() { _ = response.Body.Close() }()
-
 		delay, err := r.retryDelay(response, retryAttempt)
 		if err != nil {
+			_ = response.Body.Close()
 			return nil, err
 		}
+
+		// If the context's deadline would elapse before the backoff completes, return
+		// the response instead of sleeping through it. The caller then sees why the
+		// request actually failed (e.g. a 429) rather than a context deadline error.
+		if deadline, ok := request.Context().Deadline(); ok && time.Until(deadline) < delay {
+			return response, nil
+		}
+
+		defer func() { _ = response.Body.Close() }()
 
 		if err := sleepWithContext(request.Context(), delay); err != nil {
 			return nil, err

--- a/seed/go-sdk/pagination-uri-path/internal/retrier_test.go
+++ b/seed/go-sdk/pagination-uri-path/internal/retrier_test.go
@@ -295,7 +295,50 @@ func TestRetryWithRequestBody(t *testing.T) {
 	assert.Equal(t, expectedBody, requestBodies[1], "Second request body should match expected (retry should re-send body)")
 }
 
+// An explicit cancel (e.g. Ctrl-C wired to cancel()) must interrupt the backoff
+// wait. There is no deadline here, so the retrier cannot know the wait is futile
+// up front -- it has to be woken by the context.
 func TestRetryWaitIsInterruptedByContext(t *testing.T) {
+	var requestCount int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		w.Header().Set("Retry-After", "5")
+		w.WriteHeader(http.StatusTooManyRequests)
+	}))
+	defer server.Close()
+
+	caller := NewCaller(&CallerParams{
+		Client: server.Client(),
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		time.Sleep(100 * time.Millisecond)
+		cancel()
+	}()
+	defer cancel()
+
+	start := time.Now()
+	_, err := caller.Call(
+		ctx,
+		&CallParams{
+			URL:         server.URL,
+			Method:      http.MethodGet,
+			Request:     &InternalTestRequest{},
+			MaxAttempts: 3,
+		},
+	)
+	elapsed := time.Since(start)
+
+	assert.ErrorIs(t, err, context.Canceled)
+	assert.Equal(t, 1, requestCount, "Expected the retry to be abandoned once the context was cancelled")
+	assert.Less(t, elapsed, time.Second, "Expected the backoff to be interrupted by the context, took %v", elapsed)
+}
+
+// When the caller's deadline would elapse before the backoff finishes, sleeping
+// only guarantees a context error. Return the response instead so the caller
+// learns why the request actually failed.
+func TestRetryReturnsResponseWhenDeadlineShorterThanBackoff(t *testing.T) {
 	var requestCount int
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		requestCount++
@@ -323,9 +366,50 @@ func TestRetryWaitIsInterruptedByContext(t *testing.T) {
 	)
 	elapsed := time.Since(start)
 
-	assert.ErrorIs(t, err, context.DeadlineExceeded)
-	assert.Equal(t, 1, requestCount, "Expected the retry to be abandoned once the context expired")
-	assert.Less(t, elapsed, time.Second, "Expected the backoff to be interrupted by the context, took %v", elapsed)
+	// The caller gets the 429, not context.DeadlineExceeded.
+	var apiError *core.APIError
+	require.ErrorAs(t, err, &apiError)
+	assert.Equal(t, http.StatusTooManyRequests, apiError.StatusCode)
+	assert.NotErrorIs(t, err, context.DeadlineExceeded)
+	assert.Equal(t, 1, requestCount, "Expected no retry once the deadline was known to be too short")
+	assert.Less(t, elapsed, time.Second, "Expected to return immediately rather than sleep, took %v", elapsed)
+}
+
+// A deadline with room for the backoff must still retry as normal.
+func TestRetryProceedsWhenDeadlineLongerThanBackoff(t *testing.T) {
+	var requestCount int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		if requestCount == 1 {
+			w.Header().Set("Retry-After", "1")
+			w.WriteHeader(http.StatusTooManyRequests)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("{}"))
+	}))
+	defer server.Close()
+
+	caller := NewCaller(&CallerParams{
+		Client: server.Client(),
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	_, err := caller.Call(
+		ctx,
+		&CallParams{
+			URL:         server.URL,
+			Method:      http.MethodGet,
+			Request:     &InternalTestRequest{},
+			Response:    &InternalTestResponse{},
+			MaxAttempts: 3,
+		},
+	)
+
+	assert.NoError(t, err)
+	assert.Equal(t, 2, requestCount, "Expected the retry to proceed when the deadline allows it")
 }
 
 func TestDisableRetries(t *testing.T) {

--- a/seed/go-sdk/pagination/internal/retrier.go
+++ b/seed/go-sdk/pagination/internal/retrier.go
@@ -145,12 +145,20 @@ func (r *Retrier) run(
 	}
 
 	if r.shouldRetry(response) {
-		defer func() { _ = response.Body.Close() }()
-
 		delay, err := r.retryDelay(response, retryAttempt)
 		if err != nil {
+			_ = response.Body.Close()
 			return nil, err
 		}
+
+		// If the context's deadline would elapse before the backoff completes, return
+		// the response instead of sleeping through it. The caller then sees why the
+		// request actually failed (e.g. a 429) rather than a context deadline error.
+		if deadline, ok := request.Context().Deadline(); ok && time.Until(deadline) < delay {
+			return response, nil
+		}
+
+		defer func() { _ = response.Body.Close() }()
 
 		if err := sleepWithContext(request.Context(), delay); err != nil {
 			return nil, err

--- a/seed/go-sdk/pagination/internal/retrier_test.go
+++ b/seed/go-sdk/pagination/internal/retrier_test.go
@@ -295,7 +295,50 @@ func TestRetryWithRequestBody(t *testing.T) {
 	assert.Equal(t, expectedBody, requestBodies[1], "Second request body should match expected (retry should re-send body)")
 }
 
+// An explicit cancel (e.g. Ctrl-C wired to cancel()) must interrupt the backoff
+// wait. There is no deadline here, so the retrier cannot know the wait is futile
+// up front -- it has to be woken by the context.
 func TestRetryWaitIsInterruptedByContext(t *testing.T) {
+	var requestCount int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		w.Header().Set("Retry-After", "5")
+		w.WriteHeader(http.StatusTooManyRequests)
+	}))
+	defer server.Close()
+
+	caller := NewCaller(&CallerParams{
+		Client: server.Client(),
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		time.Sleep(100 * time.Millisecond)
+		cancel()
+	}()
+	defer cancel()
+
+	start := time.Now()
+	_, err := caller.Call(
+		ctx,
+		&CallParams{
+			URL:         server.URL,
+			Method:      http.MethodGet,
+			Request:     &InternalTestRequest{},
+			MaxAttempts: 3,
+		},
+	)
+	elapsed := time.Since(start)
+
+	assert.ErrorIs(t, err, context.Canceled)
+	assert.Equal(t, 1, requestCount, "Expected the retry to be abandoned once the context was cancelled")
+	assert.Less(t, elapsed, time.Second, "Expected the backoff to be interrupted by the context, took %v", elapsed)
+}
+
+// When the caller's deadline would elapse before the backoff finishes, sleeping
+// only guarantees a context error. Return the response instead so the caller
+// learns why the request actually failed.
+func TestRetryReturnsResponseWhenDeadlineShorterThanBackoff(t *testing.T) {
 	var requestCount int
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		requestCount++
@@ -323,9 +366,50 @@ func TestRetryWaitIsInterruptedByContext(t *testing.T) {
 	)
 	elapsed := time.Since(start)
 
-	assert.ErrorIs(t, err, context.DeadlineExceeded)
-	assert.Equal(t, 1, requestCount, "Expected the retry to be abandoned once the context expired")
-	assert.Less(t, elapsed, time.Second, "Expected the backoff to be interrupted by the context, took %v", elapsed)
+	// The caller gets the 429, not context.DeadlineExceeded.
+	var apiError *core.APIError
+	require.ErrorAs(t, err, &apiError)
+	assert.Equal(t, http.StatusTooManyRequests, apiError.StatusCode)
+	assert.NotErrorIs(t, err, context.DeadlineExceeded)
+	assert.Equal(t, 1, requestCount, "Expected no retry once the deadline was known to be too short")
+	assert.Less(t, elapsed, time.Second, "Expected to return immediately rather than sleep, took %v", elapsed)
+}
+
+// A deadline with room for the backoff must still retry as normal.
+func TestRetryProceedsWhenDeadlineLongerThanBackoff(t *testing.T) {
+	var requestCount int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		if requestCount == 1 {
+			w.Header().Set("Retry-After", "1")
+			w.WriteHeader(http.StatusTooManyRequests)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("{}"))
+	}))
+	defer server.Close()
+
+	caller := NewCaller(&CallerParams{
+		Client: server.Client(),
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	_, err := caller.Call(
+		ctx,
+		&CallParams{
+			URL:         server.URL,
+			Method:      http.MethodGet,
+			Request:     &InternalTestRequest{},
+			Response:    &InternalTestResponse{},
+			MaxAttempts: 3,
+		},
+	)
+
+	assert.NoError(t, err)
+	assert.Equal(t, 2, requestCount, "Expected the retry to proceed when the deadline allows it")
 }
 
 func TestDisableRetries(t *testing.T) {

--- a/seed/go-sdk/path-parameters/no-custom-config/internal/retrier.go
+++ b/seed/go-sdk/path-parameters/no-custom-config/internal/retrier.go
@@ -145,12 +145,20 @@ func (r *Retrier) run(
 	}
 
 	if r.shouldRetry(response) {
-		defer func() { _ = response.Body.Close() }()
-
 		delay, err := r.retryDelay(response, retryAttempt)
 		if err != nil {
+			_ = response.Body.Close()
 			return nil, err
 		}
+
+		// If the context's deadline would elapse before the backoff completes, return
+		// the response instead of sleeping through it. The caller then sees why the
+		// request actually failed (e.g. a 429) rather than a context deadline error.
+		if deadline, ok := request.Context().Deadline(); ok && time.Until(deadline) < delay {
+			return response, nil
+		}
+
+		defer func() { _ = response.Body.Close() }()
 
 		if err := sleepWithContext(request.Context(), delay); err != nil {
 			return nil, err

--- a/seed/go-sdk/path-parameters/no-custom-config/internal/retrier_test.go
+++ b/seed/go-sdk/path-parameters/no-custom-config/internal/retrier_test.go
@@ -295,7 +295,50 @@ func TestRetryWithRequestBody(t *testing.T) {
 	assert.Equal(t, expectedBody, requestBodies[1], "Second request body should match expected (retry should re-send body)")
 }
 
+// An explicit cancel (e.g. Ctrl-C wired to cancel()) must interrupt the backoff
+// wait. There is no deadline here, so the retrier cannot know the wait is futile
+// up front -- it has to be woken by the context.
 func TestRetryWaitIsInterruptedByContext(t *testing.T) {
+	var requestCount int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		w.Header().Set("Retry-After", "5")
+		w.WriteHeader(http.StatusTooManyRequests)
+	}))
+	defer server.Close()
+
+	caller := NewCaller(&CallerParams{
+		Client: server.Client(),
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		time.Sleep(100 * time.Millisecond)
+		cancel()
+	}()
+	defer cancel()
+
+	start := time.Now()
+	_, err := caller.Call(
+		ctx,
+		&CallParams{
+			URL:         server.URL,
+			Method:      http.MethodGet,
+			Request:     &InternalTestRequest{},
+			MaxAttempts: 3,
+		},
+	)
+	elapsed := time.Since(start)
+
+	assert.ErrorIs(t, err, context.Canceled)
+	assert.Equal(t, 1, requestCount, "Expected the retry to be abandoned once the context was cancelled")
+	assert.Less(t, elapsed, time.Second, "Expected the backoff to be interrupted by the context, took %v", elapsed)
+}
+
+// When the caller's deadline would elapse before the backoff finishes, sleeping
+// only guarantees a context error. Return the response instead so the caller
+// learns why the request actually failed.
+func TestRetryReturnsResponseWhenDeadlineShorterThanBackoff(t *testing.T) {
 	var requestCount int
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		requestCount++
@@ -323,9 +366,50 @@ func TestRetryWaitIsInterruptedByContext(t *testing.T) {
 	)
 	elapsed := time.Since(start)
 
-	assert.ErrorIs(t, err, context.DeadlineExceeded)
-	assert.Equal(t, 1, requestCount, "Expected the retry to be abandoned once the context expired")
-	assert.Less(t, elapsed, time.Second, "Expected the backoff to be interrupted by the context, took %v", elapsed)
+	// The caller gets the 429, not context.DeadlineExceeded.
+	var apiError *core.APIError
+	require.ErrorAs(t, err, &apiError)
+	assert.Equal(t, http.StatusTooManyRequests, apiError.StatusCode)
+	assert.NotErrorIs(t, err, context.DeadlineExceeded)
+	assert.Equal(t, 1, requestCount, "Expected no retry once the deadline was known to be too short")
+	assert.Less(t, elapsed, time.Second, "Expected to return immediately rather than sleep, took %v", elapsed)
+}
+
+// A deadline with room for the backoff must still retry as normal.
+func TestRetryProceedsWhenDeadlineLongerThanBackoff(t *testing.T) {
+	var requestCount int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		if requestCount == 1 {
+			w.Header().Set("Retry-After", "1")
+			w.WriteHeader(http.StatusTooManyRequests)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("{}"))
+	}))
+	defer server.Close()
+
+	caller := NewCaller(&CallerParams{
+		Client: server.Client(),
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	_, err := caller.Call(
+		ctx,
+		&CallParams{
+			URL:         server.URL,
+			Method:      http.MethodGet,
+			Request:     &InternalTestRequest{},
+			Response:    &InternalTestResponse{},
+			MaxAttempts: 3,
+		},
+	)
+
+	assert.NoError(t, err)
+	assert.Equal(t, 2, requestCount, "Expected the retry to proceed when the deadline allows it")
 }
 
 func TestDisableRetries(t *testing.T) {

--- a/seed/go-sdk/path-parameters/package-name/internal/retrier.go
+++ b/seed/go-sdk/path-parameters/package-name/internal/retrier.go
@@ -145,12 +145,20 @@ func (r *Retrier) run(
 	}
 
 	if r.shouldRetry(response) {
-		defer func() { _ = response.Body.Close() }()
-
 		delay, err := r.retryDelay(response, retryAttempt)
 		if err != nil {
+			_ = response.Body.Close()
 			return nil, err
 		}
+
+		// If the context's deadline would elapse before the backoff completes, return
+		// the response instead of sleeping through it. The caller then sees why the
+		// request actually failed (e.g. a 429) rather than a context deadline error.
+		if deadline, ok := request.Context().Deadline(); ok && time.Until(deadline) < delay {
+			return response, nil
+		}
+
+		defer func() { _ = response.Body.Close() }()
 
 		if err := sleepWithContext(request.Context(), delay); err != nil {
 			return nil, err

--- a/seed/go-sdk/path-parameters/package-name/internal/retrier_test.go
+++ b/seed/go-sdk/path-parameters/package-name/internal/retrier_test.go
@@ -295,7 +295,50 @@ func TestRetryWithRequestBody(t *testing.T) {
 	assert.Equal(t, expectedBody, requestBodies[1], "Second request body should match expected (retry should re-send body)")
 }
 
+// An explicit cancel (e.g. Ctrl-C wired to cancel()) must interrupt the backoff
+// wait. There is no deadline here, so the retrier cannot know the wait is futile
+// up front -- it has to be woken by the context.
 func TestRetryWaitIsInterruptedByContext(t *testing.T) {
+	var requestCount int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		w.Header().Set("Retry-After", "5")
+		w.WriteHeader(http.StatusTooManyRequests)
+	}))
+	defer server.Close()
+
+	caller := NewCaller(&CallerParams{
+		Client: server.Client(),
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		time.Sleep(100 * time.Millisecond)
+		cancel()
+	}()
+	defer cancel()
+
+	start := time.Now()
+	_, err := caller.Call(
+		ctx,
+		&CallParams{
+			URL:         server.URL,
+			Method:      http.MethodGet,
+			Request:     &InternalTestRequest{},
+			MaxAttempts: 3,
+		},
+	)
+	elapsed := time.Since(start)
+
+	assert.ErrorIs(t, err, context.Canceled)
+	assert.Equal(t, 1, requestCount, "Expected the retry to be abandoned once the context was cancelled")
+	assert.Less(t, elapsed, time.Second, "Expected the backoff to be interrupted by the context, took %v", elapsed)
+}
+
+// When the caller's deadline would elapse before the backoff finishes, sleeping
+// only guarantees a context error. Return the response instead so the caller
+// learns why the request actually failed.
+func TestRetryReturnsResponseWhenDeadlineShorterThanBackoff(t *testing.T) {
 	var requestCount int
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		requestCount++
@@ -323,9 +366,50 @@ func TestRetryWaitIsInterruptedByContext(t *testing.T) {
 	)
 	elapsed := time.Since(start)
 
-	assert.ErrorIs(t, err, context.DeadlineExceeded)
-	assert.Equal(t, 1, requestCount, "Expected the retry to be abandoned once the context expired")
-	assert.Less(t, elapsed, time.Second, "Expected the backoff to be interrupted by the context, took %v", elapsed)
+	// The caller gets the 429, not context.DeadlineExceeded.
+	var apiError *core.APIError
+	require.ErrorAs(t, err, &apiError)
+	assert.Equal(t, http.StatusTooManyRequests, apiError.StatusCode)
+	assert.NotErrorIs(t, err, context.DeadlineExceeded)
+	assert.Equal(t, 1, requestCount, "Expected no retry once the deadline was known to be too short")
+	assert.Less(t, elapsed, time.Second, "Expected to return immediately rather than sleep, took %v", elapsed)
+}
+
+// A deadline with room for the backoff must still retry as normal.
+func TestRetryProceedsWhenDeadlineLongerThanBackoff(t *testing.T) {
+	var requestCount int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		if requestCount == 1 {
+			w.Header().Set("Retry-After", "1")
+			w.WriteHeader(http.StatusTooManyRequests)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("{}"))
+	}))
+	defer server.Close()
+
+	caller := NewCaller(&CallerParams{
+		Client: server.Client(),
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	_, err := caller.Call(
+		ctx,
+		&CallParams{
+			URL:         server.URL,
+			Method:      http.MethodGet,
+			Request:     &InternalTestRequest{},
+			Response:    &InternalTestResponse{},
+			MaxAttempts: 3,
+		},
+	)
+
+	assert.NoError(t, err)
+	assert.Equal(t, 2, requestCount, "Expected the retry to proceed when the deadline allows it")
 }
 
 func TestDisableRetries(t *testing.T) {

--- a/seed/go-sdk/path-parameters/v0/internal/retrier.go
+++ b/seed/go-sdk/path-parameters/v0/internal/retrier.go
@@ -145,12 +145,20 @@ func (r *Retrier) run(
 	}
 
 	if r.shouldRetry(response) {
-		defer func() { _ = response.Body.Close() }()
-
 		delay, err := r.retryDelay(response, retryAttempt)
 		if err != nil {
+			_ = response.Body.Close()
 			return nil, err
 		}
+
+		// If the context's deadline would elapse before the backoff completes, return
+		// the response instead of sleeping through it. The caller then sees why the
+		// request actually failed (e.g. a 429) rather than a context deadline error.
+		if deadline, ok := request.Context().Deadline(); ok && time.Until(deadline) < delay {
+			return response, nil
+		}
+
+		defer func() { _ = response.Body.Close() }()
 
 		if err := sleepWithContext(request.Context(), delay); err != nil {
 			return nil, err

--- a/seed/go-sdk/path-parameters/v0/internal/retrier_test.go
+++ b/seed/go-sdk/path-parameters/v0/internal/retrier_test.go
@@ -295,7 +295,50 @@ func TestRetryWithRequestBody(t *testing.T) {
 	assert.Equal(t, expectedBody, requestBodies[1], "Second request body should match expected (retry should re-send body)")
 }
 
+// An explicit cancel (e.g. Ctrl-C wired to cancel()) must interrupt the backoff
+// wait. There is no deadline here, so the retrier cannot know the wait is futile
+// up front -- it has to be woken by the context.
 func TestRetryWaitIsInterruptedByContext(t *testing.T) {
+	var requestCount int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		w.Header().Set("Retry-After", "5")
+		w.WriteHeader(http.StatusTooManyRequests)
+	}))
+	defer server.Close()
+
+	caller := NewCaller(&CallerParams{
+		Client: server.Client(),
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		time.Sleep(100 * time.Millisecond)
+		cancel()
+	}()
+	defer cancel()
+
+	start := time.Now()
+	_, err := caller.Call(
+		ctx,
+		&CallParams{
+			URL:         server.URL,
+			Method:      http.MethodGet,
+			Request:     &InternalTestRequest{},
+			MaxAttempts: 3,
+		},
+	)
+	elapsed := time.Since(start)
+
+	assert.ErrorIs(t, err, context.Canceled)
+	assert.Equal(t, 1, requestCount, "Expected the retry to be abandoned once the context was cancelled")
+	assert.Less(t, elapsed, time.Second, "Expected the backoff to be interrupted by the context, took %v", elapsed)
+}
+
+// When the caller's deadline would elapse before the backoff finishes, sleeping
+// only guarantees a context error. Return the response instead so the caller
+// learns why the request actually failed.
+func TestRetryReturnsResponseWhenDeadlineShorterThanBackoff(t *testing.T) {
 	var requestCount int
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		requestCount++
@@ -323,9 +366,50 @@ func TestRetryWaitIsInterruptedByContext(t *testing.T) {
 	)
 	elapsed := time.Since(start)
 
-	assert.ErrorIs(t, err, context.DeadlineExceeded)
-	assert.Equal(t, 1, requestCount, "Expected the retry to be abandoned once the context expired")
-	assert.Less(t, elapsed, time.Second, "Expected the backoff to be interrupted by the context, took %v", elapsed)
+	// The caller gets the 429, not context.DeadlineExceeded.
+	var apiError *core.APIError
+	require.ErrorAs(t, err, &apiError)
+	assert.Equal(t, http.StatusTooManyRequests, apiError.StatusCode)
+	assert.NotErrorIs(t, err, context.DeadlineExceeded)
+	assert.Equal(t, 1, requestCount, "Expected no retry once the deadline was known to be too short")
+	assert.Less(t, elapsed, time.Second, "Expected to return immediately rather than sleep, took %v", elapsed)
+}
+
+// A deadline with room for the backoff must still retry as normal.
+func TestRetryProceedsWhenDeadlineLongerThanBackoff(t *testing.T) {
+	var requestCount int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		if requestCount == 1 {
+			w.Header().Set("Retry-After", "1")
+			w.WriteHeader(http.StatusTooManyRequests)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("{}"))
+	}))
+	defer server.Close()
+
+	caller := NewCaller(&CallerParams{
+		Client: server.Client(),
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	_, err := caller.Call(
+		ctx,
+		&CallParams{
+			URL:         server.URL,
+			Method:      http.MethodGet,
+			Request:     &InternalTestRequest{},
+			Response:    &InternalTestResponse{},
+			MaxAttempts: 3,
+		},
+	)
+
+	assert.NoError(t, err)
+	assert.Equal(t, 2, requestCount, "Expected the retry to proceed when the deadline allows it")
 }
 
 func TestDisableRetries(t *testing.T) {

--- a/seed/go-sdk/plain-text/internal/retrier.go
+++ b/seed/go-sdk/plain-text/internal/retrier.go
@@ -145,12 +145,20 @@ func (r *Retrier) run(
 	}
 
 	if r.shouldRetry(response) {
-		defer func() { _ = response.Body.Close() }()
-
 		delay, err := r.retryDelay(response, retryAttempt)
 		if err != nil {
+			_ = response.Body.Close()
 			return nil, err
 		}
+
+		// If the context's deadline would elapse before the backoff completes, return
+		// the response instead of sleeping through it. The caller then sees why the
+		// request actually failed (e.g. a 429) rather than a context deadline error.
+		if deadline, ok := request.Context().Deadline(); ok && time.Until(deadline) < delay {
+			return response, nil
+		}
+
+		defer func() { _ = response.Body.Close() }()
 
 		if err := sleepWithContext(request.Context(), delay); err != nil {
 			return nil, err

--- a/seed/go-sdk/plain-text/internal/retrier_test.go
+++ b/seed/go-sdk/plain-text/internal/retrier_test.go
@@ -295,7 +295,50 @@ func TestRetryWithRequestBody(t *testing.T) {
 	assert.Equal(t, expectedBody, requestBodies[1], "Second request body should match expected (retry should re-send body)")
 }
 
+// An explicit cancel (e.g. Ctrl-C wired to cancel()) must interrupt the backoff
+// wait. There is no deadline here, so the retrier cannot know the wait is futile
+// up front -- it has to be woken by the context.
 func TestRetryWaitIsInterruptedByContext(t *testing.T) {
+	var requestCount int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		w.Header().Set("Retry-After", "5")
+		w.WriteHeader(http.StatusTooManyRequests)
+	}))
+	defer server.Close()
+
+	caller := NewCaller(&CallerParams{
+		Client: server.Client(),
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		time.Sleep(100 * time.Millisecond)
+		cancel()
+	}()
+	defer cancel()
+
+	start := time.Now()
+	_, err := caller.Call(
+		ctx,
+		&CallParams{
+			URL:         server.URL,
+			Method:      http.MethodGet,
+			Request:     &InternalTestRequest{},
+			MaxAttempts: 3,
+		},
+	)
+	elapsed := time.Since(start)
+
+	assert.ErrorIs(t, err, context.Canceled)
+	assert.Equal(t, 1, requestCount, "Expected the retry to be abandoned once the context was cancelled")
+	assert.Less(t, elapsed, time.Second, "Expected the backoff to be interrupted by the context, took %v", elapsed)
+}
+
+// When the caller's deadline would elapse before the backoff finishes, sleeping
+// only guarantees a context error. Return the response instead so the caller
+// learns why the request actually failed.
+func TestRetryReturnsResponseWhenDeadlineShorterThanBackoff(t *testing.T) {
 	var requestCount int
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		requestCount++
@@ -323,9 +366,50 @@ func TestRetryWaitIsInterruptedByContext(t *testing.T) {
 	)
 	elapsed := time.Since(start)
 
-	assert.ErrorIs(t, err, context.DeadlineExceeded)
-	assert.Equal(t, 1, requestCount, "Expected the retry to be abandoned once the context expired")
-	assert.Less(t, elapsed, time.Second, "Expected the backoff to be interrupted by the context, took %v", elapsed)
+	// The caller gets the 429, not context.DeadlineExceeded.
+	var apiError *core.APIError
+	require.ErrorAs(t, err, &apiError)
+	assert.Equal(t, http.StatusTooManyRequests, apiError.StatusCode)
+	assert.NotErrorIs(t, err, context.DeadlineExceeded)
+	assert.Equal(t, 1, requestCount, "Expected no retry once the deadline was known to be too short")
+	assert.Less(t, elapsed, time.Second, "Expected to return immediately rather than sleep, took %v", elapsed)
+}
+
+// A deadline with room for the backoff must still retry as normal.
+func TestRetryProceedsWhenDeadlineLongerThanBackoff(t *testing.T) {
+	var requestCount int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		if requestCount == 1 {
+			w.Header().Set("Retry-After", "1")
+			w.WriteHeader(http.StatusTooManyRequests)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("{}"))
+	}))
+	defer server.Close()
+
+	caller := NewCaller(&CallerParams{
+		Client: server.Client(),
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	_, err := caller.Call(
+		ctx,
+		&CallParams{
+			URL:         server.URL,
+			Method:      http.MethodGet,
+			Request:     &InternalTestRequest{},
+			Response:    &InternalTestResponse{},
+			MaxAttempts: 3,
+		},
+	)
+
+	assert.NoError(t, err)
+	assert.Equal(t, 2, requestCount, "Expected the retry to proceed when the deadline allows it")
 }
 
 func TestDisableRetries(t *testing.T) {

--- a/seed/go-sdk/property-access/internal/retrier.go
+++ b/seed/go-sdk/property-access/internal/retrier.go
@@ -145,12 +145,20 @@ func (r *Retrier) run(
 	}
 
 	if r.shouldRetry(response) {
-		defer func() { _ = response.Body.Close() }()
-
 		delay, err := r.retryDelay(response, retryAttempt)
 		if err != nil {
+			_ = response.Body.Close()
 			return nil, err
 		}
+
+		// If the context's deadline would elapse before the backoff completes, return
+		// the response instead of sleeping through it. The caller then sees why the
+		// request actually failed (e.g. a 429) rather than a context deadline error.
+		if deadline, ok := request.Context().Deadline(); ok && time.Until(deadline) < delay {
+			return response, nil
+		}
+
+		defer func() { _ = response.Body.Close() }()
 
 		if err := sleepWithContext(request.Context(), delay); err != nil {
 			return nil, err

--- a/seed/go-sdk/property-access/internal/retrier_test.go
+++ b/seed/go-sdk/property-access/internal/retrier_test.go
@@ -295,7 +295,50 @@ func TestRetryWithRequestBody(t *testing.T) {
 	assert.Equal(t, expectedBody, requestBodies[1], "Second request body should match expected (retry should re-send body)")
 }
 
+// An explicit cancel (e.g. Ctrl-C wired to cancel()) must interrupt the backoff
+// wait. There is no deadline here, so the retrier cannot know the wait is futile
+// up front -- it has to be woken by the context.
 func TestRetryWaitIsInterruptedByContext(t *testing.T) {
+	var requestCount int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		w.Header().Set("Retry-After", "5")
+		w.WriteHeader(http.StatusTooManyRequests)
+	}))
+	defer server.Close()
+
+	caller := NewCaller(&CallerParams{
+		Client: server.Client(),
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		time.Sleep(100 * time.Millisecond)
+		cancel()
+	}()
+	defer cancel()
+
+	start := time.Now()
+	_, err := caller.Call(
+		ctx,
+		&CallParams{
+			URL:         server.URL,
+			Method:      http.MethodGet,
+			Request:     &InternalTestRequest{},
+			MaxAttempts: 3,
+		},
+	)
+	elapsed := time.Since(start)
+
+	assert.ErrorIs(t, err, context.Canceled)
+	assert.Equal(t, 1, requestCount, "Expected the retry to be abandoned once the context was cancelled")
+	assert.Less(t, elapsed, time.Second, "Expected the backoff to be interrupted by the context, took %v", elapsed)
+}
+
+// When the caller's deadline would elapse before the backoff finishes, sleeping
+// only guarantees a context error. Return the response instead so the caller
+// learns why the request actually failed.
+func TestRetryReturnsResponseWhenDeadlineShorterThanBackoff(t *testing.T) {
 	var requestCount int
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		requestCount++
@@ -323,9 +366,50 @@ func TestRetryWaitIsInterruptedByContext(t *testing.T) {
 	)
 	elapsed := time.Since(start)
 
-	assert.ErrorIs(t, err, context.DeadlineExceeded)
-	assert.Equal(t, 1, requestCount, "Expected the retry to be abandoned once the context expired")
-	assert.Less(t, elapsed, time.Second, "Expected the backoff to be interrupted by the context, took %v", elapsed)
+	// The caller gets the 429, not context.DeadlineExceeded.
+	var apiError *core.APIError
+	require.ErrorAs(t, err, &apiError)
+	assert.Equal(t, http.StatusTooManyRequests, apiError.StatusCode)
+	assert.NotErrorIs(t, err, context.DeadlineExceeded)
+	assert.Equal(t, 1, requestCount, "Expected no retry once the deadline was known to be too short")
+	assert.Less(t, elapsed, time.Second, "Expected to return immediately rather than sleep, took %v", elapsed)
+}
+
+// A deadline with room for the backoff must still retry as normal.
+func TestRetryProceedsWhenDeadlineLongerThanBackoff(t *testing.T) {
+	var requestCount int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		if requestCount == 1 {
+			w.Header().Set("Retry-After", "1")
+			w.WriteHeader(http.StatusTooManyRequests)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("{}"))
+	}))
+	defer server.Close()
+
+	caller := NewCaller(&CallerParams{
+		Client: server.Client(),
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	_, err := caller.Call(
+		ctx,
+		&CallParams{
+			URL:         server.URL,
+			Method:      http.MethodGet,
+			Request:     &InternalTestRequest{},
+			Response:    &InternalTestResponse{},
+			MaxAttempts: 3,
+		},
+	)
+
+	assert.NoError(t, err)
+	assert.Equal(t, 2, requestCount, "Expected the retry to proceed when the deadline allows it")
 }
 
 func TestDisableRetries(t *testing.T) {

--- a/seed/go-sdk/public-object/internal/retrier.go
+++ b/seed/go-sdk/public-object/internal/retrier.go
@@ -145,12 +145,20 @@ func (r *Retrier) run(
 	}
 
 	if r.shouldRetry(response) {
-		defer func() { _ = response.Body.Close() }()
-
 		delay, err := r.retryDelay(response, retryAttempt)
 		if err != nil {
+			_ = response.Body.Close()
 			return nil, err
 		}
+
+		// If the context's deadline would elapse before the backoff completes, return
+		// the response instead of sleeping through it. The caller then sees why the
+		// request actually failed (e.g. a 429) rather than a context deadline error.
+		if deadline, ok := request.Context().Deadline(); ok && time.Until(deadline) < delay {
+			return response, nil
+		}
+
+		defer func() { _ = response.Body.Close() }()
 
 		if err := sleepWithContext(request.Context(), delay); err != nil {
 			return nil, err

--- a/seed/go-sdk/public-object/internal/retrier_test.go
+++ b/seed/go-sdk/public-object/internal/retrier_test.go
@@ -295,7 +295,50 @@ func TestRetryWithRequestBody(t *testing.T) {
 	assert.Equal(t, expectedBody, requestBodies[1], "Second request body should match expected (retry should re-send body)")
 }
 
+// An explicit cancel (e.g. Ctrl-C wired to cancel()) must interrupt the backoff
+// wait. There is no deadline here, so the retrier cannot know the wait is futile
+// up front -- it has to be woken by the context.
 func TestRetryWaitIsInterruptedByContext(t *testing.T) {
+	var requestCount int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		w.Header().Set("Retry-After", "5")
+		w.WriteHeader(http.StatusTooManyRequests)
+	}))
+	defer server.Close()
+
+	caller := NewCaller(&CallerParams{
+		Client: server.Client(),
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		time.Sleep(100 * time.Millisecond)
+		cancel()
+	}()
+	defer cancel()
+
+	start := time.Now()
+	_, err := caller.Call(
+		ctx,
+		&CallParams{
+			URL:         server.URL,
+			Method:      http.MethodGet,
+			Request:     &InternalTestRequest{},
+			MaxAttempts: 3,
+		},
+	)
+	elapsed := time.Since(start)
+
+	assert.ErrorIs(t, err, context.Canceled)
+	assert.Equal(t, 1, requestCount, "Expected the retry to be abandoned once the context was cancelled")
+	assert.Less(t, elapsed, time.Second, "Expected the backoff to be interrupted by the context, took %v", elapsed)
+}
+
+// When the caller's deadline would elapse before the backoff finishes, sleeping
+// only guarantees a context error. Return the response instead so the caller
+// learns why the request actually failed.
+func TestRetryReturnsResponseWhenDeadlineShorterThanBackoff(t *testing.T) {
 	var requestCount int
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		requestCount++
@@ -323,9 +366,50 @@ func TestRetryWaitIsInterruptedByContext(t *testing.T) {
 	)
 	elapsed := time.Since(start)
 
-	assert.ErrorIs(t, err, context.DeadlineExceeded)
-	assert.Equal(t, 1, requestCount, "Expected the retry to be abandoned once the context expired")
-	assert.Less(t, elapsed, time.Second, "Expected the backoff to be interrupted by the context, took %v", elapsed)
+	// The caller gets the 429, not context.DeadlineExceeded.
+	var apiError *core.APIError
+	require.ErrorAs(t, err, &apiError)
+	assert.Equal(t, http.StatusTooManyRequests, apiError.StatusCode)
+	assert.NotErrorIs(t, err, context.DeadlineExceeded)
+	assert.Equal(t, 1, requestCount, "Expected no retry once the deadline was known to be too short")
+	assert.Less(t, elapsed, time.Second, "Expected to return immediately rather than sleep, took %v", elapsed)
+}
+
+// A deadline with room for the backoff must still retry as normal.
+func TestRetryProceedsWhenDeadlineLongerThanBackoff(t *testing.T) {
+	var requestCount int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		if requestCount == 1 {
+			w.Header().Set("Retry-After", "1")
+			w.WriteHeader(http.StatusTooManyRequests)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("{}"))
+	}))
+	defer server.Close()
+
+	caller := NewCaller(&CallerParams{
+		Client: server.Client(),
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	_, err := caller.Call(
+		ctx,
+		&CallParams{
+			URL:         server.URL,
+			Method:      http.MethodGet,
+			Request:     &InternalTestRequest{},
+			Response:    &InternalTestResponse{},
+			MaxAttempts: 3,
+		},
+	)
+
+	assert.NoError(t, err)
+	assert.Equal(t, 2, requestCount, "Expected the retry to proceed when the deadline allows it")
 }
 
 func TestDisableRetries(t *testing.T) {

--- a/seed/go-sdk/query-param-name-conflict/internal/retrier.go
+++ b/seed/go-sdk/query-param-name-conflict/internal/retrier.go
@@ -145,12 +145,20 @@ func (r *Retrier) run(
 	}
 
 	if r.shouldRetry(response) {
-		defer func() { _ = response.Body.Close() }()
-
 		delay, err := r.retryDelay(response, retryAttempt)
 		if err != nil {
+			_ = response.Body.Close()
 			return nil, err
 		}
+
+		// If the context's deadline would elapse before the backoff completes, return
+		// the response instead of sleeping through it. The caller then sees why the
+		// request actually failed (e.g. a 429) rather than a context deadline error.
+		if deadline, ok := request.Context().Deadline(); ok && time.Until(deadline) < delay {
+			return response, nil
+		}
+
+		defer func() { _ = response.Body.Close() }()
 
 		if err := sleepWithContext(request.Context(), delay); err != nil {
 			return nil, err

--- a/seed/go-sdk/query-param-name-conflict/internal/retrier_test.go
+++ b/seed/go-sdk/query-param-name-conflict/internal/retrier_test.go
@@ -295,7 +295,50 @@ func TestRetryWithRequestBody(t *testing.T) {
 	assert.Equal(t, expectedBody, requestBodies[1], "Second request body should match expected (retry should re-send body)")
 }
 
+// An explicit cancel (e.g. Ctrl-C wired to cancel()) must interrupt the backoff
+// wait. There is no deadline here, so the retrier cannot know the wait is futile
+// up front -- it has to be woken by the context.
 func TestRetryWaitIsInterruptedByContext(t *testing.T) {
+	var requestCount int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		w.Header().Set("Retry-After", "5")
+		w.WriteHeader(http.StatusTooManyRequests)
+	}))
+	defer server.Close()
+
+	caller := NewCaller(&CallerParams{
+		Client: server.Client(),
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		time.Sleep(100 * time.Millisecond)
+		cancel()
+	}()
+	defer cancel()
+
+	start := time.Now()
+	_, err := caller.Call(
+		ctx,
+		&CallParams{
+			URL:         server.URL,
+			Method:      http.MethodGet,
+			Request:     &InternalTestRequest{},
+			MaxAttempts: 3,
+		},
+	)
+	elapsed := time.Since(start)
+
+	assert.ErrorIs(t, err, context.Canceled)
+	assert.Equal(t, 1, requestCount, "Expected the retry to be abandoned once the context was cancelled")
+	assert.Less(t, elapsed, time.Second, "Expected the backoff to be interrupted by the context, took %v", elapsed)
+}
+
+// When the caller's deadline would elapse before the backoff finishes, sleeping
+// only guarantees a context error. Return the response instead so the caller
+// learns why the request actually failed.
+func TestRetryReturnsResponseWhenDeadlineShorterThanBackoff(t *testing.T) {
 	var requestCount int
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		requestCount++
@@ -323,9 +366,50 @@ func TestRetryWaitIsInterruptedByContext(t *testing.T) {
 	)
 	elapsed := time.Since(start)
 
-	assert.ErrorIs(t, err, context.DeadlineExceeded)
-	assert.Equal(t, 1, requestCount, "Expected the retry to be abandoned once the context expired")
-	assert.Less(t, elapsed, time.Second, "Expected the backoff to be interrupted by the context, took %v", elapsed)
+	// The caller gets the 429, not context.DeadlineExceeded.
+	var apiError *core.APIError
+	require.ErrorAs(t, err, &apiError)
+	assert.Equal(t, http.StatusTooManyRequests, apiError.StatusCode)
+	assert.NotErrorIs(t, err, context.DeadlineExceeded)
+	assert.Equal(t, 1, requestCount, "Expected no retry once the deadline was known to be too short")
+	assert.Less(t, elapsed, time.Second, "Expected to return immediately rather than sleep, took %v", elapsed)
+}
+
+// A deadline with room for the backoff must still retry as normal.
+func TestRetryProceedsWhenDeadlineLongerThanBackoff(t *testing.T) {
+	var requestCount int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		if requestCount == 1 {
+			w.Header().Set("Retry-After", "1")
+			w.WriteHeader(http.StatusTooManyRequests)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("{}"))
+	}))
+	defer server.Close()
+
+	caller := NewCaller(&CallerParams{
+		Client: server.Client(),
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	_, err := caller.Call(
+		ctx,
+		&CallParams{
+			URL:         server.URL,
+			Method:      http.MethodGet,
+			Request:     &InternalTestRequest{},
+			Response:    &InternalTestResponse{},
+			MaxAttempts: 3,
+		},
+	)
+
+	assert.NoError(t, err)
+	assert.Equal(t, 2, requestCount, "Expected the retry to proceed when the deadline allows it")
 }
 
 func TestDisableRetries(t *testing.T) {

--- a/seed/go-sdk/query-parameters-openapi-as-objects/internal/retrier.go
+++ b/seed/go-sdk/query-parameters-openapi-as-objects/internal/retrier.go
@@ -145,12 +145,20 @@ func (r *Retrier) run(
 	}
 
 	if r.shouldRetry(response) {
-		defer func() { _ = response.Body.Close() }()
-
 		delay, err := r.retryDelay(response, retryAttempt)
 		if err != nil {
+			_ = response.Body.Close()
 			return nil, err
 		}
+
+		// If the context's deadline would elapse before the backoff completes, return
+		// the response instead of sleeping through it. The caller then sees why the
+		// request actually failed (e.g. a 429) rather than a context deadline error.
+		if deadline, ok := request.Context().Deadline(); ok && time.Until(deadline) < delay {
+			return response, nil
+		}
+
+		defer func() { _ = response.Body.Close() }()
 
 		if err := sleepWithContext(request.Context(), delay); err != nil {
 			return nil, err

--- a/seed/go-sdk/query-parameters-openapi-as-objects/internal/retrier_test.go
+++ b/seed/go-sdk/query-parameters-openapi-as-objects/internal/retrier_test.go
@@ -295,7 +295,50 @@ func TestRetryWithRequestBody(t *testing.T) {
 	assert.Equal(t, expectedBody, requestBodies[1], "Second request body should match expected (retry should re-send body)")
 }
 
+// An explicit cancel (e.g. Ctrl-C wired to cancel()) must interrupt the backoff
+// wait. There is no deadline here, so the retrier cannot know the wait is futile
+// up front -- it has to be woken by the context.
 func TestRetryWaitIsInterruptedByContext(t *testing.T) {
+	var requestCount int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		w.Header().Set("Retry-After", "5")
+		w.WriteHeader(http.StatusTooManyRequests)
+	}))
+	defer server.Close()
+
+	caller := NewCaller(&CallerParams{
+		Client: server.Client(),
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		time.Sleep(100 * time.Millisecond)
+		cancel()
+	}()
+	defer cancel()
+
+	start := time.Now()
+	_, err := caller.Call(
+		ctx,
+		&CallParams{
+			URL:         server.URL,
+			Method:      http.MethodGet,
+			Request:     &InternalTestRequest{},
+			MaxAttempts: 3,
+		},
+	)
+	elapsed := time.Since(start)
+
+	assert.ErrorIs(t, err, context.Canceled)
+	assert.Equal(t, 1, requestCount, "Expected the retry to be abandoned once the context was cancelled")
+	assert.Less(t, elapsed, time.Second, "Expected the backoff to be interrupted by the context, took %v", elapsed)
+}
+
+// When the caller's deadline would elapse before the backoff finishes, sleeping
+// only guarantees a context error. Return the response instead so the caller
+// learns why the request actually failed.
+func TestRetryReturnsResponseWhenDeadlineShorterThanBackoff(t *testing.T) {
 	var requestCount int
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		requestCount++
@@ -323,9 +366,50 @@ func TestRetryWaitIsInterruptedByContext(t *testing.T) {
 	)
 	elapsed := time.Since(start)
 
-	assert.ErrorIs(t, err, context.DeadlineExceeded)
-	assert.Equal(t, 1, requestCount, "Expected the retry to be abandoned once the context expired")
-	assert.Less(t, elapsed, time.Second, "Expected the backoff to be interrupted by the context, took %v", elapsed)
+	// The caller gets the 429, not context.DeadlineExceeded.
+	var apiError *core.APIError
+	require.ErrorAs(t, err, &apiError)
+	assert.Equal(t, http.StatusTooManyRequests, apiError.StatusCode)
+	assert.NotErrorIs(t, err, context.DeadlineExceeded)
+	assert.Equal(t, 1, requestCount, "Expected no retry once the deadline was known to be too short")
+	assert.Less(t, elapsed, time.Second, "Expected to return immediately rather than sleep, took %v", elapsed)
+}
+
+// A deadline with room for the backoff must still retry as normal.
+func TestRetryProceedsWhenDeadlineLongerThanBackoff(t *testing.T) {
+	var requestCount int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		if requestCount == 1 {
+			w.Header().Set("Retry-After", "1")
+			w.WriteHeader(http.StatusTooManyRequests)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("{}"))
+	}))
+	defer server.Close()
+
+	caller := NewCaller(&CallerParams{
+		Client: server.Client(),
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	_, err := caller.Call(
+		ctx,
+		&CallParams{
+			URL:         server.URL,
+			Method:      http.MethodGet,
+			Request:     &InternalTestRequest{},
+			Response:    &InternalTestResponse{},
+			MaxAttempts: 3,
+		},
+	)
+
+	assert.NoError(t, err)
+	assert.Equal(t, 2, requestCount, "Expected the retry to proceed when the deadline allows it")
 }
 
 func TestDisableRetries(t *testing.T) {

--- a/seed/go-sdk/query-parameters-openapi/internal/retrier.go
+++ b/seed/go-sdk/query-parameters-openapi/internal/retrier.go
@@ -145,12 +145,20 @@ func (r *Retrier) run(
 	}
 
 	if r.shouldRetry(response) {
-		defer func() { _ = response.Body.Close() }()
-
 		delay, err := r.retryDelay(response, retryAttempt)
 		if err != nil {
+			_ = response.Body.Close()
 			return nil, err
 		}
+
+		// If the context's deadline would elapse before the backoff completes, return
+		// the response instead of sleeping through it. The caller then sees why the
+		// request actually failed (e.g. a 429) rather than a context deadline error.
+		if deadline, ok := request.Context().Deadline(); ok && time.Until(deadline) < delay {
+			return response, nil
+		}
+
+		defer func() { _ = response.Body.Close() }()
 
 		if err := sleepWithContext(request.Context(), delay); err != nil {
 			return nil, err

--- a/seed/go-sdk/query-parameters-openapi/internal/retrier_test.go
+++ b/seed/go-sdk/query-parameters-openapi/internal/retrier_test.go
@@ -295,7 +295,50 @@ func TestRetryWithRequestBody(t *testing.T) {
 	assert.Equal(t, expectedBody, requestBodies[1], "Second request body should match expected (retry should re-send body)")
 }
 
+// An explicit cancel (e.g. Ctrl-C wired to cancel()) must interrupt the backoff
+// wait. There is no deadline here, so the retrier cannot know the wait is futile
+// up front -- it has to be woken by the context.
 func TestRetryWaitIsInterruptedByContext(t *testing.T) {
+	var requestCount int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		w.Header().Set("Retry-After", "5")
+		w.WriteHeader(http.StatusTooManyRequests)
+	}))
+	defer server.Close()
+
+	caller := NewCaller(&CallerParams{
+		Client: server.Client(),
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		time.Sleep(100 * time.Millisecond)
+		cancel()
+	}()
+	defer cancel()
+
+	start := time.Now()
+	_, err := caller.Call(
+		ctx,
+		&CallParams{
+			URL:         server.URL,
+			Method:      http.MethodGet,
+			Request:     &InternalTestRequest{},
+			MaxAttempts: 3,
+		},
+	)
+	elapsed := time.Since(start)
+
+	assert.ErrorIs(t, err, context.Canceled)
+	assert.Equal(t, 1, requestCount, "Expected the retry to be abandoned once the context was cancelled")
+	assert.Less(t, elapsed, time.Second, "Expected the backoff to be interrupted by the context, took %v", elapsed)
+}
+
+// When the caller's deadline would elapse before the backoff finishes, sleeping
+// only guarantees a context error. Return the response instead so the caller
+// learns why the request actually failed.
+func TestRetryReturnsResponseWhenDeadlineShorterThanBackoff(t *testing.T) {
 	var requestCount int
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		requestCount++
@@ -323,9 +366,50 @@ func TestRetryWaitIsInterruptedByContext(t *testing.T) {
 	)
 	elapsed := time.Since(start)
 
-	assert.ErrorIs(t, err, context.DeadlineExceeded)
-	assert.Equal(t, 1, requestCount, "Expected the retry to be abandoned once the context expired")
-	assert.Less(t, elapsed, time.Second, "Expected the backoff to be interrupted by the context, took %v", elapsed)
+	// The caller gets the 429, not context.DeadlineExceeded.
+	var apiError *core.APIError
+	require.ErrorAs(t, err, &apiError)
+	assert.Equal(t, http.StatusTooManyRequests, apiError.StatusCode)
+	assert.NotErrorIs(t, err, context.DeadlineExceeded)
+	assert.Equal(t, 1, requestCount, "Expected no retry once the deadline was known to be too short")
+	assert.Less(t, elapsed, time.Second, "Expected to return immediately rather than sleep, took %v", elapsed)
+}
+
+// A deadline with room for the backoff must still retry as normal.
+func TestRetryProceedsWhenDeadlineLongerThanBackoff(t *testing.T) {
+	var requestCount int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		if requestCount == 1 {
+			w.Header().Set("Retry-After", "1")
+			w.WriteHeader(http.StatusTooManyRequests)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("{}"))
+	}))
+	defer server.Close()
+
+	caller := NewCaller(&CallerParams{
+		Client: server.Client(),
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	_, err := caller.Call(
+		ctx,
+		&CallParams{
+			URL:         server.URL,
+			Method:      http.MethodGet,
+			Request:     &InternalTestRequest{},
+			Response:    &InternalTestResponse{},
+			MaxAttempts: 3,
+		},
+	)
+
+	assert.NoError(t, err)
+	assert.Equal(t, 2, requestCount, "Expected the retry to proceed when the deadline allows it")
 }
 
 func TestDisableRetries(t *testing.T) {

--- a/seed/go-sdk/query-parameters/internal/retrier.go
+++ b/seed/go-sdk/query-parameters/internal/retrier.go
@@ -145,12 +145,20 @@ func (r *Retrier) run(
 	}
 
 	if r.shouldRetry(response) {
-		defer func() { _ = response.Body.Close() }()
-
 		delay, err := r.retryDelay(response, retryAttempt)
 		if err != nil {
+			_ = response.Body.Close()
 			return nil, err
 		}
+
+		// If the context's deadline would elapse before the backoff completes, return
+		// the response instead of sleeping through it. The caller then sees why the
+		// request actually failed (e.g. a 429) rather than a context deadline error.
+		if deadline, ok := request.Context().Deadline(); ok && time.Until(deadline) < delay {
+			return response, nil
+		}
+
+		defer func() { _ = response.Body.Close() }()
 
 		if err := sleepWithContext(request.Context(), delay); err != nil {
 			return nil, err

--- a/seed/go-sdk/query-parameters/internal/retrier_test.go
+++ b/seed/go-sdk/query-parameters/internal/retrier_test.go
@@ -295,7 +295,50 @@ func TestRetryWithRequestBody(t *testing.T) {
 	assert.Equal(t, expectedBody, requestBodies[1], "Second request body should match expected (retry should re-send body)")
 }
 
+// An explicit cancel (e.g. Ctrl-C wired to cancel()) must interrupt the backoff
+// wait. There is no deadline here, so the retrier cannot know the wait is futile
+// up front -- it has to be woken by the context.
 func TestRetryWaitIsInterruptedByContext(t *testing.T) {
+	var requestCount int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		w.Header().Set("Retry-After", "5")
+		w.WriteHeader(http.StatusTooManyRequests)
+	}))
+	defer server.Close()
+
+	caller := NewCaller(&CallerParams{
+		Client: server.Client(),
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		time.Sleep(100 * time.Millisecond)
+		cancel()
+	}()
+	defer cancel()
+
+	start := time.Now()
+	_, err := caller.Call(
+		ctx,
+		&CallParams{
+			URL:         server.URL,
+			Method:      http.MethodGet,
+			Request:     &InternalTestRequest{},
+			MaxAttempts: 3,
+		},
+	)
+	elapsed := time.Since(start)
+
+	assert.ErrorIs(t, err, context.Canceled)
+	assert.Equal(t, 1, requestCount, "Expected the retry to be abandoned once the context was cancelled")
+	assert.Less(t, elapsed, time.Second, "Expected the backoff to be interrupted by the context, took %v", elapsed)
+}
+
+// When the caller's deadline would elapse before the backoff finishes, sleeping
+// only guarantees a context error. Return the response instead so the caller
+// learns why the request actually failed.
+func TestRetryReturnsResponseWhenDeadlineShorterThanBackoff(t *testing.T) {
 	var requestCount int
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		requestCount++
@@ -323,9 +366,50 @@ func TestRetryWaitIsInterruptedByContext(t *testing.T) {
 	)
 	elapsed := time.Since(start)
 
-	assert.ErrorIs(t, err, context.DeadlineExceeded)
-	assert.Equal(t, 1, requestCount, "Expected the retry to be abandoned once the context expired")
-	assert.Less(t, elapsed, time.Second, "Expected the backoff to be interrupted by the context, took %v", elapsed)
+	// The caller gets the 429, not context.DeadlineExceeded.
+	var apiError *core.APIError
+	require.ErrorAs(t, err, &apiError)
+	assert.Equal(t, http.StatusTooManyRequests, apiError.StatusCode)
+	assert.NotErrorIs(t, err, context.DeadlineExceeded)
+	assert.Equal(t, 1, requestCount, "Expected no retry once the deadline was known to be too short")
+	assert.Less(t, elapsed, time.Second, "Expected to return immediately rather than sleep, took %v", elapsed)
+}
+
+// A deadline with room for the backoff must still retry as normal.
+func TestRetryProceedsWhenDeadlineLongerThanBackoff(t *testing.T) {
+	var requestCount int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		if requestCount == 1 {
+			w.Header().Set("Retry-After", "1")
+			w.WriteHeader(http.StatusTooManyRequests)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("{}"))
+	}))
+	defer server.Close()
+
+	caller := NewCaller(&CallerParams{
+		Client: server.Client(),
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	_, err := caller.Call(
+		ctx,
+		&CallParams{
+			URL:         server.URL,
+			Method:      http.MethodGet,
+			Request:     &InternalTestRequest{},
+			Response:    &InternalTestResponse{},
+			MaxAttempts: 3,
+		},
+	)
+
+	assert.NoError(t, err)
+	assert.Equal(t, 2, requestCount, "Expected the retry to proceed when the deadline allows it")
 }
 
 func TestDisableRetries(t *testing.T) {

--- a/seed/go-sdk/required-nullable/internal/retrier.go
+++ b/seed/go-sdk/required-nullable/internal/retrier.go
@@ -145,12 +145,20 @@ func (r *Retrier) run(
 	}
 
 	if r.shouldRetry(response) {
-		defer func() { _ = response.Body.Close() }()
-
 		delay, err := r.retryDelay(response, retryAttempt)
 		if err != nil {
+			_ = response.Body.Close()
 			return nil, err
 		}
+
+		// If the context's deadline would elapse before the backoff completes, return
+		// the response instead of sleeping through it. The caller then sees why the
+		// request actually failed (e.g. a 429) rather than a context deadline error.
+		if deadline, ok := request.Context().Deadline(); ok && time.Until(deadline) < delay {
+			return response, nil
+		}
+
+		defer func() { _ = response.Body.Close() }()
 
 		if err := sleepWithContext(request.Context(), delay); err != nil {
 			return nil, err

--- a/seed/go-sdk/required-nullable/internal/retrier_test.go
+++ b/seed/go-sdk/required-nullable/internal/retrier_test.go
@@ -295,7 +295,50 @@ func TestRetryWithRequestBody(t *testing.T) {
 	assert.Equal(t, expectedBody, requestBodies[1], "Second request body should match expected (retry should re-send body)")
 }
 
+// An explicit cancel (e.g. Ctrl-C wired to cancel()) must interrupt the backoff
+// wait. There is no deadline here, so the retrier cannot know the wait is futile
+// up front -- it has to be woken by the context.
 func TestRetryWaitIsInterruptedByContext(t *testing.T) {
+	var requestCount int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		w.Header().Set("Retry-After", "5")
+		w.WriteHeader(http.StatusTooManyRequests)
+	}))
+	defer server.Close()
+
+	caller := NewCaller(&CallerParams{
+		Client: server.Client(),
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		time.Sleep(100 * time.Millisecond)
+		cancel()
+	}()
+	defer cancel()
+
+	start := time.Now()
+	_, err := caller.Call(
+		ctx,
+		&CallParams{
+			URL:         server.URL,
+			Method:      http.MethodGet,
+			Request:     &InternalTestRequest{},
+			MaxAttempts: 3,
+		},
+	)
+	elapsed := time.Since(start)
+
+	assert.ErrorIs(t, err, context.Canceled)
+	assert.Equal(t, 1, requestCount, "Expected the retry to be abandoned once the context was cancelled")
+	assert.Less(t, elapsed, time.Second, "Expected the backoff to be interrupted by the context, took %v", elapsed)
+}
+
+// When the caller's deadline would elapse before the backoff finishes, sleeping
+// only guarantees a context error. Return the response instead so the caller
+// learns why the request actually failed.
+func TestRetryReturnsResponseWhenDeadlineShorterThanBackoff(t *testing.T) {
 	var requestCount int
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		requestCount++
@@ -323,9 +366,50 @@ func TestRetryWaitIsInterruptedByContext(t *testing.T) {
 	)
 	elapsed := time.Since(start)
 
-	assert.ErrorIs(t, err, context.DeadlineExceeded)
-	assert.Equal(t, 1, requestCount, "Expected the retry to be abandoned once the context expired")
-	assert.Less(t, elapsed, time.Second, "Expected the backoff to be interrupted by the context, took %v", elapsed)
+	// The caller gets the 429, not context.DeadlineExceeded.
+	var apiError *core.APIError
+	require.ErrorAs(t, err, &apiError)
+	assert.Equal(t, http.StatusTooManyRequests, apiError.StatusCode)
+	assert.NotErrorIs(t, err, context.DeadlineExceeded)
+	assert.Equal(t, 1, requestCount, "Expected no retry once the deadline was known to be too short")
+	assert.Less(t, elapsed, time.Second, "Expected to return immediately rather than sleep, took %v", elapsed)
+}
+
+// A deadline with room for the backoff must still retry as normal.
+func TestRetryProceedsWhenDeadlineLongerThanBackoff(t *testing.T) {
+	var requestCount int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		if requestCount == 1 {
+			w.Header().Set("Retry-After", "1")
+			w.WriteHeader(http.StatusTooManyRequests)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("{}"))
+	}))
+	defer server.Close()
+
+	caller := NewCaller(&CallerParams{
+		Client: server.Client(),
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	_, err := caller.Call(
+		ctx,
+		&CallParams{
+			URL:         server.URL,
+			Method:      http.MethodGet,
+			Request:     &InternalTestRequest{},
+			Response:    &InternalTestResponse{},
+			MaxAttempts: 3,
+		},
+	)
+
+	assert.NoError(t, err)
+	assert.Equal(t, 2, requestCount, "Expected the retry to proceed when the deadline allows it")
 }
 
 func TestDisableRetries(t *testing.T) {

--- a/seed/go-sdk/reserved-keywords/internal/retrier.go
+++ b/seed/go-sdk/reserved-keywords/internal/retrier.go
@@ -145,12 +145,20 @@ func (r *Retrier) run(
 	}
 
 	if r.shouldRetry(response) {
-		defer func() { _ = response.Body.Close() }()
-
 		delay, err := r.retryDelay(response, retryAttempt)
 		if err != nil {
+			_ = response.Body.Close()
 			return nil, err
 		}
+
+		// If the context's deadline would elapse before the backoff completes, return
+		// the response instead of sleeping through it. The caller then sees why the
+		// request actually failed (e.g. a 429) rather than a context deadline error.
+		if deadline, ok := request.Context().Deadline(); ok && time.Until(deadline) < delay {
+			return response, nil
+		}
+
+		defer func() { _ = response.Body.Close() }()
 
 		if err := sleepWithContext(request.Context(), delay); err != nil {
 			return nil, err

--- a/seed/go-sdk/reserved-keywords/internal/retrier_test.go
+++ b/seed/go-sdk/reserved-keywords/internal/retrier_test.go
@@ -295,7 +295,50 @@ func TestRetryWithRequestBody(t *testing.T) {
 	assert.Equal(t, expectedBody, requestBodies[1], "Second request body should match expected (retry should re-send body)")
 }
 
+// An explicit cancel (e.g. Ctrl-C wired to cancel()) must interrupt the backoff
+// wait. There is no deadline here, so the retrier cannot know the wait is futile
+// up front -- it has to be woken by the context.
 func TestRetryWaitIsInterruptedByContext(t *testing.T) {
+	var requestCount int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		w.Header().Set("Retry-After", "5")
+		w.WriteHeader(http.StatusTooManyRequests)
+	}))
+	defer server.Close()
+
+	caller := NewCaller(&CallerParams{
+		Client: server.Client(),
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		time.Sleep(100 * time.Millisecond)
+		cancel()
+	}()
+	defer cancel()
+
+	start := time.Now()
+	_, err := caller.Call(
+		ctx,
+		&CallParams{
+			URL:         server.URL,
+			Method:      http.MethodGet,
+			Request:     &InternalTestRequest{},
+			MaxAttempts: 3,
+		},
+	)
+	elapsed := time.Since(start)
+
+	assert.ErrorIs(t, err, context.Canceled)
+	assert.Equal(t, 1, requestCount, "Expected the retry to be abandoned once the context was cancelled")
+	assert.Less(t, elapsed, time.Second, "Expected the backoff to be interrupted by the context, took %v", elapsed)
+}
+
+// When the caller's deadline would elapse before the backoff finishes, sleeping
+// only guarantees a context error. Return the response instead so the caller
+// learns why the request actually failed.
+func TestRetryReturnsResponseWhenDeadlineShorterThanBackoff(t *testing.T) {
 	var requestCount int
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		requestCount++
@@ -323,9 +366,50 @@ func TestRetryWaitIsInterruptedByContext(t *testing.T) {
 	)
 	elapsed := time.Since(start)
 
-	assert.ErrorIs(t, err, context.DeadlineExceeded)
-	assert.Equal(t, 1, requestCount, "Expected the retry to be abandoned once the context expired")
-	assert.Less(t, elapsed, time.Second, "Expected the backoff to be interrupted by the context, took %v", elapsed)
+	// The caller gets the 429, not context.DeadlineExceeded.
+	var apiError *core.APIError
+	require.ErrorAs(t, err, &apiError)
+	assert.Equal(t, http.StatusTooManyRequests, apiError.StatusCode)
+	assert.NotErrorIs(t, err, context.DeadlineExceeded)
+	assert.Equal(t, 1, requestCount, "Expected no retry once the deadline was known to be too short")
+	assert.Less(t, elapsed, time.Second, "Expected to return immediately rather than sleep, took %v", elapsed)
+}
+
+// A deadline with room for the backoff must still retry as normal.
+func TestRetryProceedsWhenDeadlineLongerThanBackoff(t *testing.T) {
+	var requestCount int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		if requestCount == 1 {
+			w.Header().Set("Retry-After", "1")
+			w.WriteHeader(http.StatusTooManyRequests)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("{}"))
+	}))
+	defer server.Close()
+
+	caller := NewCaller(&CallerParams{
+		Client: server.Client(),
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	_, err := caller.Call(
+		ctx,
+		&CallParams{
+			URL:         server.URL,
+			Method:      http.MethodGet,
+			Request:     &InternalTestRequest{},
+			Response:    &InternalTestResponse{},
+			MaxAttempts: 3,
+		},
+	)
+
+	assert.NoError(t, err)
+	assert.Equal(t, 2, requestCount, "Expected the retry to proceed when the deadline allows it")
 }
 
 func TestDisableRetries(t *testing.T) {

--- a/seed/go-sdk/respect-optional-request-body/internal/retrier.go
+++ b/seed/go-sdk/respect-optional-request-body/internal/retrier.go
@@ -145,12 +145,20 @@ func (r *Retrier) run(
 	}
 
 	if r.shouldRetry(response) {
-		defer func() { _ = response.Body.Close() }()
-
 		delay, err := r.retryDelay(response, retryAttempt)
 		if err != nil {
+			_ = response.Body.Close()
 			return nil, err
 		}
+
+		// If the context's deadline would elapse before the backoff completes, return
+		// the response instead of sleeping through it. The caller then sees why the
+		// request actually failed (e.g. a 429) rather than a context deadline error.
+		if deadline, ok := request.Context().Deadline(); ok && time.Until(deadline) < delay {
+			return response, nil
+		}
+
+		defer func() { _ = response.Body.Close() }()
 
 		if err := sleepWithContext(request.Context(), delay); err != nil {
 			return nil, err

--- a/seed/go-sdk/respect-optional-request-body/internal/retrier_test.go
+++ b/seed/go-sdk/respect-optional-request-body/internal/retrier_test.go
@@ -295,7 +295,50 @@ func TestRetryWithRequestBody(t *testing.T) {
 	assert.Equal(t, expectedBody, requestBodies[1], "Second request body should match expected (retry should re-send body)")
 }
 
+// An explicit cancel (e.g. Ctrl-C wired to cancel()) must interrupt the backoff
+// wait. There is no deadline here, so the retrier cannot know the wait is futile
+// up front -- it has to be woken by the context.
 func TestRetryWaitIsInterruptedByContext(t *testing.T) {
+	var requestCount int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		w.Header().Set("Retry-After", "5")
+		w.WriteHeader(http.StatusTooManyRequests)
+	}))
+	defer server.Close()
+
+	caller := NewCaller(&CallerParams{
+		Client: server.Client(),
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		time.Sleep(100 * time.Millisecond)
+		cancel()
+	}()
+	defer cancel()
+
+	start := time.Now()
+	_, err := caller.Call(
+		ctx,
+		&CallParams{
+			URL:         server.URL,
+			Method:      http.MethodGet,
+			Request:     &InternalTestRequest{},
+			MaxAttempts: 3,
+		},
+	)
+	elapsed := time.Since(start)
+
+	assert.ErrorIs(t, err, context.Canceled)
+	assert.Equal(t, 1, requestCount, "Expected the retry to be abandoned once the context was cancelled")
+	assert.Less(t, elapsed, time.Second, "Expected the backoff to be interrupted by the context, took %v", elapsed)
+}
+
+// When the caller's deadline would elapse before the backoff finishes, sleeping
+// only guarantees a context error. Return the response instead so the caller
+// learns why the request actually failed.
+func TestRetryReturnsResponseWhenDeadlineShorterThanBackoff(t *testing.T) {
 	var requestCount int
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		requestCount++
@@ -323,9 +366,50 @@ func TestRetryWaitIsInterruptedByContext(t *testing.T) {
 	)
 	elapsed := time.Since(start)
 
-	assert.ErrorIs(t, err, context.DeadlineExceeded)
-	assert.Equal(t, 1, requestCount, "Expected the retry to be abandoned once the context expired")
-	assert.Less(t, elapsed, time.Second, "Expected the backoff to be interrupted by the context, took %v", elapsed)
+	// The caller gets the 429, not context.DeadlineExceeded.
+	var apiError *core.APIError
+	require.ErrorAs(t, err, &apiError)
+	assert.Equal(t, http.StatusTooManyRequests, apiError.StatusCode)
+	assert.NotErrorIs(t, err, context.DeadlineExceeded)
+	assert.Equal(t, 1, requestCount, "Expected no retry once the deadline was known to be too short")
+	assert.Less(t, elapsed, time.Second, "Expected to return immediately rather than sleep, took %v", elapsed)
+}
+
+// A deadline with room for the backoff must still retry as normal.
+func TestRetryProceedsWhenDeadlineLongerThanBackoff(t *testing.T) {
+	var requestCount int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		if requestCount == 1 {
+			w.Header().Set("Retry-After", "1")
+			w.WriteHeader(http.StatusTooManyRequests)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("{}"))
+	}))
+	defer server.Close()
+
+	caller := NewCaller(&CallerParams{
+		Client: server.Client(),
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	_, err := caller.Call(
+		ctx,
+		&CallParams{
+			URL:         server.URL,
+			Method:      http.MethodGet,
+			Request:     &InternalTestRequest{},
+			Response:    &InternalTestResponse{},
+			MaxAttempts: 3,
+		},
+	)
+
+	assert.NoError(t, err)
+	assert.Equal(t, 2, requestCount, "Expected the retry to proceed when the deadline allows it")
 }
 
 func TestDisableRetries(t *testing.T) {

--- a/seed/go-sdk/response-property/internal/retrier.go
+++ b/seed/go-sdk/response-property/internal/retrier.go
@@ -145,12 +145,20 @@ func (r *Retrier) run(
 	}
 
 	if r.shouldRetry(response) {
-		defer func() { _ = response.Body.Close() }()
-
 		delay, err := r.retryDelay(response, retryAttempt)
 		if err != nil {
+			_ = response.Body.Close()
 			return nil, err
 		}
+
+		// If the context's deadline would elapse before the backoff completes, return
+		// the response instead of sleeping through it. The caller then sees why the
+		// request actually failed (e.g. a 429) rather than a context deadline error.
+		if deadline, ok := request.Context().Deadline(); ok && time.Until(deadline) < delay {
+			return response, nil
+		}
+
+		defer func() { _ = response.Body.Close() }()
 
 		if err := sleepWithContext(request.Context(), delay); err != nil {
 			return nil, err

--- a/seed/go-sdk/response-property/internal/retrier_test.go
+++ b/seed/go-sdk/response-property/internal/retrier_test.go
@@ -295,7 +295,50 @@ func TestRetryWithRequestBody(t *testing.T) {
 	assert.Equal(t, expectedBody, requestBodies[1], "Second request body should match expected (retry should re-send body)")
 }
 
+// An explicit cancel (e.g. Ctrl-C wired to cancel()) must interrupt the backoff
+// wait. There is no deadline here, so the retrier cannot know the wait is futile
+// up front -- it has to be woken by the context.
 func TestRetryWaitIsInterruptedByContext(t *testing.T) {
+	var requestCount int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		w.Header().Set("Retry-After", "5")
+		w.WriteHeader(http.StatusTooManyRequests)
+	}))
+	defer server.Close()
+
+	caller := NewCaller(&CallerParams{
+		Client: server.Client(),
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		time.Sleep(100 * time.Millisecond)
+		cancel()
+	}()
+	defer cancel()
+
+	start := time.Now()
+	_, err := caller.Call(
+		ctx,
+		&CallParams{
+			URL:         server.URL,
+			Method:      http.MethodGet,
+			Request:     &InternalTestRequest{},
+			MaxAttempts: 3,
+		},
+	)
+	elapsed := time.Since(start)
+
+	assert.ErrorIs(t, err, context.Canceled)
+	assert.Equal(t, 1, requestCount, "Expected the retry to be abandoned once the context was cancelled")
+	assert.Less(t, elapsed, time.Second, "Expected the backoff to be interrupted by the context, took %v", elapsed)
+}
+
+// When the caller's deadline would elapse before the backoff finishes, sleeping
+// only guarantees a context error. Return the response instead so the caller
+// learns why the request actually failed.
+func TestRetryReturnsResponseWhenDeadlineShorterThanBackoff(t *testing.T) {
 	var requestCount int
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		requestCount++
@@ -323,9 +366,50 @@ func TestRetryWaitIsInterruptedByContext(t *testing.T) {
 	)
 	elapsed := time.Since(start)
 
-	assert.ErrorIs(t, err, context.DeadlineExceeded)
-	assert.Equal(t, 1, requestCount, "Expected the retry to be abandoned once the context expired")
-	assert.Less(t, elapsed, time.Second, "Expected the backoff to be interrupted by the context, took %v", elapsed)
+	// The caller gets the 429, not context.DeadlineExceeded.
+	var apiError *core.APIError
+	require.ErrorAs(t, err, &apiError)
+	assert.Equal(t, http.StatusTooManyRequests, apiError.StatusCode)
+	assert.NotErrorIs(t, err, context.DeadlineExceeded)
+	assert.Equal(t, 1, requestCount, "Expected no retry once the deadline was known to be too short")
+	assert.Less(t, elapsed, time.Second, "Expected to return immediately rather than sleep, took %v", elapsed)
+}
+
+// A deadline with room for the backoff must still retry as normal.
+func TestRetryProceedsWhenDeadlineLongerThanBackoff(t *testing.T) {
+	var requestCount int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		if requestCount == 1 {
+			w.Header().Set("Retry-After", "1")
+			w.WriteHeader(http.StatusTooManyRequests)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("{}"))
+	}))
+	defer server.Close()
+
+	caller := NewCaller(&CallerParams{
+		Client: server.Client(),
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	_, err := caller.Call(
+		ctx,
+		&CallParams{
+			URL:         server.URL,
+			Method:      http.MethodGet,
+			Request:     &InternalTestRequest{},
+			Response:    &InternalTestResponse{},
+			MaxAttempts: 3,
+		},
+	)
+
+	assert.NoError(t, err)
+	assert.Equal(t, 2, requestCount, "Expected the retry to proceed when the deadline allows it")
 }
 
 func TestDisableRetries(t *testing.T) {

--- a/seed/go-sdk/schemaless-request-body-examples/internal/retrier.go
+++ b/seed/go-sdk/schemaless-request-body-examples/internal/retrier.go
@@ -145,12 +145,20 @@ func (r *Retrier) run(
 	}
 
 	if r.shouldRetry(response) {
-		defer func() { _ = response.Body.Close() }()
-
 		delay, err := r.retryDelay(response, retryAttempt)
 		if err != nil {
+			_ = response.Body.Close()
 			return nil, err
 		}
+
+		// If the context's deadline would elapse before the backoff completes, return
+		// the response instead of sleeping through it. The caller then sees why the
+		// request actually failed (e.g. a 429) rather than a context deadline error.
+		if deadline, ok := request.Context().Deadline(); ok && time.Until(deadline) < delay {
+			return response, nil
+		}
+
+		defer func() { _ = response.Body.Close() }()
 
 		if err := sleepWithContext(request.Context(), delay); err != nil {
 			return nil, err

--- a/seed/go-sdk/schemaless-request-body-examples/internal/retrier_test.go
+++ b/seed/go-sdk/schemaless-request-body-examples/internal/retrier_test.go
@@ -295,7 +295,50 @@ func TestRetryWithRequestBody(t *testing.T) {
 	assert.Equal(t, expectedBody, requestBodies[1], "Second request body should match expected (retry should re-send body)")
 }
 
+// An explicit cancel (e.g. Ctrl-C wired to cancel()) must interrupt the backoff
+// wait. There is no deadline here, so the retrier cannot know the wait is futile
+// up front -- it has to be woken by the context.
 func TestRetryWaitIsInterruptedByContext(t *testing.T) {
+	var requestCount int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		w.Header().Set("Retry-After", "5")
+		w.WriteHeader(http.StatusTooManyRequests)
+	}))
+	defer server.Close()
+
+	caller := NewCaller(&CallerParams{
+		Client: server.Client(),
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		time.Sleep(100 * time.Millisecond)
+		cancel()
+	}()
+	defer cancel()
+
+	start := time.Now()
+	_, err := caller.Call(
+		ctx,
+		&CallParams{
+			URL:         server.URL,
+			Method:      http.MethodGet,
+			Request:     &InternalTestRequest{},
+			MaxAttempts: 3,
+		},
+	)
+	elapsed := time.Since(start)
+
+	assert.ErrorIs(t, err, context.Canceled)
+	assert.Equal(t, 1, requestCount, "Expected the retry to be abandoned once the context was cancelled")
+	assert.Less(t, elapsed, time.Second, "Expected the backoff to be interrupted by the context, took %v", elapsed)
+}
+
+// When the caller's deadline would elapse before the backoff finishes, sleeping
+// only guarantees a context error. Return the response instead so the caller
+// learns why the request actually failed.
+func TestRetryReturnsResponseWhenDeadlineShorterThanBackoff(t *testing.T) {
 	var requestCount int
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		requestCount++
@@ -323,9 +366,50 @@ func TestRetryWaitIsInterruptedByContext(t *testing.T) {
 	)
 	elapsed := time.Since(start)
 
-	assert.ErrorIs(t, err, context.DeadlineExceeded)
-	assert.Equal(t, 1, requestCount, "Expected the retry to be abandoned once the context expired")
-	assert.Less(t, elapsed, time.Second, "Expected the backoff to be interrupted by the context, took %v", elapsed)
+	// The caller gets the 429, not context.DeadlineExceeded.
+	var apiError *core.APIError
+	require.ErrorAs(t, err, &apiError)
+	assert.Equal(t, http.StatusTooManyRequests, apiError.StatusCode)
+	assert.NotErrorIs(t, err, context.DeadlineExceeded)
+	assert.Equal(t, 1, requestCount, "Expected no retry once the deadline was known to be too short")
+	assert.Less(t, elapsed, time.Second, "Expected to return immediately rather than sleep, took %v", elapsed)
+}
+
+// A deadline with room for the backoff must still retry as normal.
+func TestRetryProceedsWhenDeadlineLongerThanBackoff(t *testing.T) {
+	var requestCount int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		if requestCount == 1 {
+			w.Header().Set("Retry-After", "1")
+			w.WriteHeader(http.StatusTooManyRequests)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("{}"))
+	}))
+	defer server.Close()
+
+	caller := NewCaller(&CallerParams{
+		Client: server.Client(),
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	_, err := caller.Call(
+		ctx,
+		&CallParams{
+			URL:         server.URL,
+			Method:      http.MethodGet,
+			Request:     &InternalTestRequest{},
+			Response:    &InternalTestResponse{},
+			MaxAttempts: 3,
+		},
+	)
+
+	assert.NoError(t, err)
+	assert.Equal(t, 2, requestCount, "Expected the retry to proceed when the deadline allows it")
 }
 
 func TestDisableRetries(t *testing.T) {

--- a/seed/go-sdk/server-sent-event-examples/with-wire-tests/internal/retrier.go
+++ b/seed/go-sdk/server-sent-event-examples/with-wire-tests/internal/retrier.go
@@ -145,12 +145,20 @@ func (r *Retrier) run(
 	}
 
 	if r.shouldRetry(response) {
-		defer func() { _ = response.Body.Close() }()
-
 		delay, err := r.retryDelay(response, retryAttempt)
 		if err != nil {
+			_ = response.Body.Close()
 			return nil, err
 		}
+
+		// If the context's deadline would elapse before the backoff completes, return
+		// the response instead of sleeping through it. The caller then sees why the
+		// request actually failed (e.g. a 429) rather than a context deadline error.
+		if deadline, ok := request.Context().Deadline(); ok && time.Until(deadline) < delay {
+			return response, nil
+		}
+
+		defer func() { _ = response.Body.Close() }()
 
 		if err := sleepWithContext(request.Context(), delay); err != nil {
 			return nil, err

--- a/seed/go-sdk/server-sent-event-examples/with-wire-tests/internal/retrier_test.go
+++ b/seed/go-sdk/server-sent-event-examples/with-wire-tests/internal/retrier_test.go
@@ -295,7 +295,50 @@ func TestRetryWithRequestBody(t *testing.T) {
 	assert.Equal(t, expectedBody, requestBodies[1], "Second request body should match expected (retry should re-send body)")
 }
 
+// An explicit cancel (e.g. Ctrl-C wired to cancel()) must interrupt the backoff
+// wait. There is no deadline here, so the retrier cannot know the wait is futile
+// up front -- it has to be woken by the context.
 func TestRetryWaitIsInterruptedByContext(t *testing.T) {
+	var requestCount int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		w.Header().Set("Retry-After", "5")
+		w.WriteHeader(http.StatusTooManyRequests)
+	}))
+	defer server.Close()
+
+	caller := NewCaller(&CallerParams{
+		Client: server.Client(),
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		time.Sleep(100 * time.Millisecond)
+		cancel()
+	}()
+	defer cancel()
+
+	start := time.Now()
+	_, err := caller.Call(
+		ctx,
+		&CallParams{
+			URL:         server.URL,
+			Method:      http.MethodGet,
+			Request:     &InternalTestRequest{},
+			MaxAttempts: 3,
+		},
+	)
+	elapsed := time.Since(start)
+
+	assert.ErrorIs(t, err, context.Canceled)
+	assert.Equal(t, 1, requestCount, "Expected the retry to be abandoned once the context was cancelled")
+	assert.Less(t, elapsed, time.Second, "Expected the backoff to be interrupted by the context, took %v", elapsed)
+}
+
+// When the caller's deadline would elapse before the backoff finishes, sleeping
+// only guarantees a context error. Return the response instead so the caller
+// learns why the request actually failed.
+func TestRetryReturnsResponseWhenDeadlineShorterThanBackoff(t *testing.T) {
 	var requestCount int
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		requestCount++
@@ -323,9 +366,50 @@ func TestRetryWaitIsInterruptedByContext(t *testing.T) {
 	)
 	elapsed := time.Since(start)
 
-	assert.ErrorIs(t, err, context.DeadlineExceeded)
-	assert.Equal(t, 1, requestCount, "Expected the retry to be abandoned once the context expired")
-	assert.Less(t, elapsed, time.Second, "Expected the backoff to be interrupted by the context, took %v", elapsed)
+	// The caller gets the 429, not context.DeadlineExceeded.
+	var apiError *core.APIError
+	require.ErrorAs(t, err, &apiError)
+	assert.Equal(t, http.StatusTooManyRequests, apiError.StatusCode)
+	assert.NotErrorIs(t, err, context.DeadlineExceeded)
+	assert.Equal(t, 1, requestCount, "Expected no retry once the deadline was known to be too short")
+	assert.Less(t, elapsed, time.Second, "Expected to return immediately rather than sleep, took %v", elapsed)
+}
+
+// A deadline with room for the backoff must still retry as normal.
+func TestRetryProceedsWhenDeadlineLongerThanBackoff(t *testing.T) {
+	var requestCount int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		if requestCount == 1 {
+			w.Header().Set("Retry-After", "1")
+			w.WriteHeader(http.StatusTooManyRequests)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("{}"))
+	}))
+	defer server.Close()
+
+	caller := NewCaller(&CallerParams{
+		Client: server.Client(),
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	_, err := caller.Call(
+		ctx,
+		&CallParams{
+			URL:         server.URL,
+			Method:      http.MethodGet,
+			Request:     &InternalTestRequest{},
+			Response:    &InternalTestResponse{},
+			MaxAttempts: 3,
+		},
+	)
+
+	assert.NoError(t, err)
+	assert.Equal(t, 2, requestCount, "Expected the retry to proceed when the deadline allows it")
 }
 
 func TestDisableRetries(t *testing.T) {

--- a/seed/go-sdk/server-sent-events-openapi/with-wire-tests/internal/retrier.go
+++ b/seed/go-sdk/server-sent-events-openapi/with-wire-tests/internal/retrier.go
@@ -145,12 +145,20 @@ func (r *Retrier) run(
 	}
 
 	if r.shouldRetry(response) {
-		defer func() { _ = response.Body.Close() }()
-
 		delay, err := r.retryDelay(response, retryAttempt)
 		if err != nil {
+			_ = response.Body.Close()
 			return nil, err
 		}
+
+		// If the context's deadline would elapse before the backoff completes, return
+		// the response instead of sleeping through it. The caller then sees why the
+		// request actually failed (e.g. a 429) rather than a context deadline error.
+		if deadline, ok := request.Context().Deadline(); ok && time.Until(deadline) < delay {
+			return response, nil
+		}
+
+		defer func() { _ = response.Body.Close() }()
 
 		if err := sleepWithContext(request.Context(), delay); err != nil {
 			return nil, err

--- a/seed/go-sdk/server-sent-events-openapi/with-wire-tests/internal/retrier_test.go
+++ b/seed/go-sdk/server-sent-events-openapi/with-wire-tests/internal/retrier_test.go
@@ -295,7 +295,50 @@ func TestRetryWithRequestBody(t *testing.T) {
 	assert.Equal(t, expectedBody, requestBodies[1], "Second request body should match expected (retry should re-send body)")
 }
 
+// An explicit cancel (e.g. Ctrl-C wired to cancel()) must interrupt the backoff
+// wait. There is no deadline here, so the retrier cannot know the wait is futile
+// up front -- it has to be woken by the context.
 func TestRetryWaitIsInterruptedByContext(t *testing.T) {
+	var requestCount int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		w.Header().Set("Retry-After", "5")
+		w.WriteHeader(http.StatusTooManyRequests)
+	}))
+	defer server.Close()
+
+	caller := NewCaller(&CallerParams{
+		Client: server.Client(),
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		time.Sleep(100 * time.Millisecond)
+		cancel()
+	}()
+	defer cancel()
+
+	start := time.Now()
+	_, err := caller.Call(
+		ctx,
+		&CallParams{
+			URL:         server.URL,
+			Method:      http.MethodGet,
+			Request:     &InternalTestRequest{},
+			MaxAttempts: 3,
+		},
+	)
+	elapsed := time.Since(start)
+
+	assert.ErrorIs(t, err, context.Canceled)
+	assert.Equal(t, 1, requestCount, "Expected the retry to be abandoned once the context was cancelled")
+	assert.Less(t, elapsed, time.Second, "Expected the backoff to be interrupted by the context, took %v", elapsed)
+}
+
+// When the caller's deadline would elapse before the backoff finishes, sleeping
+// only guarantees a context error. Return the response instead so the caller
+// learns why the request actually failed.
+func TestRetryReturnsResponseWhenDeadlineShorterThanBackoff(t *testing.T) {
 	var requestCount int
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		requestCount++
@@ -323,9 +366,50 @@ func TestRetryWaitIsInterruptedByContext(t *testing.T) {
 	)
 	elapsed := time.Since(start)
 
-	assert.ErrorIs(t, err, context.DeadlineExceeded)
-	assert.Equal(t, 1, requestCount, "Expected the retry to be abandoned once the context expired")
-	assert.Less(t, elapsed, time.Second, "Expected the backoff to be interrupted by the context, took %v", elapsed)
+	// The caller gets the 429, not context.DeadlineExceeded.
+	var apiError *core.APIError
+	require.ErrorAs(t, err, &apiError)
+	assert.Equal(t, http.StatusTooManyRequests, apiError.StatusCode)
+	assert.NotErrorIs(t, err, context.DeadlineExceeded)
+	assert.Equal(t, 1, requestCount, "Expected no retry once the deadline was known to be too short")
+	assert.Less(t, elapsed, time.Second, "Expected to return immediately rather than sleep, took %v", elapsed)
+}
+
+// A deadline with room for the backoff must still retry as normal.
+func TestRetryProceedsWhenDeadlineLongerThanBackoff(t *testing.T) {
+	var requestCount int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		if requestCount == 1 {
+			w.Header().Set("Retry-After", "1")
+			w.WriteHeader(http.StatusTooManyRequests)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("{}"))
+	}))
+	defer server.Close()
+
+	caller := NewCaller(&CallerParams{
+		Client: server.Client(),
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	_, err := caller.Call(
+		ctx,
+		&CallParams{
+			URL:         server.URL,
+			Method:      http.MethodGet,
+			Request:     &InternalTestRequest{},
+			Response:    &InternalTestResponse{},
+			MaxAttempts: 3,
+		},
+	)
+
+	assert.NoError(t, err)
+	assert.Equal(t, 2, requestCount, "Expected the retry to proceed when the deadline allows it")
 }
 
 func TestDisableRetries(t *testing.T) {

--- a/seed/go-sdk/server-sent-events-resumable/internal/retrier.go
+++ b/seed/go-sdk/server-sent-events-resumable/internal/retrier.go
@@ -145,12 +145,20 @@ func (r *Retrier) run(
 	}
 
 	if r.shouldRetry(response) {
-		defer func() { _ = response.Body.Close() }()
-
 		delay, err := r.retryDelay(response, retryAttempt)
 		if err != nil {
+			_ = response.Body.Close()
 			return nil, err
 		}
+
+		// If the context's deadline would elapse before the backoff completes, return
+		// the response instead of sleeping through it. The caller then sees why the
+		// request actually failed (e.g. a 429) rather than a context deadline error.
+		if deadline, ok := request.Context().Deadline(); ok && time.Until(deadline) < delay {
+			return response, nil
+		}
+
+		defer func() { _ = response.Body.Close() }()
 
 		if err := sleepWithContext(request.Context(), delay); err != nil {
 			return nil, err

--- a/seed/go-sdk/server-sent-events-resumable/internal/retrier_test.go
+++ b/seed/go-sdk/server-sent-events-resumable/internal/retrier_test.go
@@ -295,7 +295,50 @@ func TestRetryWithRequestBody(t *testing.T) {
 	assert.Equal(t, expectedBody, requestBodies[1], "Second request body should match expected (retry should re-send body)")
 }
 
+// An explicit cancel (e.g. Ctrl-C wired to cancel()) must interrupt the backoff
+// wait. There is no deadline here, so the retrier cannot know the wait is futile
+// up front -- it has to be woken by the context.
 func TestRetryWaitIsInterruptedByContext(t *testing.T) {
+	var requestCount int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		w.Header().Set("Retry-After", "5")
+		w.WriteHeader(http.StatusTooManyRequests)
+	}))
+	defer server.Close()
+
+	caller := NewCaller(&CallerParams{
+		Client: server.Client(),
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		time.Sleep(100 * time.Millisecond)
+		cancel()
+	}()
+	defer cancel()
+
+	start := time.Now()
+	_, err := caller.Call(
+		ctx,
+		&CallParams{
+			URL:         server.URL,
+			Method:      http.MethodGet,
+			Request:     &InternalTestRequest{},
+			MaxAttempts: 3,
+		},
+	)
+	elapsed := time.Since(start)
+
+	assert.ErrorIs(t, err, context.Canceled)
+	assert.Equal(t, 1, requestCount, "Expected the retry to be abandoned once the context was cancelled")
+	assert.Less(t, elapsed, time.Second, "Expected the backoff to be interrupted by the context, took %v", elapsed)
+}
+
+// When the caller's deadline would elapse before the backoff finishes, sleeping
+// only guarantees a context error. Return the response instead so the caller
+// learns why the request actually failed.
+func TestRetryReturnsResponseWhenDeadlineShorterThanBackoff(t *testing.T) {
 	var requestCount int
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		requestCount++
@@ -323,9 +366,50 @@ func TestRetryWaitIsInterruptedByContext(t *testing.T) {
 	)
 	elapsed := time.Since(start)
 
-	assert.ErrorIs(t, err, context.DeadlineExceeded)
-	assert.Equal(t, 1, requestCount, "Expected the retry to be abandoned once the context expired")
-	assert.Less(t, elapsed, time.Second, "Expected the backoff to be interrupted by the context, took %v", elapsed)
+	// The caller gets the 429, not context.DeadlineExceeded.
+	var apiError *core.APIError
+	require.ErrorAs(t, err, &apiError)
+	assert.Equal(t, http.StatusTooManyRequests, apiError.StatusCode)
+	assert.NotErrorIs(t, err, context.DeadlineExceeded)
+	assert.Equal(t, 1, requestCount, "Expected no retry once the deadline was known to be too short")
+	assert.Less(t, elapsed, time.Second, "Expected to return immediately rather than sleep, took %v", elapsed)
+}
+
+// A deadline with room for the backoff must still retry as normal.
+func TestRetryProceedsWhenDeadlineLongerThanBackoff(t *testing.T) {
+	var requestCount int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		if requestCount == 1 {
+			w.Header().Set("Retry-After", "1")
+			w.WriteHeader(http.StatusTooManyRequests)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("{}"))
+	}))
+	defer server.Close()
+
+	caller := NewCaller(&CallerParams{
+		Client: server.Client(),
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	_, err := caller.Call(
+		ctx,
+		&CallParams{
+			URL:         server.URL,
+			Method:      http.MethodGet,
+			Request:     &InternalTestRequest{},
+			Response:    &InternalTestResponse{},
+			MaxAttempts: 3,
+		},
+	)
+
+	assert.NoError(t, err)
+	assert.Equal(t, 2, requestCount, "Expected the retry to proceed when the deadline allows it")
 }
 
 func TestDisableRetries(t *testing.T) {

--- a/seed/go-sdk/server-sent-events/with-wire-tests/internal/retrier.go
+++ b/seed/go-sdk/server-sent-events/with-wire-tests/internal/retrier.go
@@ -145,12 +145,20 @@ func (r *Retrier) run(
 	}
 
 	if r.shouldRetry(response) {
-		defer func() { _ = response.Body.Close() }()
-
 		delay, err := r.retryDelay(response, retryAttempt)
 		if err != nil {
+			_ = response.Body.Close()
 			return nil, err
 		}
+
+		// If the context's deadline would elapse before the backoff completes, return
+		// the response instead of sleeping through it. The caller then sees why the
+		// request actually failed (e.g. a 429) rather than a context deadline error.
+		if deadline, ok := request.Context().Deadline(); ok && time.Until(deadline) < delay {
+			return response, nil
+		}
+
+		defer func() { _ = response.Body.Close() }()
 
 		if err := sleepWithContext(request.Context(), delay); err != nil {
 			return nil, err

--- a/seed/go-sdk/server-sent-events/with-wire-tests/internal/retrier_test.go
+++ b/seed/go-sdk/server-sent-events/with-wire-tests/internal/retrier_test.go
@@ -295,7 +295,50 @@ func TestRetryWithRequestBody(t *testing.T) {
 	assert.Equal(t, expectedBody, requestBodies[1], "Second request body should match expected (retry should re-send body)")
 }
 
+// An explicit cancel (e.g. Ctrl-C wired to cancel()) must interrupt the backoff
+// wait. There is no deadline here, so the retrier cannot know the wait is futile
+// up front -- it has to be woken by the context.
 func TestRetryWaitIsInterruptedByContext(t *testing.T) {
+	var requestCount int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		w.Header().Set("Retry-After", "5")
+		w.WriteHeader(http.StatusTooManyRequests)
+	}))
+	defer server.Close()
+
+	caller := NewCaller(&CallerParams{
+		Client: server.Client(),
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		time.Sleep(100 * time.Millisecond)
+		cancel()
+	}()
+	defer cancel()
+
+	start := time.Now()
+	_, err := caller.Call(
+		ctx,
+		&CallParams{
+			URL:         server.URL,
+			Method:      http.MethodGet,
+			Request:     &InternalTestRequest{},
+			MaxAttempts: 3,
+		},
+	)
+	elapsed := time.Since(start)
+
+	assert.ErrorIs(t, err, context.Canceled)
+	assert.Equal(t, 1, requestCount, "Expected the retry to be abandoned once the context was cancelled")
+	assert.Less(t, elapsed, time.Second, "Expected the backoff to be interrupted by the context, took %v", elapsed)
+}
+
+// When the caller's deadline would elapse before the backoff finishes, sleeping
+// only guarantees a context error. Return the response instead so the caller
+// learns why the request actually failed.
+func TestRetryReturnsResponseWhenDeadlineShorterThanBackoff(t *testing.T) {
 	var requestCount int
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		requestCount++
@@ -323,9 +366,50 @@ func TestRetryWaitIsInterruptedByContext(t *testing.T) {
 	)
 	elapsed := time.Since(start)
 
-	assert.ErrorIs(t, err, context.DeadlineExceeded)
-	assert.Equal(t, 1, requestCount, "Expected the retry to be abandoned once the context expired")
-	assert.Less(t, elapsed, time.Second, "Expected the backoff to be interrupted by the context, took %v", elapsed)
+	// The caller gets the 429, not context.DeadlineExceeded.
+	var apiError *core.APIError
+	require.ErrorAs(t, err, &apiError)
+	assert.Equal(t, http.StatusTooManyRequests, apiError.StatusCode)
+	assert.NotErrorIs(t, err, context.DeadlineExceeded)
+	assert.Equal(t, 1, requestCount, "Expected no retry once the deadline was known to be too short")
+	assert.Less(t, elapsed, time.Second, "Expected to return immediately rather than sleep, took %v", elapsed)
+}
+
+// A deadline with room for the backoff must still retry as normal.
+func TestRetryProceedsWhenDeadlineLongerThanBackoff(t *testing.T) {
+	var requestCount int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		if requestCount == 1 {
+			w.Header().Set("Retry-After", "1")
+			w.WriteHeader(http.StatusTooManyRequests)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("{}"))
+	}))
+	defer server.Close()
+
+	caller := NewCaller(&CallerParams{
+		Client: server.Client(),
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	_, err := caller.Call(
+		ctx,
+		&CallParams{
+			URL:         server.URL,
+			Method:      http.MethodGet,
+			Request:     &InternalTestRequest{},
+			Response:    &InternalTestResponse{},
+			MaxAttempts: 3,
+		},
+	)
+
+	assert.NoError(t, err)
+	assert.Equal(t, 2, requestCount, "Expected the retry to proceed when the deadline allows it")
 }
 
 func TestDisableRetries(t *testing.T) {

--- a/seed/go-sdk/server-url-templating-single-url/disable-server-url-variables/internal/retrier.go
+++ b/seed/go-sdk/server-url-templating-single-url/disable-server-url-variables/internal/retrier.go
@@ -145,12 +145,20 @@ func (r *Retrier) run(
 	}
 
 	if r.shouldRetry(response) {
-		defer func() { _ = response.Body.Close() }()
-
 		delay, err := r.retryDelay(response, retryAttempt)
 		if err != nil {
+			_ = response.Body.Close()
 			return nil, err
 		}
+
+		// If the context's deadline would elapse before the backoff completes, return
+		// the response instead of sleeping through it. The caller then sees why the
+		// request actually failed (e.g. a 429) rather than a context deadline error.
+		if deadline, ok := request.Context().Deadline(); ok && time.Until(deadline) < delay {
+			return response, nil
+		}
+
+		defer func() { _ = response.Body.Close() }()
 
 		if err := sleepWithContext(request.Context(), delay); err != nil {
 			return nil, err

--- a/seed/go-sdk/server-url-templating-single-url/disable-server-url-variables/internal/retrier_test.go
+++ b/seed/go-sdk/server-url-templating-single-url/disable-server-url-variables/internal/retrier_test.go
@@ -295,7 +295,50 @@ func TestRetryWithRequestBody(t *testing.T) {
 	assert.Equal(t, expectedBody, requestBodies[1], "Second request body should match expected (retry should re-send body)")
 }
 
+// An explicit cancel (e.g. Ctrl-C wired to cancel()) must interrupt the backoff
+// wait. There is no deadline here, so the retrier cannot know the wait is futile
+// up front -- it has to be woken by the context.
 func TestRetryWaitIsInterruptedByContext(t *testing.T) {
+	var requestCount int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		w.Header().Set("Retry-After", "5")
+		w.WriteHeader(http.StatusTooManyRequests)
+	}))
+	defer server.Close()
+
+	caller := NewCaller(&CallerParams{
+		Client: server.Client(),
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		time.Sleep(100 * time.Millisecond)
+		cancel()
+	}()
+	defer cancel()
+
+	start := time.Now()
+	_, err := caller.Call(
+		ctx,
+		&CallParams{
+			URL:         server.URL,
+			Method:      http.MethodGet,
+			Request:     &InternalTestRequest{},
+			MaxAttempts: 3,
+		},
+	)
+	elapsed := time.Since(start)
+
+	assert.ErrorIs(t, err, context.Canceled)
+	assert.Equal(t, 1, requestCount, "Expected the retry to be abandoned once the context was cancelled")
+	assert.Less(t, elapsed, time.Second, "Expected the backoff to be interrupted by the context, took %v", elapsed)
+}
+
+// When the caller's deadline would elapse before the backoff finishes, sleeping
+// only guarantees a context error. Return the response instead so the caller
+// learns why the request actually failed.
+func TestRetryReturnsResponseWhenDeadlineShorterThanBackoff(t *testing.T) {
 	var requestCount int
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		requestCount++
@@ -323,9 +366,50 @@ func TestRetryWaitIsInterruptedByContext(t *testing.T) {
 	)
 	elapsed := time.Since(start)
 
-	assert.ErrorIs(t, err, context.DeadlineExceeded)
-	assert.Equal(t, 1, requestCount, "Expected the retry to be abandoned once the context expired")
-	assert.Less(t, elapsed, time.Second, "Expected the backoff to be interrupted by the context, took %v", elapsed)
+	// The caller gets the 429, not context.DeadlineExceeded.
+	var apiError *core.APIError
+	require.ErrorAs(t, err, &apiError)
+	assert.Equal(t, http.StatusTooManyRequests, apiError.StatusCode)
+	assert.NotErrorIs(t, err, context.DeadlineExceeded)
+	assert.Equal(t, 1, requestCount, "Expected no retry once the deadline was known to be too short")
+	assert.Less(t, elapsed, time.Second, "Expected to return immediately rather than sleep, took %v", elapsed)
+}
+
+// A deadline with room for the backoff must still retry as normal.
+func TestRetryProceedsWhenDeadlineLongerThanBackoff(t *testing.T) {
+	var requestCount int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		if requestCount == 1 {
+			w.Header().Set("Retry-After", "1")
+			w.WriteHeader(http.StatusTooManyRequests)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("{}"))
+	}))
+	defer server.Close()
+
+	caller := NewCaller(&CallerParams{
+		Client: server.Client(),
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	_, err := caller.Call(
+		ctx,
+		&CallParams{
+			URL:         server.URL,
+			Method:      http.MethodGet,
+			Request:     &InternalTestRequest{},
+			Response:    &InternalTestResponse{},
+			MaxAttempts: 3,
+		},
+	)
+
+	assert.NoError(t, err)
+	assert.Equal(t, 2, requestCount, "Expected the retry to proceed when the deadline allows it")
 }
 
 func TestDisableRetries(t *testing.T) {

--- a/seed/go-sdk/server-url-templating-single-url/no-custom-config/internal/retrier.go
+++ b/seed/go-sdk/server-url-templating-single-url/no-custom-config/internal/retrier.go
@@ -145,12 +145,20 @@ func (r *Retrier) run(
 	}
 
 	if r.shouldRetry(response) {
-		defer func() { _ = response.Body.Close() }()
-
 		delay, err := r.retryDelay(response, retryAttempt)
 		if err != nil {
+			_ = response.Body.Close()
 			return nil, err
 		}
+
+		// If the context's deadline would elapse before the backoff completes, return
+		// the response instead of sleeping through it. The caller then sees why the
+		// request actually failed (e.g. a 429) rather than a context deadline error.
+		if deadline, ok := request.Context().Deadline(); ok && time.Until(deadline) < delay {
+			return response, nil
+		}
+
+		defer func() { _ = response.Body.Close() }()
 
 		if err := sleepWithContext(request.Context(), delay); err != nil {
 			return nil, err

--- a/seed/go-sdk/server-url-templating-single-url/no-custom-config/internal/retrier_test.go
+++ b/seed/go-sdk/server-url-templating-single-url/no-custom-config/internal/retrier_test.go
@@ -295,7 +295,50 @@ func TestRetryWithRequestBody(t *testing.T) {
 	assert.Equal(t, expectedBody, requestBodies[1], "Second request body should match expected (retry should re-send body)")
 }
 
+// An explicit cancel (e.g. Ctrl-C wired to cancel()) must interrupt the backoff
+// wait. There is no deadline here, so the retrier cannot know the wait is futile
+// up front -- it has to be woken by the context.
 func TestRetryWaitIsInterruptedByContext(t *testing.T) {
+	var requestCount int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		w.Header().Set("Retry-After", "5")
+		w.WriteHeader(http.StatusTooManyRequests)
+	}))
+	defer server.Close()
+
+	caller := NewCaller(&CallerParams{
+		Client: server.Client(),
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		time.Sleep(100 * time.Millisecond)
+		cancel()
+	}()
+	defer cancel()
+
+	start := time.Now()
+	_, err := caller.Call(
+		ctx,
+		&CallParams{
+			URL:         server.URL,
+			Method:      http.MethodGet,
+			Request:     &InternalTestRequest{},
+			MaxAttempts: 3,
+		},
+	)
+	elapsed := time.Since(start)
+
+	assert.ErrorIs(t, err, context.Canceled)
+	assert.Equal(t, 1, requestCount, "Expected the retry to be abandoned once the context was cancelled")
+	assert.Less(t, elapsed, time.Second, "Expected the backoff to be interrupted by the context, took %v", elapsed)
+}
+
+// When the caller's deadline would elapse before the backoff finishes, sleeping
+// only guarantees a context error. Return the response instead so the caller
+// learns why the request actually failed.
+func TestRetryReturnsResponseWhenDeadlineShorterThanBackoff(t *testing.T) {
 	var requestCount int
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		requestCount++
@@ -323,9 +366,50 @@ func TestRetryWaitIsInterruptedByContext(t *testing.T) {
 	)
 	elapsed := time.Since(start)
 
-	assert.ErrorIs(t, err, context.DeadlineExceeded)
-	assert.Equal(t, 1, requestCount, "Expected the retry to be abandoned once the context expired")
-	assert.Less(t, elapsed, time.Second, "Expected the backoff to be interrupted by the context, took %v", elapsed)
+	// The caller gets the 429, not context.DeadlineExceeded.
+	var apiError *core.APIError
+	require.ErrorAs(t, err, &apiError)
+	assert.Equal(t, http.StatusTooManyRequests, apiError.StatusCode)
+	assert.NotErrorIs(t, err, context.DeadlineExceeded)
+	assert.Equal(t, 1, requestCount, "Expected no retry once the deadline was known to be too short")
+	assert.Less(t, elapsed, time.Second, "Expected to return immediately rather than sleep, took %v", elapsed)
+}
+
+// A deadline with room for the backoff must still retry as normal.
+func TestRetryProceedsWhenDeadlineLongerThanBackoff(t *testing.T) {
+	var requestCount int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		if requestCount == 1 {
+			w.Header().Set("Retry-After", "1")
+			w.WriteHeader(http.StatusTooManyRequests)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("{}"))
+	}))
+	defer server.Close()
+
+	caller := NewCaller(&CallerParams{
+		Client: server.Client(),
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	_, err := caller.Call(
+		ctx,
+		&CallParams{
+			URL:         server.URL,
+			Method:      http.MethodGet,
+			Request:     &InternalTestRequest{},
+			Response:    &InternalTestResponse{},
+			MaxAttempts: 3,
+		},
+	)
+
+	assert.NoError(t, err)
+	assert.Equal(t, 2, requestCount, "Expected the retry to proceed when the deadline allows it")
 }
 
 func TestDisableRetries(t *testing.T) {

--- a/seed/go-sdk/server-url-templating/disable-server-url-variables/internal/retrier.go
+++ b/seed/go-sdk/server-url-templating/disable-server-url-variables/internal/retrier.go
@@ -145,12 +145,20 @@ func (r *Retrier) run(
 	}
 
 	if r.shouldRetry(response) {
-		defer func() { _ = response.Body.Close() }()
-
 		delay, err := r.retryDelay(response, retryAttempt)
 		if err != nil {
+			_ = response.Body.Close()
 			return nil, err
 		}
+
+		// If the context's deadline would elapse before the backoff completes, return
+		// the response instead of sleeping through it. The caller then sees why the
+		// request actually failed (e.g. a 429) rather than a context deadline error.
+		if deadline, ok := request.Context().Deadline(); ok && time.Until(deadline) < delay {
+			return response, nil
+		}
+
+		defer func() { _ = response.Body.Close() }()
 
 		if err := sleepWithContext(request.Context(), delay); err != nil {
 			return nil, err

--- a/seed/go-sdk/server-url-templating/disable-server-url-variables/internal/retrier_test.go
+++ b/seed/go-sdk/server-url-templating/disable-server-url-variables/internal/retrier_test.go
@@ -295,7 +295,50 @@ func TestRetryWithRequestBody(t *testing.T) {
 	assert.Equal(t, expectedBody, requestBodies[1], "Second request body should match expected (retry should re-send body)")
 }
 
+// An explicit cancel (e.g. Ctrl-C wired to cancel()) must interrupt the backoff
+// wait. There is no deadline here, so the retrier cannot know the wait is futile
+// up front -- it has to be woken by the context.
 func TestRetryWaitIsInterruptedByContext(t *testing.T) {
+	var requestCount int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		w.Header().Set("Retry-After", "5")
+		w.WriteHeader(http.StatusTooManyRequests)
+	}))
+	defer server.Close()
+
+	caller := NewCaller(&CallerParams{
+		Client: server.Client(),
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		time.Sleep(100 * time.Millisecond)
+		cancel()
+	}()
+	defer cancel()
+
+	start := time.Now()
+	_, err := caller.Call(
+		ctx,
+		&CallParams{
+			URL:         server.URL,
+			Method:      http.MethodGet,
+			Request:     &InternalTestRequest{},
+			MaxAttempts: 3,
+		},
+	)
+	elapsed := time.Since(start)
+
+	assert.ErrorIs(t, err, context.Canceled)
+	assert.Equal(t, 1, requestCount, "Expected the retry to be abandoned once the context was cancelled")
+	assert.Less(t, elapsed, time.Second, "Expected the backoff to be interrupted by the context, took %v", elapsed)
+}
+
+// When the caller's deadline would elapse before the backoff finishes, sleeping
+// only guarantees a context error. Return the response instead so the caller
+// learns why the request actually failed.
+func TestRetryReturnsResponseWhenDeadlineShorterThanBackoff(t *testing.T) {
 	var requestCount int
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		requestCount++
@@ -323,9 +366,50 @@ func TestRetryWaitIsInterruptedByContext(t *testing.T) {
 	)
 	elapsed := time.Since(start)
 
-	assert.ErrorIs(t, err, context.DeadlineExceeded)
-	assert.Equal(t, 1, requestCount, "Expected the retry to be abandoned once the context expired")
-	assert.Less(t, elapsed, time.Second, "Expected the backoff to be interrupted by the context, took %v", elapsed)
+	// The caller gets the 429, not context.DeadlineExceeded.
+	var apiError *core.APIError
+	require.ErrorAs(t, err, &apiError)
+	assert.Equal(t, http.StatusTooManyRequests, apiError.StatusCode)
+	assert.NotErrorIs(t, err, context.DeadlineExceeded)
+	assert.Equal(t, 1, requestCount, "Expected no retry once the deadline was known to be too short")
+	assert.Less(t, elapsed, time.Second, "Expected to return immediately rather than sleep, took %v", elapsed)
+}
+
+// A deadline with room for the backoff must still retry as normal.
+func TestRetryProceedsWhenDeadlineLongerThanBackoff(t *testing.T) {
+	var requestCount int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		if requestCount == 1 {
+			w.Header().Set("Retry-After", "1")
+			w.WriteHeader(http.StatusTooManyRequests)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("{}"))
+	}))
+	defer server.Close()
+
+	caller := NewCaller(&CallerParams{
+		Client: server.Client(),
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	_, err := caller.Call(
+		ctx,
+		&CallParams{
+			URL:         server.URL,
+			Method:      http.MethodGet,
+			Request:     &InternalTestRequest{},
+			Response:    &InternalTestResponse{},
+			MaxAttempts: 3,
+		},
+	)
+
+	assert.NoError(t, err)
+	assert.Equal(t, 2, requestCount, "Expected the retry to proceed when the deadline allows it")
 }
 
 func TestDisableRetries(t *testing.T) {

--- a/seed/go-sdk/server-url-templating/no-custom-config/internal/retrier.go
+++ b/seed/go-sdk/server-url-templating/no-custom-config/internal/retrier.go
@@ -145,12 +145,20 @@ func (r *Retrier) run(
 	}
 
 	if r.shouldRetry(response) {
-		defer func() { _ = response.Body.Close() }()
-
 		delay, err := r.retryDelay(response, retryAttempt)
 		if err != nil {
+			_ = response.Body.Close()
 			return nil, err
 		}
+
+		// If the context's deadline would elapse before the backoff completes, return
+		// the response instead of sleeping through it. The caller then sees why the
+		// request actually failed (e.g. a 429) rather than a context deadline error.
+		if deadline, ok := request.Context().Deadline(); ok && time.Until(deadline) < delay {
+			return response, nil
+		}
+
+		defer func() { _ = response.Body.Close() }()
 
 		if err := sleepWithContext(request.Context(), delay); err != nil {
 			return nil, err

--- a/seed/go-sdk/server-url-templating/no-custom-config/internal/retrier_test.go
+++ b/seed/go-sdk/server-url-templating/no-custom-config/internal/retrier_test.go
@@ -295,7 +295,50 @@ func TestRetryWithRequestBody(t *testing.T) {
 	assert.Equal(t, expectedBody, requestBodies[1], "Second request body should match expected (retry should re-send body)")
 }
 
+// An explicit cancel (e.g. Ctrl-C wired to cancel()) must interrupt the backoff
+// wait. There is no deadline here, so the retrier cannot know the wait is futile
+// up front -- it has to be woken by the context.
 func TestRetryWaitIsInterruptedByContext(t *testing.T) {
+	var requestCount int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		w.Header().Set("Retry-After", "5")
+		w.WriteHeader(http.StatusTooManyRequests)
+	}))
+	defer server.Close()
+
+	caller := NewCaller(&CallerParams{
+		Client: server.Client(),
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		time.Sleep(100 * time.Millisecond)
+		cancel()
+	}()
+	defer cancel()
+
+	start := time.Now()
+	_, err := caller.Call(
+		ctx,
+		&CallParams{
+			URL:         server.URL,
+			Method:      http.MethodGet,
+			Request:     &InternalTestRequest{},
+			MaxAttempts: 3,
+		},
+	)
+	elapsed := time.Since(start)
+
+	assert.ErrorIs(t, err, context.Canceled)
+	assert.Equal(t, 1, requestCount, "Expected the retry to be abandoned once the context was cancelled")
+	assert.Less(t, elapsed, time.Second, "Expected the backoff to be interrupted by the context, took %v", elapsed)
+}
+
+// When the caller's deadline would elapse before the backoff finishes, sleeping
+// only guarantees a context error. Return the response instead so the caller
+// learns why the request actually failed.
+func TestRetryReturnsResponseWhenDeadlineShorterThanBackoff(t *testing.T) {
 	var requestCount int
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		requestCount++
@@ -323,9 +366,50 @@ func TestRetryWaitIsInterruptedByContext(t *testing.T) {
 	)
 	elapsed := time.Since(start)
 
-	assert.ErrorIs(t, err, context.DeadlineExceeded)
-	assert.Equal(t, 1, requestCount, "Expected the retry to be abandoned once the context expired")
-	assert.Less(t, elapsed, time.Second, "Expected the backoff to be interrupted by the context, took %v", elapsed)
+	// The caller gets the 429, not context.DeadlineExceeded.
+	var apiError *core.APIError
+	require.ErrorAs(t, err, &apiError)
+	assert.Equal(t, http.StatusTooManyRequests, apiError.StatusCode)
+	assert.NotErrorIs(t, err, context.DeadlineExceeded)
+	assert.Equal(t, 1, requestCount, "Expected no retry once the deadline was known to be too short")
+	assert.Less(t, elapsed, time.Second, "Expected to return immediately rather than sleep, took %v", elapsed)
+}
+
+// A deadline with room for the backoff must still retry as normal.
+func TestRetryProceedsWhenDeadlineLongerThanBackoff(t *testing.T) {
+	var requestCount int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		if requestCount == 1 {
+			w.Header().Set("Retry-After", "1")
+			w.WriteHeader(http.StatusTooManyRequests)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("{}"))
+	}))
+	defer server.Close()
+
+	caller := NewCaller(&CallerParams{
+		Client: server.Client(),
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	_, err := caller.Call(
+		ctx,
+		&CallParams{
+			URL:         server.URL,
+			Method:      http.MethodGet,
+			Request:     &InternalTestRequest{},
+			Response:    &InternalTestResponse{},
+			MaxAttempts: 3,
+		},
+	)
+
+	assert.NoError(t, err)
+	assert.Equal(t, 2, requestCount, "Expected the retry to proceed when the deadline allows it")
 }
 
 func TestDisableRetries(t *testing.T) {

--- a/seed/go-sdk/simple-api/internal/retrier.go
+++ b/seed/go-sdk/simple-api/internal/retrier.go
@@ -145,12 +145,20 @@ func (r *Retrier) run(
 	}
 
 	if r.shouldRetry(response) {
-		defer func() { _ = response.Body.Close() }()
-
 		delay, err := r.retryDelay(response, retryAttempt)
 		if err != nil {
+			_ = response.Body.Close()
 			return nil, err
 		}
+
+		// If the context's deadline would elapse before the backoff completes, return
+		// the response instead of sleeping through it. The caller then sees why the
+		// request actually failed (e.g. a 429) rather than a context deadline error.
+		if deadline, ok := request.Context().Deadline(); ok && time.Until(deadline) < delay {
+			return response, nil
+		}
+
+		defer func() { _ = response.Body.Close() }()
 
 		if err := sleepWithContext(request.Context(), delay); err != nil {
 			return nil, err

--- a/seed/go-sdk/simple-api/internal/retrier_test.go
+++ b/seed/go-sdk/simple-api/internal/retrier_test.go
@@ -295,7 +295,50 @@ func TestRetryWithRequestBody(t *testing.T) {
 	assert.Equal(t, expectedBody, requestBodies[1], "Second request body should match expected (retry should re-send body)")
 }
 
+// An explicit cancel (e.g. Ctrl-C wired to cancel()) must interrupt the backoff
+// wait. There is no deadline here, so the retrier cannot know the wait is futile
+// up front -- it has to be woken by the context.
 func TestRetryWaitIsInterruptedByContext(t *testing.T) {
+	var requestCount int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		w.Header().Set("Retry-After", "5")
+		w.WriteHeader(http.StatusTooManyRequests)
+	}))
+	defer server.Close()
+
+	caller := NewCaller(&CallerParams{
+		Client: server.Client(),
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		time.Sleep(100 * time.Millisecond)
+		cancel()
+	}()
+	defer cancel()
+
+	start := time.Now()
+	_, err := caller.Call(
+		ctx,
+		&CallParams{
+			URL:         server.URL,
+			Method:      http.MethodGet,
+			Request:     &InternalTestRequest{},
+			MaxAttempts: 3,
+		},
+	)
+	elapsed := time.Since(start)
+
+	assert.ErrorIs(t, err, context.Canceled)
+	assert.Equal(t, 1, requestCount, "Expected the retry to be abandoned once the context was cancelled")
+	assert.Less(t, elapsed, time.Second, "Expected the backoff to be interrupted by the context, took %v", elapsed)
+}
+
+// When the caller's deadline would elapse before the backoff finishes, sleeping
+// only guarantees a context error. Return the response instead so the caller
+// learns why the request actually failed.
+func TestRetryReturnsResponseWhenDeadlineShorterThanBackoff(t *testing.T) {
 	var requestCount int
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		requestCount++
@@ -323,9 +366,50 @@ func TestRetryWaitIsInterruptedByContext(t *testing.T) {
 	)
 	elapsed := time.Since(start)
 
-	assert.ErrorIs(t, err, context.DeadlineExceeded)
-	assert.Equal(t, 1, requestCount, "Expected the retry to be abandoned once the context expired")
-	assert.Less(t, elapsed, time.Second, "Expected the backoff to be interrupted by the context, took %v", elapsed)
+	// The caller gets the 429, not context.DeadlineExceeded.
+	var apiError *core.APIError
+	require.ErrorAs(t, err, &apiError)
+	assert.Equal(t, http.StatusTooManyRequests, apiError.StatusCode)
+	assert.NotErrorIs(t, err, context.DeadlineExceeded)
+	assert.Equal(t, 1, requestCount, "Expected no retry once the deadline was known to be too short")
+	assert.Less(t, elapsed, time.Second, "Expected to return immediately rather than sleep, took %v", elapsed)
+}
+
+// A deadline with room for the backoff must still retry as normal.
+func TestRetryProceedsWhenDeadlineLongerThanBackoff(t *testing.T) {
+	var requestCount int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		if requestCount == 1 {
+			w.Header().Set("Retry-After", "1")
+			w.WriteHeader(http.StatusTooManyRequests)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("{}"))
+	}))
+	defer server.Close()
+
+	caller := NewCaller(&CallerParams{
+		Client: server.Client(),
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	_, err := caller.Call(
+		ctx,
+		&CallParams{
+			URL:         server.URL,
+			Method:      http.MethodGet,
+			Request:     &InternalTestRequest{},
+			Response:    &InternalTestResponse{},
+			MaxAttempts: 3,
+		},
+	)
+
+	assert.NoError(t, err)
+	assert.Equal(t, 2, requestCount, "Expected the retry to proceed when the deadline allows it")
 }
 
 func TestDisableRetries(t *testing.T) {

--- a/seed/go-sdk/simple-fhir/internal/retrier.go
+++ b/seed/go-sdk/simple-fhir/internal/retrier.go
@@ -145,12 +145,20 @@ func (r *Retrier) run(
 	}
 
 	if r.shouldRetry(response) {
-		defer func() { _ = response.Body.Close() }()
-
 		delay, err := r.retryDelay(response, retryAttempt)
 		if err != nil {
+			_ = response.Body.Close()
 			return nil, err
 		}
+
+		// If the context's deadline would elapse before the backoff completes, return
+		// the response instead of sleeping through it. The caller then sees why the
+		// request actually failed (e.g. a 429) rather than a context deadline error.
+		if deadline, ok := request.Context().Deadline(); ok && time.Until(deadline) < delay {
+			return response, nil
+		}
+
+		defer func() { _ = response.Body.Close() }()
 
 		if err := sleepWithContext(request.Context(), delay); err != nil {
 			return nil, err

--- a/seed/go-sdk/simple-fhir/internal/retrier_test.go
+++ b/seed/go-sdk/simple-fhir/internal/retrier_test.go
@@ -295,7 +295,50 @@ func TestRetryWithRequestBody(t *testing.T) {
 	assert.Equal(t, expectedBody, requestBodies[1], "Second request body should match expected (retry should re-send body)")
 }
 
+// An explicit cancel (e.g. Ctrl-C wired to cancel()) must interrupt the backoff
+// wait. There is no deadline here, so the retrier cannot know the wait is futile
+// up front -- it has to be woken by the context.
 func TestRetryWaitIsInterruptedByContext(t *testing.T) {
+	var requestCount int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		w.Header().Set("Retry-After", "5")
+		w.WriteHeader(http.StatusTooManyRequests)
+	}))
+	defer server.Close()
+
+	caller := NewCaller(&CallerParams{
+		Client: server.Client(),
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		time.Sleep(100 * time.Millisecond)
+		cancel()
+	}()
+	defer cancel()
+
+	start := time.Now()
+	_, err := caller.Call(
+		ctx,
+		&CallParams{
+			URL:         server.URL,
+			Method:      http.MethodGet,
+			Request:     &InternalTestRequest{},
+			MaxAttempts: 3,
+		},
+	)
+	elapsed := time.Since(start)
+
+	assert.ErrorIs(t, err, context.Canceled)
+	assert.Equal(t, 1, requestCount, "Expected the retry to be abandoned once the context was cancelled")
+	assert.Less(t, elapsed, time.Second, "Expected the backoff to be interrupted by the context, took %v", elapsed)
+}
+
+// When the caller's deadline would elapse before the backoff finishes, sleeping
+// only guarantees a context error. Return the response instead so the caller
+// learns why the request actually failed.
+func TestRetryReturnsResponseWhenDeadlineShorterThanBackoff(t *testing.T) {
 	var requestCount int
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		requestCount++
@@ -323,9 +366,50 @@ func TestRetryWaitIsInterruptedByContext(t *testing.T) {
 	)
 	elapsed := time.Since(start)
 
-	assert.ErrorIs(t, err, context.DeadlineExceeded)
-	assert.Equal(t, 1, requestCount, "Expected the retry to be abandoned once the context expired")
-	assert.Less(t, elapsed, time.Second, "Expected the backoff to be interrupted by the context, took %v", elapsed)
+	// The caller gets the 429, not context.DeadlineExceeded.
+	var apiError *core.APIError
+	require.ErrorAs(t, err, &apiError)
+	assert.Equal(t, http.StatusTooManyRequests, apiError.StatusCode)
+	assert.NotErrorIs(t, err, context.DeadlineExceeded)
+	assert.Equal(t, 1, requestCount, "Expected no retry once the deadline was known to be too short")
+	assert.Less(t, elapsed, time.Second, "Expected to return immediately rather than sleep, took %v", elapsed)
+}
+
+// A deadline with room for the backoff must still retry as normal.
+func TestRetryProceedsWhenDeadlineLongerThanBackoff(t *testing.T) {
+	var requestCount int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		if requestCount == 1 {
+			w.Header().Set("Retry-After", "1")
+			w.WriteHeader(http.StatusTooManyRequests)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("{}"))
+	}))
+	defer server.Close()
+
+	caller := NewCaller(&CallerParams{
+		Client: server.Client(),
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	_, err := caller.Call(
+		ctx,
+		&CallParams{
+			URL:         server.URL,
+			Method:      http.MethodGet,
+			Request:     &InternalTestRequest{},
+			Response:    &InternalTestResponse{},
+			MaxAttempts: 3,
+		},
+	)
+
+	assert.NoError(t, err)
+	assert.Equal(t, 2, requestCount, "Expected the retry to proceed when the deadline allows it")
 }
 
 func TestDisableRetries(t *testing.T) {

--- a/seed/go-sdk/single-url-environment-default/internal/retrier.go
+++ b/seed/go-sdk/single-url-environment-default/internal/retrier.go
@@ -145,12 +145,20 @@ func (r *Retrier) run(
 	}
 
 	if r.shouldRetry(response) {
-		defer func() { _ = response.Body.Close() }()
-
 		delay, err := r.retryDelay(response, retryAttempt)
 		if err != nil {
+			_ = response.Body.Close()
 			return nil, err
 		}
+
+		// If the context's deadline would elapse before the backoff completes, return
+		// the response instead of sleeping through it. The caller then sees why the
+		// request actually failed (e.g. a 429) rather than a context deadline error.
+		if deadline, ok := request.Context().Deadline(); ok && time.Until(deadline) < delay {
+			return response, nil
+		}
+
+		defer func() { _ = response.Body.Close() }()
 
 		if err := sleepWithContext(request.Context(), delay); err != nil {
 			return nil, err

--- a/seed/go-sdk/single-url-environment-default/internal/retrier_test.go
+++ b/seed/go-sdk/single-url-environment-default/internal/retrier_test.go
@@ -295,7 +295,50 @@ func TestRetryWithRequestBody(t *testing.T) {
 	assert.Equal(t, expectedBody, requestBodies[1], "Second request body should match expected (retry should re-send body)")
 }
 
+// An explicit cancel (e.g. Ctrl-C wired to cancel()) must interrupt the backoff
+// wait. There is no deadline here, so the retrier cannot know the wait is futile
+// up front -- it has to be woken by the context.
 func TestRetryWaitIsInterruptedByContext(t *testing.T) {
+	var requestCount int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		w.Header().Set("Retry-After", "5")
+		w.WriteHeader(http.StatusTooManyRequests)
+	}))
+	defer server.Close()
+
+	caller := NewCaller(&CallerParams{
+		Client: server.Client(),
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		time.Sleep(100 * time.Millisecond)
+		cancel()
+	}()
+	defer cancel()
+
+	start := time.Now()
+	_, err := caller.Call(
+		ctx,
+		&CallParams{
+			URL:         server.URL,
+			Method:      http.MethodGet,
+			Request:     &InternalTestRequest{},
+			MaxAttempts: 3,
+		},
+	)
+	elapsed := time.Since(start)
+
+	assert.ErrorIs(t, err, context.Canceled)
+	assert.Equal(t, 1, requestCount, "Expected the retry to be abandoned once the context was cancelled")
+	assert.Less(t, elapsed, time.Second, "Expected the backoff to be interrupted by the context, took %v", elapsed)
+}
+
+// When the caller's deadline would elapse before the backoff finishes, sleeping
+// only guarantees a context error. Return the response instead so the caller
+// learns why the request actually failed.
+func TestRetryReturnsResponseWhenDeadlineShorterThanBackoff(t *testing.T) {
 	var requestCount int
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		requestCount++
@@ -323,9 +366,50 @@ func TestRetryWaitIsInterruptedByContext(t *testing.T) {
 	)
 	elapsed := time.Since(start)
 
-	assert.ErrorIs(t, err, context.DeadlineExceeded)
-	assert.Equal(t, 1, requestCount, "Expected the retry to be abandoned once the context expired")
-	assert.Less(t, elapsed, time.Second, "Expected the backoff to be interrupted by the context, took %v", elapsed)
+	// The caller gets the 429, not context.DeadlineExceeded.
+	var apiError *core.APIError
+	require.ErrorAs(t, err, &apiError)
+	assert.Equal(t, http.StatusTooManyRequests, apiError.StatusCode)
+	assert.NotErrorIs(t, err, context.DeadlineExceeded)
+	assert.Equal(t, 1, requestCount, "Expected no retry once the deadline was known to be too short")
+	assert.Less(t, elapsed, time.Second, "Expected to return immediately rather than sleep, took %v", elapsed)
+}
+
+// A deadline with room for the backoff must still retry as normal.
+func TestRetryProceedsWhenDeadlineLongerThanBackoff(t *testing.T) {
+	var requestCount int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		if requestCount == 1 {
+			w.Header().Set("Retry-After", "1")
+			w.WriteHeader(http.StatusTooManyRequests)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("{}"))
+	}))
+	defer server.Close()
+
+	caller := NewCaller(&CallerParams{
+		Client: server.Client(),
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	_, err := caller.Call(
+		ctx,
+		&CallParams{
+			URL:         server.URL,
+			Method:      http.MethodGet,
+			Request:     &InternalTestRequest{},
+			Response:    &InternalTestResponse{},
+			MaxAttempts: 3,
+		},
+	)
+
+	assert.NoError(t, err)
+	assert.Equal(t, 2, requestCount, "Expected the retry to proceed when the deadline allows it")
 }
 
 func TestDisableRetries(t *testing.T) {

--- a/seed/go-sdk/single-url-environment-no-default/internal/retrier.go
+++ b/seed/go-sdk/single-url-environment-no-default/internal/retrier.go
@@ -145,12 +145,20 @@ func (r *Retrier) run(
 	}
 
 	if r.shouldRetry(response) {
-		defer func() { _ = response.Body.Close() }()
-
 		delay, err := r.retryDelay(response, retryAttempt)
 		if err != nil {
+			_ = response.Body.Close()
 			return nil, err
 		}
+
+		// If the context's deadline would elapse before the backoff completes, return
+		// the response instead of sleeping through it. The caller then sees why the
+		// request actually failed (e.g. a 429) rather than a context deadline error.
+		if deadline, ok := request.Context().Deadline(); ok && time.Until(deadline) < delay {
+			return response, nil
+		}
+
+		defer func() { _ = response.Body.Close() }()
 
 		if err := sleepWithContext(request.Context(), delay); err != nil {
 			return nil, err

--- a/seed/go-sdk/single-url-environment-no-default/internal/retrier_test.go
+++ b/seed/go-sdk/single-url-environment-no-default/internal/retrier_test.go
@@ -295,7 +295,50 @@ func TestRetryWithRequestBody(t *testing.T) {
 	assert.Equal(t, expectedBody, requestBodies[1], "Second request body should match expected (retry should re-send body)")
 }
 
+// An explicit cancel (e.g. Ctrl-C wired to cancel()) must interrupt the backoff
+// wait. There is no deadline here, so the retrier cannot know the wait is futile
+// up front -- it has to be woken by the context.
 func TestRetryWaitIsInterruptedByContext(t *testing.T) {
+	var requestCount int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		w.Header().Set("Retry-After", "5")
+		w.WriteHeader(http.StatusTooManyRequests)
+	}))
+	defer server.Close()
+
+	caller := NewCaller(&CallerParams{
+		Client: server.Client(),
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		time.Sleep(100 * time.Millisecond)
+		cancel()
+	}()
+	defer cancel()
+
+	start := time.Now()
+	_, err := caller.Call(
+		ctx,
+		&CallParams{
+			URL:         server.URL,
+			Method:      http.MethodGet,
+			Request:     &InternalTestRequest{},
+			MaxAttempts: 3,
+		},
+	)
+	elapsed := time.Since(start)
+
+	assert.ErrorIs(t, err, context.Canceled)
+	assert.Equal(t, 1, requestCount, "Expected the retry to be abandoned once the context was cancelled")
+	assert.Less(t, elapsed, time.Second, "Expected the backoff to be interrupted by the context, took %v", elapsed)
+}
+
+// When the caller's deadline would elapse before the backoff finishes, sleeping
+// only guarantees a context error. Return the response instead so the caller
+// learns why the request actually failed.
+func TestRetryReturnsResponseWhenDeadlineShorterThanBackoff(t *testing.T) {
 	var requestCount int
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		requestCount++
@@ -323,9 +366,50 @@ func TestRetryWaitIsInterruptedByContext(t *testing.T) {
 	)
 	elapsed := time.Since(start)
 
-	assert.ErrorIs(t, err, context.DeadlineExceeded)
-	assert.Equal(t, 1, requestCount, "Expected the retry to be abandoned once the context expired")
-	assert.Less(t, elapsed, time.Second, "Expected the backoff to be interrupted by the context, took %v", elapsed)
+	// The caller gets the 429, not context.DeadlineExceeded.
+	var apiError *core.APIError
+	require.ErrorAs(t, err, &apiError)
+	assert.Equal(t, http.StatusTooManyRequests, apiError.StatusCode)
+	assert.NotErrorIs(t, err, context.DeadlineExceeded)
+	assert.Equal(t, 1, requestCount, "Expected no retry once the deadline was known to be too short")
+	assert.Less(t, elapsed, time.Second, "Expected to return immediately rather than sleep, took %v", elapsed)
+}
+
+// A deadline with room for the backoff must still retry as normal.
+func TestRetryProceedsWhenDeadlineLongerThanBackoff(t *testing.T) {
+	var requestCount int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		if requestCount == 1 {
+			w.Header().Set("Retry-After", "1")
+			w.WriteHeader(http.StatusTooManyRequests)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("{}"))
+	}))
+	defer server.Close()
+
+	caller := NewCaller(&CallerParams{
+		Client: server.Client(),
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	_, err := caller.Call(
+		ctx,
+		&CallParams{
+			URL:         server.URL,
+			Method:      http.MethodGet,
+			Request:     &InternalTestRequest{},
+			Response:    &InternalTestResponse{},
+			MaxAttempts: 3,
+		},
+	)
+
+	assert.NoError(t, err)
+	assert.Equal(t, 2, requestCount, "Expected the retry to proceed when the deadline allows it")
 }
 
 func TestDisableRetries(t *testing.T) {

--- a/seed/go-sdk/streaming-parameter/internal/retrier.go
+++ b/seed/go-sdk/streaming-parameter/internal/retrier.go
@@ -145,12 +145,20 @@ func (r *Retrier) run(
 	}
 
 	if r.shouldRetry(response) {
-		defer func() { _ = response.Body.Close() }()
-
 		delay, err := r.retryDelay(response, retryAttempt)
 		if err != nil {
+			_ = response.Body.Close()
 			return nil, err
 		}
+
+		// If the context's deadline would elapse before the backoff completes, return
+		// the response instead of sleeping through it. The caller then sees why the
+		// request actually failed (e.g. a 429) rather than a context deadline error.
+		if deadline, ok := request.Context().Deadline(); ok && time.Until(deadline) < delay {
+			return response, nil
+		}
+
+		defer func() { _ = response.Body.Close() }()
 
 		if err := sleepWithContext(request.Context(), delay); err != nil {
 			return nil, err

--- a/seed/go-sdk/streaming-parameter/internal/retrier_test.go
+++ b/seed/go-sdk/streaming-parameter/internal/retrier_test.go
@@ -295,7 +295,50 @@ func TestRetryWithRequestBody(t *testing.T) {
 	assert.Equal(t, expectedBody, requestBodies[1], "Second request body should match expected (retry should re-send body)")
 }
 
+// An explicit cancel (e.g. Ctrl-C wired to cancel()) must interrupt the backoff
+// wait. There is no deadline here, so the retrier cannot know the wait is futile
+// up front -- it has to be woken by the context.
 func TestRetryWaitIsInterruptedByContext(t *testing.T) {
+	var requestCount int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		w.Header().Set("Retry-After", "5")
+		w.WriteHeader(http.StatusTooManyRequests)
+	}))
+	defer server.Close()
+
+	caller := NewCaller(&CallerParams{
+		Client: server.Client(),
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		time.Sleep(100 * time.Millisecond)
+		cancel()
+	}()
+	defer cancel()
+
+	start := time.Now()
+	_, err := caller.Call(
+		ctx,
+		&CallParams{
+			URL:         server.URL,
+			Method:      http.MethodGet,
+			Request:     &InternalTestRequest{},
+			MaxAttempts: 3,
+		},
+	)
+	elapsed := time.Since(start)
+
+	assert.ErrorIs(t, err, context.Canceled)
+	assert.Equal(t, 1, requestCount, "Expected the retry to be abandoned once the context was cancelled")
+	assert.Less(t, elapsed, time.Second, "Expected the backoff to be interrupted by the context, took %v", elapsed)
+}
+
+// When the caller's deadline would elapse before the backoff finishes, sleeping
+// only guarantees a context error. Return the response instead so the caller
+// learns why the request actually failed.
+func TestRetryReturnsResponseWhenDeadlineShorterThanBackoff(t *testing.T) {
 	var requestCount int
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		requestCount++
@@ -323,9 +366,50 @@ func TestRetryWaitIsInterruptedByContext(t *testing.T) {
 	)
 	elapsed := time.Since(start)
 
-	assert.ErrorIs(t, err, context.DeadlineExceeded)
-	assert.Equal(t, 1, requestCount, "Expected the retry to be abandoned once the context expired")
-	assert.Less(t, elapsed, time.Second, "Expected the backoff to be interrupted by the context, took %v", elapsed)
+	// The caller gets the 429, not context.DeadlineExceeded.
+	var apiError *core.APIError
+	require.ErrorAs(t, err, &apiError)
+	assert.Equal(t, http.StatusTooManyRequests, apiError.StatusCode)
+	assert.NotErrorIs(t, err, context.DeadlineExceeded)
+	assert.Equal(t, 1, requestCount, "Expected no retry once the deadline was known to be too short")
+	assert.Less(t, elapsed, time.Second, "Expected to return immediately rather than sleep, took %v", elapsed)
+}
+
+// A deadline with room for the backoff must still retry as normal.
+func TestRetryProceedsWhenDeadlineLongerThanBackoff(t *testing.T) {
+	var requestCount int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		if requestCount == 1 {
+			w.Header().Set("Retry-After", "1")
+			w.WriteHeader(http.StatusTooManyRequests)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("{}"))
+	}))
+	defer server.Close()
+
+	caller := NewCaller(&CallerParams{
+		Client: server.Client(),
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	_, err := caller.Call(
+		ctx,
+		&CallParams{
+			URL:         server.URL,
+			Method:      http.MethodGet,
+			Request:     &InternalTestRequest{},
+			Response:    &InternalTestResponse{},
+			MaxAttempts: 3,
+		},
+	)
+
+	assert.NoError(t, err)
+	assert.Equal(t, 2, requestCount, "Expected the retry to proceed when the deadline allows it")
 }
 
 func TestDisableRetries(t *testing.T) {

--- a/seed/go-sdk/streaming/internal/retrier.go
+++ b/seed/go-sdk/streaming/internal/retrier.go
@@ -145,12 +145,20 @@ func (r *Retrier) run(
 	}
 
 	if r.shouldRetry(response) {
-		defer func() { _ = response.Body.Close() }()
-
 		delay, err := r.retryDelay(response, retryAttempt)
 		if err != nil {
+			_ = response.Body.Close()
 			return nil, err
 		}
+
+		// If the context's deadline would elapse before the backoff completes, return
+		// the response instead of sleeping through it. The caller then sees why the
+		// request actually failed (e.g. a 429) rather than a context deadline error.
+		if deadline, ok := request.Context().Deadline(); ok && time.Until(deadline) < delay {
+			return response, nil
+		}
+
+		defer func() { _ = response.Body.Close() }()
 
 		if err := sleepWithContext(request.Context(), delay); err != nil {
 			return nil, err

--- a/seed/go-sdk/streaming/internal/retrier_test.go
+++ b/seed/go-sdk/streaming/internal/retrier_test.go
@@ -295,7 +295,50 @@ func TestRetryWithRequestBody(t *testing.T) {
 	assert.Equal(t, expectedBody, requestBodies[1], "Second request body should match expected (retry should re-send body)")
 }
 
+// An explicit cancel (e.g. Ctrl-C wired to cancel()) must interrupt the backoff
+// wait. There is no deadline here, so the retrier cannot know the wait is futile
+// up front -- it has to be woken by the context.
 func TestRetryWaitIsInterruptedByContext(t *testing.T) {
+	var requestCount int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		w.Header().Set("Retry-After", "5")
+		w.WriteHeader(http.StatusTooManyRequests)
+	}))
+	defer server.Close()
+
+	caller := NewCaller(&CallerParams{
+		Client: server.Client(),
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		time.Sleep(100 * time.Millisecond)
+		cancel()
+	}()
+	defer cancel()
+
+	start := time.Now()
+	_, err := caller.Call(
+		ctx,
+		&CallParams{
+			URL:         server.URL,
+			Method:      http.MethodGet,
+			Request:     &InternalTestRequest{},
+			MaxAttempts: 3,
+		},
+	)
+	elapsed := time.Since(start)
+
+	assert.ErrorIs(t, err, context.Canceled)
+	assert.Equal(t, 1, requestCount, "Expected the retry to be abandoned once the context was cancelled")
+	assert.Less(t, elapsed, time.Second, "Expected the backoff to be interrupted by the context, took %v", elapsed)
+}
+
+// When the caller's deadline would elapse before the backoff finishes, sleeping
+// only guarantees a context error. Return the response instead so the caller
+// learns why the request actually failed.
+func TestRetryReturnsResponseWhenDeadlineShorterThanBackoff(t *testing.T) {
 	var requestCount int
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		requestCount++
@@ -323,9 +366,50 @@ func TestRetryWaitIsInterruptedByContext(t *testing.T) {
 	)
 	elapsed := time.Since(start)
 
-	assert.ErrorIs(t, err, context.DeadlineExceeded)
-	assert.Equal(t, 1, requestCount, "Expected the retry to be abandoned once the context expired")
-	assert.Less(t, elapsed, time.Second, "Expected the backoff to be interrupted by the context, took %v", elapsed)
+	// The caller gets the 429, not context.DeadlineExceeded.
+	var apiError *core.APIError
+	require.ErrorAs(t, err, &apiError)
+	assert.Equal(t, http.StatusTooManyRequests, apiError.StatusCode)
+	assert.NotErrorIs(t, err, context.DeadlineExceeded)
+	assert.Equal(t, 1, requestCount, "Expected no retry once the deadline was known to be too short")
+	assert.Less(t, elapsed, time.Second, "Expected to return immediately rather than sleep, took %v", elapsed)
+}
+
+// A deadline with room for the backoff must still retry as normal.
+func TestRetryProceedsWhenDeadlineLongerThanBackoff(t *testing.T) {
+	var requestCount int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		if requestCount == 1 {
+			w.Header().Set("Retry-After", "1")
+			w.WriteHeader(http.StatusTooManyRequests)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("{}"))
+	}))
+	defer server.Close()
+
+	caller := NewCaller(&CallerParams{
+		Client: server.Client(),
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	_, err := caller.Call(
+		ctx,
+		&CallParams{
+			URL:         server.URL,
+			Method:      http.MethodGet,
+			Request:     &InternalTestRequest{},
+			Response:    &InternalTestResponse{},
+			MaxAttempts: 3,
+		},
+	)
+
+	assert.NoError(t, err)
+	assert.Equal(t, 2, requestCount, "Expected the retry to proceed when the deadline allows it")
 }
 
 func TestDisableRetries(t *testing.T) {

--- a/seed/go-sdk/trace/internal/retrier.go
+++ b/seed/go-sdk/trace/internal/retrier.go
@@ -145,12 +145,20 @@ func (r *Retrier) run(
 	}
 
 	if r.shouldRetry(response) {
-		defer func() { _ = response.Body.Close() }()
-
 		delay, err := r.retryDelay(response, retryAttempt)
 		if err != nil {
+			_ = response.Body.Close()
 			return nil, err
 		}
+
+		// If the context's deadline would elapse before the backoff completes, return
+		// the response instead of sleeping through it. The caller then sees why the
+		// request actually failed (e.g. a 429) rather than a context deadline error.
+		if deadline, ok := request.Context().Deadline(); ok && time.Until(deadline) < delay {
+			return response, nil
+		}
+
+		defer func() { _ = response.Body.Close() }()
 
 		if err := sleepWithContext(request.Context(), delay); err != nil {
 			return nil, err

--- a/seed/go-sdk/trace/internal/retrier_test.go
+++ b/seed/go-sdk/trace/internal/retrier_test.go
@@ -295,7 +295,50 @@ func TestRetryWithRequestBody(t *testing.T) {
 	assert.Equal(t, expectedBody, requestBodies[1], "Second request body should match expected (retry should re-send body)")
 }
 
+// An explicit cancel (e.g. Ctrl-C wired to cancel()) must interrupt the backoff
+// wait. There is no deadline here, so the retrier cannot know the wait is futile
+// up front -- it has to be woken by the context.
 func TestRetryWaitIsInterruptedByContext(t *testing.T) {
+	var requestCount int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		w.Header().Set("Retry-After", "5")
+		w.WriteHeader(http.StatusTooManyRequests)
+	}))
+	defer server.Close()
+
+	caller := NewCaller(&CallerParams{
+		Client: server.Client(),
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		time.Sleep(100 * time.Millisecond)
+		cancel()
+	}()
+	defer cancel()
+
+	start := time.Now()
+	_, err := caller.Call(
+		ctx,
+		&CallParams{
+			URL:         server.URL,
+			Method:      http.MethodGet,
+			Request:     &InternalTestRequest{},
+			MaxAttempts: 3,
+		},
+	)
+	elapsed := time.Since(start)
+
+	assert.ErrorIs(t, err, context.Canceled)
+	assert.Equal(t, 1, requestCount, "Expected the retry to be abandoned once the context was cancelled")
+	assert.Less(t, elapsed, time.Second, "Expected the backoff to be interrupted by the context, took %v", elapsed)
+}
+
+// When the caller's deadline would elapse before the backoff finishes, sleeping
+// only guarantees a context error. Return the response instead so the caller
+// learns why the request actually failed.
+func TestRetryReturnsResponseWhenDeadlineShorterThanBackoff(t *testing.T) {
 	var requestCount int
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		requestCount++
@@ -323,9 +366,50 @@ func TestRetryWaitIsInterruptedByContext(t *testing.T) {
 	)
 	elapsed := time.Since(start)
 
-	assert.ErrorIs(t, err, context.DeadlineExceeded)
-	assert.Equal(t, 1, requestCount, "Expected the retry to be abandoned once the context expired")
-	assert.Less(t, elapsed, time.Second, "Expected the backoff to be interrupted by the context, took %v", elapsed)
+	// The caller gets the 429, not context.DeadlineExceeded.
+	var apiError *core.APIError
+	require.ErrorAs(t, err, &apiError)
+	assert.Equal(t, http.StatusTooManyRequests, apiError.StatusCode)
+	assert.NotErrorIs(t, err, context.DeadlineExceeded)
+	assert.Equal(t, 1, requestCount, "Expected no retry once the deadline was known to be too short")
+	assert.Less(t, elapsed, time.Second, "Expected to return immediately rather than sleep, took %v", elapsed)
+}
+
+// A deadline with room for the backoff must still retry as normal.
+func TestRetryProceedsWhenDeadlineLongerThanBackoff(t *testing.T) {
+	var requestCount int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		if requestCount == 1 {
+			w.Header().Set("Retry-After", "1")
+			w.WriteHeader(http.StatusTooManyRequests)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("{}"))
+	}))
+	defer server.Close()
+
+	caller := NewCaller(&CallerParams{
+		Client: server.Client(),
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	_, err := caller.Call(
+		ctx,
+		&CallParams{
+			URL:         server.URL,
+			Method:      http.MethodGet,
+			Request:     &InternalTestRequest{},
+			Response:    &InternalTestResponse{},
+			MaxAttempts: 3,
+		},
+	)
+
+	assert.NoError(t, err)
+	assert.Equal(t, 2, requestCount, "Expected the retry to proceed when the deadline allows it")
 }
 
 func TestDisableRetries(t *testing.T) {

--- a/seed/go-sdk/undiscriminated-union-with-response-property/internal/retrier.go
+++ b/seed/go-sdk/undiscriminated-union-with-response-property/internal/retrier.go
@@ -145,12 +145,20 @@ func (r *Retrier) run(
 	}
 
 	if r.shouldRetry(response) {
-		defer func() { _ = response.Body.Close() }()
-
 		delay, err := r.retryDelay(response, retryAttempt)
 		if err != nil {
+			_ = response.Body.Close()
 			return nil, err
 		}
+
+		// If the context's deadline would elapse before the backoff completes, return
+		// the response instead of sleeping through it. The caller then sees why the
+		// request actually failed (e.g. a 429) rather than a context deadline error.
+		if deadline, ok := request.Context().Deadline(); ok && time.Until(deadline) < delay {
+			return response, nil
+		}
+
+		defer func() { _ = response.Body.Close() }()
 
 		if err := sleepWithContext(request.Context(), delay); err != nil {
 			return nil, err

--- a/seed/go-sdk/undiscriminated-union-with-response-property/internal/retrier_test.go
+++ b/seed/go-sdk/undiscriminated-union-with-response-property/internal/retrier_test.go
@@ -295,7 +295,50 @@ func TestRetryWithRequestBody(t *testing.T) {
 	assert.Equal(t, expectedBody, requestBodies[1], "Second request body should match expected (retry should re-send body)")
 }
 
+// An explicit cancel (e.g. Ctrl-C wired to cancel()) must interrupt the backoff
+// wait. There is no deadline here, so the retrier cannot know the wait is futile
+// up front -- it has to be woken by the context.
 func TestRetryWaitIsInterruptedByContext(t *testing.T) {
+	var requestCount int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		w.Header().Set("Retry-After", "5")
+		w.WriteHeader(http.StatusTooManyRequests)
+	}))
+	defer server.Close()
+
+	caller := NewCaller(&CallerParams{
+		Client: server.Client(),
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		time.Sleep(100 * time.Millisecond)
+		cancel()
+	}()
+	defer cancel()
+
+	start := time.Now()
+	_, err := caller.Call(
+		ctx,
+		&CallParams{
+			URL:         server.URL,
+			Method:      http.MethodGet,
+			Request:     &InternalTestRequest{},
+			MaxAttempts: 3,
+		},
+	)
+	elapsed := time.Since(start)
+
+	assert.ErrorIs(t, err, context.Canceled)
+	assert.Equal(t, 1, requestCount, "Expected the retry to be abandoned once the context was cancelled")
+	assert.Less(t, elapsed, time.Second, "Expected the backoff to be interrupted by the context, took %v", elapsed)
+}
+
+// When the caller's deadline would elapse before the backoff finishes, sleeping
+// only guarantees a context error. Return the response instead so the caller
+// learns why the request actually failed.
+func TestRetryReturnsResponseWhenDeadlineShorterThanBackoff(t *testing.T) {
 	var requestCount int
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		requestCount++
@@ -323,9 +366,50 @@ func TestRetryWaitIsInterruptedByContext(t *testing.T) {
 	)
 	elapsed := time.Since(start)
 
-	assert.ErrorIs(t, err, context.DeadlineExceeded)
-	assert.Equal(t, 1, requestCount, "Expected the retry to be abandoned once the context expired")
-	assert.Less(t, elapsed, time.Second, "Expected the backoff to be interrupted by the context, took %v", elapsed)
+	// The caller gets the 429, not context.DeadlineExceeded.
+	var apiError *core.APIError
+	require.ErrorAs(t, err, &apiError)
+	assert.Equal(t, http.StatusTooManyRequests, apiError.StatusCode)
+	assert.NotErrorIs(t, err, context.DeadlineExceeded)
+	assert.Equal(t, 1, requestCount, "Expected no retry once the deadline was known to be too short")
+	assert.Less(t, elapsed, time.Second, "Expected to return immediately rather than sleep, took %v", elapsed)
+}
+
+// A deadline with room for the backoff must still retry as normal.
+func TestRetryProceedsWhenDeadlineLongerThanBackoff(t *testing.T) {
+	var requestCount int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		if requestCount == 1 {
+			w.Header().Set("Retry-After", "1")
+			w.WriteHeader(http.StatusTooManyRequests)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("{}"))
+	}))
+	defer server.Close()
+
+	caller := NewCaller(&CallerParams{
+		Client: server.Client(),
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	_, err := caller.Call(
+		ctx,
+		&CallParams{
+			URL:         server.URL,
+			Method:      http.MethodGet,
+			Request:     &InternalTestRequest{},
+			Response:    &InternalTestResponse{},
+			MaxAttempts: 3,
+		},
+	)
+
+	assert.NoError(t, err)
+	assert.Equal(t, 2, requestCount, "Expected the retry to proceed when the deadline allows it")
 }
 
 func TestDisableRetries(t *testing.T) {

--- a/seed/go-sdk/undiscriminated-unions/no-custom-config/internal/retrier.go
+++ b/seed/go-sdk/undiscriminated-unions/no-custom-config/internal/retrier.go
@@ -145,12 +145,20 @@ func (r *Retrier) run(
 	}
 
 	if r.shouldRetry(response) {
-		defer func() { _ = response.Body.Close() }()
-
 		delay, err := r.retryDelay(response, retryAttempt)
 		if err != nil {
+			_ = response.Body.Close()
 			return nil, err
 		}
+
+		// If the context's deadline would elapse before the backoff completes, return
+		// the response instead of sleeping through it. The caller then sees why the
+		// request actually failed (e.g. a 429) rather than a context deadline error.
+		if deadline, ok := request.Context().Deadline(); ok && time.Until(deadline) < delay {
+			return response, nil
+		}
+
+		defer func() { _ = response.Body.Close() }()
 
 		if err := sleepWithContext(request.Context(), delay); err != nil {
 			return nil, err

--- a/seed/go-sdk/undiscriminated-unions/no-custom-config/internal/retrier_test.go
+++ b/seed/go-sdk/undiscriminated-unions/no-custom-config/internal/retrier_test.go
@@ -295,7 +295,50 @@ func TestRetryWithRequestBody(t *testing.T) {
 	assert.Equal(t, expectedBody, requestBodies[1], "Second request body should match expected (retry should re-send body)")
 }
 
+// An explicit cancel (e.g. Ctrl-C wired to cancel()) must interrupt the backoff
+// wait. There is no deadline here, so the retrier cannot know the wait is futile
+// up front -- it has to be woken by the context.
 func TestRetryWaitIsInterruptedByContext(t *testing.T) {
+	var requestCount int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		w.Header().Set("Retry-After", "5")
+		w.WriteHeader(http.StatusTooManyRequests)
+	}))
+	defer server.Close()
+
+	caller := NewCaller(&CallerParams{
+		Client: server.Client(),
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		time.Sleep(100 * time.Millisecond)
+		cancel()
+	}()
+	defer cancel()
+
+	start := time.Now()
+	_, err := caller.Call(
+		ctx,
+		&CallParams{
+			URL:         server.URL,
+			Method:      http.MethodGet,
+			Request:     &InternalTestRequest{},
+			MaxAttempts: 3,
+		},
+	)
+	elapsed := time.Since(start)
+
+	assert.ErrorIs(t, err, context.Canceled)
+	assert.Equal(t, 1, requestCount, "Expected the retry to be abandoned once the context was cancelled")
+	assert.Less(t, elapsed, time.Second, "Expected the backoff to be interrupted by the context, took %v", elapsed)
+}
+
+// When the caller's deadline would elapse before the backoff finishes, sleeping
+// only guarantees a context error. Return the response instead so the caller
+// learns why the request actually failed.
+func TestRetryReturnsResponseWhenDeadlineShorterThanBackoff(t *testing.T) {
 	var requestCount int
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		requestCount++
@@ -323,9 +366,50 @@ func TestRetryWaitIsInterruptedByContext(t *testing.T) {
 	)
 	elapsed := time.Since(start)
 
-	assert.ErrorIs(t, err, context.DeadlineExceeded)
-	assert.Equal(t, 1, requestCount, "Expected the retry to be abandoned once the context expired")
-	assert.Less(t, elapsed, time.Second, "Expected the backoff to be interrupted by the context, took %v", elapsed)
+	// The caller gets the 429, not context.DeadlineExceeded.
+	var apiError *core.APIError
+	require.ErrorAs(t, err, &apiError)
+	assert.Equal(t, http.StatusTooManyRequests, apiError.StatusCode)
+	assert.NotErrorIs(t, err, context.DeadlineExceeded)
+	assert.Equal(t, 1, requestCount, "Expected no retry once the deadline was known to be too short")
+	assert.Less(t, elapsed, time.Second, "Expected to return immediately rather than sleep, took %v", elapsed)
+}
+
+// A deadline with room for the backoff must still retry as normal.
+func TestRetryProceedsWhenDeadlineLongerThanBackoff(t *testing.T) {
+	var requestCount int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		if requestCount == 1 {
+			w.Header().Set("Retry-After", "1")
+			w.WriteHeader(http.StatusTooManyRequests)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("{}"))
+	}))
+	defer server.Close()
+
+	caller := NewCaller(&CallerParams{
+		Client: server.Client(),
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	_, err := caller.Call(
+		ctx,
+		&CallParams{
+			URL:         server.URL,
+			Method:      http.MethodGet,
+			Request:     &InternalTestRequest{},
+			Response:    &InternalTestResponse{},
+			MaxAttempts: 3,
+		},
+	)
+
+	assert.NoError(t, err)
+	assert.Equal(t, 2, requestCount, "Expected the retry to proceed when the deadline allows it")
 }
 
 func TestDisableRetries(t *testing.T) {

--- a/seed/go-sdk/undiscriminated-unions/v0/internal/retrier.go
+++ b/seed/go-sdk/undiscriminated-unions/v0/internal/retrier.go
@@ -145,12 +145,20 @@ func (r *Retrier) run(
 	}
 
 	if r.shouldRetry(response) {
-		defer func() { _ = response.Body.Close() }()
-
 		delay, err := r.retryDelay(response, retryAttempt)
 		if err != nil {
+			_ = response.Body.Close()
 			return nil, err
 		}
+
+		// If the context's deadline would elapse before the backoff completes, return
+		// the response instead of sleeping through it. The caller then sees why the
+		// request actually failed (e.g. a 429) rather than a context deadline error.
+		if deadline, ok := request.Context().Deadline(); ok && time.Until(deadline) < delay {
+			return response, nil
+		}
+
+		defer func() { _ = response.Body.Close() }()
 
 		if err := sleepWithContext(request.Context(), delay); err != nil {
 			return nil, err

--- a/seed/go-sdk/undiscriminated-unions/v0/internal/retrier_test.go
+++ b/seed/go-sdk/undiscriminated-unions/v0/internal/retrier_test.go
@@ -295,7 +295,50 @@ func TestRetryWithRequestBody(t *testing.T) {
 	assert.Equal(t, expectedBody, requestBodies[1], "Second request body should match expected (retry should re-send body)")
 }
 
+// An explicit cancel (e.g. Ctrl-C wired to cancel()) must interrupt the backoff
+// wait. There is no deadline here, so the retrier cannot know the wait is futile
+// up front -- it has to be woken by the context.
 func TestRetryWaitIsInterruptedByContext(t *testing.T) {
+	var requestCount int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		w.Header().Set("Retry-After", "5")
+		w.WriteHeader(http.StatusTooManyRequests)
+	}))
+	defer server.Close()
+
+	caller := NewCaller(&CallerParams{
+		Client: server.Client(),
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		time.Sleep(100 * time.Millisecond)
+		cancel()
+	}()
+	defer cancel()
+
+	start := time.Now()
+	_, err := caller.Call(
+		ctx,
+		&CallParams{
+			URL:         server.URL,
+			Method:      http.MethodGet,
+			Request:     &InternalTestRequest{},
+			MaxAttempts: 3,
+		},
+	)
+	elapsed := time.Since(start)
+
+	assert.ErrorIs(t, err, context.Canceled)
+	assert.Equal(t, 1, requestCount, "Expected the retry to be abandoned once the context was cancelled")
+	assert.Less(t, elapsed, time.Second, "Expected the backoff to be interrupted by the context, took %v", elapsed)
+}
+
+// When the caller's deadline would elapse before the backoff finishes, sleeping
+// only guarantees a context error. Return the response instead so the caller
+// learns why the request actually failed.
+func TestRetryReturnsResponseWhenDeadlineShorterThanBackoff(t *testing.T) {
 	var requestCount int
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		requestCount++
@@ -323,9 +366,50 @@ func TestRetryWaitIsInterruptedByContext(t *testing.T) {
 	)
 	elapsed := time.Since(start)
 
-	assert.ErrorIs(t, err, context.DeadlineExceeded)
-	assert.Equal(t, 1, requestCount, "Expected the retry to be abandoned once the context expired")
-	assert.Less(t, elapsed, time.Second, "Expected the backoff to be interrupted by the context, took %v", elapsed)
+	// The caller gets the 429, not context.DeadlineExceeded.
+	var apiError *core.APIError
+	require.ErrorAs(t, err, &apiError)
+	assert.Equal(t, http.StatusTooManyRequests, apiError.StatusCode)
+	assert.NotErrorIs(t, err, context.DeadlineExceeded)
+	assert.Equal(t, 1, requestCount, "Expected no retry once the deadline was known to be too short")
+	assert.Less(t, elapsed, time.Second, "Expected to return immediately rather than sleep, took %v", elapsed)
+}
+
+// A deadline with room for the backoff must still retry as normal.
+func TestRetryProceedsWhenDeadlineLongerThanBackoff(t *testing.T) {
+	var requestCount int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		if requestCount == 1 {
+			w.Header().Set("Retry-After", "1")
+			w.WriteHeader(http.StatusTooManyRequests)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("{}"))
+	}))
+	defer server.Close()
+
+	caller := NewCaller(&CallerParams{
+		Client: server.Client(),
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	_, err := caller.Call(
+		ctx,
+		&CallParams{
+			URL:         server.URL,
+			Method:      http.MethodGet,
+			Request:     &InternalTestRequest{},
+			Response:    &InternalTestResponse{},
+			MaxAttempts: 3,
+		},
+	)
+
+	assert.NoError(t, err)
+	assert.Equal(t, 2, requestCount, "Expected the retry to proceed when the deadline allows it")
 }
 
 func TestDisableRetries(t *testing.T) {

--- a/seed/go-sdk/union-query-parameters/internal/retrier.go
+++ b/seed/go-sdk/union-query-parameters/internal/retrier.go
@@ -145,12 +145,20 @@ func (r *Retrier) run(
 	}
 
 	if r.shouldRetry(response) {
-		defer func() { _ = response.Body.Close() }()
-
 		delay, err := r.retryDelay(response, retryAttempt)
 		if err != nil {
+			_ = response.Body.Close()
 			return nil, err
 		}
+
+		// If the context's deadline would elapse before the backoff completes, return
+		// the response instead of sleeping through it. The caller then sees why the
+		// request actually failed (e.g. a 429) rather than a context deadline error.
+		if deadline, ok := request.Context().Deadline(); ok && time.Until(deadline) < delay {
+			return response, nil
+		}
+
+		defer func() { _ = response.Body.Close() }()
 
 		if err := sleepWithContext(request.Context(), delay); err != nil {
 			return nil, err

--- a/seed/go-sdk/union-query-parameters/internal/retrier_test.go
+++ b/seed/go-sdk/union-query-parameters/internal/retrier_test.go
@@ -295,7 +295,50 @@ func TestRetryWithRequestBody(t *testing.T) {
 	assert.Equal(t, expectedBody, requestBodies[1], "Second request body should match expected (retry should re-send body)")
 }
 
+// An explicit cancel (e.g. Ctrl-C wired to cancel()) must interrupt the backoff
+// wait. There is no deadline here, so the retrier cannot know the wait is futile
+// up front -- it has to be woken by the context.
 func TestRetryWaitIsInterruptedByContext(t *testing.T) {
+	var requestCount int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		w.Header().Set("Retry-After", "5")
+		w.WriteHeader(http.StatusTooManyRequests)
+	}))
+	defer server.Close()
+
+	caller := NewCaller(&CallerParams{
+		Client: server.Client(),
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		time.Sleep(100 * time.Millisecond)
+		cancel()
+	}()
+	defer cancel()
+
+	start := time.Now()
+	_, err := caller.Call(
+		ctx,
+		&CallParams{
+			URL:         server.URL,
+			Method:      http.MethodGet,
+			Request:     &InternalTestRequest{},
+			MaxAttempts: 3,
+		},
+	)
+	elapsed := time.Since(start)
+
+	assert.ErrorIs(t, err, context.Canceled)
+	assert.Equal(t, 1, requestCount, "Expected the retry to be abandoned once the context was cancelled")
+	assert.Less(t, elapsed, time.Second, "Expected the backoff to be interrupted by the context, took %v", elapsed)
+}
+
+// When the caller's deadline would elapse before the backoff finishes, sleeping
+// only guarantees a context error. Return the response instead so the caller
+// learns why the request actually failed.
+func TestRetryReturnsResponseWhenDeadlineShorterThanBackoff(t *testing.T) {
 	var requestCount int
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		requestCount++
@@ -323,9 +366,50 @@ func TestRetryWaitIsInterruptedByContext(t *testing.T) {
 	)
 	elapsed := time.Since(start)
 
-	assert.ErrorIs(t, err, context.DeadlineExceeded)
-	assert.Equal(t, 1, requestCount, "Expected the retry to be abandoned once the context expired")
-	assert.Less(t, elapsed, time.Second, "Expected the backoff to be interrupted by the context, took %v", elapsed)
+	// The caller gets the 429, not context.DeadlineExceeded.
+	var apiError *core.APIError
+	require.ErrorAs(t, err, &apiError)
+	assert.Equal(t, http.StatusTooManyRequests, apiError.StatusCode)
+	assert.NotErrorIs(t, err, context.DeadlineExceeded)
+	assert.Equal(t, 1, requestCount, "Expected no retry once the deadline was known to be too short")
+	assert.Less(t, elapsed, time.Second, "Expected to return immediately rather than sleep, took %v", elapsed)
+}
+
+// A deadline with room for the backoff must still retry as normal.
+func TestRetryProceedsWhenDeadlineLongerThanBackoff(t *testing.T) {
+	var requestCount int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		if requestCount == 1 {
+			w.Header().Set("Retry-After", "1")
+			w.WriteHeader(http.StatusTooManyRequests)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("{}"))
+	}))
+	defer server.Close()
+
+	caller := NewCaller(&CallerParams{
+		Client: server.Client(),
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	_, err := caller.Call(
+		ctx,
+		&CallParams{
+			URL:         server.URL,
+			Method:      http.MethodGet,
+			Request:     &InternalTestRequest{},
+			Response:    &InternalTestResponse{},
+			MaxAttempts: 3,
+		},
+	)
+
+	assert.NoError(t, err)
+	assert.Equal(t, 2, requestCount, "Expected the retry to proceed when the deadline allows it")
 }
 
 func TestDisableRetries(t *testing.T) {

--- a/seed/go-sdk/unions-with-local-date/internal/retrier.go
+++ b/seed/go-sdk/unions-with-local-date/internal/retrier.go
@@ -145,12 +145,20 @@ func (r *Retrier) run(
 	}
 
 	if r.shouldRetry(response) {
-		defer func() { _ = response.Body.Close() }()
-
 		delay, err := r.retryDelay(response, retryAttempt)
 		if err != nil {
+			_ = response.Body.Close()
 			return nil, err
 		}
+
+		// If the context's deadline would elapse before the backoff completes, return
+		// the response instead of sleeping through it. The caller then sees why the
+		// request actually failed (e.g. a 429) rather than a context deadline error.
+		if deadline, ok := request.Context().Deadline(); ok && time.Until(deadline) < delay {
+			return response, nil
+		}
+
+		defer func() { _ = response.Body.Close() }()
 
 		if err := sleepWithContext(request.Context(), delay); err != nil {
 			return nil, err

--- a/seed/go-sdk/unions-with-local-date/internal/retrier_test.go
+++ b/seed/go-sdk/unions-with-local-date/internal/retrier_test.go
@@ -295,7 +295,50 @@ func TestRetryWithRequestBody(t *testing.T) {
 	assert.Equal(t, expectedBody, requestBodies[1], "Second request body should match expected (retry should re-send body)")
 }
 
+// An explicit cancel (e.g. Ctrl-C wired to cancel()) must interrupt the backoff
+// wait. There is no deadline here, so the retrier cannot know the wait is futile
+// up front -- it has to be woken by the context.
 func TestRetryWaitIsInterruptedByContext(t *testing.T) {
+	var requestCount int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		w.Header().Set("Retry-After", "5")
+		w.WriteHeader(http.StatusTooManyRequests)
+	}))
+	defer server.Close()
+
+	caller := NewCaller(&CallerParams{
+		Client: server.Client(),
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		time.Sleep(100 * time.Millisecond)
+		cancel()
+	}()
+	defer cancel()
+
+	start := time.Now()
+	_, err := caller.Call(
+		ctx,
+		&CallParams{
+			URL:         server.URL,
+			Method:      http.MethodGet,
+			Request:     &InternalTestRequest{},
+			MaxAttempts: 3,
+		},
+	)
+	elapsed := time.Since(start)
+
+	assert.ErrorIs(t, err, context.Canceled)
+	assert.Equal(t, 1, requestCount, "Expected the retry to be abandoned once the context was cancelled")
+	assert.Less(t, elapsed, time.Second, "Expected the backoff to be interrupted by the context, took %v", elapsed)
+}
+
+// When the caller's deadline would elapse before the backoff finishes, sleeping
+// only guarantees a context error. Return the response instead so the caller
+// learns why the request actually failed.
+func TestRetryReturnsResponseWhenDeadlineShorterThanBackoff(t *testing.T) {
 	var requestCount int
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		requestCount++
@@ -323,9 +366,50 @@ func TestRetryWaitIsInterruptedByContext(t *testing.T) {
 	)
 	elapsed := time.Since(start)
 
-	assert.ErrorIs(t, err, context.DeadlineExceeded)
-	assert.Equal(t, 1, requestCount, "Expected the retry to be abandoned once the context expired")
-	assert.Less(t, elapsed, time.Second, "Expected the backoff to be interrupted by the context, took %v", elapsed)
+	// The caller gets the 429, not context.DeadlineExceeded.
+	var apiError *core.APIError
+	require.ErrorAs(t, err, &apiError)
+	assert.Equal(t, http.StatusTooManyRequests, apiError.StatusCode)
+	assert.NotErrorIs(t, err, context.DeadlineExceeded)
+	assert.Equal(t, 1, requestCount, "Expected no retry once the deadline was known to be too short")
+	assert.Less(t, elapsed, time.Second, "Expected to return immediately rather than sleep, took %v", elapsed)
+}
+
+// A deadline with room for the backoff must still retry as normal.
+func TestRetryProceedsWhenDeadlineLongerThanBackoff(t *testing.T) {
+	var requestCount int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		if requestCount == 1 {
+			w.Header().Set("Retry-After", "1")
+			w.WriteHeader(http.StatusTooManyRequests)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("{}"))
+	}))
+	defer server.Close()
+
+	caller := NewCaller(&CallerParams{
+		Client: server.Client(),
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	_, err := caller.Call(
+		ctx,
+		&CallParams{
+			URL:         server.URL,
+			Method:      http.MethodGet,
+			Request:     &InternalTestRequest{},
+			Response:    &InternalTestResponse{},
+			MaxAttempts: 3,
+		},
+	)
+
+	assert.NoError(t, err)
+	assert.Equal(t, 2, requestCount, "Expected the retry to proceed when the deadline allows it")
 }
 
 func TestDisableRetries(t *testing.T) {

--- a/seed/go-sdk/unions/no-custom-config/internal/retrier.go
+++ b/seed/go-sdk/unions/no-custom-config/internal/retrier.go
@@ -145,12 +145,20 @@ func (r *Retrier) run(
 	}
 
 	if r.shouldRetry(response) {
-		defer func() { _ = response.Body.Close() }()
-
 		delay, err := r.retryDelay(response, retryAttempt)
 		if err != nil {
+			_ = response.Body.Close()
 			return nil, err
 		}
+
+		// If the context's deadline would elapse before the backoff completes, return
+		// the response instead of sleeping through it. The caller then sees why the
+		// request actually failed (e.g. a 429) rather than a context deadline error.
+		if deadline, ok := request.Context().Deadline(); ok && time.Until(deadline) < delay {
+			return response, nil
+		}
+
+		defer func() { _ = response.Body.Close() }()
 
 		if err := sleepWithContext(request.Context(), delay); err != nil {
 			return nil, err

--- a/seed/go-sdk/unions/no-custom-config/internal/retrier_test.go
+++ b/seed/go-sdk/unions/no-custom-config/internal/retrier_test.go
@@ -295,7 +295,50 @@ func TestRetryWithRequestBody(t *testing.T) {
 	assert.Equal(t, expectedBody, requestBodies[1], "Second request body should match expected (retry should re-send body)")
 }
 
+// An explicit cancel (e.g. Ctrl-C wired to cancel()) must interrupt the backoff
+// wait. There is no deadline here, so the retrier cannot know the wait is futile
+// up front -- it has to be woken by the context.
 func TestRetryWaitIsInterruptedByContext(t *testing.T) {
+	var requestCount int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		w.Header().Set("Retry-After", "5")
+		w.WriteHeader(http.StatusTooManyRequests)
+	}))
+	defer server.Close()
+
+	caller := NewCaller(&CallerParams{
+		Client: server.Client(),
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		time.Sleep(100 * time.Millisecond)
+		cancel()
+	}()
+	defer cancel()
+
+	start := time.Now()
+	_, err := caller.Call(
+		ctx,
+		&CallParams{
+			URL:         server.URL,
+			Method:      http.MethodGet,
+			Request:     &InternalTestRequest{},
+			MaxAttempts: 3,
+		},
+	)
+	elapsed := time.Since(start)
+
+	assert.ErrorIs(t, err, context.Canceled)
+	assert.Equal(t, 1, requestCount, "Expected the retry to be abandoned once the context was cancelled")
+	assert.Less(t, elapsed, time.Second, "Expected the backoff to be interrupted by the context, took %v", elapsed)
+}
+
+// When the caller's deadline would elapse before the backoff finishes, sleeping
+// only guarantees a context error. Return the response instead so the caller
+// learns why the request actually failed.
+func TestRetryReturnsResponseWhenDeadlineShorterThanBackoff(t *testing.T) {
 	var requestCount int
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		requestCount++
@@ -323,9 +366,50 @@ func TestRetryWaitIsInterruptedByContext(t *testing.T) {
 	)
 	elapsed := time.Since(start)
 
-	assert.ErrorIs(t, err, context.DeadlineExceeded)
-	assert.Equal(t, 1, requestCount, "Expected the retry to be abandoned once the context expired")
-	assert.Less(t, elapsed, time.Second, "Expected the backoff to be interrupted by the context, took %v", elapsed)
+	// The caller gets the 429, not context.DeadlineExceeded.
+	var apiError *core.APIError
+	require.ErrorAs(t, err, &apiError)
+	assert.Equal(t, http.StatusTooManyRequests, apiError.StatusCode)
+	assert.NotErrorIs(t, err, context.DeadlineExceeded)
+	assert.Equal(t, 1, requestCount, "Expected no retry once the deadline was known to be too short")
+	assert.Less(t, elapsed, time.Second, "Expected to return immediately rather than sleep, took %v", elapsed)
+}
+
+// A deadline with room for the backoff must still retry as normal.
+func TestRetryProceedsWhenDeadlineLongerThanBackoff(t *testing.T) {
+	var requestCount int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		if requestCount == 1 {
+			w.Header().Set("Retry-After", "1")
+			w.WriteHeader(http.StatusTooManyRequests)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("{}"))
+	}))
+	defer server.Close()
+
+	caller := NewCaller(&CallerParams{
+		Client: server.Client(),
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	_, err := caller.Call(
+		ctx,
+		&CallParams{
+			URL:         server.URL,
+			Method:      http.MethodGet,
+			Request:     &InternalTestRequest{},
+			Response:    &InternalTestResponse{},
+			MaxAttempts: 3,
+		},
+	)
+
+	assert.NoError(t, err)
+	assert.Equal(t, 2, requestCount, "Expected the retry to proceed when the deadline allows it")
 }
 
 func TestDisableRetries(t *testing.T) {

--- a/seed/go-sdk/unions/package-name/internal/retrier.go
+++ b/seed/go-sdk/unions/package-name/internal/retrier.go
@@ -145,12 +145,20 @@ func (r *Retrier) run(
 	}
 
 	if r.shouldRetry(response) {
-		defer func() { _ = response.Body.Close() }()
-
 		delay, err := r.retryDelay(response, retryAttempt)
 		if err != nil {
+			_ = response.Body.Close()
 			return nil, err
 		}
+
+		// If the context's deadline would elapse before the backoff completes, return
+		// the response instead of sleeping through it. The caller then sees why the
+		// request actually failed (e.g. a 429) rather than a context deadline error.
+		if deadline, ok := request.Context().Deadline(); ok && time.Until(deadline) < delay {
+			return response, nil
+		}
+
+		defer func() { _ = response.Body.Close() }()
 
 		if err := sleepWithContext(request.Context(), delay); err != nil {
 			return nil, err

--- a/seed/go-sdk/unions/package-name/internal/retrier_test.go
+++ b/seed/go-sdk/unions/package-name/internal/retrier_test.go
@@ -295,7 +295,50 @@ func TestRetryWithRequestBody(t *testing.T) {
 	assert.Equal(t, expectedBody, requestBodies[1], "Second request body should match expected (retry should re-send body)")
 }
 
+// An explicit cancel (e.g. Ctrl-C wired to cancel()) must interrupt the backoff
+// wait. There is no deadline here, so the retrier cannot know the wait is futile
+// up front -- it has to be woken by the context.
 func TestRetryWaitIsInterruptedByContext(t *testing.T) {
+	var requestCount int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		w.Header().Set("Retry-After", "5")
+		w.WriteHeader(http.StatusTooManyRequests)
+	}))
+	defer server.Close()
+
+	caller := NewCaller(&CallerParams{
+		Client: server.Client(),
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		time.Sleep(100 * time.Millisecond)
+		cancel()
+	}()
+	defer cancel()
+
+	start := time.Now()
+	_, err := caller.Call(
+		ctx,
+		&CallParams{
+			URL:         server.URL,
+			Method:      http.MethodGet,
+			Request:     &InternalTestRequest{},
+			MaxAttempts: 3,
+		},
+	)
+	elapsed := time.Since(start)
+
+	assert.ErrorIs(t, err, context.Canceled)
+	assert.Equal(t, 1, requestCount, "Expected the retry to be abandoned once the context was cancelled")
+	assert.Less(t, elapsed, time.Second, "Expected the backoff to be interrupted by the context, took %v", elapsed)
+}
+
+// When the caller's deadline would elapse before the backoff finishes, sleeping
+// only guarantees a context error. Return the response instead so the caller
+// learns why the request actually failed.
+func TestRetryReturnsResponseWhenDeadlineShorterThanBackoff(t *testing.T) {
 	var requestCount int
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		requestCount++
@@ -323,9 +366,50 @@ func TestRetryWaitIsInterruptedByContext(t *testing.T) {
 	)
 	elapsed := time.Since(start)
 
-	assert.ErrorIs(t, err, context.DeadlineExceeded)
-	assert.Equal(t, 1, requestCount, "Expected the retry to be abandoned once the context expired")
-	assert.Less(t, elapsed, time.Second, "Expected the backoff to be interrupted by the context, took %v", elapsed)
+	// The caller gets the 429, not context.DeadlineExceeded.
+	var apiError *core.APIError
+	require.ErrorAs(t, err, &apiError)
+	assert.Equal(t, http.StatusTooManyRequests, apiError.StatusCode)
+	assert.NotErrorIs(t, err, context.DeadlineExceeded)
+	assert.Equal(t, 1, requestCount, "Expected no retry once the deadline was known to be too short")
+	assert.Less(t, elapsed, time.Second, "Expected to return immediately rather than sleep, took %v", elapsed)
+}
+
+// A deadline with room for the backoff must still retry as normal.
+func TestRetryProceedsWhenDeadlineLongerThanBackoff(t *testing.T) {
+	var requestCount int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		if requestCount == 1 {
+			w.Header().Set("Retry-After", "1")
+			w.WriteHeader(http.StatusTooManyRequests)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("{}"))
+	}))
+	defer server.Close()
+
+	caller := NewCaller(&CallerParams{
+		Client: server.Client(),
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	_, err := caller.Call(
+		ctx,
+		&CallParams{
+			URL:         server.URL,
+			Method:      http.MethodGet,
+			Request:     &InternalTestRequest{},
+			Response:    &InternalTestResponse{},
+			MaxAttempts: 3,
+		},
+	)
+
+	assert.NoError(t, err)
+	assert.Equal(t, 2, requestCount, "Expected the retry to proceed when the deadline allows it")
 }
 
 func TestDisableRetries(t *testing.T) {

--- a/seed/go-sdk/unions/v0/internal/retrier.go
+++ b/seed/go-sdk/unions/v0/internal/retrier.go
@@ -145,12 +145,20 @@ func (r *Retrier) run(
 	}
 
 	if r.shouldRetry(response) {
-		defer func() { _ = response.Body.Close() }()
-
 		delay, err := r.retryDelay(response, retryAttempt)
 		if err != nil {
+			_ = response.Body.Close()
 			return nil, err
 		}
+
+		// If the context's deadline would elapse before the backoff completes, return
+		// the response instead of sleeping through it. The caller then sees why the
+		// request actually failed (e.g. a 429) rather than a context deadline error.
+		if deadline, ok := request.Context().Deadline(); ok && time.Until(deadline) < delay {
+			return response, nil
+		}
+
+		defer func() { _ = response.Body.Close() }()
 
 		if err := sleepWithContext(request.Context(), delay); err != nil {
 			return nil, err

--- a/seed/go-sdk/unions/v0/internal/retrier_test.go
+++ b/seed/go-sdk/unions/v0/internal/retrier_test.go
@@ -295,7 +295,50 @@ func TestRetryWithRequestBody(t *testing.T) {
 	assert.Equal(t, expectedBody, requestBodies[1], "Second request body should match expected (retry should re-send body)")
 }
 
+// An explicit cancel (e.g. Ctrl-C wired to cancel()) must interrupt the backoff
+// wait. There is no deadline here, so the retrier cannot know the wait is futile
+// up front -- it has to be woken by the context.
 func TestRetryWaitIsInterruptedByContext(t *testing.T) {
+	var requestCount int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		w.Header().Set("Retry-After", "5")
+		w.WriteHeader(http.StatusTooManyRequests)
+	}))
+	defer server.Close()
+
+	caller := NewCaller(&CallerParams{
+		Client: server.Client(),
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		time.Sleep(100 * time.Millisecond)
+		cancel()
+	}()
+	defer cancel()
+
+	start := time.Now()
+	_, err := caller.Call(
+		ctx,
+		&CallParams{
+			URL:         server.URL,
+			Method:      http.MethodGet,
+			Request:     &InternalTestRequest{},
+			MaxAttempts: 3,
+		},
+	)
+	elapsed := time.Since(start)
+
+	assert.ErrorIs(t, err, context.Canceled)
+	assert.Equal(t, 1, requestCount, "Expected the retry to be abandoned once the context was cancelled")
+	assert.Less(t, elapsed, time.Second, "Expected the backoff to be interrupted by the context, took %v", elapsed)
+}
+
+// When the caller's deadline would elapse before the backoff finishes, sleeping
+// only guarantees a context error. Return the response instead so the caller
+// learns why the request actually failed.
+func TestRetryReturnsResponseWhenDeadlineShorterThanBackoff(t *testing.T) {
 	var requestCount int
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		requestCount++
@@ -323,9 +366,50 @@ func TestRetryWaitIsInterruptedByContext(t *testing.T) {
 	)
 	elapsed := time.Since(start)
 
-	assert.ErrorIs(t, err, context.DeadlineExceeded)
-	assert.Equal(t, 1, requestCount, "Expected the retry to be abandoned once the context expired")
-	assert.Less(t, elapsed, time.Second, "Expected the backoff to be interrupted by the context, took %v", elapsed)
+	// The caller gets the 429, not context.DeadlineExceeded.
+	var apiError *core.APIError
+	require.ErrorAs(t, err, &apiError)
+	assert.Equal(t, http.StatusTooManyRequests, apiError.StatusCode)
+	assert.NotErrorIs(t, err, context.DeadlineExceeded)
+	assert.Equal(t, 1, requestCount, "Expected no retry once the deadline was known to be too short")
+	assert.Less(t, elapsed, time.Second, "Expected to return immediately rather than sleep, took %v", elapsed)
+}
+
+// A deadline with room for the backoff must still retry as normal.
+func TestRetryProceedsWhenDeadlineLongerThanBackoff(t *testing.T) {
+	var requestCount int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		if requestCount == 1 {
+			w.Header().Set("Retry-After", "1")
+			w.WriteHeader(http.StatusTooManyRequests)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("{}"))
+	}))
+	defer server.Close()
+
+	caller := NewCaller(&CallerParams{
+		Client: server.Client(),
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	_, err := caller.Call(
+		ctx,
+		&CallParams{
+			URL:         server.URL,
+			Method:      http.MethodGet,
+			Request:     &InternalTestRequest{},
+			Response:    &InternalTestResponse{},
+			MaxAttempts: 3,
+		},
+	)
+
+	assert.NoError(t, err)
+	assert.Equal(t, 2, requestCount, "Expected the retry to proceed when the deadline allows it")
 }
 
 func TestDisableRetries(t *testing.T) {

--- a/seed/go-sdk/unknown/internal/retrier.go
+++ b/seed/go-sdk/unknown/internal/retrier.go
@@ -145,12 +145,20 @@ func (r *Retrier) run(
 	}
 
 	if r.shouldRetry(response) {
-		defer func() { _ = response.Body.Close() }()
-
 		delay, err := r.retryDelay(response, retryAttempt)
 		if err != nil {
+			_ = response.Body.Close()
 			return nil, err
 		}
+
+		// If the context's deadline would elapse before the backoff completes, return
+		// the response instead of sleeping through it. The caller then sees why the
+		// request actually failed (e.g. a 429) rather than a context deadline error.
+		if deadline, ok := request.Context().Deadline(); ok && time.Until(deadline) < delay {
+			return response, nil
+		}
+
+		defer func() { _ = response.Body.Close() }()
 
 		if err := sleepWithContext(request.Context(), delay); err != nil {
 			return nil, err

--- a/seed/go-sdk/unknown/internal/retrier_test.go
+++ b/seed/go-sdk/unknown/internal/retrier_test.go
@@ -295,7 +295,50 @@ func TestRetryWithRequestBody(t *testing.T) {
 	assert.Equal(t, expectedBody, requestBodies[1], "Second request body should match expected (retry should re-send body)")
 }
 
+// An explicit cancel (e.g. Ctrl-C wired to cancel()) must interrupt the backoff
+// wait. There is no deadline here, so the retrier cannot know the wait is futile
+// up front -- it has to be woken by the context.
 func TestRetryWaitIsInterruptedByContext(t *testing.T) {
+	var requestCount int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		w.Header().Set("Retry-After", "5")
+		w.WriteHeader(http.StatusTooManyRequests)
+	}))
+	defer server.Close()
+
+	caller := NewCaller(&CallerParams{
+		Client: server.Client(),
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		time.Sleep(100 * time.Millisecond)
+		cancel()
+	}()
+	defer cancel()
+
+	start := time.Now()
+	_, err := caller.Call(
+		ctx,
+		&CallParams{
+			URL:         server.URL,
+			Method:      http.MethodGet,
+			Request:     &InternalTestRequest{},
+			MaxAttempts: 3,
+		},
+	)
+	elapsed := time.Since(start)
+
+	assert.ErrorIs(t, err, context.Canceled)
+	assert.Equal(t, 1, requestCount, "Expected the retry to be abandoned once the context was cancelled")
+	assert.Less(t, elapsed, time.Second, "Expected the backoff to be interrupted by the context, took %v", elapsed)
+}
+
+// When the caller's deadline would elapse before the backoff finishes, sleeping
+// only guarantees a context error. Return the response instead so the caller
+// learns why the request actually failed.
+func TestRetryReturnsResponseWhenDeadlineShorterThanBackoff(t *testing.T) {
 	var requestCount int
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		requestCount++
@@ -323,9 +366,50 @@ func TestRetryWaitIsInterruptedByContext(t *testing.T) {
 	)
 	elapsed := time.Since(start)
 
-	assert.ErrorIs(t, err, context.DeadlineExceeded)
-	assert.Equal(t, 1, requestCount, "Expected the retry to be abandoned once the context expired")
-	assert.Less(t, elapsed, time.Second, "Expected the backoff to be interrupted by the context, took %v", elapsed)
+	// The caller gets the 429, not context.DeadlineExceeded.
+	var apiError *core.APIError
+	require.ErrorAs(t, err, &apiError)
+	assert.Equal(t, http.StatusTooManyRequests, apiError.StatusCode)
+	assert.NotErrorIs(t, err, context.DeadlineExceeded)
+	assert.Equal(t, 1, requestCount, "Expected no retry once the deadline was known to be too short")
+	assert.Less(t, elapsed, time.Second, "Expected to return immediately rather than sleep, took %v", elapsed)
+}
+
+// A deadline with room for the backoff must still retry as normal.
+func TestRetryProceedsWhenDeadlineLongerThanBackoff(t *testing.T) {
+	var requestCount int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		if requestCount == 1 {
+			w.Header().Set("Retry-After", "1")
+			w.WriteHeader(http.StatusTooManyRequests)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("{}"))
+	}))
+	defer server.Close()
+
+	caller := NewCaller(&CallerParams{
+		Client: server.Client(),
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	_, err := caller.Call(
+		ctx,
+		&CallParams{
+			URL:         server.URL,
+			Method:      http.MethodGet,
+			Request:     &InternalTestRequest{},
+			Response:    &InternalTestResponse{},
+			MaxAttempts: 3,
+		},
+	)
+
+	assert.NoError(t, err)
+	assert.Equal(t, 2, requestCount, "Expected the retry to proceed when the deadline allows it")
 }
 
 func TestDisableRetries(t *testing.T) {

--- a/seed/go-sdk/url-form-encoded/internal/retrier.go
+++ b/seed/go-sdk/url-form-encoded/internal/retrier.go
@@ -145,12 +145,20 @@ func (r *Retrier) run(
 	}
 
 	if r.shouldRetry(response) {
-		defer func() { _ = response.Body.Close() }()
-
 		delay, err := r.retryDelay(response, retryAttempt)
 		if err != nil {
+			_ = response.Body.Close()
 			return nil, err
 		}
+
+		// If the context's deadline would elapse before the backoff completes, return
+		// the response instead of sleeping through it. The caller then sees why the
+		// request actually failed (e.g. a 429) rather than a context deadline error.
+		if deadline, ok := request.Context().Deadline(); ok && time.Until(deadline) < delay {
+			return response, nil
+		}
+
+		defer func() { _ = response.Body.Close() }()
 
 		if err := sleepWithContext(request.Context(), delay); err != nil {
 			return nil, err

--- a/seed/go-sdk/url-form-encoded/internal/retrier_test.go
+++ b/seed/go-sdk/url-form-encoded/internal/retrier_test.go
@@ -295,7 +295,50 @@ func TestRetryWithRequestBody(t *testing.T) {
 	assert.Equal(t, expectedBody, requestBodies[1], "Second request body should match expected (retry should re-send body)")
 }
 
+// An explicit cancel (e.g. Ctrl-C wired to cancel()) must interrupt the backoff
+// wait. There is no deadline here, so the retrier cannot know the wait is futile
+// up front -- it has to be woken by the context.
 func TestRetryWaitIsInterruptedByContext(t *testing.T) {
+	var requestCount int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		w.Header().Set("Retry-After", "5")
+		w.WriteHeader(http.StatusTooManyRequests)
+	}))
+	defer server.Close()
+
+	caller := NewCaller(&CallerParams{
+		Client: server.Client(),
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		time.Sleep(100 * time.Millisecond)
+		cancel()
+	}()
+	defer cancel()
+
+	start := time.Now()
+	_, err := caller.Call(
+		ctx,
+		&CallParams{
+			URL:         server.URL,
+			Method:      http.MethodGet,
+			Request:     &InternalTestRequest{},
+			MaxAttempts: 3,
+		},
+	)
+	elapsed := time.Since(start)
+
+	assert.ErrorIs(t, err, context.Canceled)
+	assert.Equal(t, 1, requestCount, "Expected the retry to be abandoned once the context was cancelled")
+	assert.Less(t, elapsed, time.Second, "Expected the backoff to be interrupted by the context, took %v", elapsed)
+}
+
+// When the caller's deadline would elapse before the backoff finishes, sleeping
+// only guarantees a context error. Return the response instead so the caller
+// learns why the request actually failed.
+func TestRetryReturnsResponseWhenDeadlineShorterThanBackoff(t *testing.T) {
 	var requestCount int
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		requestCount++
@@ -323,9 +366,50 @@ func TestRetryWaitIsInterruptedByContext(t *testing.T) {
 	)
 	elapsed := time.Since(start)
 
-	assert.ErrorIs(t, err, context.DeadlineExceeded)
-	assert.Equal(t, 1, requestCount, "Expected the retry to be abandoned once the context expired")
-	assert.Less(t, elapsed, time.Second, "Expected the backoff to be interrupted by the context, took %v", elapsed)
+	// The caller gets the 429, not context.DeadlineExceeded.
+	var apiError *core.APIError
+	require.ErrorAs(t, err, &apiError)
+	assert.Equal(t, http.StatusTooManyRequests, apiError.StatusCode)
+	assert.NotErrorIs(t, err, context.DeadlineExceeded)
+	assert.Equal(t, 1, requestCount, "Expected no retry once the deadline was known to be too short")
+	assert.Less(t, elapsed, time.Second, "Expected to return immediately rather than sleep, took %v", elapsed)
+}
+
+// A deadline with room for the backoff must still retry as normal.
+func TestRetryProceedsWhenDeadlineLongerThanBackoff(t *testing.T) {
+	var requestCount int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		if requestCount == 1 {
+			w.Header().Set("Retry-After", "1")
+			w.WriteHeader(http.StatusTooManyRequests)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("{}"))
+	}))
+	defer server.Close()
+
+	caller := NewCaller(&CallerParams{
+		Client: server.Client(),
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	_, err := caller.Call(
+		ctx,
+		&CallParams{
+			URL:         server.URL,
+			Method:      http.MethodGet,
+			Request:     &InternalTestRequest{},
+			Response:    &InternalTestResponse{},
+			MaxAttempts: 3,
+		},
+	)
+
+	assert.NoError(t, err)
+	assert.Equal(t, 2, requestCount, "Expected the retry to proceed when the deadline allows it")
 }
 
 func TestDisableRetries(t *testing.T) {

--- a/seed/go-sdk/validation/internal/retrier.go
+++ b/seed/go-sdk/validation/internal/retrier.go
@@ -145,12 +145,20 @@ func (r *Retrier) run(
 	}
 
 	if r.shouldRetry(response) {
-		defer func() { _ = response.Body.Close() }()
-
 		delay, err := r.retryDelay(response, retryAttempt)
 		if err != nil {
+			_ = response.Body.Close()
 			return nil, err
 		}
+
+		// If the context's deadline would elapse before the backoff completes, return
+		// the response instead of sleeping through it. The caller then sees why the
+		// request actually failed (e.g. a 429) rather than a context deadline error.
+		if deadline, ok := request.Context().Deadline(); ok && time.Until(deadline) < delay {
+			return response, nil
+		}
+
+		defer func() { _ = response.Body.Close() }()
 
 		if err := sleepWithContext(request.Context(), delay); err != nil {
 			return nil, err

--- a/seed/go-sdk/validation/internal/retrier_test.go
+++ b/seed/go-sdk/validation/internal/retrier_test.go
@@ -295,7 +295,50 @@ func TestRetryWithRequestBody(t *testing.T) {
 	assert.Equal(t, expectedBody, requestBodies[1], "Second request body should match expected (retry should re-send body)")
 }
 
+// An explicit cancel (e.g. Ctrl-C wired to cancel()) must interrupt the backoff
+// wait. There is no deadline here, so the retrier cannot know the wait is futile
+// up front -- it has to be woken by the context.
 func TestRetryWaitIsInterruptedByContext(t *testing.T) {
+	var requestCount int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		w.Header().Set("Retry-After", "5")
+		w.WriteHeader(http.StatusTooManyRequests)
+	}))
+	defer server.Close()
+
+	caller := NewCaller(&CallerParams{
+		Client: server.Client(),
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		time.Sleep(100 * time.Millisecond)
+		cancel()
+	}()
+	defer cancel()
+
+	start := time.Now()
+	_, err := caller.Call(
+		ctx,
+		&CallParams{
+			URL:         server.URL,
+			Method:      http.MethodGet,
+			Request:     &InternalTestRequest{},
+			MaxAttempts: 3,
+		},
+	)
+	elapsed := time.Since(start)
+
+	assert.ErrorIs(t, err, context.Canceled)
+	assert.Equal(t, 1, requestCount, "Expected the retry to be abandoned once the context was cancelled")
+	assert.Less(t, elapsed, time.Second, "Expected the backoff to be interrupted by the context, took %v", elapsed)
+}
+
+// When the caller's deadline would elapse before the backoff finishes, sleeping
+// only guarantees a context error. Return the response instead so the caller
+// learns why the request actually failed.
+func TestRetryReturnsResponseWhenDeadlineShorterThanBackoff(t *testing.T) {
 	var requestCount int
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		requestCount++
@@ -323,9 +366,50 @@ func TestRetryWaitIsInterruptedByContext(t *testing.T) {
 	)
 	elapsed := time.Since(start)
 
-	assert.ErrorIs(t, err, context.DeadlineExceeded)
-	assert.Equal(t, 1, requestCount, "Expected the retry to be abandoned once the context expired")
-	assert.Less(t, elapsed, time.Second, "Expected the backoff to be interrupted by the context, took %v", elapsed)
+	// The caller gets the 429, not context.DeadlineExceeded.
+	var apiError *core.APIError
+	require.ErrorAs(t, err, &apiError)
+	assert.Equal(t, http.StatusTooManyRequests, apiError.StatusCode)
+	assert.NotErrorIs(t, err, context.DeadlineExceeded)
+	assert.Equal(t, 1, requestCount, "Expected no retry once the deadline was known to be too short")
+	assert.Less(t, elapsed, time.Second, "Expected to return immediately rather than sleep, took %v", elapsed)
+}
+
+// A deadline with room for the backoff must still retry as normal.
+func TestRetryProceedsWhenDeadlineLongerThanBackoff(t *testing.T) {
+	var requestCount int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		if requestCount == 1 {
+			w.Header().Set("Retry-After", "1")
+			w.WriteHeader(http.StatusTooManyRequests)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("{}"))
+	}))
+	defer server.Close()
+
+	caller := NewCaller(&CallerParams{
+		Client: server.Client(),
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	_, err := caller.Call(
+		ctx,
+		&CallParams{
+			URL:         server.URL,
+			Method:      http.MethodGet,
+			Request:     &InternalTestRequest{},
+			Response:    &InternalTestResponse{},
+			MaxAttempts: 3,
+		},
+	)
+
+	assert.NoError(t, err)
+	assert.Equal(t, 2, requestCount, "Expected the retry to proceed when the deadline allows it")
 }
 
 func TestDisableRetries(t *testing.T) {

--- a/seed/go-sdk/variables/internal/retrier.go
+++ b/seed/go-sdk/variables/internal/retrier.go
@@ -145,12 +145,20 @@ func (r *Retrier) run(
 	}
 
 	if r.shouldRetry(response) {
-		defer func() { _ = response.Body.Close() }()
-
 		delay, err := r.retryDelay(response, retryAttempt)
 		if err != nil {
+			_ = response.Body.Close()
 			return nil, err
 		}
+
+		// If the context's deadline would elapse before the backoff completes, return
+		// the response instead of sleeping through it. The caller then sees why the
+		// request actually failed (e.g. a 429) rather than a context deadline error.
+		if deadline, ok := request.Context().Deadline(); ok && time.Until(deadline) < delay {
+			return response, nil
+		}
+
+		defer func() { _ = response.Body.Close() }()
 
 		if err := sleepWithContext(request.Context(), delay); err != nil {
 			return nil, err

--- a/seed/go-sdk/variables/internal/retrier_test.go
+++ b/seed/go-sdk/variables/internal/retrier_test.go
@@ -295,7 +295,50 @@ func TestRetryWithRequestBody(t *testing.T) {
 	assert.Equal(t, expectedBody, requestBodies[1], "Second request body should match expected (retry should re-send body)")
 }
 
+// An explicit cancel (e.g. Ctrl-C wired to cancel()) must interrupt the backoff
+// wait. There is no deadline here, so the retrier cannot know the wait is futile
+// up front -- it has to be woken by the context.
 func TestRetryWaitIsInterruptedByContext(t *testing.T) {
+	var requestCount int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		w.Header().Set("Retry-After", "5")
+		w.WriteHeader(http.StatusTooManyRequests)
+	}))
+	defer server.Close()
+
+	caller := NewCaller(&CallerParams{
+		Client: server.Client(),
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		time.Sleep(100 * time.Millisecond)
+		cancel()
+	}()
+	defer cancel()
+
+	start := time.Now()
+	_, err := caller.Call(
+		ctx,
+		&CallParams{
+			URL:         server.URL,
+			Method:      http.MethodGet,
+			Request:     &InternalTestRequest{},
+			MaxAttempts: 3,
+		},
+	)
+	elapsed := time.Since(start)
+
+	assert.ErrorIs(t, err, context.Canceled)
+	assert.Equal(t, 1, requestCount, "Expected the retry to be abandoned once the context was cancelled")
+	assert.Less(t, elapsed, time.Second, "Expected the backoff to be interrupted by the context, took %v", elapsed)
+}
+
+// When the caller's deadline would elapse before the backoff finishes, sleeping
+// only guarantees a context error. Return the response instead so the caller
+// learns why the request actually failed.
+func TestRetryReturnsResponseWhenDeadlineShorterThanBackoff(t *testing.T) {
 	var requestCount int
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		requestCount++
@@ -323,9 +366,50 @@ func TestRetryWaitIsInterruptedByContext(t *testing.T) {
 	)
 	elapsed := time.Since(start)
 
-	assert.ErrorIs(t, err, context.DeadlineExceeded)
-	assert.Equal(t, 1, requestCount, "Expected the retry to be abandoned once the context expired")
-	assert.Less(t, elapsed, time.Second, "Expected the backoff to be interrupted by the context, took %v", elapsed)
+	// The caller gets the 429, not context.DeadlineExceeded.
+	var apiError *core.APIError
+	require.ErrorAs(t, err, &apiError)
+	assert.Equal(t, http.StatusTooManyRequests, apiError.StatusCode)
+	assert.NotErrorIs(t, err, context.DeadlineExceeded)
+	assert.Equal(t, 1, requestCount, "Expected no retry once the deadline was known to be too short")
+	assert.Less(t, elapsed, time.Second, "Expected to return immediately rather than sleep, took %v", elapsed)
+}
+
+// A deadline with room for the backoff must still retry as normal.
+func TestRetryProceedsWhenDeadlineLongerThanBackoff(t *testing.T) {
+	var requestCount int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		if requestCount == 1 {
+			w.Header().Set("Retry-After", "1")
+			w.WriteHeader(http.StatusTooManyRequests)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("{}"))
+	}))
+	defer server.Close()
+
+	caller := NewCaller(&CallerParams{
+		Client: server.Client(),
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	_, err := caller.Call(
+		ctx,
+		&CallParams{
+			URL:         server.URL,
+			Method:      http.MethodGet,
+			Request:     &InternalTestRequest{},
+			Response:    &InternalTestResponse{},
+			MaxAttempts: 3,
+		},
+	)
+
+	assert.NoError(t, err)
+	assert.Equal(t, 2, requestCount, "Expected the retry to proceed when the deadline allows it")
 }
 
 func TestDisableRetries(t *testing.T) {

--- a/seed/go-sdk/version-no-default/internal/retrier.go
+++ b/seed/go-sdk/version-no-default/internal/retrier.go
@@ -145,12 +145,20 @@ func (r *Retrier) run(
 	}
 
 	if r.shouldRetry(response) {
-		defer func() { _ = response.Body.Close() }()
-
 		delay, err := r.retryDelay(response, retryAttempt)
 		if err != nil {
+			_ = response.Body.Close()
 			return nil, err
 		}
+
+		// If the context's deadline would elapse before the backoff completes, return
+		// the response instead of sleeping through it. The caller then sees why the
+		// request actually failed (e.g. a 429) rather than a context deadline error.
+		if deadline, ok := request.Context().Deadline(); ok && time.Until(deadline) < delay {
+			return response, nil
+		}
+
+		defer func() { _ = response.Body.Close() }()
 
 		if err := sleepWithContext(request.Context(), delay); err != nil {
 			return nil, err

--- a/seed/go-sdk/version-no-default/internal/retrier_test.go
+++ b/seed/go-sdk/version-no-default/internal/retrier_test.go
@@ -295,7 +295,50 @@ func TestRetryWithRequestBody(t *testing.T) {
 	assert.Equal(t, expectedBody, requestBodies[1], "Second request body should match expected (retry should re-send body)")
 }
 
+// An explicit cancel (e.g. Ctrl-C wired to cancel()) must interrupt the backoff
+// wait. There is no deadline here, so the retrier cannot know the wait is futile
+// up front -- it has to be woken by the context.
 func TestRetryWaitIsInterruptedByContext(t *testing.T) {
+	var requestCount int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		w.Header().Set("Retry-After", "5")
+		w.WriteHeader(http.StatusTooManyRequests)
+	}))
+	defer server.Close()
+
+	caller := NewCaller(&CallerParams{
+		Client: server.Client(),
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		time.Sleep(100 * time.Millisecond)
+		cancel()
+	}()
+	defer cancel()
+
+	start := time.Now()
+	_, err := caller.Call(
+		ctx,
+		&CallParams{
+			URL:         server.URL,
+			Method:      http.MethodGet,
+			Request:     &InternalTestRequest{},
+			MaxAttempts: 3,
+		},
+	)
+	elapsed := time.Since(start)
+
+	assert.ErrorIs(t, err, context.Canceled)
+	assert.Equal(t, 1, requestCount, "Expected the retry to be abandoned once the context was cancelled")
+	assert.Less(t, elapsed, time.Second, "Expected the backoff to be interrupted by the context, took %v", elapsed)
+}
+
+// When the caller's deadline would elapse before the backoff finishes, sleeping
+// only guarantees a context error. Return the response instead so the caller
+// learns why the request actually failed.
+func TestRetryReturnsResponseWhenDeadlineShorterThanBackoff(t *testing.T) {
 	var requestCount int
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		requestCount++
@@ -323,9 +366,50 @@ func TestRetryWaitIsInterruptedByContext(t *testing.T) {
 	)
 	elapsed := time.Since(start)
 
-	assert.ErrorIs(t, err, context.DeadlineExceeded)
-	assert.Equal(t, 1, requestCount, "Expected the retry to be abandoned once the context expired")
-	assert.Less(t, elapsed, time.Second, "Expected the backoff to be interrupted by the context, took %v", elapsed)
+	// The caller gets the 429, not context.DeadlineExceeded.
+	var apiError *core.APIError
+	require.ErrorAs(t, err, &apiError)
+	assert.Equal(t, http.StatusTooManyRequests, apiError.StatusCode)
+	assert.NotErrorIs(t, err, context.DeadlineExceeded)
+	assert.Equal(t, 1, requestCount, "Expected no retry once the deadline was known to be too short")
+	assert.Less(t, elapsed, time.Second, "Expected to return immediately rather than sleep, took %v", elapsed)
+}
+
+// A deadline with room for the backoff must still retry as normal.
+func TestRetryProceedsWhenDeadlineLongerThanBackoff(t *testing.T) {
+	var requestCount int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		if requestCount == 1 {
+			w.Header().Set("Retry-After", "1")
+			w.WriteHeader(http.StatusTooManyRequests)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("{}"))
+	}))
+	defer server.Close()
+
+	caller := NewCaller(&CallerParams{
+		Client: server.Client(),
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	_, err := caller.Call(
+		ctx,
+		&CallParams{
+			URL:         server.URL,
+			Method:      http.MethodGet,
+			Request:     &InternalTestRequest{},
+			Response:    &InternalTestResponse{},
+			MaxAttempts: 3,
+		},
+	)
+
+	assert.NoError(t, err)
+	assert.Equal(t, 2, requestCount, "Expected the retry to proceed when the deadline allows it")
 }
 
 func TestDisableRetries(t *testing.T) {

--- a/seed/go-sdk/version/internal/retrier.go
+++ b/seed/go-sdk/version/internal/retrier.go
@@ -145,12 +145,20 @@ func (r *Retrier) run(
 	}
 
 	if r.shouldRetry(response) {
-		defer func() { _ = response.Body.Close() }()
-
 		delay, err := r.retryDelay(response, retryAttempt)
 		if err != nil {
+			_ = response.Body.Close()
 			return nil, err
 		}
+
+		// If the context's deadline would elapse before the backoff completes, return
+		// the response instead of sleeping through it. The caller then sees why the
+		// request actually failed (e.g. a 429) rather than a context deadline error.
+		if deadline, ok := request.Context().Deadline(); ok && time.Until(deadline) < delay {
+			return response, nil
+		}
+
+		defer func() { _ = response.Body.Close() }()
 
 		if err := sleepWithContext(request.Context(), delay); err != nil {
 			return nil, err

--- a/seed/go-sdk/version/internal/retrier_test.go
+++ b/seed/go-sdk/version/internal/retrier_test.go
@@ -295,7 +295,50 @@ func TestRetryWithRequestBody(t *testing.T) {
 	assert.Equal(t, expectedBody, requestBodies[1], "Second request body should match expected (retry should re-send body)")
 }
 
+// An explicit cancel (e.g. Ctrl-C wired to cancel()) must interrupt the backoff
+// wait. There is no deadline here, so the retrier cannot know the wait is futile
+// up front -- it has to be woken by the context.
 func TestRetryWaitIsInterruptedByContext(t *testing.T) {
+	var requestCount int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		w.Header().Set("Retry-After", "5")
+		w.WriteHeader(http.StatusTooManyRequests)
+	}))
+	defer server.Close()
+
+	caller := NewCaller(&CallerParams{
+		Client: server.Client(),
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		time.Sleep(100 * time.Millisecond)
+		cancel()
+	}()
+	defer cancel()
+
+	start := time.Now()
+	_, err := caller.Call(
+		ctx,
+		&CallParams{
+			URL:         server.URL,
+			Method:      http.MethodGet,
+			Request:     &InternalTestRequest{},
+			MaxAttempts: 3,
+		},
+	)
+	elapsed := time.Since(start)
+
+	assert.ErrorIs(t, err, context.Canceled)
+	assert.Equal(t, 1, requestCount, "Expected the retry to be abandoned once the context was cancelled")
+	assert.Less(t, elapsed, time.Second, "Expected the backoff to be interrupted by the context, took %v", elapsed)
+}
+
+// When the caller's deadline would elapse before the backoff finishes, sleeping
+// only guarantees a context error. Return the response instead so the caller
+// learns why the request actually failed.
+func TestRetryReturnsResponseWhenDeadlineShorterThanBackoff(t *testing.T) {
 	var requestCount int
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		requestCount++
@@ -323,9 +366,50 @@ func TestRetryWaitIsInterruptedByContext(t *testing.T) {
 	)
 	elapsed := time.Since(start)
 
-	assert.ErrorIs(t, err, context.DeadlineExceeded)
-	assert.Equal(t, 1, requestCount, "Expected the retry to be abandoned once the context expired")
-	assert.Less(t, elapsed, time.Second, "Expected the backoff to be interrupted by the context, took %v", elapsed)
+	// The caller gets the 429, not context.DeadlineExceeded.
+	var apiError *core.APIError
+	require.ErrorAs(t, err, &apiError)
+	assert.Equal(t, http.StatusTooManyRequests, apiError.StatusCode)
+	assert.NotErrorIs(t, err, context.DeadlineExceeded)
+	assert.Equal(t, 1, requestCount, "Expected no retry once the deadline was known to be too short")
+	assert.Less(t, elapsed, time.Second, "Expected to return immediately rather than sleep, took %v", elapsed)
+}
+
+// A deadline with room for the backoff must still retry as normal.
+func TestRetryProceedsWhenDeadlineLongerThanBackoff(t *testing.T) {
+	var requestCount int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		if requestCount == 1 {
+			w.Header().Set("Retry-After", "1")
+			w.WriteHeader(http.StatusTooManyRequests)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("{}"))
+	}))
+	defer server.Close()
+
+	caller := NewCaller(&CallerParams{
+		Client: server.Client(),
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	_, err := caller.Call(
+		ctx,
+		&CallParams{
+			URL:         server.URL,
+			Method:      http.MethodGet,
+			Request:     &InternalTestRequest{},
+			Response:    &InternalTestResponse{},
+			MaxAttempts: 3,
+		},
+	)
+
+	assert.NoError(t, err)
+	assert.Equal(t, 2, requestCount, "Expected the retry to proceed when the deadline allows it")
 }
 
 func TestDisableRetries(t *testing.T) {

--- a/seed/go-sdk/webhook-audience/internal/retrier.go
+++ b/seed/go-sdk/webhook-audience/internal/retrier.go
@@ -145,12 +145,20 @@ func (r *Retrier) run(
 	}
 
 	if r.shouldRetry(response) {
-		defer func() { _ = response.Body.Close() }()
-
 		delay, err := r.retryDelay(response, retryAttempt)
 		if err != nil {
+			_ = response.Body.Close()
 			return nil, err
 		}
+
+		// If the context's deadline would elapse before the backoff completes, return
+		// the response instead of sleeping through it. The caller then sees why the
+		// request actually failed (e.g. a 429) rather than a context deadline error.
+		if deadline, ok := request.Context().Deadline(); ok && time.Until(deadline) < delay {
+			return response, nil
+		}
+
+		defer func() { _ = response.Body.Close() }()
 
 		if err := sleepWithContext(request.Context(), delay); err != nil {
 			return nil, err

--- a/seed/go-sdk/webhook-audience/internal/retrier_test.go
+++ b/seed/go-sdk/webhook-audience/internal/retrier_test.go
@@ -295,7 +295,50 @@ func TestRetryWithRequestBody(t *testing.T) {
 	assert.Equal(t, expectedBody, requestBodies[1], "Second request body should match expected (retry should re-send body)")
 }
 
+// An explicit cancel (e.g. Ctrl-C wired to cancel()) must interrupt the backoff
+// wait. There is no deadline here, so the retrier cannot know the wait is futile
+// up front -- it has to be woken by the context.
 func TestRetryWaitIsInterruptedByContext(t *testing.T) {
+	var requestCount int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		w.Header().Set("Retry-After", "5")
+		w.WriteHeader(http.StatusTooManyRequests)
+	}))
+	defer server.Close()
+
+	caller := NewCaller(&CallerParams{
+		Client: server.Client(),
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		time.Sleep(100 * time.Millisecond)
+		cancel()
+	}()
+	defer cancel()
+
+	start := time.Now()
+	_, err := caller.Call(
+		ctx,
+		&CallParams{
+			URL:         server.URL,
+			Method:      http.MethodGet,
+			Request:     &InternalTestRequest{},
+			MaxAttempts: 3,
+		},
+	)
+	elapsed := time.Since(start)
+
+	assert.ErrorIs(t, err, context.Canceled)
+	assert.Equal(t, 1, requestCount, "Expected the retry to be abandoned once the context was cancelled")
+	assert.Less(t, elapsed, time.Second, "Expected the backoff to be interrupted by the context, took %v", elapsed)
+}
+
+// When the caller's deadline would elapse before the backoff finishes, sleeping
+// only guarantees a context error. Return the response instead so the caller
+// learns why the request actually failed.
+func TestRetryReturnsResponseWhenDeadlineShorterThanBackoff(t *testing.T) {
 	var requestCount int
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		requestCount++
@@ -323,9 +366,50 @@ func TestRetryWaitIsInterruptedByContext(t *testing.T) {
 	)
 	elapsed := time.Since(start)
 
-	assert.ErrorIs(t, err, context.DeadlineExceeded)
-	assert.Equal(t, 1, requestCount, "Expected the retry to be abandoned once the context expired")
-	assert.Less(t, elapsed, time.Second, "Expected the backoff to be interrupted by the context, took %v", elapsed)
+	// The caller gets the 429, not context.DeadlineExceeded.
+	var apiError *core.APIError
+	require.ErrorAs(t, err, &apiError)
+	assert.Equal(t, http.StatusTooManyRequests, apiError.StatusCode)
+	assert.NotErrorIs(t, err, context.DeadlineExceeded)
+	assert.Equal(t, 1, requestCount, "Expected no retry once the deadline was known to be too short")
+	assert.Less(t, elapsed, time.Second, "Expected to return immediately rather than sleep, took %v", elapsed)
+}
+
+// A deadline with room for the backoff must still retry as normal.
+func TestRetryProceedsWhenDeadlineLongerThanBackoff(t *testing.T) {
+	var requestCount int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		if requestCount == 1 {
+			w.Header().Set("Retry-After", "1")
+			w.WriteHeader(http.StatusTooManyRequests)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("{}"))
+	}))
+	defer server.Close()
+
+	caller := NewCaller(&CallerParams{
+		Client: server.Client(),
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	_, err := caller.Call(
+		ctx,
+		&CallParams{
+			URL:         server.URL,
+			Method:      http.MethodGet,
+			Request:     &InternalTestRequest{},
+			Response:    &InternalTestResponse{},
+			MaxAttempts: 3,
+		},
+	)
+
+	assert.NoError(t, err)
+	assert.Equal(t, 2, requestCount, "Expected the retry to proceed when the deadline allows it")
 }
 
 func TestDisableRetries(t *testing.T) {

--- a/seed/go-sdk/webhooks/internal/retrier.go
+++ b/seed/go-sdk/webhooks/internal/retrier.go
@@ -145,12 +145,20 @@ func (r *Retrier) run(
 	}
 
 	if r.shouldRetry(response) {
-		defer func() { _ = response.Body.Close() }()
-
 		delay, err := r.retryDelay(response, retryAttempt)
 		if err != nil {
+			_ = response.Body.Close()
 			return nil, err
 		}
+
+		// If the context's deadline would elapse before the backoff completes, return
+		// the response instead of sleeping through it. The caller then sees why the
+		// request actually failed (e.g. a 429) rather than a context deadline error.
+		if deadline, ok := request.Context().Deadline(); ok && time.Until(deadline) < delay {
+			return response, nil
+		}
+
+		defer func() { _ = response.Body.Close() }()
 
 		if err := sleepWithContext(request.Context(), delay); err != nil {
 			return nil, err

--- a/seed/go-sdk/webhooks/internal/retrier_test.go
+++ b/seed/go-sdk/webhooks/internal/retrier_test.go
@@ -295,7 +295,50 @@ func TestRetryWithRequestBody(t *testing.T) {
 	assert.Equal(t, expectedBody, requestBodies[1], "Second request body should match expected (retry should re-send body)")
 }
 
+// An explicit cancel (e.g. Ctrl-C wired to cancel()) must interrupt the backoff
+// wait. There is no deadline here, so the retrier cannot know the wait is futile
+// up front -- it has to be woken by the context.
 func TestRetryWaitIsInterruptedByContext(t *testing.T) {
+	var requestCount int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		w.Header().Set("Retry-After", "5")
+		w.WriteHeader(http.StatusTooManyRequests)
+	}))
+	defer server.Close()
+
+	caller := NewCaller(&CallerParams{
+		Client: server.Client(),
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		time.Sleep(100 * time.Millisecond)
+		cancel()
+	}()
+	defer cancel()
+
+	start := time.Now()
+	_, err := caller.Call(
+		ctx,
+		&CallParams{
+			URL:         server.URL,
+			Method:      http.MethodGet,
+			Request:     &InternalTestRequest{},
+			MaxAttempts: 3,
+		},
+	)
+	elapsed := time.Since(start)
+
+	assert.ErrorIs(t, err, context.Canceled)
+	assert.Equal(t, 1, requestCount, "Expected the retry to be abandoned once the context was cancelled")
+	assert.Less(t, elapsed, time.Second, "Expected the backoff to be interrupted by the context, took %v", elapsed)
+}
+
+// When the caller's deadline would elapse before the backoff finishes, sleeping
+// only guarantees a context error. Return the response instead so the caller
+// learns why the request actually failed.
+func TestRetryReturnsResponseWhenDeadlineShorterThanBackoff(t *testing.T) {
 	var requestCount int
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		requestCount++
@@ -323,9 +366,50 @@ func TestRetryWaitIsInterruptedByContext(t *testing.T) {
 	)
 	elapsed := time.Since(start)
 
-	assert.ErrorIs(t, err, context.DeadlineExceeded)
-	assert.Equal(t, 1, requestCount, "Expected the retry to be abandoned once the context expired")
-	assert.Less(t, elapsed, time.Second, "Expected the backoff to be interrupted by the context, took %v", elapsed)
+	// The caller gets the 429, not context.DeadlineExceeded.
+	var apiError *core.APIError
+	require.ErrorAs(t, err, &apiError)
+	assert.Equal(t, http.StatusTooManyRequests, apiError.StatusCode)
+	assert.NotErrorIs(t, err, context.DeadlineExceeded)
+	assert.Equal(t, 1, requestCount, "Expected no retry once the deadline was known to be too short")
+	assert.Less(t, elapsed, time.Second, "Expected to return immediately rather than sleep, took %v", elapsed)
+}
+
+// A deadline with room for the backoff must still retry as normal.
+func TestRetryProceedsWhenDeadlineLongerThanBackoff(t *testing.T) {
+	var requestCount int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		if requestCount == 1 {
+			w.Header().Set("Retry-After", "1")
+			w.WriteHeader(http.StatusTooManyRequests)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("{}"))
+	}))
+	defer server.Close()
+
+	caller := NewCaller(&CallerParams{
+		Client: server.Client(),
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	_, err := caller.Call(
+		ctx,
+		&CallParams{
+			URL:         server.URL,
+			Method:      http.MethodGet,
+			Request:     &InternalTestRequest{},
+			Response:    &InternalTestResponse{},
+			MaxAttempts: 3,
+		},
+	)
+
+	assert.NoError(t, err)
+	assert.Equal(t, 2, requestCount, "Expected the retry to proceed when the deadline allows it")
 }
 
 func TestDisableRetries(t *testing.T) {

--- a/seed/go-sdk/websocket-bearer-auth/internal/retrier.go
+++ b/seed/go-sdk/websocket-bearer-auth/internal/retrier.go
@@ -145,12 +145,20 @@ func (r *Retrier) run(
 	}
 
 	if r.shouldRetry(response) {
-		defer func() { _ = response.Body.Close() }()
-
 		delay, err := r.retryDelay(response, retryAttempt)
 		if err != nil {
+			_ = response.Body.Close()
 			return nil, err
 		}
+
+		// If the context's deadline would elapse before the backoff completes, return
+		// the response instead of sleeping through it. The caller then sees why the
+		// request actually failed (e.g. a 429) rather than a context deadline error.
+		if deadline, ok := request.Context().Deadline(); ok && time.Until(deadline) < delay {
+			return response, nil
+		}
+
+		defer func() { _ = response.Body.Close() }()
 
 		if err := sleepWithContext(request.Context(), delay); err != nil {
 			return nil, err

--- a/seed/go-sdk/websocket-bearer-auth/internal/retrier_test.go
+++ b/seed/go-sdk/websocket-bearer-auth/internal/retrier_test.go
@@ -295,7 +295,50 @@ func TestRetryWithRequestBody(t *testing.T) {
 	assert.Equal(t, expectedBody, requestBodies[1], "Second request body should match expected (retry should re-send body)")
 }
 
+// An explicit cancel (e.g. Ctrl-C wired to cancel()) must interrupt the backoff
+// wait. There is no deadline here, so the retrier cannot know the wait is futile
+// up front -- it has to be woken by the context.
 func TestRetryWaitIsInterruptedByContext(t *testing.T) {
+	var requestCount int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		w.Header().Set("Retry-After", "5")
+		w.WriteHeader(http.StatusTooManyRequests)
+	}))
+	defer server.Close()
+
+	caller := NewCaller(&CallerParams{
+		Client: server.Client(),
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		time.Sleep(100 * time.Millisecond)
+		cancel()
+	}()
+	defer cancel()
+
+	start := time.Now()
+	_, err := caller.Call(
+		ctx,
+		&CallParams{
+			URL:         server.URL,
+			Method:      http.MethodGet,
+			Request:     &InternalTestRequest{},
+			MaxAttempts: 3,
+		},
+	)
+	elapsed := time.Since(start)
+
+	assert.ErrorIs(t, err, context.Canceled)
+	assert.Equal(t, 1, requestCount, "Expected the retry to be abandoned once the context was cancelled")
+	assert.Less(t, elapsed, time.Second, "Expected the backoff to be interrupted by the context, took %v", elapsed)
+}
+
+// When the caller's deadline would elapse before the backoff finishes, sleeping
+// only guarantees a context error. Return the response instead so the caller
+// learns why the request actually failed.
+func TestRetryReturnsResponseWhenDeadlineShorterThanBackoff(t *testing.T) {
 	var requestCount int
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		requestCount++
@@ -323,9 +366,50 @@ func TestRetryWaitIsInterruptedByContext(t *testing.T) {
 	)
 	elapsed := time.Since(start)
 
-	assert.ErrorIs(t, err, context.DeadlineExceeded)
-	assert.Equal(t, 1, requestCount, "Expected the retry to be abandoned once the context expired")
-	assert.Less(t, elapsed, time.Second, "Expected the backoff to be interrupted by the context, took %v", elapsed)
+	// The caller gets the 429, not context.DeadlineExceeded.
+	var apiError *core.APIError
+	require.ErrorAs(t, err, &apiError)
+	assert.Equal(t, http.StatusTooManyRequests, apiError.StatusCode)
+	assert.NotErrorIs(t, err, context.DeadlineExceeded)
+	assert.Equal(t, 1, requestCount, "Expected no retry once the deadline was known to be too short")
+	assert.Less(t, elapsed, time.Second, "Expected to return immediately rather than sleep, took %v", elapsed)
+}
+
+// A deadline with room for the backoff must still retry as normal.
+func TestRetryProceedsWhenDeadlineLongerThanBackoff(t *testing.T) {
+	var requestCount int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		if requestCount == 1 {
+			w.Header().Set("Retry-After", "1")
+			w.WriteHeader(http.StatusTooManyRequests)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("{}"))
+	}))
+	defer server.Close()
+
+	caller := NewCaller(&CallerParams{
+		Client: server.Client(),
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	_, err := caller.Call(
+		ctx,
+		&CallParams{
+			URL:         server.URL,
+			Method:      http.MethodGet,
+			Request:     &InternalTestRequest{},
+			Response:    &InternalTestResponse{},
+			MaxAttempts: 3,
+		},
+	)
+
+	assert.NoError(t, err)
+	assert.Equal(t, 2, requestCount, "Expected the retry to proceed when the deadline allows it")
 }
 
 func TestDisableRetries(t *testing.T) {

--- a/seed/go-sdk/websocket-inferred-auth/internal/retrier.go
+++ b/seed/go-sdk/websocket-inferred-auth/internal/retrier.go
@@ -145,12 +145,20 @@ func (r *Retrier) run(
 	}
 
 	if r.shouldRetry(response) {
-		defer func() { _ = response.Body.Close() }()
-
 		delay, err := r.retryDelay(response, retryAttempt)
 		if err != nil {
+			_ = response.Body.Close()
 			return nil, err
 		}
+
+		// If the context's deadline would elapse before the backoff completes, return
+		// the response instead of sleeping through it. The caller then sees why the
+		// request actually failed (e.g. a 429) rather than a context deadline error.
+		if deadline, ok := request.Context().Deadline(); ok && time.Until(deadline) < delay {
+			return response, nil
+		}
+
+		defer func() { _ = response.Body.Close() }()
 
 		if err := sleepWithContext(request.Context(), delay); err != nil {
 			return nil, err

--- a/seed/go-sdk/websocket-inferred-auth/internal/retrier_test.go
+++ b/seed/go-sdk/websocket-inferred-auth/internal/retrier_test.go
@@ -295,7 +295,50 @@ func TestRetryWithRequestBody(t *testing.T) {
 	assert.Equal(t, expectedBody, requestBodies[1], "Second request body should match expected (retry should re-send body)")
 }
 
+// An explicit cancel (e.g. Ctrl-C wired to cancel()) must interrupt the backoff
+// wait. There is no deadline here, so the retrier cannot know the wait is futile
+// up front -- it has to be woken by the context.
 func TestRetryWaitIsInterruptedByContext(t *testing.T) {
+	var requestCount int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		w.Header().Set("Retry-After", "5")
+		w.WriteHeader(http.StatusTooManyRequests)
+	}))
+	defer server.Close()
+
+	caller := NewCaller(&CallerParams{
+		Client: server.Client(),
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		time.Sleep(100 * time.Millisecond)
+		cancel()
+	}()
+	defer cancel()
+
+	start := time.Now()
+	_, err := caller.Call(
+		ctx,
+		&CallParams{
+			URL:         server.URL,
+			Method:      http.MethodGet,
+			Request:     &InternalTestRequest{},
+			MaxAttempts: 3,
+		},
+	)
+	elapsed := time.Since(start)
+
+	assert.ErrorIs(t, err, context.Canceled)
+	assert.Equal(t, 1, requestCount, "Expected the retry to be abandoned once the context was cancelled")
+	assert.Less(t, elapsed, time.Second, "Expected the backoff to be interrupted by the context, took %v", elapsed)
+}
+
+// When the caller's deadline would elapse before the backoff finishes, sleeping
+// only guarantees a context error. Return the response instead so the caller
+// learns why the request actually failed.
+func TestRetryReturnsResponseWhenDeadlineShorterThanBackoff(t *testing.T) {
 	var requestCount int
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		requestCount++
@@ -323,9 +366,50 @@ func TestRetryWaitIsInterruptedByContext(t *testing.T) {
 	)
 	elapsed := time.Since(start)
 
-	assert.ErrorIs(t, err, context.DeadlineExceeded)
-	assert.Equal(t, 1, requestCount, "Expected the retry to be abandoned once the context expired")
-	assert.Less(t, elapsed, time.Second, "Expected the backoff to be interrupted by the context, took %v", elapsed)
+	// The caller gets the 429, not context.DeadlineExceeded.
+	var apiError *core.APIError
+	require.ErrorAs(t, err, &apiError)
+	assert.Equal(t, http.StatusTooManyRequests, apiError.StatusCode)
+	assert.NotErrorIs(t, err, context.DeadlineExceeded)
+	assert.Equal(t, 1, requestCount, "Expected no retry once the deadline was known to be too short")
+	assert.Less(t, elapsed, time.Second, "Expected to return immediately rather than sleep, took %v", elapsed)
+}
+
+// A deadline with room for the backoff must still retry as normal.
+func TestRetryProceedsWhenDeadlineLongerThanBackoff(t *testing.T) {
+	var requestCount int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		if requestCount == 1 {
+			w.Header().Set("Retry-After", "1")
+			w.WriteHeader(http.StatusTooManyRequests)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("{}"))
+	}))
+	defer server.Close()
+
+	caller := NewCaller(&CallerParams{
+		Client: server.Client(),
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	_, err := caller.Call(
+		ctx,
+		&CallParams{
+			URL:         server.URL,
+			Method:      http.MethodGet,
+			Request:     &InternalTestRequest{},
+			Response:    &InternalTestResponse{},
+			MaxAttempts: 3,
+		},
+	)
+
+	assert.NoError(t, err)
+	assert.Equal(t, 2, requestCount, "Expected the retry to proceed when the deadline allows it")
 }
 
 func TestDisableRetries(t *testing.T) {

--- a/seed/go-sdk/websocket-multi-url/internal/retrier.go
+++ b/seed/go-sdk/websocket-multi-url/internal/retrier.go
@@ -145,12 +145,20 @@ func (r *Retrier) run(
 	}
 
 	if r.shouldRetry(response) {
-		defer func() { _ = response.Body.Close() }()
-
 		delay, err := r.retryDelay(response, retryAttempt)
 		if err != nil {
+			_ = response.Body.Close()
 			return nil, err
 		}
+
+		// If the context's deadline would elapse before the backoff completes, return
+		// the response instead of sleeping through it. The caller then sees why the
+		// request actually failed (e.g. a 429) rather than a context deadline error.
+		if deadline, ok := request.Context().Deadline(); ok && time.Until(deadline) < delay {
+			return response, nil
+		}
+
+		defer func() { _ = response.Body.Close() }()
 
 		if err := sleepWithContext(request.Context(), delay); err != nil {
 			return nil, err

--- a/seed/go-sdk/websocket-multi-url/internal/retrier_test.go
+++ b/seed/go-sdk/websocket-multi-url/internal/retrier_test.go
@@ -295,7 +295,50 @@ func TestRetryWithRequestBody(t *testing.T) {
 	assert.Equal(t, expectedBody, requestBodies[1], "Second request body should match expected (retry should re-send body)")
 }
 
+// An explicit cancel (e.g. Ctrl-C wired to cancel()) must interrupt the backoff
+// wait. There is no deadline here, so the retrier cannot know the wait is futile
+// up front -- it has to be woken by the context.
 func TestRetryWaitIsInterruptedByContext(t *testing.T) {
+	var requestCount int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		w.Header().Set("Retry-After", "5")
+		w.WriteHeader(http.StatusTooManyRequests)
+	}))
+	defer server.Close()
+
+	caller := NewCaller(&CallerParams{
+		Client: server.Client(),
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		time.Sleep(100 * time.Millisecond)
+		cancel()
+	}()
+	defer cancel()
+
+	start := time.Now()
+	_, err := caller.Call(
+		ctx,
+		&CallParams{
+			URL:         server.URL,
+			Method:      http.MethodGet,
+			Request:     &InternalTestRequest{},
+			MaxAttempts: 3,
+		},
+	)
+	elapsed := time.Since(start)
+
+	assert.ErrorIs(t, err, context.Canceled)
+	assert.Equal(t, 1, requestCount, "Expected the retry to be abandoned once the context was cancelled")
+	assert.Less(t, elapsed, time.Second, "Expected the backoff to be interrupted by the context, took %v", elapsed)
+}
+
+// When the caller's deadline would elapse before the backoff finishes, sleeping
+// only guarantees a context error. Return the response instead so the caller
+// learns why the request actually failed.
+func TestRetryReturnsResponseWhenDeadlineShorterThanBackoff(t *testing.T) {
 	var requestCount int
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		requestCount++
@@ -323,9 +366,50 @@ func TestRetryWaitIsInterruptedByContext(t *testing.T) {
 	)
 	elapsed := time.Since(start)
 
-	assert.ErrorIs(t, err, context.DeadlineExceeded)
-	assert.Equal(t, 1, requestCount, "Expected the retry to be abandoned once the context expired")
-	assert.Less(t, elapsed, time.Second, "Expected the backoff to be interrupted by the context, took %v", elapsed)
+	// The caller gets the 429, not context.DeadlineExceeded.
+	var apiError *core.APIError
+	require.ErrorAs(t, err, &apiError)
+	assert.Equal(t, http.StatusTooManyRequests, apiError.StatusCode)
+	assert.NotErrorIs(t, err, context.DeadlineExceeded)
+	assert.Equal(t, 1, requestCount, "Expected no retry once the deadline was known to be too short")
+	assert.Less(t, elapsed, time.Second, "Expected to return immediately rather than sleep, took %v", elapsed)
+}
+
+// A deadline with room for the backoff must still retry as normal.
+func TestRetryProceedsWhenDeadlineLongerThanBackoff(t *testing.T) {
+	var requestCount int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		if requestCount == 1 {
+			w.Header().Set("Retry-After", "1")
+			w.WriteHeader(http.StatusTooManyRequests)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("{}"))
+	}))
+	defer server.Close()
+
+	caller := NewCaller(&CallerParams{
+		Client: server.Client(),
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	_, err := caller.Call(
+		ctx,
+		&CallParams{
+			URL:         server.URL,
+			Method:      http.MethodGet,
+			Request:     &InternalTestRequest{},
+			Response:    &InternalTestResponse{},
+			MaxAttempts: 3,
+		},
+	)
+
+	assert.NoError(t, err)
+	assert.Equal(t, 2, requestCount, "Expected the retry to proceed when the deadline allows it")
 }
 
 func TestDisableRetries(t *testing.T) {

--- a/seed/go-sdk/websocket/internal/retrier.go
+++ b/seed/go-sdk/websocket/internal/retrier.go
@@ -145,12 +145,20 @@ func (r *Retrier) run(
 	}
 
 	if r.shouldRetry(response) {
-		defer func() { _ = response.Body.Close() }()
-
 		delay, err := r.retryDelay(response, retryAttempt)
 		if err != nil {
+			_ = response.Body.Close()
 			return nil, err
 		}
+
+		// If the context's deadline would elapse before the backoff completes, return
+		// the response instead of sleeping through it. The caller then sees why the
+		// request actually failed (e.g. a 429) rather than a context deadline error.
+		if deadline, ok := request.Context().Deadline(); ok && time.Until(deadline) < delay {
+			return response, nil
+		}
+
+		defer func() { _ = response.Body.Close() }()
 
 		if err := sleepWithContext(request.Context(), delay); err != nil {
 			return nil, err

--- a/seed/go-sdk/websocket/internal/retrier_test.go
+++ b/seed/go-sdk/websocket/internal/retrier_test.go
@@ -295,7 +295,50 @@ func TestRetryWithRequestBody(t *testing.T) {
 	assert.Equal(t, expectedBody, requestBodies[1], "Second request body should match expected (retry should re-send body)")
 }
 
+// An explicit cancel (e.g. Ctrl-C wired to cancel()) must interrupt the backoff
+// wait. There is no deadline here, so the retrier cannot know the wait is futile
+// up front -- it has to be woken by the context.
 func TestRetryWaitIsInterruptedByContext(t *testing.T) {
+	var requestCount int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		w.Header().Set("Retry-After", "5")
+		w.WriteHeader(http.StatusTooManyRequests)
+	}))
+	defer server.Close()
+
+	caller := NewCaller(&CallerParams{
+		Client: server.Client(),
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		time.Sleep(100 * time.Millisecond)
+		cancel()
+	}()
+	defer cancel()
+
+	start := time.Now()
+	_, err := caller.Call(
+		ctx,
+		&CallParams{
+			URL:         server.URL,
+			Method:      http.MethodGet,
+			Request:     &InternalTestRequest{},
+			MaxAttempts: 3,
+		},
+	)
+	elapsed := time.Since(start)
+
+	assert.ErrorIs(t, err, context.Canceled)
+	assert.Equal(t, 1, requestCount, "Expected the retry to be abandoned once the context was cancelled")
+	assert.Less(t, elapsed, time.Second, "Expected the backoff to be interrupted by the context, took %v", elapsed)
+}
+
+// When the caller's deadline would elapse before the backoff finishes, sleeping
+// only guarantees a context error. Return the response instead so the caller
+// learns why the request actually failed.
+func TestRetryReturnsResponseWhenDeadlineShorterThanBackoff(t *testing.T) {
 	var requestCount int
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		requestCount++
@@ -323,9 +366,50 @@ func TestRetryWaitIsInterruptedByContext(t *testing.T) {
 	)
 	elapsed := time.Since(start)
 
-	assert.ErrorIs(t, err, context.DeadlineExceeded)
-	assert.Equal(t, 1, requestCount, "Expected the retry to be abandoned once the context expired")
-	assert.Less(t, elapsed, time.Second, "Expected the backoff to be interrupted by the context, took %v", elapsed)
+	// The caller gets the 429, not context.DeadlineExceeded.
+	var apiError *core.APIError
+	require.ErrorAs(t, err, &apiError)
+	assert.Equal(t, http.StatusTooManyRequests, apiError.StatusCode)
+	assert.NotErrorIs(t, err, context.DeadlineExceeded)
+	assert.Equal(t, 1, requestCount, "Expected no retry once the deadline was known to be too short")
+	assert.Less(t, elapsed, time.Second, "Expected to return immediately rather than sleep, took %v", elapsed)
+}
+
+// A deadline with room for the backoff must still retry as normal.
+func TestRetryProceedsWhenDeadlineLongerThanBackoff(t *testing.T) {
+	var requestCount int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		if requestCount == 1 {
+			w.Header().Set("Retry-After", "1")
+			w.WriteHeader(http.StatusTooManyRequests)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("{}"))
+	}))
+	defer server.Close()
+
+	caller := NewCaller(&CallerParams{
+		Client: server.Client(),
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	_, err := caller.Call(
+		ctx,
+		&CallParams{
+			URL:         server.URL,
+			Method:      http.MethodGet,
+			Request:     &InternalTestRequest{},
+			Response:    &InternalTestResponse{},
+			MaxAttempts: 3,
+		},
+	)
+
+	assert.NoError(t, err)
+	assert.Equal(t, 2, requestCount, "Expected the retry to proceed when the deadline allows it")
 }
 
 func TestDisableRetries(t *testing.T) {

--- a/seed/go-sdk/x-fern-default/apply-query-defaults-on-nil-request/internal/retrier.go
+++ b/seed/go-sdk/x-fern-default/apply-query-defaults-on-nil-request/internal/retrier.go
@@ -145,12 +145,20 @@ func (r *Retrier) run(
 	}
 
 	if r.shouldRetry(response) {
-		defer func() { _ = response.Body.Close() }()
-
 		delay, err := r.retryDelay(response, retryAttempt)
 		if err != nil {
+			_ = response.Body.Close()
 			return nil, err
 		}
+
+		// If the context's deadline would elapse before the backoff completes, return
+		// the response instead of sleeping through it. The caller then sees why the
+		// request actually failed (e.g. a 429) rather than a context deadline error.
+		if deadline, ok := request.Context().Deadline(); ok && time.Until(deadline) < delay {
+			return response, nil
+		}
+
+		defer func() { _ = response.Body.Close() }()
 
 		if err := sleepWithContext(request.Context(), delay); err != nil {
 			return nil, err

--- a/seed/go-sdk/x-fern-default/apply-query-defaults-on-nil-request/internal/retrier_test.go
+++ b/seed/go-sdk/x-fern-default/apply-query-defaults-on-nil-request/internal/retrier_test.go
@@ -295,7 +295,50 @@ func TestRetryWithRequestBody(t *testing.T) {
 	assert.Equal(t, expectedBody, requestBodies[1], "Second request body should match expected (retry should re-send body)")
 }
 
+// An explicit cancel (e.g. Ctrl-C wired to cancel()) must interrupt the backoff
+// wait. There is no deadline here, so the retrier cannot know the wait is futile
+// up front -- it has to be woken by the context.
 func TestRetryWaitIsInterruptedByContext(t *testing.T) {
+	var requestCount int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		w.Header().Set("Retry-After", "5")
+		w.WriteHeader(http.StatusTooManyRequests)
+	}))
+	defer server.Close()
+
+	caller := NewCaller(&CallerParams{
+		Client: server.Client(),
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		time.Sleep(100 * time.Millisecond)
+		cancel()
+	}()
+	defer cancel()
+
+	start := time.Now()
+	_, err := caller.Call(
+		ctx,
+		&CallParams{
+			URL:         server.URL,
+			Method:      http.MethodGet,
+			Request:     &InternalTestRequest{},
+			MaxAttempts: 3,
+		},
+	)
+	elapsed := time.Since(start)
+
+	assert.ErrorIs(t, err, context.Canceled)
+	assert.Equal(t, 1, requestCount, "Expected the retry to be abandoned once the context was cancelled")
+	assert.Less(t, elapsed, time.Second, "Expected the backoff to be interrupted by the context, took %v", elapsed)
+}
+
+// When the caller's deadline would elapse before the backoff finishes, sleeping
+// only guarantees a context error. Return the response instead so the caller
+// learns why the request actually failed.
+func TestRetryReturnsResponseWhenDeadlineShorterThanBackoff(t *testing.T) {
 	var requestCount int
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		requestCount++
@@ -323,9 +366,50 @@ func TestRetryWaitIsInterruptedByContext(t *testing.T) {
 	)
 	elapsed := time.Since(start)
 
-	assert.ErrorIs(t, err, context.DeadlineExceeded)
-	assert.Equal(t, 1, requestCount, "Expected the retry to be abandoned once the context expired")
-	assert.Less(t, elapsed, time.Second, "Expected the backoff to be interrupted by the context, took %v", elapsed)
+	// The caller gets the 429, not context.DeadlineExceeded.
+	var apiError *core.APIError
+	require.ErrorAs(t, err, &apiError)
+	assert.Equal(t, http.StatusTooManyRequests, apiError.StatusCode)
+	assert.NotErrorIs(t, err, context.DeadlineExceeded)
+	assert.Equal(t, 1, requestCount, "Expected no retry once the deadline was known to be too short")
+	assert.Less(t, elapsed, time.Second, "Expected to return immediately rather than sleep, took %v", elapsed)
+}
+
+// A deadline with room for the backoff must still retry as normal.
+func TestRetryProceedsWhenDeadlineLongerThanBackoff(t *testing.T) {
+	var requestCount int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		if requestCount == 1 {
+			w.Header().Set("Retry-After", "1")
+			w.WriteHeader(http.StatusTooManyRequests)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("{}"))
+	}))
+	defer server.Close()
+
+	caller := NewCaller(&CallerParams{
+		Client: server.Client(),
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	_, err := caller.Call(
+		ctx,
+		&CallParams{
+			URL:         server.URL,
+			Method:      http.MethodGet,
+			Request:     &InternalTestRequest{},
+			Response:    &InternalTestResponse{},
+			MaxAttempts: 3,
+		},
+	)
+
+	assert.NoError(t, err)
+	assert.Equal(t, 2, requestCount, "Expected the retry to proceed when the deadline allows it")
 }
 
 func TestDisableRetries(t *testing.T) {

--- a/seed/go-sdk/x-fern-default/no-custom-config/internal/retrier.go
+++ b/seed/go-sdk/x-fern-default/no-custom-config/internal/retrier.go
@@ -145,12 +145,20 @@ func (r *Retrier) run(
 	}
 
 	if r.shouldRetry(response) {
-		defer func() { _ = response.Body.Close() }()
-
 		delay, err := r.retryDelay(response, retryAttempt)
 		if err != nil {
+			_ = response.Body.Close()
 			return nil, err
 		}
+
+		// If the context's deadline would elapse before the backoff completes, return
+		// the response instead of sleeping through it. The caller then sees why the
+		// request actually failed (e.g. a 429) rather than a context deadline error.
+		if deadline, ok := request.Context().Deadline(); ok && time.Until(deadline) < delay {
+			return response, nil
+		}
+
+		defer func() { _ = response.Body.Close() }()
 
 		if err := sleepWithContext(request.Context(), delay); err != nil {
 			return nil, err

--- a/seed/go-sdk/x-fern-default/no-custom-config/internal/retrier_test.go
+++ b/seed/go-sdk/x-fern-default/no-custom-config/internal/retrier_test.go
@@ -295,7 +295,50 @@ func TestRetryWithRequestBody(t *testing.T) {
 	assert.Equal(t, expectedBody, requestBodies[1], "Second request body should match expected (retry should re-send body)")
 }
 
+// An explicit cancel (e.g. Ctrl-C wired to cancel()) must interrupt the backoff
+// wait. There is no deadline here, so the retrier cannot know the wait is futile
+// up front -- it has to be woken by the context.
 func TestRetryWaitIsInterruptedByContext(t *testing.T) {
+	var requestCount int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		w.Header().Set("Retry-After", "5")
+		w.WriteHeader(http.StatusTooManyRequests)
+	}))
+	defer server.Close()
+
+	caller := NewCaller(&CallerParams{
+		Client: server.Client(),
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		time.Sleep(100 * time.Millisecond)
+		cancel()
+	}()
+	defer cancel()
+
+	start := time.Now()
+	_, err := caller.Call(
+		ctx,
+		&CallParams{
+			URL:         server.URL,
+			Method:      http.MethodGet,
+			Request:     &InternalTestRequest{},
+			MaxAttempts: 3,
+		},
+	)
+	elapsed := time.Since(start)
+
+	assert.ErrorIs(t, err, context.Canceled)
+	assert.Equal(t, 1, requestCount, "Expected the retry to be abandoned once the context was cancelled")
+	assert.Less(t, elapsed, time.Second, "Expected the backoff to be interrupted by the context, took %v", elapsed)
+}
+
+// When the caller's deadline would elapse before the backoff finishes, sleeping
+// only guarantees a context error. Return the response instead so the caller
+// learns why the request actually failed.
+func TestRetryReturnsResponseWhenDeadlineShorterThanBackoff(t *testing.T) {
 	var requestCount int
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		requestCount++
@@ -323,9 +366,50 @@ func TestRetryWaitIsInterruptedByContext(t *testing.T) {
 	)
 	elapsed := time.Since(start)
 
-	assert.ErrorIs(t, err, context.DeadlineExceeded)
-	assert.Equal(t, 1, requestCount, "Expected the retry to be abandoned once the context expired")
-	assert.Less(t, elapsed, time.Second, "Expected the backoff to be interrupted by the context, took %v", elapsed)
+	// The caller gets the 429, not context.DeadlineExceeded.
+	var apiError *core.APIError
+	require.ErrorAs(t, err, &apiError)
+	assert.Equal(t, http.StatusTooManyRequests, apiError.StatusCode)
+	assert.NotErrorIs(t, err, context.DeadlineExceeded)
+	assert.Equal(t, 1, requestCount, "Expected no retry once the deadline was known to be too short")
+	assert.Less(t, elapsed, time.Second, "Expected to return immediately rather than sleep, took %v", elapsed)
+}
+
+// A deadline with room for the backoff must still retry as normal.
+func TestRetryProceedsWhenDeadlineLongerThanBackoff(t *testing.T) {
+	var requestCount int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		if requestCount == 1 {
+			w.Header().Set("Retry-After", "1")
+			w.WriteHeader(http.StatusTooManyRequests)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("{}"))
+	}))
+	defer server.Close()
+
+	caller := NewCaller(&CallerParams{
+		Client: server.Client(),
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	_, err := caller.Call(
+		ctx,
+		&CallParams{
+			URL:         server.URL,
+			Method:      http.MethodGet,
+			Request:     &InternalTestRequest{},
+			Response:    &InternalTestResponse{},
+			MaxAttempts: 3,
+		},
+	)
+
+	assert.NoError(t, err)
+	assert.Equal(t, 2, requestCount, "Expected the retry to proceed when the deadline allows it")
 }
 
 func TestDisableRetries(t *testing.T) {

--- a/seed/go-sdk/x-fern-global-parameters/internal/retrier.go
+++ b/seed/go-sdk/x-fern-global-parameters/internal/retrier.go
@@ -145,12 +145,20 @@ func (r *Retrier) run(
 	}
 
 	if r.shouldRetry(response) {
-		defer func() { _ = response.Body.Close() }()
-
 		delay, err := r.retryDelay(response, retryAttempt)
 		if err != nil {
+			_ = response.Body.Close()
 			return nil, err
 		}
+
+		// If the context's deadline would elapse before the backoff completes, return
+		// the response instead of sleeping through it. The caller then sees why the
+		// request actually failed (e.g. a 429) rather than a context deadline error.
+		if deadline, ok := request.Context().Deadline(); ok && time.Until(deadline) < delay {
+			return response, nil
+		}
+
+		defer func() { _ = response.Body.Close() }()
 
 		if err := sleepWithContext(request.Context(), delay); err != nil {
 			return nil, err

--- a/seed/go-sdk/x-fern-global-parameters/internal/retrier_test.go
+++ b/seed/go-sdk/x-fern-global-parameters/internal/retrier_test.go
@@ -295,7 +295,50 @@ func TestRetryWithRequestBody(t *testing.T) {
 	assert.Equal(t, expectedBody, requestBodies[1], "Second request body should match expected (retry should re-send body)")
 }
 
+// An explicit cancel (e.g. Ctrl-C wired to cancel()) must interrupt the backoff
+// wait. There is no deadline here, so the retrier cannot know the wait is futile
+// up front -- it has to be woken by the context.
 func TestRetryWaitIsInterruptedByContext(t *testing.T) {
+	var requestCount int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		w.Header().Set("Retry-After", "5")
+		w.WriteHeader(http.StatusTooManyRequests)
+	}))
+	defer server.Close()
+
+	caller := NewCaller(&CallerParams{
+		Client: server.Client(),
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		time.Sleep(100 * time.Millisecond)
+		cancel()
+	}()
+	defer cancel()
+
+	start := time.Now()
+	_, err := caller.Call(
+		ctx,
+		&CallParams{
+			URL:         server.URL,
+			Method:      http.MethodGet,
+			Request:     &InternalTestRequest{},
+			MaxAttempts: 3,
+		},
+	)
+	elapsed := time.Since(start)
+
+	assert.ErrorIs(t, err, context.Canceled)
+	assert.Equal(t, 1, requestCount, "Expected the retry to be abandoned once the context was cancelled")
+	assert.Less(t, elapsed, time.Second, "Expected the backoff to be interrupted by the context, took %v", elapsed)
+}
+
+// When the caller's deadline would elapse before the backoff finishes, sleeping
+// only guarantees a context error. Return the response instead so the caller
+// learns why the request actually failed.
+func TestRetryReturnsResponseWhenDeadlineShorterThanBackoff(t *testing.T) {
 	var requestCount int
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		requestCount++
@@ -323,9 +366,50 @@ func TestRetryWaitIsInterruptedByContext(t *testing.T) {
 	)
 	elapsed := time.Since(start)
 
-	assert.ErrorIs(t, err, context.DeadlineExceeded)
-	assert.Equal(t, 1, requestCount, "Expected the retry to be abandoned once the context expired")
-	assert.Less(t, elapsed, time.Second, "Expected the backoff to be interrupted by the context, took %v", elapsed)
+	// The caller gets the 429, not context.DeadlineExceeded.
+	var apiError *core.APIError
+	require.ErrorAs(t, err, &apiError)
+	assert.Equal(t, http.StatusTooManyRequests, apiError.StatusCode)
+	assert.NotErrorIs(t, err, context.DeadlineExceeded)
+	assert.Equal(t, 1, requestCount, "Expected no retry once the deadline was known to be too short")
+	assert.Less(t, elapsed, time.Second, "Expected to return immediately rather than sleep, took %v", elapsed)
+}
+
+// A deadline with room for the backoff must still retry as normal.
+func TestRetryProceedsWhenDeadlineLongerThanBackoff(t *testing.T) {
+	var requestCount int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		if requestCount == 1 {
+			w.Header().Set("Retry-After", "1")
+			w.WriteHeader(http.StatusTooManyRequests)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("{}"))
+	}))
+	defer server.Close()
+
+	caller := NewCaller(&CallerParams{
+		Client: server.Client(),
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	_, err := caller.Call(
+		ctx,
+		&CallParams{
+			URL:         server.URL,
+			Method:      http.MethodGet,
+			Request:     &InternalTestRequest{},
+			Response:    &InternalTestResponse{},
+			MaxAttempts: 3,
+		},
+	)
+
+	assert.NoError(t, err)
+	assert.Equal(t, 2, requestCount, "Expected the retry to proceed when the deadline allows it")
 }
 
 func TestDisableRetries(t *testing.T) {


### PR DESCRIPTION
## Description

Follow-up to #17498, requested by name.com as the optional item in their report.

When a retryable response arrived and the request context's deadline would elapse before the computed backoff finished, the retrier slept anyway and the caller received `context deadline exceeded` — discarding the response that explained the failure. With `Retry-After` honored up to `maxRetryDelay` (60s), a single 429 became an opaque timeout.

The retrier now compares the remaining deadline against the delay and returns the response instead of sleeping:

```go
delay, err := r.retryDelay(response, retryAttempt)
if err != nil {
    _ = response.Body.Close()
    return nil, err
}

// If the context's deadline would elapse before the backoff completes, return
// the response instead of sleeping through it.
if deadline, ok := request.Context().Deadline(); ok && time.Until(deadline) < delay {
    return response, nil
}

defer func() { _ = response.Body.Close() }()
```

The `defer response.Body.Close()` moves below the early return — otherwise the caller gets a closed body.

## Behavior change worth a close look

**This is user-visible, not a pure bugfix.** Code doing `errors.Is(err, context.DeadlineExceeded)` on a rate-limited call now gets a `*core.APIError` with `StatusCode: 429` instead. That is what was asked for and it is strictly more informative, but it is a change in what callers observe.

It also flips a test added in #17498. `TestRetryWaitIsInterruptedByContext` used `WithTimeout(100ms)` against `Retry-After: 5` and asserted `context.DeadlineExceeded` — exactly the case this change now resolves to a 429. I treated the two behaviors as complementary rather than competing:

- deadline too short for the backoff → return the response (new)
- explicit `cancel()` during the backoff → return `ctx.Err()` (unchanged; still reachable when there is no deadline, which is the Ctrl-C case `sleepWithContext` exists for)

So that test is rewritten to use `context.WithCancel`, which is what it was actually about.

One deliberate omission: the comparison is a bare `time.Until(deadline) < delay` with no margin for the request itself. If the remaining time only slightly exceeds the delay, we still sleep and the next attempt likely dies on the deadline. I matched the reporter's suggestion exactly rather than pick a margin size — happy to add one if reviewers prefer.

## Changes

- `generators/go-v2/base/src/asIs/internal/retrier.go_`: deadline-vs-backoff comparison; `Body.Close()` reordered.
- `generators/go-v2/base/src/asIs/internal/retrier_test.go_`: `TestRetryWaitIsInterruptedByContext` rewritten to cover cancellation; added `TestRetryReturnsResponseWhenDeadlineShorterThanBackoff` and `TestRetryProceedsWhenDeadlineLongerThanBackoff`.
- Go SDK changelog entry.
- Regenerated `seed/go-sdk/**/internal/retrier{,_test}.go` (366 files).

## Testing

Built the generator from this branch and generated name.com's real SDK from their spec and `generators.yml`. Their original repro now returns `429: {"message":"slow down"}` in ~3ms, where 1.57.9 returns `context deadline exceeded` after 2s.

- All 8 retrier test functions pass as generated, including the 2 new ones.
- `go build ./...` and `go vet ./...` clean.
- Full-suite failure profile identical to 1.57.9 (only WireMock tests needing a local server).
- Seed fixtures `exhaustive/no-custom-config`, `imdb/no-custom-config`, `idempotency-headers` build and pass.

Note on the snapshots: I patched them mechanically rather than running seed, since these are `asIs` files whose only per-fixture variation is the module path (verified: all 183 `shouldRetry` bodies identical, all 366 files `gofmt`-clean). I validated the shortcut by diffing a patched snapshot against genuine generator output — byte-identical modulo the module path. Worth re-running `pnpm seed` if you would rather not rely on that.

Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/17521" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->