### PR TITLE
feat(cli): add generator compatibility validation

### DIFF
--- a/packages/cli/generation/remote-generation/remote-workspace-runner/src/__test__/sdkGenClientCompatibility.test.ts
+++ b/packages/cli/generation/remote-generation/remote-workspace-runner/src/__test__/sdkGenClientCompatibility.test.ts
@@ -1,0 +1,213 @@
+// cspell:ignore kotlin
+import { describe, expect, it } from "vitest";
+import {
+    type GenerationConfigKind,
+    type GenerationConfigRoute,
+    GeneratorConfigCompatibilityError,
+    type GeneratorLanguage,
+    getGeneratorLanguage,
+    validateGeneratorConfigCompatibility
+} from "../sdk-gen-client/index.js";
+
+interface LanguageBoundary {
+    generatorId: string;
+    language: GeneratorLanguage;
+    below: string;
+    cutover: string;
+    above: string;
+}
+
+const LANGUAGE_BOUNDARIES: readonly LanguageBoundary[] = [
+    {
+        generatorId: "fernapi/fern-typescript-sdk",
+        language: "typescript",
+        below: "3.999.999",
+        cutover: "4.0.0",
+        above: "4.0.1"
+    },
+    {
+        generatorId: "fernapi/fern-python-sdk",
+        language: "python",
+        below: "5.999.999",
+        cutover: "6.0.0",
+        above: "6.0.1"
+    },
+    {
+        generatorId: "fernapi/fern-java-sdk",
+        language: "java",
+        below: "4.999.999",
+        cutover: "5.0.0",
+        above: "5.0.1"
+    },
+    {
+        generatorId: "fernapi/fern-kotlin-sdk",
+        language: "kotlin",
+        below: "4.999.999",
+        cutover: "5.0.0",
+        above: "5.0.1"
+    },
+    {
+        generatorId: "fernapi/fern-go-sdk",
+        language: "go",
+        below: "1.999.999",
+        cutover: "2.0.0",
+        above: "2.0.1"
+    },
+    {
+        generatorId: "fernapi/fern-csharp-sdk",
+        language: "csharp",
+        below: "2.999.999",
+        cutover: "3.0.0",
+        above: "3.0.1"
+    },
+    {
+        generatorId: "fernapi/fern-php-sdk",
+        language: "php",
+        below: "2.999.999",
+        cutover: "3.0.0",
+        above: "3.0.1"
+    },
+    {
+        generatorId: "fernapi/fern-ruby-sdk",
+        language: "ruby",
+        below: "1.999.999",
+        cutover: "2.0.0",
+        above: "2.0.1"
+    },
+    {
+        generatorId: "fernapi/fern-rust-sdk",
+        language: "rust",
+        below: "0.999.999",
+        cutover: "1.0.0",
+        above: "1.0.1"
+    },
+    {
+        generatorId: "fernapi/fern-swift-sdk",
+        language: "swift",
+        below: "0.999.999",
+        cutover: "1.0.0",
+        above: "1.0.1"
+    },
+    {
+        generatorId: "fernapi/fern-cli",
+        language: "cli",
+        below: "0.999.999",
+        cutover: "1.0.0",
+        above: "1.0.1"
+    }
+];
+
+const GENERATOR_ALIASES: ReadonlyArray<readonly [string, GeneratorLanguage, string]> = [
+    ["fernapi/fern-typescript", "typescript", "4.0.0"],
+    ["fernapi/fern-typescript-sdk", "typescript", "4.0.0"],
+    ["fernapi/fern-typescript-node-sdk", "typescript", "4.0.0"],
+    ["fernapi/fern-typescript-browser-sdk", "typescript", "4.0.0"],
+    ["fernapi/fern-python-sdk", "python", "6.0.0"],
+    ["fernapi/fern-java-sdk", "java", "5.0.0"],
+    ["fernapi/fern-kotlin-sdk", "kotlin", "5.0.0"],
+    ["fernapi/fern-go-sdk", "go", "2.0.0"],
+    ["fernapi/fern-csharp-sdk", "csharp", "3.0.0"],
+    ["fernapi/fern-php-sdk", "php", "3.0.0"],
+    ["fernapi/fern-ruby-sdk", "ruby", "2.0.0"],
+    ["fernapi/fern-ruby-sdk-v2", "ruby", "2.0.0"],
+    ["fernapi/fern-rust-sdk", "rust", "1.0.0"],
+    ["fernapi/fern-swift-sdk", "swift", "1.0.0"],
+    ["fernapi/fern-cli", "cli", "1.0.0"],
+    ["fernapi/fern-cli-generator", "cli", "1.0.0"]
+];
+
+describe("validateGeneratorConfigCompatibility", () => {
+    describe.each(LANGUAGE_BOUNDARIES)("$language cutover", (boundary) => {
+        it("routes cutover-1 to the Fern runtime bundle", () => {
+            expect(validate(boundary, boundary.below, "legacy-fern")).toEqual({
+                generatorId: boundary.generatorId,
+                language: boundary.language,
+                requestedVersion: boundary.below,
+                cutoverVersion: boundary.cutover,
+                configKind: "legacy-fern",
+                payloadKind: "fern-runtime-bundle"
+            });
+        });
+
+        it("rejects SDK Config at cutover-1", () => {
+            const error = captureError(() => validate(boundary, boundary.below, "sdk-config-v1"));
+            expect(error).toMatchObject({
+                code: "LEGACY_FERN_CONFIG_REQUIRED",
+                generatorId: boundary.generatorId,
+                language: boundary.language,
+                requestedVersion: boundary.below,
+                cutoverVersion: boundary.cutover,
+                receivedConfigKind: "sdk-config-v1",
+                expectedConfigKind: "legacy-fern",
+                expectedLanguage: boundary.language,
+                retryable: false,
+                recommendedAction: "USE_LEGACY_FERN_CONFIG"
+            });
+        });
+
+        it("routes cutover to SDK Config IR v1", () => {
+            expect(validate(boundary, boundary.cutover, "sdk-config-v1").payloadKind).toBe("sdk-config-ir-v1");
+        });
+
+        it("rejects legacy Fern configuration at cutover", () => {
+            const error = captureError(() => validate(boundary, boundary.cutover, "legacy-fern"));
+            expect(error).toMatchObject({
+                code: "SDK_CONFIG_V1_REQUIRED",
+                generatorId: boundary.generatorId,
+                language: boundary.language,
+                requestedVersion: boundary.cutover,
+                cutoverVersion: boundary.cutover,
+                receivedConfigKind: "legacy-fern",
+                expectedConfigKind: "sdk-config-v1",
+                expectedLanguage: boundary.language,
+                retryable: false,
+                recommendedAction: "USE_SDK_CONFIG_V1"
+            });
+        });
+
+        it("routes cutover+1 to SDK Config IR v1", () => {
+            expect(validate(boundary, boundary.above, "sdk-config-v1").payloadKind).toBe("sdk-config-ir-v1");
+        });
+    });
+
+    it.each(GENERATOR_ALIASES)("maps alias %s to %s", (generatorId, language, cutoverVersion) => {
+        expect(getGeneratorLanguage(generatorId)).toBe(language);
+        expect(
+            validateGeneratorConfigCompatibility({
+                generatorId,
+                language,
+                requestedVersion: cutoverVersion,
+                configKind: "sdk-config-v1"
+            })
+        ).toMatchObject({ language, cutoverVersion, payloadKind: "sdk-config-ir-v1" });
+    });
+
+    it("does not expose a language for an unknown generator", () => {
+        expect(getGeneratorLanguage("acme/custom-generator")).toBeUndefined();
+    });
+});
+
+function validate(
+    boundary: LanguageBoundary,
+    requestedVersion: string,
+    configKind: GenerationConfigKind
+): GenerationConfigRoute {
+    return validateGeneratorConfigCompatibility({
+        generatorId: boundary.generatorId,
+        language: boundary.language,
+        requestedVersion,
+        configKind
+    });
+}
+
+function captureError(action: () => unknown): GeneratorConfigCompatibilityError {
+    try {
+        action();
+    } catch (error: unknown) {
+        if (error instanceof GeneratorConfigCompatibilityError) {
+            return error;
+        }
+        throw error;
+    }
+    throw new Error("Expected compatibility validation to throw");
+}

