### PR TITLE
fix(cli): stamp configured default locale on docs ledger manifest

### DIFF
--- a/packages/cli/cli/changes/unreleased/fix-default-locale-manifest-key.yml
+++ b/packages/cli/cli/changes/unreleased/fix-default-locale-manifest-key.yml
@@ -1,0 +1,5 @@
+# yaml-language-server: $schema=../../../../../fern-changes-yml.schema.json
+
+- summary: |
+    Publish the configured default locale as the docs manifest locale key instead of always using "en".
+  type: fix

--- a/packages/cli/generation/remote-generation/remote-workspace-runner/src/__test__/buildLedgerInput.test.ts
+++ b/packages/cli/generation/remote-generation/remote-workspace-runner/src/__test__/buildLedgerInput.test.ts
@@ -23,15 +23,17 @@ const MINIMAL_ROOT = {
 
 function makeDocsDefinition({
     pages = {},
-    root = MINIMAL_ROOT
+    root = MINIMAL_ROOT,
+    translations
 }: {
     pages?: Record<string, { markdown: string }>;
     root?: unknown;
+    translations?: { defaultLocale: string; translations?: string[] };
 } = {}) {
     // Minimal DocsDefinition shape — only the fields buildLedgerInput reads.
     return {
         pages,
-        config: { root }
+        config: { root, ...(translations != null ? { translations } : {}) }
     } as Parameters<typeof buildLedgerInput>[0]["docsDefinition"];
 }
 
@@ -216,6 +218,52 @@ describe("buildLedgerInput", () => {
     it("defaults locale to en", () => {
         const { localeEntry } = buildLedgerInput({
             docsDefinition: makeDocsDefinition(),
+            apiDefinitions: new Map()
+        });
+
+        expect(localeEntry.locale).toBe("en");
+    });
+
+    it("keys the base segment by the configured default locale", () => {
+        const { localeEntry } = buildLedgerInput({
+            docsDefinition: makeDocsDefinition({
+                translations: { defaultLocale: "en-US", translations: ["en-US", "pt-BR", "ja-JP"] }
+            }),
+            apiDefinitions: new Map()
+        });
+
+        // publishInput.defaultLocale is derived from this value, so the
+        // manifest's defaultLocale and its base locales[] key stay in sync
+        // with the tag readers look up from docs.yml.
+        expect(localeEntry.locale).toBe("en-US");
+    });
+
+    it("preserves a non-English default locale", () => {
+        const { localeEntry } = buildLedgerInput({
+            docsDefinition: makeDocsDefinition({
+                translations: { defaultLocale: "de-DE", translations: ["de-DE", "en"] }
+            }),
+            apiDefinitions: new Map()
+        });
+
+        expect(localeEntry.locale).toBe("de-DE");
+    });
+
+    it("keeps an explicitly passed translation locale, including regional tags", () => {
+        const { localeEntry } = buildLedgerInput({
+            docsDefinition: makeDocsDefinition({
+                translations: { defaultLocale: "en-US", translations: ["en-US", "pt-BR"] }
+            }),
+            apiDefinitions: new Map(),
+            locale: "pt-BR"
+        });
+
+        expect(localeEntry.locale).toBe("pt-BR");
+    });
+
+    it("keys the base segment by en when the site declares no translations", () => {
+        const { localeEntry } = buildLedgerInput({
+            docsDefinition: makeDocsDefinition({ pages: { "page-1": { markdown: "# Hi" } } }),
             apiDefinitions: new Map()
         });
 

--- a/packages/cli/generation/remote-generation/remote-workspace-runner/src/publishDocsLedger.ts
+++ b/packages/cli/generation/remote-generation/remote-workspace-runner/src/publishDocsLedger.ts
@@ -123,7 +123,7 @@ export function buildLedgerInput({
     fileManifest,
     fileIdToPath,
     editThisPage,
-    locale = "en"
+    locale
 }: {
     docsDefinition: DocsDefinition;
     git?: DocsPublishGitInput;
@@ -139,7 +139,11 @@ export function buildLedgerInput({
     fileIdToPath?: Map<string, string>;
     /** Raw edit-this-page config from docs.yml, forwarded to LedgerConfig. */
     editThisPage?: { github?: { owner: string; repo: string; branch?: string; host?: string } };
-    /** Locale to stamp on segments. Defaults to "en". */
+    /**
+     * Locale to stamp on segments. When omitted (the base segment), it falls
+     * back to the default locale the docs config declares, and to "en" for
+     * sites that declare no translations.
+     */
     locale?: string;
 }): { localeEntry: LocaleEntry; blobs: Map<string, Buffer> } {
     const blobs = new Map<string, Buffer>();
@@ -225,7 +229,7 @@ export function buildLedgerInput({
         jsFiles: jsFilesRef,
         fileManifest,
         redirects: null,
-        locale,
+        locale: locale ?? docsDefinition.config.translations?.defaultLocale ?? "en",
         git
     };
 


### PR DESCRIPTION
## Description

The ledger publish path hardcoded `"en"` as the locale key for the base (default-locale) segment. `buildLedgerInput` defaulted its `locale` parameter to `"en"` and the base call site never passed one, so a site whose `docs.yml` declares

```yaml
translations:
  - lang: en-US
    default: true
  - lang: pt-BR
```

published `defaultLocale: "en"` and `locales: { en: {...}, "pt-BR": {...} }` — the non-default translations kept their real tags (that call site already passes `locale`), only the base entry was flattened. `publishInput.defaultLocale` is derived from `baseLocale.locale`, so it inherited the same wrong value.

A reader that looks up the tag it read from `docs.yml` (`en-US`) misses `manifest.locales`. The Next.js reader survives via `ledgerManifestClient`'s fallback chain (requested locale → `manifest.defaultLocale` → first published locale); the Astro static build had no such fallback and threw, emitting a docs site with zero routes that still deployed.

The configured default is already on the payload `publishDocsLedger` receives: `DocsDefinitionResolver.getDocsTranslationsConfig()` writes it to `docsDefinition.config.translations.defaultLocale`, so no new parameter or plumbing is needed.

Existing published manifests still key their base segment as `en`, so reader-side fallbacks must stay in place; this is not a breaking change for them.

## Changes Made
- `buildLedgerInput` resolves the segment locale as `locale ?? docsDefinition.config.translations?.defaultLocale ?? "en"` — the base segment (and therefore `publishInput.defaultLocale`) now uses the configured default, translation segments keep the explicit locale they already pass, and sites with no `translations` block still publish `"en"` unchanged.
- The locale is treated as an opaque string: no normalization, canonicalization, or BCP-47 validation.
- Changelog entry under `packages/cli/cli/changes/unreleased/`.

## Testing
- [x] Unit tests added/updated — `buildLedgerInput.test.ts`: `en-US` default keys the base entry `en-US`; a `de-DE` default is preserved; an explicit `pt-BR` translation locale round-trips; no `translations` block still yields `en`.
- [ ] Manual testing completed

```
pnpm check:fix    # no fixes applied
pnpm lint:biome   # clean
pnpm turbo run test --filter "*remote-workspace-runner*"   # 24 files, 269 tests passed (includes compile)
```

Deliberately out of scope: any change in fern-api/fern-platform (the Astro reader fallback is fern-platform#14141), locale-tag validation, and the FDR V2→ledger automigration path.


Link to Devin session: https://app.devin.ai/sessions/4868e3907f9843dd9edca82754a8fcd6
Requested by: @Ryan-Amirthan
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/17531" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->