### PR TITLE
fix(cli): hydrate Git LFS assets for git-ref docs builds

### DIFF
--- a/packages/cli/cli/changes/unreleased/fix-git-ref-lfs-assets.yml
+++ b/packages/cli/cli/changes/unreleased/fix-git-ref-lfs-assets.yml
@@ -1,0 +1,5 @@
+# yaml-language-server: $schema=../../../../../fern-changes-yml.schema.json
+
+- summary: |
+    Materialize Git LFS assets when building docs versions from Git refs.
+  type: fix

--- a/packages/cli/configuration-loader/src/docs-yml/__test__/gitRefVersioning.matrix.test.ts
+++ b/packages/cli/configuration-loader/src/docs-yml/__test__/gitRefVersioning.matrix.test.ts
@@ -1,7 +1,7 @@
 import { AbsoluteFilePath, join, RelativeFilePath } from "@fern-api/fs-utils";
 import { createMockTaskContext } from "@fern-api/task-context";
 import { execFileSync } from "child_process";
-import { mkdir, mkdtemp, rm, writeFile } from "fs/promises";
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "fs/promises";
 import { tmpdir } from "os";
 import { join as pathJoin } from "path";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
@@ -12,11 +12,16 @@ import { resolveRefContentRoot } from "../git-versions/resolveRefContentRoot.js"
 const context = createMockTaskContext();
 
 function git(cwd: string, ...args: string[]): string {
+    return gitWithEnv(cwd, {}, ...args);
+}
+
+function gitWithEnv(cwd: string, env: NodeJS.ProcessEnv, ...args: string[]): string {
     return execFileSync("git", args, {
         cwd,
         encoding: "utf-8",
         env: {
             ...process.env,
+            ...env,
             GIT_AUTHOR_NAME: "test",
             GIT_AUTHOR_EMAIL: "test@example.com",
             GIT_COMMITTER_NAME: "test",
@@ -46,6 +51,62 @@ const VERSION_FILE = "navigation:\n  - section: V2\n    contents:\n      - page:
 const DOCS_WITH_TOP_NAV =
     "instances: []\nnavigation:\n  - section: V1\n    contents:\n      - page: P1\n        path: ./pages/v1.mdx\n";
 const DOCS_WITH_NEITHER = "instances: []\n";
+
+describe("git-ref versioning: Git LFS", () => {
+    let workdir: string;
+    let clone: string;
+    let refSha: string;
+    const pdfContents = "%PDF-1.7\nmaterialized Git LFS contents\n";
+
+    beforeAll(async () => {
+        workdir = await mkdtemp(pathJoin(tmpdir(), "git-ref-lfs-"));
+        const origin = pathJoin(workdir, "origin");
+        await mkdir(origin, { recursive: true });
+        git(origin, "init", "-b", "main");
+        git(origin, "lfs", "install", "--local");
+        git(origin, "lfs", "track", "*.pdf");
+
+        await write(origin, "fern/docs.yml", DOCS_WITH_TOP_NAV);
+        await write(origin, "fern/pages/v1.mdx", "# v1\n");
+        await write(origin, "fern/assets/manual.pdf", pdfContents);
+        refSha = await commitAll(origin, "LFS-backed docs");
+        git(origin, "tag", "lfs-docs");
+
+        clone = pathJoin(workdir, "clone");
+        gitWithEnv(workdir, { GIT_LFS_SKIP_SMUDGE: "1" }, "clone", "file://" + origin, clone);
+        git(clone, "lfs", "install", "--local");
+    });
+
+    afterAll(async () => {
+        await rm(workdir, { recursive: true, force: true });
+    });
+
+    it("materializes LFS files when checkout smudging is disabled", async () => {
+        expect(await readFile(pathJoin(clone, "fern/assets/manual.pdf"), "utf-8")).toContain(
+            "version https://git-lfs.github.com/spec/v1"
+        );
+
+        const previousSkipSmudge = process.env.GIT_LFS_SKIP_SMUDGE;
+        process.env.GIT_LFS_SKIP_SMUDGE = "1";
+        try {
+            const materialized = await materializeGitRef({
+                ref: "lfs-docs",
+                absolutePathToFernFolder: fernFolder(clone),
+                context
+            });
+            expect(materialized.sha).toBe(refSha);
+            expect(
+                await readFile(pathJoin(materialized.absolutePathToRepoRoot, "fern/assets/manual.pdf"), "utf-8")
+            ).toBe(pdfContents);
+        } finally {
+            if (previousSkipSmudge == null) {
+                delete process.env.GIT_LFS_SKIP_SMUDGE;
+            } else {
+                process.env.GIT_LFS_SKIP_SMUDGE = previousSkipSmudge;
+            }
+        }
+    });
+});
 
 /**
  * A single origin repository holding the historical refs that a real docs

--- a/packages/cli/configuration-loader/src/docs-yml/git-versions/materializeGitRef.ts
+++ b/packages/cli/configuration-loader/src/docs-yml/git-versions/materializeGitRef.ts
@@ -92,6 +92,77 @@ async function getDefaultRemote({
     return remotes.includes("origin") ? "origin" : remotes[0];
 }
 
+async function worktreeContainsGitLfsPointers({
+    worktreePath,
+    ref,
+    sha,
+    context
+}: {
+    worktreePath: AbsoluteFilePath;
+    ref: string;
+    sha: string;
+    context: TaskContext;
+}): Promise<boolean> {
+    const result = await runGit({
+        args: ["grep", "-l", "-I", "-e", "^version https://git-lfs.github.com/spec/v1$", "--", "."],
+        cwd: worktreePath,
+        context
+    });
+    if (result.exitCode === 0) {
+        return true;
+    }
+    if (result.exitCode === 1) {
+        return false;
+    }
+
+    throw new CliError({
+        message: `Failed to inspect git ref '${ref}' (${sha}) for Git LFS pointers: ${result.stderr || result.stdout}`,
+        code: CliError.Code.ConfigError
+    });
+}
+
+async function materializeGitLfsFiles({
+    worktreePath,
+    ref,
+    sha,
+    context
+}: {
+    worktreePath: AbsoluteFilePath;
+    ref: string;
+    sha: string;
+    context: TaskContext;
+}): Promise<void> {
+    if (!(await worktreeContainsGitLfsPointers({ worktreePath, ref, sha, context }))) {
+        return;
+    }
+
+    const remote = await getDefaultRemote({ repoRoot: worktreePath, context });
+    const pullResult = await runGit({
+        args: remote != null ? ["lfs", "pull", "--include=*", "--exclude=", remote] : ["lfs", "checkout"],
+        cwd: worktreePath,
+        context
+    });
+    if (pullResult.exitCode !== 0) {
+        const output = pullResult.stderr || pullResult.stdout;
+        const gitLfsUnavailable = output.includes("'lfs' is not a git command");
+        throw new CliError({
+            message: gitLfsUnavailable
+                ? `Git LFS is required to materialize files for git ref '${ref}' (${sha}). Install Git LFS and retry.`
+                : `Failed to materialize Git LFS files for git ref '${ref}' (${sha}): ${output}`,
+            code: CliError.Code.ConfigError
+        });
+    }
+
+    if (await worktreeContainsGitLfsPointers({ worktreePath, ref, sha, context })) {
+        throw new CliError({
+            message:
+                `Git LFS files for git ref '${ref}' (${sha}) could not be materialized. ` +
+                "Ensure the required LFS objects are available from the configured git remote.",
+            code: CliError.Code.ConfigError
+        });
+    }
+}
+
 async function tryResolveSha({
     repoRoot,
     ref,
@@ -333,6 +404,8 @@ export async function materializeGitRef({
             code: CliError.Code.ConfigError
         });
     }
+
+    await materializeGitLfsFiles({ worktreePath, ref, sha, context });
 
     const materialized: MaterializedGitRef = {
         ref,


### PR DESCRIPTION
## Description
Jira ticket: Refs https://postmanlabs.atlassian.net/browse/FERNDOCS-71

Git-ref docs builds now hydrate unresolved Git LFS pointers in their detached worktree before configuration and assets are consumed. This prevents LFS-backed PDFs and other assets from being published as pointer metadata.

## Changes Made
- Detect unresolved Git LFS pointer files after materializing a Git-ref worktree.
- Pull LFS objects from the repository remote, fall back to the local LFS cache when no remote is available, and fail with actionable errors if pointers remain.
- Add a regression test that clones an LFS-backed docs repository with smudging disabled and verifies the materialized PDF contents.
- [ ] Updated README.md generator (if applicable)

## Testing
- [x] Unit tests added/updated: `pnpm --filter @fern-api/configuration-loader test -- gitRefVersioning.matrix.test.ts`
- [x] TypeScript compilation: `pnpm --filter @fern-api/configuration-loader compile`
- [x] Lint/checks: `pnpm check:fix`, `pnpm lint:biome`
- [x] Manual end-to-end testing: a disposable `ryanstep-config` clone published a 128-byte LFS pointer with the base CLI and a 708-byte valid PDF with this PR; missing LFS objects fail the publish instead of uploading pointers.

Live fixed fixture: https://git-ref-lfs-dev-test.docs.dev.buildwithfern.com/2-0/manual

Link to Devin session: https://app.devin.ai/sessions/37f5c8458ae74148beab512287fed2c6
Requested by: @Ryan-Amirthan
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/17524" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->