--- a/packages/cli/generation/remote-generation/remote-workspace-runner/src/__test__/sdkGenClientDiagnostics.test.ts
+++ b/packages/cli/generation/remote-generation/remote-workspace-runner/src/__test__/sdkGenClientDiagnostics.test.ts
@@ -1,0 +1,243 @@
+import { describe, expect, it } from "vitest";
+import { compareSemver, parseExactSemver } from "../sdk-gen-client/exactSemver.js";
+import {
+    createGeneratorPolicies,
+    GeneratorConfigPolicyInvariantError
+} from "../sdk-gen-client/generatorConfigPolicy.js";
+import {
+    GeneratorConfigCompatibilityError,
+    type ValidateGeneratorConfigCompatibilityInput,
+    validateGeneratorConfigCompatibility
+} from "../sdk-gen-client/index.js";
+
+const VALID_INPUT: ValidateGeneratorConfigCompatibilityInput = {
+    generatorId: "fernapi/fern-typescript-sdk",
+    language: "typescript",
+    requestedVersion: "4.0.0",
+    configKind: "sdk-config-v1"
+};
+
+describe("generator configuration diagnostics", () => {
+    it.each([
+        "",
+        "AUTO",
+        "latest",
+        "4",
+        "4.0",
+        "v4.0.0",
+        "^4.0.0",
+        "~4.0.0",
+        ">=4.0.0",
+        "4.x",
+        "4.0.0 || 5.0.0",
+        " 4.0.0",
+        "4.0.0 ",
+        "04.0.0",
+        "4.00.0",
+        "4.0.00",
+        "4.0.0.0",
+        "4.0.0-01"
+    ])("rejects non-exact or malformed version %j", (requestedVersion) => {
+        const error = captureError(() => validateGeneratorConfigCompatibility({ ...VALID_INPUT, requestedVersion }));
+
+        expect(error).toMatchObject({
+            code: "INVALID_GENERATOR_VERSION",
+            generatorId: VALID_INPUT.generatorId,
+            language: VALID_INPUT.language,
+            requestedVersion,
+            cutoverVersion: "4.0.0",
+            receivedConfigKind: "sdk-config-v1",
+            expectedConfigKind: null,
+            expectedLanguage: "typescript",
+            retryable: false,
+            recommendedAction: "USE_EXACT_GENERATOR_VERSION"
+        });
+    });
+
+    it.each([
+        ["missing", undefined],
+        ["null", null],
+        ["object", { kind: "sdk-config-v1" }],
+        ["arbitrary string", "sdk-config-v2"],
+        ["number", 1]
+    ])("rejects a %s config kind at runtime", (_label, receivedConfigKind) => {
+        const malformedInput = {
+            ...VALID_INPUT,
+            configKind: receivedConfigKind
+        } as unknown as ValidateGeneratorConfigCompatibilityInput;
+        const error = captureError(() => validateGeneratorConfigCompatibility(malformedInput));
+
+        expect(error).toMatchObject({
+            code: "INVALID_CONFIG_KIND",
+            generatorId: VALID_INPUT.generatorId,
+            language: VALID_INPUT.language,
+            requestedVersion: VALID_INPUT.requestedVersion,
+            cutoverVersion: "4.0.0",
+            receivedConfigKind,
+            expectedConfigKind: "sdk-config-v1",
+            expectedLanguage: "typescript",
+            retryable: false,
+            recommendedAction: "USE_SUPPORTED_CONFIG_KIND"
+        });
+    });
+
+    it("rejects a physically missing config kind property", () => {
+        const { configKind: _configKind, ...inputWithoutConfigKind } = VALID_INPUT;
+        const error = captureError(() =>
+            validateGeneratorConfigCompatibility(inputWithoutConfigKind as ValidateGeneratorConfigCompatibilityInput)
+        );
+
+        expect(Object.hasOwn(error, "receivedConfigKind")).toBe(true);
+        expect(error).toMatchObject({
+            code: "INVALID_CONFIG_KIND",
+            receivedConfigKind: undefined,
+            retryable: false,
+            recommendedAction: "USE_SUPPORTED_CONFIG_KIND"
+        });
+    });
+
+    it("compares exact prerelease, build, and large numeric versions safely", () => {
+        expect(
+            validateGeneratorConfigCompatibility({
+                ...VALID_INPUT,
+                requestedVersion: "4.0.0-rc.1",
+                configKind: "legacy-fern"
+            }).payloadKind
+        ).toBe("fern-runtime-bundle");
+
+        expect(
+            validateGeneratorConfigCompatibility({
+                ...VALID_INPUT,
+                requestedVersion: "4.0.0+build.123"
+            }).payloadKind
+        ).toBe("sdk-config-ir-v1");
+
+        expect(
+            validateGeneratorConfigCompatibility({
+                ...VALID_INPUT,
+                requestedVersion: "900719925474099300000.0.0"
+            }).payloadKind
+        ).toBe("sdk-config-ir-v1");
+    });
+
+    it("follows SemVer prerelease precedence", () => {
+        const versions = [
+            "1.0.0-alpha",
+            "1.0.0-alpha.1",
+            "1.0.0-alpha.beta",
+            "1.0.0-beta",
+            "1.0.0-beta.2",
+            "1.0.0-beta.11",
+            "1.0.0-rc.1",
+            "1.0.0"
+        ];
+
+        for (let index = 1; index < versions.length; index += 1) {
+            expect(compareSemver(parse(versions[index - 1] ?? ""), parse(versions[index] ?? ""))).toBeLessThan(0);
+        }
+    });
+
+    it.each([
+        "1.0.0-",
+        "1.0.0+",
+        "1.0.0-alpha..1",
+        "1.0.0+build..1",
+        "1.0.0-alpha_1"
+    ])("rejects malformed prerelease or build version %s", (version) => {
+        expect(parseExactSemver(version)).toBeNull();
+    });
+
+    it("returns stable diagnostics for an unknown generator", () => {
+        const error = captureError(() =>
+            validateGeneratorConfigCompatibility({
+                ...VALID_INPUT,
+                generatorId: "acme/custom-generator"
+            })
+        );
+
+        expect(error).toMatchObject({
+            name: "GeneratorConfigCompatibilityError",
+            code: "UNKNOWN_GENERATOR",
+            generatorId: "acme/custom-generator",
+            language: "typescript",
+            requestedVersion: "4.0.0",
+            cutoverVersion: null,
+            receivedConfigKind: "sdk-config-v1",
+            expectedConfigKind: null,
+            expectedLanguage: null,
+            retryable: false,
+            recommendedAction: "USE_KNOWN_GENERATOR_ID"
+        });
+    });
+
+    it("returns stable diagnostics for a language mismatch", () => {
+        const error = captureError(() =>
+            validateGeneratorConfigCompatibility({
+                ...VALID_INPUT,
+                generatorId: "fernapi/fern-typescript-node-sdk",
+                language: "python"
+            })
+        );
+
+        expect(error).toMatchObject({
+            code: "GENERATOR_LANGUAGE_MISMATCH",
+            generatorId: "fernapi/fern-typescript-node-sdk",
+            language: "python",
+            requestedVersion: "4.0.0",
+            cutoverVersion: "4.0.0",
+            receivedConfigKind: "sdk-config-v1",
+            expectedConfigKind: null,
+            expectedLanguage: "typescript",
+            retryable: false,
+            recommendedAction: "USE_GENERATOR_LANGUAGE"
+        });
+    });
+
+    it("fails malformed internal cutovers with a typed invariant diagnostic", () => {
+        const error = capturePolicyError(() =>
+            createGeneratorPolicies([["fernapi/invalid-sdk", { language: "typescript", cutoverVersion: "AUTO" }]])
+        );
+
+        expect(error).toMatchObject({
+            name: "GeneratorConfigPolicyInvariantError",
+            code: "INVALID_GENERATOR_CUTOVER_POLICY",
+            generatorId: "fernapi/invalid-sdk",
+            language: "typescript",
+            cutoverVersion: "AUTO",
+            retryable: false,
+            recommendedAction: "FIX_GENERATOR_CUTOVER_POLICY"
+        });
+    });
+});
+
+function captureError(action: () => unknown): GeneratorConfigCompatibilityError {
+    try {
+        action();
+    } catch (error: unknown) {
+        if (error instanceof GeneratorConfigCompatibilityError) {
+            return error;
+        }
+        throw error;
+    }
+    throw new Error("Expected compatibility validation to throw");
+}
+
+function parse(version: string) {
+    const parsed = parseExactSemver(version);
+    if (parsed == null) {
+        throw new Error(`Expected an exact semantic version: ${version}`);
+    }
+    return parsed;
+}
+
+function capturePolicyError(action: () => unknown): GeneratorConfigPolicyInvariantError {
+    try {
+        action();
+    } catch (error: unknown) {
+        if (error instanceof GeneratorConfigPolicyInvariantError) {
+            return error;
+        }
+        throw error;
+    }
+    throw new Error("Expected policy validation to throw");
+}

--- a/packages/cli/generation/remote-generation/remote-workspace-runner/src/sdk-gen-client/README.md
+++ b/packages/cli/generation/remote-generation/remote-workspace-runner/src/sdk-gen-client/README.md
@@ -1,0 +1,57 @@
+# SDK generation client
+
+Internal Fern-first client logic for cloud SDK generation. It lives beside the
+remote workspace runner because that runner owns sdk-gen-api request preparation,
+submission, polling, and result handling.
+
+This is not a separately published package. Keep its API private to the remote
+workspace runner unless another concrete Fern consumer requires it.
+
+## Current API
+
+`validateGeneratorConfigCompatibility()` is the authority for known first-party
+generator aliases, language agreement, exact-version cutovers, accepted
+configuration kinds, and payload routes.
+
+```ts
+import { validateGeneratorConfigCompatibility } from "./sdk-gen-client/index.js";
+
+const route = validateGeneratorConfigCompatibility({
+    generatorId: "fernapi/fern-typescript-sdk",
+    language: "typescript",
+    requestedVersion: "4.0.0",
+    configKind: "sdk-config-v1"
+});
+
+// route.payloadKind === "sdk-config-ir-v1"
+```
+
+Versions below a generator's cutover require `legacy-fern` and route to a Fern
+runtime bundle. Versions at or above cutover require `sdk-config-v1` and route to
+SDK Config IR v1.
+
+Failures throw `GeneratorConfigCompatibilityError`, which carries stable input,
+expected-value, retryability, and recommended-action fields. Product-specific
+CLI guidance belongs at the call site.
+
+The alias and cutover matrix is private. Call `getGeneratorLanguage()` or the
+validator instead of importing or copying policy data.
+
+## Direction
+
+This directory is the expansion point for Fern's sdk-gen-api client behavior:
+
+- authentication adaptation without owning Fern's login flow;
+- multipart request construction and source upload;
+- polling, timeout policy, target results, and lifecycle events;
+- stable API errors, redaction, and artifact handoff; and
+- fallback decisions before either backend creates side effects.
+
+Add behavior here only when it can replace duplicated logic in the remote runner.
+Do not introduce fixed rollout cohorts by language, generator, or version.
+
+## Tests
+
+Compatibility tests live in the runner's `src/__test__` directory and cover all
+aliases, cutover boundaries, malformed inputs, stable diagnostics, prereleases,
+and large SemVer identifiers.

--- a/packages/cli/generation/remote-generation/remote-workspace-runner/src/sdk-gen-client/README.md
+++ b/packages/cli/generation/remote-generation/remote-workspace-runner/src/sdk-gen-client/README.md
@@ -1,13 +1,4 @@
-# SDK generation client
-
-Internal Fern-first client logic for cloud SDK generation. It lives beside the
-remote workspace runner because that runner owns sdk-gen-api request preparation,
-submission, polling, and result handling.
-
-This is not a separately published package. Keep its API private to the remote
-workspace runner unless another concrete Fern consumer requires it.
-
-## Current API
+# Generator configuration compatibility
 
 `validateGeneratorConfigCompatibility()` is the authority for known first-party
 generator aliases, language agreement, exact-version cutovers, accepted
@@ -36,19 +27,6 @@ CLI guidance belongs at the call site.
 
 The alias and cutover matrix is private. Call `getGeneratorLanguage()` or the
 validator instead of importing or copying policy data.
-
-## Direction
-
-This directory is the expansion point for Fern's sdk-gen-api client behavior:
-
-- authentication adaptation without owning Fern's login flow;
-- multipart request construction and source upload;
-- polling, timeout policy, target results, and lifecycle events;
-- stable API errors, redaction, and artifact handoff; and
-- fallback decisions before either backend creates side effects.
-
-Add behavior here only when it can replace duplicated logic in the remote runner.
-Do not introduce fixed rollout cohorts by language, generator, or version.
 
 ## Tests
 

--- a/packages/cli/generation/remote-generation/remote-workspace-runner/src/sdk-gen-client/exactSemver.ts
+++ b/packages/cli/generation/remote-generation/remote-workspace-runner/src/sdk-gen-client/exactSemver.ts
@@ -1,0 +1,74 @@
+/** Parsed SemVer precedence components, excluding build metadata. */
+export interface ParsedSemver {
+    core: readonly [string, string, string];
+    prerelease: readonly string[] | null;
+}
+
+const EXACT_SEMVER_PATTERN =
+    /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[A-Za-z-][0-9A-Za-z-]*)(?:\.(?:0|[1-9]\d*|\d*[A-Za-z-][0-9A-Za-z-]*))*))?(?:\+[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?$/;
+
+/** Parses only complete SemVer 2.0 versions, rejecting ranges, aliases, and partial versions. */
+export function parseExactSemver(value: string): ParsedSemver | null {
+    const match = EXACT_SEMVER_PATTERN.exec(value);
+    if (match === null || match[1] === undefined || match[2] === undefined || match[3] === undefined) {
+        return null;
+    }
+
+    return {
+        core: [match[1], match[2], match[3]],
+        prerelease: match[4]?.split(".") ?? null
+    };
+}
+
+/** Compares two parsed exact versions according to SemVer 2.0 precedence. */
+export function compareSemver(left: ParsedSemver, right: ParsedSemver): number {
+    for (let index = 0; index < left.core.length; index += 1) {
+        const result = compareNumericIdentifier(left.core[index] ?? "", right.core[index] ?? "");
+        if (result !== 0) {
+            return result;
+        }
+    }
+
+    return comparePrerelease(left.prerelease, right.prerelease);
+}
+
+function comparePrerelease(left: readonly string[] | null, right: readonly string[] | null): number {
+    if (left === null || right === null) {
+        return left === right ? 0 : left === null ? 1 : -1;
+    }
+
+    const length = Math.max(left.length, right.length);
+    for (let index = 0; index < length; index += 1) {
+        const leftIdentifier = left[index];
+        const rightIdentifier = right[index];
+        if (leftIdentifier === undefined || rightIdentifier === undefined) {
+            return leftIdentifier === rightIdentifier ? 0 : leftIdentifier === undefined ? -1 : 1;
+        }
+
+        const result = comparePrereleaseIdentifier(leftIdentifier, rightIdentifier);
+        if (result !== 0) {
+            return result;
+        }
+    }
+
+    return 0;
+}
+
+function comparePrereleaseIdentifier(left: string, right: string): number {
+    const leftIsNumeric = /^\d+$/.test(left);
+    const rightIsNumeric = /^\d+$/.test(right);
+    if (leftIsNumeric && rightIsNumeric) {
+        return compareNumericIdentifier(left, right);
+    }
+    if (leftIsNumeric !== rightIsNumeric) {
+        return leftIsNumeric ? -1 : 1;
+    }
+    return left === right ? 0 : left < right ? -1 : 1;
+}
+
+function compareNumericIdentifier(left: string, right: string): number {
+    if (left.length !== right.length) {
+        return left.length < right.length ? -1 : 1;
+    }
+    return left === right ? 0 : left < right ? -1 : 1;
+}

--- a/packages/cli/generation/remote-generation/remote-workspace-runner/src/sdk-gen-client/generatorConfigCompatibility.ts
+++ b/packages/cli/generation/remote-generation/remote-workspace-runner/src/sdk-gen-client/generatorConfigCompatibility.ts
@@ -1,0 +1,214 @@
+// cspell:ignore kotlin
+import { compareSemver, parseExactSemver } from "./exactSemver.js";
+import { type GeneratorPolicy, getGeneratorPolicy } from "./generatorConfigPolicy.js";
+
+export type GeneratorLanguage =
+    | "typescript"
+    | "python"
+    | "java"
+    | "kotlin"
+    | "go"
+    | "csharp"
+    | "php"
+    | "ruby"
+    | "rust"
+    | "swift"
+    | "cli";
+
+export type GenerationConfigKind = "legacy-fern" | "sdk-config-v1";
+
+export type GenerationPayloadKind = "fern-runtime-bundle" | "sdk-config-ir-v1";
+
+/** Inputs used to select the configuration payload route for a generator invocation. */
+export interface ValidateGeneratorConfigCompatibilityInput {
+    generatorId: string;
+    language: GeneratorLanguage;
+    requestedVersion: string;
+    configKind: GenerationConfigKind;
+}
+
+/** Validated route and payload kind that the caller should submit for generation. */
+export interface GenerationConfigRoute {
+    generatorId: string;
+    language: GeneratorLanguage;
+    requestedVersion: string;
+    cutoverVersion: string;
+    configKind: GenerationConfigKind;
+    payloadKind: GenerationPayloadKind;
+}
+
+export type GeneratorConfigCompatibilityErrorCode =
+    | "UNKNOWN_GENERATOR"
+    | "GENERATOR_LANGUAGE_MISMATCH"
+    | "INVALID_GENERATOR_VERSION"
+    | "INVALID_CONFIG_KIND"
+    | "LEGACY_FERN_CONFIG_REQUIRED"
+    | "SDK_CONFIG_V1_REQUIRED";
+
+export type GeneratorConfigCompatibilityRecommendedAction =
+    | "USE_KNOWN_GENERATOR_ID"
+    | "USE_GENERATOR_LANGUAGE"
+    | "USE_EXACT_GENERATOR_VERSION"
+    | "USE_SUPPORTED_CONFIG_KIND"
+    | "USE_LEGACY_FERN_CONFIG"
+    | "USE_SDK_CONFIG_V1";
+
+interface GeneratorConfigCompatibilityErrorInput {
+    code: GeneratorConfigCompatibilityErrorCode;
+    message: string;
+    generatorId: string;
+    language: GeneratorLanguage;
+    requestedVersion: string;
+    cutoverVersion: string | null;
+    receivedConfigKind: unknown;
+    expectedLanguage: GeneratorLanguage | null;
+    expectedConfigKind: GenerationConfigKind | null;
+    recommendedAction: GeneratorConfigCompatibilityRecommendedAction;
+}
+
+/** Stable diagnostic that the CLI can translate at its product boundary. */
+export class GeneratorConfigCompatibilityError extends Error {
+    public override readonly name = "GeneratorConfigCompatibilityError";
+    public readonly code: GeneratorConfigCompatibilityErrorCode;
+    public readonly generatorId: string;
+    public readonly language: GeneratorLanguage;
+    public readonly requestedVersion: string;
+    public readonly cutoverVersion: string | null;
+    public readonly receivedConfigKind: unknown;
+    public readonly expectedConfigKind: GenerationConfigKind | null;
+    public readonly expectedLanguage: GeneratorLanguage | null;
+    public readonly retryable = false;
+    public readonly recommendedAction: GeneratorConfigCompatibilityRecommendedAction;
+
+    public constructor(input: GeneratorConfigCompatibilityErrorInput) {
+        super(input.message);
+        this.code = input.code;
+        this.generatorId = input.generatorId;
+        this.language = input.language;
+        this.requestedVersion = input.requestedVersion;
+        this.cutoverVersion = input.cutoverVersion;
+        this.receivedConfigKind = input.receivedConfigKind;
+        this.expectedConfigKind = input.expectedConfigKind;
+        this.expectedLanguage = input.expectedLanguage;
+        this.recommendedAction = input.recommendedAction;
+    }
+}
+
+/** Returns a known generator's language without exposing its cutover policy. */
+export function getGeneratorLanguage(generatorId: string): GeneratorLanguage | undefined {
+    return getGeneratorPolicy(generatorId)?.language;
+}
+
+/** Validates identity, language, exact version, and config kind, then selects the payload route. */
+export function validateGeneratorConfigCompatibility(
+    input: ValidateGeneratorConfigCompatibilityInput
+): GenerationConfigRoute {
+    const policy = getGeneratorPolicy(input.generatorId);
+    if (policy === undefined) {
+        throw compatibilityError(input, {
+            code: "UNKNOWN_GENERATOR",
+            message: `Unknown first-party generator: ${input.generatorId}`,
+            cutoverVersion: null,
+            expectedLanguage: null,
+            expectedConfigKind: null,
+            recommendedAction: "USE_KNOWN_GENERATOR_ID"
+        });
+    }
+
+    if (policy.language !== input.language) {
+        throw compatibilityError(input, {
+            code: "GENERATOR_LANGUAGE_MISMATCH",
+            message: `Generator ${input.generatorId} targets ${policy.language}, not ${input.language}`,
+            cutoverVersion: policy.cutoverVersion,
+            expectedLanguage: policy.language,
+            expectedConfigKind: null,
+            recommendedAction: "USE_GENERATOR_LANGUAGE"
+        });
+    }
+
+    const requestedVersion = parseExactSemver(input.requestedVersion);
+    if (requestedVersion === null) {
+        throw compatibilityError(input, {
+            code: "INVALID_GENERATOR_VERSION",
+            message: `Generator version must be an exact semantic version: ${input.requestedVersion}`,
+            cutoverVersion: policy.cutoverVersion,
+            expectedLanguage: policy.language,
+            expectedConfigKind: null,
+            recommendedAction: "USE_EXACT_GENERATOR_VERSION"
+        });
+    }
+
+    const isBeforeCutover = compareSemver(requestedVersion, policy.parsedCutoverVersion) < 0;
+    const expectedConfigKind = isBeforeCutover ? "legacy-fern" : "sdk-config-v1";
+    const receivedConfigKind: unknown = input.configKind;
+    if (!isGenerationConfigKind(receivedConfigKind)) {
+        throw compatibilityError(
+            input,
+            {
+                code: "INVALID_CONFIG_KIND",
+                message: "Configuration kind must be legacy-fern or sdk-config-v1",
+                cutoverVersion: policy.cutoverVersion,
+                expectedLanguage: policy.language,
+                expectedConfigKind,
+                recommendedAction: "USE_SUPPORTED_CONFIG_KIND"
+            },
+            receivedConfigKind
+        );
+    }
+    if (receivedConfigKind !== expectedConfigKind) {
+        throw configKindError(input, policy, expectedConfigKind, receivedConfigKind);
+    }
+
+    return {
+        generatorId: input.generatorId,
+        language: policy.language,
+        requestedVersion: input.requestedVersion,
+        cutoverVersion: policy.cutoverVersion,
+        configKind: receivedConfigKind,
+        payloadKind: isBeforeCutover ? "fern-runtime-bundle" : "sdk-config-ir-v1"
+    };
+}
+
+function compatibilityError(
+    input: ValidateGeneratorConfigCompatibilityInput,
+    details: Omit<
+        GeneratorConfigCompatibilityErrorInput,
+        "generatorId" | "language" | "requestedVersion" | "receivedConfigKind"
+    >,
+    receivedConfigKind: unknown = input.configKind
+): GeneratorConfigCompatibilityError {
+    return new GeneratorConfigCompatibilityError({
+        generatorId: input.generatorId,
+        language: input.language,
+        requestedVersion: input.requestedVersion,
+        receivedConfigKind,
+        ...details
+    });
+}
+
+function configKindError(
+    input: ValidateGeneratorConfigCompatibilityInput,
+    policy: GeneratorPolicy,
+    expectedConfigKind: GenerationConfigKind,
+    receivedConfigKind: GenerationConfigKind
+): GeneratorConfigCompatibilityError {
+    const requiresLegacy = expectedConfigKind === "legacy-fern";
+    return compatibilityError(
+        input,
+        {
+            code: requiresLegacy ? "LEGACY_FERN_CONFIG_REQUIRED" : "SDK_CONFIG_V1_REQUIRED",
+            message: requiresLegacy
+                ? `Generator ${input.generatorId} ${input.requestedVersion} requires legacy Fern configuration`
+                : `Generator ${input.generatorId} ${input.requestedVersion} requires SDK Config v1`,
+            cutoverVersion: policy.cutoverVersion,
+            expectedLanguage: policy.language,
+            expectedConfigKind,
+            recommendedAction: requiresLegacy ? "USE_LEGACY_FERN_CONFIG" : "USE_SDK_CONFIG_V1"
+        },
+        receivedConfigKind
+    );
+}
+
+function isGenerationConfigKind(value: unknown): value is GenerationConfigKind {
+    return value === "legacy-fern" || value === "sdk-config-v1";
+}

--- a/packages/cli/generation/remote-generation/remote-workspace-runner/src/sdk-gen-client/generatorConfigPolicy.ts
+++ b/packages/cli/generation/remote-generation/remote-workspace-runner/src/sdk-gen-client/generatorConfigPolicy.ts
@@ -1,0 +1,73 @@
+// cspell:ignore kotlin
+import { type ParsedSemver, parseExactSemver } from "./exactSemver.js";
+import type { GeneratorLanguage } from "./generatorConfigCompatibility.js";
+
+interface GeneratorPolicyDefinition {
+    language: GeneratorLanguage;
+    cutoverVersion: string;
+}
+
+/** Validated internal policy associated with one first-party generator alias. */
+export interface GeneratorPolicy extends GeneratorPolicyDefinition {
+    parsedCutoverVersion: ParsedSemver;
+}
+
+type GeneratorPolicyEntry = readonly [string, GeneratorPolicyDefinition];
+
+/** Typed startup failure for an invalid private generator cutover definition. */
+export class GeneratorConfigPolicyInvariantError extends Error {
+    public override readonly name = "GeneratorConfigPolicyInvariantError";
+    public readonly code = "INVALID_GENERATOR_CUTOVER_POLICY";
+    public readonly generatorId: string;
+    public readonly language: GeneratorLanguage;
+    public readonly cutoverVersion: string;
+    public readonly retryable = false;
+    public readonly recommendedAction = "FIX_GENERATOR_CUTOVER_POLICY";
+
+    public constructor(generatorId: string, policy: GeneratorPolicyDefinition) {
+        super(`Generator ${generatorId} has an invalid cutover version: ${policy.cutoverVersion}`);
+        this.generatorId = generatorId;
+        this.language = policy.language;
+        this.cutoverVersion = policy.cutoverVersion;
+    }
+}
+
+/** Internal constructor exported only for direct invariant testing. */
+export function createGeneratorPolicies(
+    entries: readonly GeneratorPolicyEntry[]
+): ReadonlyMap<string, GeneratorPolicy> {
+    return new Map(
+        entries.map(([generatorId, policy]) => {
+            const parsedCutoverVersion = parseExactSemver(policy.cutoverVersion);
+            if (parsedCutoverVersion === null) {
+                throw new GeneratorConfigPolicyInvariantError(generatorId, policy);
+            }
+            return [generatorId, { ...policy, parsedCutoverVersion }];
+        })
+    );
+}
+
+// This is the sole authority for first-party aliases and cutovers.
+const GENERATOR_POLICIES = createGeneratorPolicies([
+    ["fernapi/fern-typescript", { language: "typescript", cutoverVersion: "4.0.0" }],
+    ["fernapi/fern-typescript-sdk", { language: "typescript", cutoverVersion: "4.0.0" }],
+    ["fernapi/fern-typescript-node-sdk", { language: "typescript", cutoverVersion: "4.0.0" }],
+    ["fernapi/fern-typescript-browser-sdk", { language: "typescript", cutoverVersion: "4.0.0" }],
+    ["fernapi/fern-python-sdk", { language: "python", cutoverVersion: "6.0.0" }],
+    ["fernapi/fern-java-sdk", { language: "java", cutoverVersion: "5.0.0" }],
+    ["fernapi/fern-kotlin-sdk", { language: "kotlin", cutoverVersion: "5.0.0" }],
+    ["fernapi/fern-go-sdk", { language: "go", cutoverVersion: "2.0.0" }],
+    ["fernapi/fern-csharp-sdk", { language: "csharp", cutoverVersion: "3.0.0" }],
+    ["fernapi/fern-php-sdk", { language: "php", cutoverVersion: "3.0.0" }],
+    ["fernapi/fern-ruby-sdk", { language: "ruby", cutoverVersion: "2.0.0" }],
+    ["fernapi/fern-ruby-sdk-v2", { language: "ruby", cutoverVersion: "2.0.0" }],
+    ["fernapi/fern-rust-sdk", { language: "rust", cutoverVersion: "1.0.0" }],
+    ["fernapi/fern-swift-sdk", { language: "swift", cutoverVersion: "1.0.0" }],
+    ["fernapi/fern-cli", { language: "cli", cutoverVersion: "1.0.0" }],
+    ["fernapi/fern-cli-generator", { language: "cli", cutoverVersion: "1.0.0" }]
+]);
+
+/** Resolves one alias without exposing the private policy collection. */
+export function getGeneratorPolicy(generatorId: string): GeneratorPolicy | undefined {
+    return GENERATOR_POLICIES.get(generatorId);
+}

--- a/packages/cli/generation/remote-generation/remote-workspace-runner/src/sdk-gen-client/index.ts
+++ b/packages/cli/generation/remote-generation/remote-workspace-runner/src/sdk-gen-client/index.ts
@@ -1,0 +1,14 @@
+export type {
+    GenerationConfigKind,
+    GenerationConfigRoute,
+    GenerationPayloadKind,
+    GeneratorConfigCompatibilityErrorCode,
+    GeneratorConfigCompatibilityRecommendedAction,
+    GeneratorLanguage,
+    ValidateGeneratorConfigCompatibilityInput
+} from "./generatorConfigCompatibility.js";
+export {
+    GeneratorConfigCompatibilityError,
+    getGeneratorLanguage,
+    validateGeneratorConfigCompatibility
+} from "./generatorConfigCompatibility.js";


### PR DESCRIPTION
## Summary

- add exact-version generator/configuration compatibility validation to the remote workspace runner
- keep the first-party alias and cutover policy private behind a narrow internal API
- preserve exhaustive cutover, alias, diagnostic, and SemVer coverage
- avoid a separately published dependency

## Architecture

The compatibility policy is colocated with the remote workspace runner and is not exported as a workspace or published package.

## Verification

- 106 focused compatibility tests
- 365 remote workspace runner tests
- dependency-aware TypeScript compile across 48 packages
- Biome
- CSpell
- frozen pnpm install
- `git diff --check`