### PR TITLE
feat(cli): prototype stub-mode fern mcp init/list/tools/dev flow

### DIFF
--- a/packages/cli/cli/changes/unreleased/mcp-prototype-init-flow.yml
+++ b/packages/cli/cli/changes/unreleased/mcp-prototype-init-flow.yml
@@ -1,0 +1,10 @@
+# yaml-language-server: $schema=../../../../../fern-changes-yml.schema.json
+
+- summary: |
+    Add a stub-mode prototype of the MCP creation flow: `fern mcp init` (toolset
+    wizard that writes an mcp group to generators.yml), `fern mcp list`,
+    `fern mcp tools` (with --refine), `fern mcp generate` (stub transcript +
+    tools.lock), and `fern mcp dev` (local inspector guidance). All backend
+    functionality (costing, AI curation, generation, MCP runtime) is stubbed
+    locally — this is a UX prototype.
+  type: feat

--- a/packages/cli/cli/src/cli.ts
+++ b/packages/cli/cli/src/cli.ts
@@ -85,6 +85,12 @@ import { installDependencies } from "./commands/install-dependencies/installDepe
 import { generateJsonschemaForWorkspaces } from "./commands/jsonschema/generateJsonschemaForWorkspace.js";
 import { installMcpServer } from "./commands/mcp/installMcpServer.js";
 import { MCP_CLIENTS, McpClient } from "./commands/mcp/mcpConfig.js";
+import { devMcp, generateMcp } from "./commands/mcp/prototype/generateMcp.js";
+import { initMcp } from "./commands/mcp/prototype/initMcp.js";
+import { listMcp } from "./commands/mcp/prototype/listMcp.js";
+import { DEFAULT_MCP_GROUP_NAME } from "./commands/mcp/prototype/mcpGeneratorsYml.js";
+import { BUILTIN_PRESET_KEYS } from "./commands/mcp/prototype/presets.js";
+import { toolsMcp } from "./commands/mcp/prototype/toolsMcp.js";
 import { mergeOpenAPIWithOverrides } from "./commands/merge/mergeOpenAPIWithOverrides.js";
 import { mockServer } from "./commands/mock/mockServer.js";
 import {
@@ -1690,6 +1696,171 @@ function addMcpCommand(cli: Argv<GlobalCliOptions>, cliContext: CliContext) {
                             context
                         });
                     });
+                }
+            )
+            .command(
+                "init",
+                "Create an MCP server from your API definition (prototype: backend is stubbed)",
+                (initYargs) =>
+                    initYargs
+                        .option("api", {
+                            type: "string",
+                            description: "The API to create an MCP server for (if the project has several)"
+                        })
+                        .option("name", {
+                            type: "string",
+                            description: "Server name (defaults to a slug derived from the API title)"
+                        })
+                        .option("preset", {
+                            type: "string",
+                            choices: BUILTIN_PRESET_KEYS,
+                            description: "Toolset preset to use noninteractively"
+                        })
+                        .option("intent", {
+                            type: "string",
+                            description: "Describe what agents should do — used by the AI-curated toolset"
+                        })
+                        .option("group", {
+                            type: "string",
+                            description: `Name of the generators.yml group to write (default: ${DEFAULT_MCP_GROUP_NAME})`
+                        })
+                        .option("yes", {
+                            alias: "y",
+                            boolean: true,
+                            default: false,
+                            description: "Accept defaults and skip prompts (read-only preset)"
+                        })
+                        .option("json", {
+                            boolean: true,
+                            default: false,
+                            description: "Output a machine-readable summary; verdicts become warnings"
+                        }),
+                async (argv) => {
+                    cliContext.instrumentPostHogEvent({ command: "fern mcp init" });
+                    const project = await loadProjectAndRegisterWorkspacesWithContext(cliContext, {
+                        commandLineApiWorkspace: undefined,
+                        defaultToAllApiWorkspaces: true
+                    });
+                    await initMcp({
+                        project,
+                        cliContext,
+                        api: argv.api,
+                        name: argv.name,
+                        preset: argv.preset,
+                        intent: argv.intent,
+                        group: argv.group,
+                        yes: argv.yes,
+                        json: argv.json
+                    });
+                }
+            )
+            .command(
+                "list",
+                "List the MCP servers configured in generators.yml (prototype)",
+                (listYargs) =>
+                    listYargs.option("json", {
+                        boolean: true,
+                        default: false,
+                        description: "Output as JSON"
+                    }),
+                async (argv) => {
+                    cliContext.instrumentPostHogEvent({ command: "fern mcp list" });
+                    const project = await loadProjectAndRegisterWorkspacesWithContext(cliContext, {
+                        commandLineApiWorkspace: undefined,
+                        defaultToAllApiWorkspaces: true
+                    });
+                    await listMcp({ project, cliContext, json: argv.json });
+                }
+            )
+            .command(
+                "tools",
+                "Print the resolved tool surface for an MCP group (prototype)",
+                (toolsYargs) =>
+                    toolsYargs
+                        .option("api", {
+                            type: "string",
+                            description: "The API to resolve tools against (if the project has several)"
+                        })
+                        .option("group", {
+                            type: "string",
+                            default: DEFAULT_MCP_GROUP_NAME,
+                            description: "The generators.yml group to inspect"
+                        })
+                        .option("preset", {
+                            type: "string",
+                            description: "Resolve a named preset from the group's tools.presets"
+                        })
+                        .option("json", {
+                            boolean: true,
+                            default: false,
+                            description: "Output as JSON"
+                        })
+                        .option("refine", {
+                            boolean: true,
+                            default: false,
+                            description: "Interactively trim the toolset and rewrite the config"
+                        }),
+                async (argv) => {
+                    cliContext.instrumentPostHogEvent({ command: "fern mcp tools" });
+                    const project = await loadProjectAndRegisterWorkspacesWithContext(cliContext, {
+                        commandLineApiWorkspace: undefined,
+                        defaultToAllApiWorkspaces: true
+                    });
+                    await toolsMcp({
+                        project,
+                        cliContext,
+                        api: argv.api,
+                        group: argv.group,
+                        preset: argv.preset,
+                        json: argv.json,
+                        refine: argv.refine
+                    });
+                }
+            )
+            .command(
+                "generate",
+                "Generate the MCP server for a group (prototype: prints a stub transcript and writes tools.lock)",
+                (generateYargs) =>
+                    generateYargs
+                        .option("api", {
+                            type: "string",
+                            description: "The API to generate for (if the project has several)"
+                        })
+                        .option("group", {
+                            type: "string",
+                            default: DEFAULT_MCP_GROUP_NAME,
+                            description: "The generators.yml group to generate"
+                        }),
+                async (argv) => {
+                    cliContext.instrumentPostHogEvent({ command: "fern mcp generate" });
+                    const project = await loadProjectAndRegisterWorkspacesWithContext(cliContext, {
+                        commandLineApiWorkspace: undefined,
+                        defaultToAllApiWorkspaces: true
+                    });
+                    await generateMcp({ project, cliContext, api: argv.api, group: argv.group });
+                }
+            )
+            .command(
+                "dev",
+                "Print local dev / inspector instructions for an MCP group (prototype)",
+                (devYargs) =>
+                    devYargs
+                        .option("api", {
+                            type: "string",
+                            description: "The API to use (if the project has several)"
+                        })
+                        .option("group", {
+                            type: "string",
+                            default: DEFAULT_MCP_GROUP_NAME,
+                            description: "The generators.yml group to use"
+                        }),
+                async (argv) => {
+                    cliContext.instrumentPostHogEvent({ command: "fern mcp dev" });
+                    const project = await loadProjectAndRegisterWorkspacesWithContext(cliContext, {
+                        commandLineApiWorkspace: undefined,
+                        defaultToAllApiWorkspaces: true
+                    });
+                    await devMcp({ project, cliContext, api: argv.api, group: argv.group });
                 }
             )
             .demandCommand(1, "Specify a subcommand, e.g. `fern mcp install`.");

--- a/packages/cli/cli/src/commands/mcp/prototype/__test__/openapiSummary.test.ts
+++ b/packages/cli/cli/src/commands/mcp/prototype/__test__/openapiSummary.test.ts
@@ -1,0 +1,63 @@
+import { mkdtemp, rm, writeFile } from "fs/promises";
+import { tmpdir } from "os";
+import { join } from "path";
+
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+import { loadSpecSummaries } from "../openapiSummary.js";
+
+const SPEC = `openapi: 3.0.0
+info:
+  title: Swagger Petstore
+paths:
+  /pets:
+    get:
+      operationId: listPets
+      summary: List all pets
+      tags: [pets]
+    post:
+      operationId: createPet
+      tags: [pets]
+  /pets/{petId}:
+    get:
+      operationId: getPet
+      tags: [pets]
+components:
+  securitySchemes:
+    apiKey:
+      type: apiKey
+      in: header
+      name: X-API-Key
+`;
+
+describe("loadSpecSummaries", () => {
+    let directory: string;
+
+    beforeAll(async () => {
+        directory = await mkdtemp(join(tmpdir(), "mcp-prototype-"));
+        await writeFile(join(directory, "openapi.yml"), SPEC);
+        await writeFile(join(directory, "not-a-spec.yml"), "just: some yaml\n");
+    });
+
+    afterAll(async () => {
+        await rm(directory, { recursive: true, force: true });
+    });
+
+    it("summarizes endpoints from an OpenAPI document and skips non-specs", async () => {
+        const summaries = await loadSpecSummaries(directory);
+        expect(summaries).toHaveLength(1);
+        const summary = summaries[0];
+        expect(summary?.title).toBe("Swagger Petstore");
+        expect(summary?.endpoints).toHaveLength(3);
+        expect(summary?.endpoints.map((endpoint) => `${endpoint.method} ${endpoint.path}`)).toEqual([
+            "GET /pets",
+            "POST /pets",
+            "GET /pets/{petId}"
+        ]);
+        expect(summary?.securitySchemeNames).toEqual(["apiKey"]);
+        const listPets = summary?.endpoints.find((endpoint) => endpoint.operationId === "listPets");
+        expect(listPets?.tags).toEqual(["pets"]);
+        expect(listPets?.summary).toBe("List all pets");
+        expect(listPets?.estimatedTokens).toBeGreaterThan(60);
+    });
+});

--- a/packages/cli/cli/src/commands/mcp/prototype/__test__/presets.test.ts
+++ b/packages/cli/cli/src/commands/mcp/prototype/__test__/presets.test.ts
@@ -1,8 +1,7 @@
 import { describe, expect, it } from "vitest";
-
+import { proposeAiRuleset } from "../aiCurated.js";
 import { EndpointSummary } from "../openapiSummary.js";
 import { buildMainResourcesPreset, buildReadOnlyPreset, isAmbiguousReadPost, isReadLikePost } from "../presets.js";
-import { proposeAiRuleset } from "../aiCurated.js";
 import { resolveTools } from "../toolset.js";
 
 function endpoint(overrides: Partial<EndpointSummary>): EndpointSummary {

--- a/packages/cli/cli/src/commands/mcp/prototype/__test__/presets.test.ts
+++ b/packages/cli/cli/src/commands/mcp/prototype/__test__/presets.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it } from "vitest";
+
+import { EndpointSummary } from "../openapiSummary.js";
+import { buildMainResourcesPreset, buildReadOnlyPreset, isAmbiguousReadPost, isReadLikePost } from "../presets.js";
+import { proposeAiRuleset } from "../aiCurated.js";
+import { resolveTools } from "../toolset.js";
+
+function endpoint(overrides: Partial<EndpointSummary>): EndpointSummary {
+    return {
+        method: "GET",
+        path: "/pets",
+        operationId: undefined,
+        tags: [],
+        summary: undefined,
+        description: undefined,
+        estimatedTokens: 100,
+        ...overrides
+    };
+}
+
+describe("read-only preset", () => {
+    it("includes GETs and read-like POSTs, excludes writes", () => {
+        const endpoints = [
+            endpoint({ method: "GET", path: "/pets", operationId: "listPets" }),
+            endpoint({ method: "POST", path: "/pets/search", operationId: "searchPets" }),
+            endpoint({ method: "POST", path: "/pets", operationId: "createPet" }),
+            endpoint({ method: "DELETE", path: "/pets/{id}", operationId: "deletePet" })
+        ];
+        const preset = buildReadOnlyPreset(endpoints);
+        const tools = resolveTools(endpoints, preset.config);
+        expect(tools.map((tool) => tool.endpoint.operationId)).toEqual(["listPets", "searchPets"]);
+    });
+
+    it("detects read-like POSTs by operationId, path segment, and summary", () => {
+        expect(isReadLikePost(endpoint({ method: "POST", operationId: "queryOrders" }))).toBe(true);
+        expect(isReadLikePost(endpoint({ method: "POST", path: "/orders/search" }))).toBe(true);
+        expect(isReadLikePost(endpoint({ method: "POST", summary: "List all orders" }))).toBe(true);
+        expect(isReadLikePost(endpoint({ method: "POST", operationId: "createOrder" }))).toBe(false);
+        expect(isReadLikePost(endpoint({ method: "GET", operationId: "listOrders" }))).toBe(false);
+    });
+
+    it("flags ambiguous read-like POSTs instead of including them", () => {
+        const ambiguous = endpoint({ method: "POST", operationId: "runSavedSearch", path: "/reports/run" });
+        expect(isReadLikePost(ambiguous)).toBe(false);
+        expect(isAmbiguousReadPost(ambiguous)).toBe(true);
+    });
+});
+
+describe("main-resources preset", () => {
+    it("ranks tags and excludes admin/internal-like ones", () => {
+        const endpoints = [
+            ...["GET", "POST", "PUT", "DELETE"].map((method) => endpoint({ method, tags: ["pets"] })),
+            ...["GET", "POST"].map((method) => endpoint({ method, path: "/orders", tags: ["orders"] })),
+            endpoint({ path: "/admin", tags: ["admin"] }),
+            endpoint({ path: "/hooks", tags: ["webhooks"] })
+        ];
+        const preset = buildMainResourcesPreset(endpoints);
+        expect(preset.available).toBe(true);
+        expect(preset.config.include?.map((selector) => selector.tag)).toEqual(["pets", "orders"]);
+        expect(preset.config.exclude?.map((selector) => selector.tag)).toEqual(
+            expect.arrayContaining(["admin", "webhooks"])
+        );
+    });
+
+    it("is unavailable on tag-less specs", () => {
+        const preset = buildMainResourcesPreset([endpoint({}), endpoint({ path: "/orders" })]);
+        expect(preset.available).toBe(false);
+        expect(preset.unavailableReason).toBeDefined();
+    });
+});
+
+describe("AI-curated proposal (stub)", () => {
+    const endpoints = [
+        endpoint({ tags: ["payments"] }),
+        endpoint({ method: "POST", path: "/refunds", tags: ["refunds"] }),
+        endpoint({ method: "DELETE", path: "/payments/{id}", tags: ["payments"] })
+    ];
+
+    it("excludes negated tags and presents exclusions", () => {
+        const proposal = proposeAiRuleset("help with payments but never touch refunds", endpoints);
+        expect(proposal.config.exclude).toEqual(expect.arrayContaining([{ tag: "refunds" }]));
+        expect(proposal.excludeReasons.length).toBeGreaterThan(0);
+        expect(proposal.config.include).toEqual(expect.arrayContaining([{ tag: "payments" }]));
+    });
+
+    it("excludes DELETE when the intent forbids deleting", () => {
+        const proposal = proposeAiRuleset("manage payments, never delete anything", endpoints);
+        expect(proposal.config.exclude).toEqual(expect.arrayContaining([{ method: "DELETE" }]));
+    });
+
+    it("persists the intent and defaults to read-only includes", () => {
+        const proposal = proposeAiRuleset("just browse things", endpoints);
+        expect(proposal.config.intent).toBe("just browse things");
+        expect(proposal.config.include).toEqual([{ method: "GET" }]);
+    });
+});

--- a/packages/cli/cli/src/commands/mcp/prototype/__test__/toolset.test.ts
+++ b/packages/cli/cli/src/commands/mcp/prototype/__test__/toolset.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it } from "vitest";
+
+import { EndpointSummary } from "../openapiSummary.js";
+import { computeVerdict, resolveTools, toolNameForEndpoint } from "../toolset.js";
+
+function endpoint(overrides: Partial<EndpointSummary>): EndpointSummary {
+    return {
+        method: "GET",
+        path: "/pets",
+        operationId: undefined,
+        tags: [],
+        summary: undefined,
+        description: undefined,
+        estimatedTokens: 100,
+        ...overrides
+    };
+}
+
+const ENDPOINTS: EndpointSummary[] = [
+    endpoint({ method: "GET", path: "/pets", operationId: "listPets", tags: ["pets"] }),
+    endpoint({ method: "POST", path: "/pets", operationId: "createPet", tags: ["pets"] }),
+    endpoint({ method: "DELETE", path: "/pets/{id}", operationId: "deletePet", tags: ["pets"] }),
+    endpoint({ method: "GET", path: "/admin/users", operationId: "listUsers", tags: ["admin"] })
+];
+
+describe("resolveTools", () => {
+    it("returns all endpoints for an empty config", () => {
+        expect(resolveTools(ENDPOINTS, {})).toHaveLength(4);
+    });
+
+    it("ANDs fields within a selector", () => {
+        const tools = resolveTools(ENDPOINTS, { include: [{ tag: "pets", method: "GET" }] });
+        expect(tools.map((tool) => tool.endpoint.operationId)).toEqual(["listPets"]);
+    });
+
+    it("ORs selectors across the include list", () => {
+        const tools = resolveTools(ENDPOINTS, { include: [{ method: "DELETE" }, { tag: "admin" }] });
+        expect(tools.map((tool) => tool.endpoint.operationId)).toEqual(["deletePet", "listUsers"]);
+    });
+
+    it("lets exclude win over include", () => {
+        const tools = resolveTools(ENDPOINTS, { include: [{ tag: "pets" }], exclude: [{ method: "DELETE" }] });
+        expect(tools.map((tool) => tool.endpoint.operationId)).toEqual(["listPets", "createPet"]);
+    });
+
+    it("matches path prefixes", () => {
+        const tools = resolveTools(ENDPOINTS, { include: [{ "path-prefix": "/admin" }] });
+        expect(tools.map((tool) => tool.endpoint.operationId)).toEqual(["listUsers"]);
+    });
+
+    it("matches exact endpoints", () => {
+        const tools = resolveTools(ENDPOINTS, { include: [{ endpoint: "POST /pets" }] });
+        expect(tools.map((tool) => tool.endpoint.operationId)).toEqual(["createPet"]);
+    });
+});
+
+describe("toolNameForEndpoint", () => {
+    it("prefers the operationId in snake_case", () => {
+        expect(toolNameForEndpoint(endpoint({ operationId: "listPets" }))).toBe("list_pets");
+    });
+
+    it("falls back to method + path", () => {
+        expect(toolNameForEndpoint(endpoint({ method: "GET", path: "/pets/{id}" }))).toBe("get_pets_id");
+    });
+});
+
+describe("computeVerdict", () => {
+    it("is green within budget", () => {
+        const verdict = computeVerdict(resolveTools(ENDPOINTS, {}), { maxTools: 40, maxTokens: 60_000 });
+        expect(verdict.level).toBe("green");
+        expect(verdict.toolCount).toBe(4);
+    });
+
+    it("is amber when over budget but within 3x", () => {
+        const many = Array.from({ length: 80 }, (_, index) => endpoint({ path: `/things/${index}` }));
+        const verdict = computeVerdict(resolveTools(many, {}), { maxTools: 40, maxTokens: 60_000 });
+        expect(verdict.level).toBe("amber");
+    });
+
+    it("is red when over 3x budget", () => {
+        const many = Array.from({ length: 200 }, (_, index) => endpoint({ path: `/things/${index}` }));
+        const verdict = computeVerdict(resolveTools(many, {}), { maxTools: 40, maxTokens: 60_000 });
+        expect(verdict.level).toBe("red");
+    });
+
+    it("takes the worse of the two clauses", () => {
+        const heavy = [endpoint({ estimatedTokens: 70_000 })];
+        const verdict = computeVerdict(resolveTools(heavy, {}), { maxTools: 40, maxTokens: 60_000 });
+        expect(verdict.level).toBe("amber");
+    });
+});

--- a/packages/cli/cli/src/commands/mcp/prototype/aiCurated.ts
+++ b/packages/cli/cli/src/commands/mcp/prototype/aiCurated.ts
@@ -1,0 +1,91 @@
+import { EndpointSummary } from "./openapiSummary.js";
+import { ToolSelector, ToolsConfig } from "./toolset.js";
+
+/**
+ * Stubbed "Fern Agent" ruleset proposal: pattern-matches the user's intent
+ * against the spec's tags and methods to produce a plausible declarative
+ * ruleset. The real implementation is server-side (FAI); this exists so the
+ * wizard's AI-curated path can be demoed end-to-end.
+ */
+
+export interface AiProposal {
+    config: ToolsConfig;
+    /** Human-readable reasons, keyed by the emitted selector, exclusions first. */
+    excludeReasons: string[];
+    includeReasons: string[];
+}
+
+const NEGATION_PATTERN = /(never|no|not|don'?t|avoid|exclude)\s+(?:touch\s+|use\s+|call\s+)?([a-z][a-z0-9_-]*)/gi;
+const READ_ONLY_HINT_PATTERN = /(read[\s-]?only|look\s?ups?|search|browse|nothing that writes|view)/i;
+const DELETE_HINT_PATTERN = /(never|no|not|don'?t)\s+(?:\w+\s+){0,2}delete/i;
+
+function uniqueTags(endpoints: EndpointSummary[]): string[] {
+    return [...new Set(endpoints.flatMap((endpoint) => endpoint.tags))];
+}
+
+function mentionsTag(intent: string, tag: string): boolean {
+    const lowered = intent.toLowerCase();
+    const loweredTag = tag.toLowerCase();
+    const singular = loweredTag.endsWith("s") ? loweredTag.slice(0, -1) : loweredTag;
+    return lowered.includes(loweredTag) || lowered.includes(singular);
+}
+
+function findNegatedTerms(intent: string): string[] {
+    const terms: string[] = [];
+    for (const match of intent.matchAll(NEGATION_PATTERN)) {
+        const term = match[2];
+        if (term != null) {
+            terms.push(term.toLowerCase());
+        }
+    }
+    return terms;
+}
+
+export function proposeAiRuleset(intent: string, endpoints: EndpointSummary[]): AiProposal {
+    const tags = uniqueTags(endpoints);
+    const negatedTerms = findNegatedTerms(intent);
+    const exclude: ToolSelector[] = [];
+    const excludeReasons: string[] = [];
+    const include: ToolSelector[] = [];
+    const includeReasons: string[] = [];
+
+    for (const tag of tags) {
+        const negated = negatedTerms.some((term) => tag.toLowerCase().includes(term));
+        if (negated) {
+            exclude.push({ tag });
+            excludeReasons.push(`{ tag: ${tag} } — you said not to touch "${tag}"`);
+        }
+    }
+    if (DELETE_HINT_PATTERN.test(intent)) {
+        exclude.push({ method: "DELETE" });
+        excludeReasons.push('{ method: DELETE } — "never delete anything"');
+    }
+
+    const readOnly = READ_ONLY_HINT_PATTERN.test(intent);
+    const mentionedTags = tags.filter(
+        (tag) => mentionsTag(intent, tag) && !exclude.some((selector) => selector.tag === tag)
+    );
+    for (const tag of mentionedTags) {
+        const selector: ToolSelector = readOnly ? { tag, method: "GET" } : { tag };
+        include.push(selector);
+        includeReasons.push(
+            readOnly
+                ? `{ tag: ${tag}, method: GET } — read-only ${tag}`
+                : `{ tag: ${tag} } — mentioned in your description`
+        );
+    }
+    if (include.length === 0) {
+        include.push({ method: "GET" });
+        includeReasons.push("{ method: GET } — defaulting to read-only lookups from your description");
+    }
+
+    return {
+        config: {
+            intent,
+            include,
+            exclude: exclude.length > 0 ? exclude : undefined
+        },
+        excludeReasons,
+        includeReasons
+    };
+}

--- a/packages/cli/cli/src/commands/mcp/prototype/generateMcp.ts
+++ b/packages/cli/cli/src/commands/mcp/prototype/generateMcp.ts
@@ -7,14 +7,11 @@ import { dirname, join } from "path";
 
 import { CliContext } from "../../../cli-context/CliContext.js";
 import { findMcpGroup, MCP_GENERATOR_NAME, MCP_GENERATOR_VERSION } from "./mcpGeneratorsYml.js";
-import { computeVerdict, formatVerdictLine, resolveTools } from "./toolset.js";
+import { computeVerdict, resolveTools } from "./toolset.js";
+import { banner, command, hint, ICONS, sleep, styledVerdictLine, withSpinner } from "./ui.js";
 import { pickWorkspaceAndLoadSpec } from "./workspace.js";
 
 const STUB_STEP_DELAY_MS = 400;
-
-async function sleep(milliseconds: number): Promise<void> {
-    await new Promise((resolve) => setTimeout(resolve, milliseconds));
-}
 
 export async function generateMcp({
     project,
@@ -51,15 +48,19 @@ export async function generateMcp({
     const serverName = found.config["server-name"];
 
     cliContext.logger.info("");
-    cliContext.logger.info(chalk.bold(`[mcp] Generating ${serverName} (group: ${group})`));
-    cliContext.logger.info(chalk.dim("[mcp] NOTE: this is a stubbed prototype — no code is actually generated."));
-    cliContext.logger.info(`[mcp] Using generator ${MCP_GENERATOR_NAME}@${MCP_GENERATOR_VERSION}`);
-    await sleep(STUB_STEP_DELAY_MS);
-    cliContext.logger.info(`[mcp] Parsed spec: ${spec.endpoints.length} endpoints`);
-    cliContext.logger.info(`[mcp] Resolved tool surface: ${formatVerdictLine(verdict)}`);
-    await sleep(STUB_STEP_DELAY_MS);
-    cliContext.logger.info(`[mcp] Building tool schemas… ${tools.length}/${tools.length}`);
-    await sleep(STUB_STEP_DELAY_MS);
+    cliContext.logger.info(
+        banner(`Generating ${serverName}`, [
+            `group ${chalk.bold(group)} ${ICONS.bullet} ${MCP_GENERATOR_NAME}@${MCP_GENERATOR_VERSION}`,
+            hint("stubbed prototype — no code is actually generated")
+        ])
+    );
+    cliContext.logger.info("");
+    await withSpinner(`Parsing spec…`, () => sleep(STUB_STEP_DELAY_MS));
+    cliContext.logger.info(`${ICONS.success} Parsed spec ${hint(`· ${spec.endpoints.length} endpoints`)}`);
+    await withSpinner(`Resolving tool surface…`, () => sleep(STUB_STEP_DELAY_MS));
+    cliContext.logger.info(`${ICONS.success} Resolved tool surface  ${styledVerdictLine(verdict)}`);
+    await withSpinner(`Building tool schemas…`, () => sleep(STUB_STEP_DELAY_MS));
+    cliContext.logger.info(`${ICONS.success} Built tool schemas ${hint(`· ${tools.length}/${tools.length}`)}`);
 
     const schemaHash = createHash("sha256")
         .update(JSON.stringify(tools.map((tool) => [tool.name, tool.endpoint.method, tool.endpoint.path])))
@@ -84,10 +85,11 @@ export async function generateMcp({
     const lockPath = join(dirname(found.absolutePathToGeneratorsConfiguration), "tools.lock");
     await writeFile(lockPath, yaml.dump(lock));
 
-    cliContext.logger.info(`[mcp] Wrote lockfile: ${lockPath}`);
-    cliContext.logger.info(chalk.green(`[mcp] Done. ${tools.length} tools locked for ${serverName}.`));
+    cliContext.logger.info(`${ICONS.success} Wrote lockfile ${hint(`· ${lockPath}`)}`);
     cliContext.logger.info("");
-    cliContext.logger.info(`Next: fern mcp dev --group ${group}`);
+    cliContext.logger.info(chalk.green(`${tools.length} tools locked for ${chalk.bold(serverName)}.`));
+    cliContext.logger.info("");
+    cliContext.logger.info(`${ICONS.pointer} Next: ${command(`fern mcp dev --group ${group}`)}`);
 }
 
 export async function devMcp({
@@ -121,17 +123,23 @@ export async function devMcp({
     const serverPath = found.outputLocation ?? `generated/${group}`;
 
     cliContext.logger.info("");
-    cliContext.logger.info(chalk.bold(`Local dev for ${serverName} (group: ${group})`));
-    cliContext.logger.info(chalk.dim("This prototype does not start a real MCP runtime — here's how you would:"));
+    cliContext.logger.info(
+        banner(`Local dev for ${serverName}`, [
+            `group ${chalk.bold(group)}`,
+            hint("this prototype does not start a real MCP runtime — here's how you would")
+        ])
+    );
     cliContext.logger.info("");
-    cliContext.logger.info("1. Generate the server (stubbed in this prototype):");
-    cliContext.logger.info(`     fern mcp generate --group ${group}`);
+    cliContext.logger.info(`${chalk.bold("1.")} Generate the server ${hint("(stubbed in this prototype)")}`);
+    cliContext.logger.info(`   ${command(`fern mcp generate --group ${group}`)}`);
     cliContext.logger.info("");
-    cliContext.logger.info("2. Inspect it with the MCP Inspector:");
-    cliContext.logger.info(chalk.cyan(`     npx @modelcontextprotocol/inspector node ${serverPath}/server.js`));
+    cliContext.logger.info(`${chalk.bold("2.")} Inspect it with the MCP Inspector`);
+    cliContext.logger.info(`   ${command(`npx @modelcontextprotocol/inspector node ${serverPath}/server.js`)}`);
     cliContext.logger.info("");
-    cliContext.logger.info("3. Or wire it into your agent (e.g. Claude Desktop / Cursor) with:");
-    cliContext.logger.info(`     { "command": "node", "args": ["${serverPath}/server.js"] }`);
+    cliContext.logger.info(`${chalk.bold("3.")} Or wire it into your agent ${hint("(e.g. Claude Desktop / Cursor)")}`);
+    cliContext.logger.info(`   ${hint(`{ "command": "node", "args": ["${serverPath}/server.js"] }`)}`);
     cliContext.logger.info("");
-    cliContext.logger.info(`Tool surface: run \`fern mcp tools --group ${group}\` to review before shipping.`);
+    cliContext.logger.info(
+        `${ICONS.pointer} Review the tool surface before shipping: ${command(`fern mcp tools --group ${group}`)}`
+    );
 }

--- a/packages/cli/cli/src/commands/mcp/prototype/generateMcp.ts
+++ b/packages/cli/cli/src/commands/mcp/prototype/generateMcp.ts
@@ -1,10 +1,9 @@
-import { createHash } from "crypto";
-import { writeFile } from "fs/promises";
-import { dirname, join } from "path";
-
 import { Project } from "@fern-api/project-loader";
 import chalk from "chalk";
+import { createHash } from "crypto";
+import { writeFile } from "fs/promises";
 import yaml from "js-yaml";
+import { dirname, join } from "path";
 
 import { CliContext } from "../../../cli-context/CliContext.js";
 import { findMcpGroup, MCP_GENERATOR_NAME, MCP_GENERATOR_VERSION } from "./mcpGeneratorsYml.js";

--- a/packages/cli/cli/src/commands/mcp/prototype/generateMcp.ts
+++ b/packages/cli/cli/src/commands/mcp/prototype/generateMcp.ts
@@ -1,0 +1,138 @@
+import { createHash } from "crypto";
+import { writeFile } from "fs/promises";
+import { dirname, join } from "path";
+
+import { Project } from "@fern-api/project-loader";
+import chalk from "chalk";
+import yaml from "js-yaml";
+
+import { CliContext } from "../../../cli-context/CliContext.js";
+import { findMcpGroup, MCP_GENERATOR_NAME, MCP_GENERATOR_VERSION } from "./mcpGeneratorsYml.js";
+import { computeVerdict, formatVerdictLine, resolveTools } from "./toolset.js";
+import { pickWorkspaceAndLoadSpec } from "./workspace.js";
+
+const STUB_STEP_DELAY_MS = 400;
+
+async function sleep(milliseconds: number): Promise<void> {
+    await new Promise((resolve) => setTimeout(resolve, milliseconds));
+}
+
+export async function generateMcp({
+    project,
+    cliContext,
+    api,
+    group
+}: {
+    project: Project;
+    cliContext: CliContext;
+    api: string | undefined;
+    group: string;
+}): Promise<void> {
+    const workspaceSpec = await pickWorkspaceAndLoadSpec({
+        project,
+        cliContext,
+        apiFilter: api,
+        interactive: false
+    });
+    if (workspaceSpec == null) {
+        return;
+    }
+    const { spec, absolutePathToWorkspace } = workspaceSpec;
+
+    const found = await cliContext.runTask((context) =>
+        findMcpGroup({ context, absolutePathToWorkspace, groupName: group })
+    );
+    if (found == null) {
+        cliContext.failAndThrow(`No MCP generator found in group "${group}". Run \`fern mcp init\` first.`);
+        return;
+    }
+
+    const tools = resolveTools(spec.endpoints, found.config.tools ?? {});
+    const verdict = computeVerdict(tools);
+    const serverName = found.config["server-name"];
+
+    cliContext.logger.info("");
+    cliContext.logger.info(chalk.bold(`[mcp] Generating ${serverName} (group: ${group})`));
+    cliContext.logger.info(chalk.dim("[mcp] NOTE: this is a stubbed prototype — no code is actually generated."));
+    cliContext.logger.info(`[mcp] Using generator ${MCP_GENERATOR_NAME}@${MCP_GENERATOR_VERSION}`);
+    await sleep(STUB_STEP_DELAY_MS);
+    cliContext.logger.info(`[mcp] Parsed spec: ${spec.endpoints.length} endpoints`);
+    cliContext.logger.info(`[mcp] Resolved tool surface: ${formatVerdictLine(verdict)}`);
+    await sleep(STUB_STEP_DELAY_MS);
+    cliContext.logger.info(`[mcp] Building tool schemas… ${tools.length}/${tools.length}`);
+    await sleep(STUB_STEP_DELAY_MS);
+
+    const schemaHash = createHash("sha256")
+        .update(JSON.stringify(tools.map((tool) => [tool.name, tool.endpoint.method, tool.endpoint.path])))
+        .digest("hex")
+        .slice(0, 16);
+
+    const lock = {
+        version: 1,
+        group,
+        "server-name": serverName,
+        generator: `${MCP_GENERATOR_NAME}@${MCP_GENERATOR_VERSION}`,
+        "schema-hash": `sha256:${schemaHash}`,
+        "generated-at": new Date().toISOString(),
+        "tool-count": tools.length,
+        "estimated-tokens": verdict.estimatedTokens,
+        tools: tools.map((tool) => ({
+            name: tool.name,
+            endpoint: `${tool.endpoint.method} ${tool.endpoint.path}`,
+            "estimated-tokens": tool.endpoint.estimatedTokens
+        }))
+    };
+    const lockPath = join(dirname(found.absolutePathToGeneratorsConfiguration), "tools.lock");
+    await writeFile(lockPath, yaml.dump(lock));
+
+    cliContext.logger.info(`[mcp] Wrote lockfile: ${lockPath}`);
+    cliContext.logger.info(chalk.green(`[mcp] Done. ${tools.length} tools locked for ${serverName}.`));
+    cliContext.logger.info("");
+    cliContext.logger.info(`Next: fern mcp dev --group ${group}`);
+}
+
+export async function devMcp({
+    project,
+    cliContext,
+    api,
+    group
+}: {
+    project: Project;
+    cliContext: CliContext;
+    api: string | undefined;
+    group: string;
+}): Promise<void> {
+    const workspaceSpec = await pickWorkspaceAndLoadSpec({
+        project,
+        cliContext,
+        apiFilter: api,
+        interactive: false
+    });
+    if (workspaceSpec == null) {
+        return;
+    }
+    const found = await cliContext.runTask((context) =>
+        findMcpGroup({ context, absolutePathToWorkspace: workspaceSpec.absolutePathToWorkspace, groupName: group })
+    );
+    if (found == null) {
+        cliContext.failAndThrow(`No MCP generator found in group "${group}". Run \`fern mcp init\` first.`);
+        return;
+    }
+    const serverName = found.config["server-name"];
+    const serverPath = found.outputLocation ?? `generated/${group}`;
+
+    cliContext.logger.info("");
+    cliContext.logger.info(chalk.bold(`Local dev for ${serverName} (group: ${group})`));
+    cliContext.logger.info(chalk.dim("This prototype does not start a real MCP runtime — here's how you would:"));
+    cliContext.logger.info("");
+    cliContext.logger.info("1. Generate the server (stubbed in this prototype):");
+    cliContext.logger.info(`     fern mcp generate --group ${group}`);
+    cliContext.logger.info("");
+    cliContext.logger.info("2. Inspect it with the MCP Inspector:");
+    cliContext.logger.info(chalk.cyan(`     npx @modelcontextprotocol/inspector node ${serverPath}/server.js`));
+    cliContext.logger.info("");
+    cliContext.logger.info("3. Or wire it into your agent (e.g. Claude Desktop / Cursor) with:");
+    cliContext.logger.info(`     { "command": "node", "args": ["${serverPath}/server.js"] }`);
+    cliContext.logger.info("");
+    cliContext.logger.info(`Tool surface: run \`fern mcp tools --group ${group}\` to review before shipping.`);
+}

--- a/packages/cli/cli/src/commands/mcp/prototype/initMcp.ts
+++ b/packages/cli/cli/src/commands/mcp/prototype/initMcp.ts
@@ -3,6 +3,7 @@ import { AbsoluteFilePath } from "@fern-api/fs-utils";
 import { Project } from "@fern-api/project-loader";
 import { select } from "@inquirer/prompts";
 import chalk from "chalk";
+import path from "path";
 
 import { CliContext } from "../../../cli-context/CliContext.js";
 import { proposeAiRuleset } from "./aiCurated.js";
@@ -20,6 +21,7 @@ import { banner, command, hint, ICONS, radioChoice, selectTheme, sleep, styledVe
 import { pickWorkspaceAndLoadSpec } from "./workspace.js";
 
 const AI_SPINNER_DELAY_MS = 1200;
+const SPEC_SCAN_DELAY_MS = 600;
 
 export interface InitMcpArgs {
     project: Project;
@@ -103,6 +105,11 @@ export async function initMcp(args: InitMcpArgs): Promise<void> {
     const { project, cliContext, yes, json } = args;
     const interactive = !yes && !json;
 
+    if (!json) {
+        cliContext.logger.info("");
+        await withSpinner("Scanning workspace for API specs…", () => sleep(SPEC_SCAN_DELAY_MS));
+    }
+
     const workspaceSpec = await pickWorkspaceAndLoadSpec({
         project,
         cliContext,
@@ -120,6 +127,10 @@ export async function initMcp(args: InitMcpArgs): Promise<void> {
     if (!json) {
         const title = spec.title ?? workspaceName;
         const tagless = endpoints.every((endpoint) => endpoint.tags.length === 0);
+        const relativeSpecPath = path.relative(absolutePathToWorkspace, spec.absoluteFilePath);
+        cliContext.logger.info(
+            `${ICONS.success} Found spec ${chalk.bold(relativeSpecPath)} ${hint(`${ICONS.bullet} ${title} ${ICONS.bullet} ${endpoints.length} endpoints`)}`
+        );
         cliContext.logger.info("");
         cliContext.logger.info(
             banner("Create an MCP server", [

--- a/packages/cli/cli/src/commands/mcp/prototype/initMcp.ts
+++ b/packages/cli/cli/src/commands/mcp/prototype/initMcp.ts
@@ -1,0 +1,318 @@
+import { loadRawGeneratorsConfiguration } from "@fern-api/configuration-loader";
+import { assertNever } from "@fern-api/core-utils";
+import { AbsoluteFilePath } from "@fern-api/fs-utils";
+import { Project } from "@fern-api/project-loader";
+import { select } from "@inquirer/prompts";
+import chalk from "chalk";
+
+import { CliContext } from "../../../cli-context/CliContext.js";
+import { proposeAiRuleset } from "./aiCurated.js";
+import {
+    DEFAULT_MCP_GROUP_NAME,
+    getMcpGeneratorEntries,
+    writeMcpGroupToGeneratorsYml,
+    WriteMcpGroupResult
+} from "./mcpGeneratorsYml.js";
+import { EndpointSummary } from "./openapiSummary.js";
+import { BuiltinPresetKey, buildBuiltinPresets, PresetResolution } from "./presets.js";
+import { computeVerdict, formatTokens, formatVerdictLine, resolveTools, ToolsConfig, Verdict } from "./toolset.js";
+import { runTrimLoop } from "./trimLoop.js";
+import { pickWorkspaceAndLoadSpec } from "./workspace.js";
+
+const AI_SPINNER_DELAY_MS = 1200;
+
+export interface InitMcpArgs {
+    project: Project;
+    cliContext: CliContext;
+    api: string | undefined;
+    name: string | undefined;
+    preset: BuiltinPresetKey | undefined;
+    intent: string | undefined;
+    group: string | undefined;
+    yes: boolean;
+    json: boolean;
+}
+
+function deriveServerName(title: string | undefined, workspaceName: string): string {
+    const base = title ?? workspaceName;
+    const slug = base
+        .toLowerCase()
+        .replace(/[^a-z0-9]+/g, "-")
+        .replace(/^-|-$/g, "");
+    return slug.endsWith("-mcp") ? slug : `${slug}-mcp`;
+}
+
+function verdictColor(verdict: Verdict, text: string): string {
+    switch (verdict.level) {
+        case "green":
+            return chalk.green(text);
+        case "amber":
+            return chalk.yellow(text);
+        case "red":
+            return chalk.red(text);
+        default:
+            assertNever(verdict.level);
+    }
+}
+
+async function sleep(milliseconds: number): Promise<void> {
+    await new Promise((resolve) => setTimeout(resolve, milliseconds));
+}
+
+async function promptForAiCuratedConfig({
+    cliContext,
+    endpoints,
+    initialIntent
+}: {
+    cliContext: CliContext;
+    endpoints: EndpointSummary[];
+    initialIntent: string | undefined;
+}): Promise<ToolsConfig> {
+    const intent =
+        initialIntent ??
+        (await cliContext.getInput({
+            message: "Describe what this MCP should let an agent do (and anything it must never touch)"
+        }));
+    cliContext.logger.info(chalk.dim("✦ Fern Agent is proposing a ruleset… (stubbed locally in this prototype)"));
+    await sleep(AI_SPINNER_DELAY_MS);
+    const proposal = proposeAiRuleset(intent, endpoints);
+    cliContext.logger.info("");
+    cliContext.logger.info("✦ Proposed ruleset (exclusions first — that's the part worth reviewing):");
+    if (proposal.excludeReasons.length > 0) {
+        cliContext.logger.info("  exclude:");
+        for (const reason of proposal.excludeReasons) {
+            cliContext.logger.info(`    - ${reason}`);
+        }
+    } else {
+        cliContext.logger.info(chalk.dim("  (nothing excluded)"));
+    }
+    cliContext.logger.info("  include:");
+    for (const reason of proposal.includeReasons) {
+        cliContext.logger.info(`    - ${reason}`);
+    }
+    return proposal.config;
+}
+
+interface JsonSummary {
+    serverName: string;
+    group: string;
+    preset: string;
+    toolCount: number;
+    estimatedTokens: number;
+    verdict: string;
+    warnings: string[];
+    generatorsYml: string;
+}
+
+export async function initMcp(args: InitMcpArgs): Promise<void> {
+    const { project, cliContext, yes, json } = args;
+    const interactive = !yes && !json;
+
+    const workspaceSpec = await pickWorkspaceAndLoadSpec({
+        project,
+        cliContext,
+        apiFilter: args.api,
+        interactive
+    });
+    if (workspaceSpec == null) {
+        return;
+    }
+    const { spec, workspaceName, absolutePathToWorkspace } = workspaceSpec;
+    const endpoints = spec.endpoints;
+    const allTools = resolveTools(endpoints, {});
+    const everythingVerdict = computeVerdict(allTools);
+
+    if (!json) {
+        cliContext.logger.info("");
+        cliContext.logger.info(chalk.bold("┌ Create an MCP server"));
+        const title = spec.title ?? workspaceName;
+        const tagless = endpoints.every((endpoint) => endpoint.tags.length === 0);
+        cliContext.logger.info(
+            `│  ${title}: ${endpoints.length} endpoints · ~${formatTokens(everythingVerdict.estimatedTokens)} tokens (est.) if all become tools${
+                tagless ? " · no tags — grouping by path prefix" : ""
+            }`
+        );
+        cliContext.logger.info("│  Recommended budget: 40 tools · 60k tokens (adjustable later)");
+        cliContext.logger.info("");
+    }
+
+    const defaultServerName = deriveServerName(spec.title, workspaceName);
+    const serverName =
+        args.name ??
+        (interactive
+            ? await cliContext.getInput({ message: "Server name", default: defaultServerName })
+            : defaultServerName);
+
+    const presets = buildBuiltinPresets(endpoints);
+    let presetKey: string;
+    let toolsConfig: ToolsConfig;
+
+    if (args.intent != null && args.preset == null) {
+        presetKey = "ai-curated";
+        toolsConfig = await promptForAiCuratedConfig({ cliContext, endpoints, initialIntent: args.intent });
+    } else if (!interactive || args.preset != null) {
+        presetKey = args.preset ?? "read-only";
+        const resolution = presets[args.preset ?? "read-only"];
+        toolsConfig = resolution.config;
+        if (args.intent != null) {
+            toolsConfig = { ...toolsConfig, intent: args.intent };
+        }
+    } else {
+        const existingPresets = await loadExistingPresets({ cliContext, absolutePathToWorkspace });
+        const choice = await promptForToolsetChoice({ cliContext, presets, existingPresets, endpoints });
+        presetKey = choice.presetKey;
+        if (choice.presetKey === "ai-curated") {
+            toolsConfig = await promptForAiCuratedConfig({ cliContext, endpoints, initialIntent: undefined });
+        } else {
+            toolsConfig = choice.config;
+        }
+    }
+
+    let verdict = computeVerdict(resolveTools(endpoints, toolsConfig));
+    const warnings: string[] = [];
+    if (verdict.level !== "green") {
+        if (interactive) {
+            cliContext.logger.info("");
+            cliContext.logger.info(
+                `Your pick: ${verdictColor(verdict, formatVerdictLine(verdict))}. Agents handle ~40 tools well — let's trim it (or keep it as-is).`
+            );
+            toolsConfig = await runTrimLoop({ cliContext, endpoints, initialConfig: toolsConfig });
+            verdict = computeVerdict(resolveTools(endpoints, toolsConfig));
+        } else {
+            warnings.push(`Toolset is over budget: ${formatVerdictLine(verdict)}`);
+        }
+    }
+
+    const groupName = args.group ?? DEFAULT_MCP_GROUP_NAME;
+    let written: WriteMcpGroupResult | undefined;
+    await cliContext.runTaskForWorkspace(workspaceSpec.workspace, async (context) => {
+        written = await writeMcpGroupToGeneratorsYml({
+            absolutePathToWorkspace,
+            context,
+            groupName,
+            serverName,
+            toolsConfig
+        });
+    });
+    if (written == null) {
+        cliContext.failAndThrow("Could not find a generators.yml to write to in this workspace.");
+        return;
+    }
+    const result = written;
+
+    if (json) {
+        const summary: JsonSummary = {
+            serverName,
+            group: groupName,
+            preset: presetKey,
+            toolCount: verdict.toolCount,
+            estimatedTokens: verdict.estimatedTokens,
+            verdict: verdict.level,
+            warnings,
+            generatorsYml: result.absolutePathToGeneratorsConfiguration
+        };
+        cliContext.logger.info(JSON.stringify(summary, null, 2));
+        return;
+    }
+
+    for (const warning of warnings) {
+        cliContext.logger.warn(chalk.yellow(`⚠ ${warning}`));
+    }
+    cliContext.logger.info("");
+    cliContext.logger.info(
+        chalk.green(`└ Wrote group "${groupName}" to ${result.absolutePathToGeneratorsConfiguration}`)
+    );
+    cliContext.logger.info("");
+    cliContext.logger.info(result.yamlBlock.trimEnd());
+    cliContext.logger.info("");
+    cliContext.logger.info(`Verdict: ${verdictColor(verdict, formatVerdictLine(verdict))}`);
+    cliContext.logger.info("");
+    cliContext.logger.info("Next steps:");
+    cliContext.logger.info(`  fern generate --group ${groupName}     # build it`);
+    cliContext.logger.info(`  fern mcp dev --group ${groupName}      # try it locally with an inspector`);
+}
+
+async function loadExistingPresets({
+    cliContext,
+    absolutePathToWorkspace
+}: {
+    cliContext: CliContext;
+    absolutePathToWorkspace: AbsoluteFilePath;
+}): Promise<{ name: string; config: ToolsConfig }[]> {
+    const existing: { name: string; config: ToolsConfig }[] = [];
+    await cliContext.runTask(async (context) => {
+        const rawConfiguration = await loadRawGeneratorsConfiguration({ absolutePathToWorkspace, context });
+        if (rawConfiguration == null) {
+            return;
+        }
+        for (const entry of getMcpGeneratorEntries(rawConfiguration)) {
+            for (const [name, presetConfig] of Object.entries(entry.config.tools?.presets ?? {})) {
+                existing.push({ name: `${name} (from group ${entry.groupName})`, config: presetConfig });
+            }
+        }
+    });
+    return existing;
+}
+
+interface ToolsetChoice {
+    presetKey: string;
+    config: ToolsConfig;
+}
+
+async function promptForToolsetChoice({
+    cliContext,
+    presets,
+    existingPresets,
+    endpoints
+}: {
+    cliContext: CliContext;
+    presets: Record<BuiltinPresetKey, PresetResolution>;
+    existingPresets: { name: string; config: ToolsConfig }[];
+    endpoints: EndpointSummary[];
+}): Promise<ToolsetChoice> {
+    interface Choice {
+        name: string;
+        value: ToolsetChoice;
+        disabled?: string | boolean;
+    }
+    const choices: Choice[] = [];
+    for (const existing of existingPresets) {
+        const verdict = computeVerdict(resolveTools(endpoints, existing.config));
+        choices.push({
+            name: `${existing.name}\n       ${formatVerdictLine(verdict)}`,
+            value: { presetKey: existing.name, config: existing.config }
+        });
+    }
+    for (const key of ["read-only", "main-resources"] as const) {
+        const preset = presets[key];
+        if (!preset.available) {
+            choices.push({
+                name: preset.label,
+                value: { presetKey: key, config: preset.config },
+                disabled: `(${preset.unavailableReason ?? "unavailable"})`
+            });
+            continue;
+        }
+        const noteSuffix = preset.notes.length > 0 ? `\n       ${chalk.dim(preset.notes.join(" · "))}` : "";
+        choices.push({
+            name: `${preset.label}\n       ${formatVerdictLine(preset.verdict)}${noteSuffix}`,
+            value: { presetKey: key, config: preset.config }
+        });
+    }
+    choices.push({
+        name: "AI-curated — Fern Agent picks tools from your description (requires fern login)\n       resolved after you describe what agents should do",
+        value: { presetKey: "ai-curated", config: {} }
+    });
+    const everything = presets.everything;
+    choices.push({
+        name: `${everything.label}\n       ${formatVerdictLine(everything.verdict)}`,
+        value: { presetKey: "everything", config: everything.config }
+    });
+
+    cliContext.logger.info("");
+    return await select<ToolsetChoice>({
+        message: "Which tools should this server expose?",
+        choices,
+        pageSize: 12
+    });
+}

--- a/packages/cli/cli/src/commands/mcp/prototype/initMcp.ts
+++ b/packages/cli/cli/src/commands/mcp/prototype/initMcp.ts
@@ -1,5 +1,4 @@
 import { loadRawGeneratorsConfiguration } from "@fern-api/configuration-loader";
-import { assertNever } from "@fern-api/core-utils";
 import { AbsoluteFilePath } from "@fern-api/fs-utils";
 import { Project } from "@fern-api/project-loader";
 import { select } from "@inquirer/prompts";
@@ -15,8 +14,9 @@ import {
 } from "./mcpGeneratorsYml.js";
 import { EndpointSummary } from "./openapiSummary.js";
 import { BuiltinPresetKey, buildBuiltinPresets, PresetResolution } from "./presets.js";
-import { computeVerdict, formatTokens, formatVerdictLine, resolveTools, ToolsConfig, Verdict } from "./toolset.js";
+import { computeVerdict, formatTokens, formatVerdictLine, resolveTools, ToolsConfig } from "./toolset.js";
 import { runTrimLoop } from "./trimLoop.js";
+import { banner, command, hint, ICONS, sleep, styledVerdictLine, withSpinner } from "./ui.js";
 import { pickWorkspaceAndLoadSpec } from "./workspace.js";
 
 const AI_SPINNER_DELAY_MS = 1200;
@@ -42,23 +42,6 @@ function deriveServerName(title: string | undefined, workspaceName: string): str
     return slug.endsWith("-mcp") ? slug : `${slug}-mcp`;
 }
 
-function verdictColor(verdict: Verdict, text: string): string {
-    switch (verdict.level) {
-        case "green":
-            return chalk.green(text);
-        case "amber":
-            return chalk.yellow(text);
-        case "red":
-            return chalk.red(text);
-        default:
-            assertNever(verdict.level);
-    }
-}
-
-async function sleep(milliseconds: number): Promise<void> {
-    await new Promise((resolve) => setTimeout(resolve, milliseconds));
-}
-
 async function promptForAiCuratedConfig({
     cliContext,
     endpoints,
@@ -78,22 +61,29 @@ async function promptForAiCuratedConfig({
     if (quiet) {
         return proposeAiRuleset(intent, endpoints).config;
     }
-    cliContext.logger.info(chalk.dim("✦ Fern Agent is proposing a ruleset… (stubbed locally in this prototype)"));
-    await sleep(AI_SPINNER_DELAY_MS);
-    const proposal = proposeAiRuleset(intent, endpoints);
     cliContext.logger.info("");
-    cliContext.logger.info("✦ Proposed ruleset (exclusions first — that's the part worth reviewing):");
+    const proposal = await withSpinner(
+        `${chalk.magenta("Fern Agent")} is picking tools for you… ${hint("(stubbed locally in this prototype)")}`,
+        async () => {
+            await sleep(AI_SPINNER_DELAY_MS);
+            return proposeAiRuleset(intent, endpoints);
+        }
+    );
+    cliContext.logger.info(
+        `${ICONS.agent} ${chalk.bold("Proposed toolset")} ${hint("(exclusions first — that's the part worth reviewing)")}`
+    );
+    cliContext.logger.info("");
     if (proposal.excludeReasons.length > 0) {
-        cliContext.logger.info("  exclude:");
+        cliContext.logger.info(`  ${chalk.red("excluded")}`);
         for (const reason of proposal.excludeReasons) {
-            cliContext.logger.info(`    - ${reason}`);
+            cliContext.logger.info(`    ${chalk.red("−")} ${reason}`);
         }
     } else {
-        cliContext.logger.info(chalk.dim("  (nothing excluded)"));
+        cliContext.logger.info(hint("  (nothing excluded)"));
     }
-    cliContext.logger.info("  include:");
+    cliContext.logger.info(`  ${chalk.green("included")}`);
     for (const reason of proposal.includeReasons) {
-        cliContext.logger.info(`    - ${reason}`);
+        cliContext.logger.info(`    ${chalk.green("+")} ${reason}`);
     }
     return proposal.config;
 }
@@ -128,16 +118,17 @@ export async function initMcp(args: InitMcpArgs): Promise<void> {
     const everythingVerdict = computeVerdict(allTools);
 
     if (!json) {
-        cliContext.logger.info("");
-        cliContext.logger.info(chalk.bold("┌ Create an MCP server"));
         const title = spec.title ?? workspaceName;
         const tagless = endpoints.every((endpoint) => endpoint.tags.length === 0);
+        cliContext.logger.info("");
         cliContext.logger.info(
-            `│  ${title}: ${endpoints.length} endpoints · ~${formatTokens(everythingVerdict.estimatedTokens)} tokens (est.) if all become tools${
-                tagless ? " · no tags — grouping by path prefix" : ""
-            }`
+            banner("Create an MCP server", [
+                `${chalk.green(title)} ${ICONS.bullet} ${chalk.bold(endpoints.length)} endpoints ${ICONS.bullet} ~${chalk.bold(formatTokens(everythingVerdict.estimatedTokens))} tokens (est.) if all become tools${
+                    tagless ? ` ${ICONS.bullet} no tags — grouping by path prefix` : ""
+                }`,
+                hint("Recommended budget: 40 tools · 60k tokens (adjustable later)")
+            ])
         );
-        cliContext.logger.info("│  Recommended budget: 40 tools · 60k tokens (adjustable later)");
         cliContext.logger.info("");
     }
 
@@ -183,9 +174,8 @@ export async function initMcp(args: InitMcpArgs): Promise<void> {
     if (verdict.level !== "green") {
         if (interactive) {
             cliContext.logger.info("");
-            cliContext.logger.info(
-                `Your pick: ${verdictColor(verdict, formatVerdictLine(verdict))}. Agents handle ~40 tools well — let's trim it (or keep it as-is).`
-            );
+            cliContext.logger.info(`Your pick: ${styledVerdictLine(verdict)}`);
+            cliContext.logger.info(hint("Agents handle ~40 tools well — let's trim it (or keep it as-is)."));
             toolsConfig = await runTrimLoop({ cliContext, endpoints, initialConfig: toolsConfig });
             verdict = computeVerdict(resolveTools(endpoints, toolsConfig));
         } else {
@@ -226,20 +216,28 @@ export async function initMcp(args: InitMcpArgs): Promise<void> {
     }
 
     for (const warning of warnings) {
-        cliContext.logger.warn(chalk.yellow(`⚠ ${warning}`));
+        cliContext.logger.warn(`${ICONS.warning} ${chalk.yellow(warning)}`);
     }
     cliContext.logger.info("");
     cliContext.logger.info(
-        chalk.green(`└ Wrote group "${groupName}" to ${result.absolutePathToGeneratorsConfiguration}`)
+        `${ICONS.success} Wrote group ${chalk.bold(`"${groupName}"`)} to ${chalk.green(result.absolutePathToGeneratorsConfiguration)}`
     );
     cliContext.logger.info("");
-    cliContext.logger.info(result.yamlBlock.trimEnd());
+    cliContext.logger.info(
+        result.yamlBlock
+            .trimEnd()
+            .split("\n")
+            .map((line) => `  ${chalk.dim("│")} ${line}`)
+            .join("\n")
+    );
     cliContext.logger.info("");
-    cliContext.logger.info(`Verdict: ${verdictColor(verdict, formatVerdictLine(verdict))}`);
+    cliContext.logger.info(styledVerdictLine(verdict));
     cliContext.logger.info("");
-    cliContext.logger.info("Next steps:");
-    cliContext.logger.info(`  fern generate --group ${groupName}     # build it`);
-    cliContext.logger.info(`  fern mcp dev --group ${groupName}      # try it locally with an inspector`);
+    cliContext.logger.info(chalk.bold("Next steps"));
+    cliContext.logger.info(`  ${ICONS.pointer} ${command(`fern generate --group ${groupName}`)}   ${hint("build it")}`);
+    cliContext.logger.info(
+        `  ${ICONS.pointer} ${command(`fern mcp dev --group ${groupName}`)}    ${hint("try it locally with an inspector")}`
+    );
 }
 
 async function loadExistingPresets({
@@ -289,7 +287,7 @@ async function promptForToolsetChoice({
     for (const existing of existingPresets) {
         const verdict = computeVerdict(resolveTools(endpoints, existing.config));
         choices.push({
-            name: `${existing.name}\n       ${formatVerdictLine(verdict)}`,
+            name: `${existing.name}\n       ${styledVerdictLine(verdict)}`,
             value: { presetKey: existing.name, config: existing.config }
         });
     }
@@ -305,17 +303,17 @@ async function promptForToolsetChoice({
         }
         const noteSuffix = preset.notes.length > 0 ? `\n       ${chalk.dim(preset.notes.join(" · "))}` : "";
         choices.push({
-            name: `${preset.label}\n       ${formatVerdictLine(preset.verdict)}${noteSuffix}`,
+            name: `${preset.label}\n       ${styledVerdictLine(preset.verdict)}${noteSuffix}`,
             value: { presetKey: key, config: preset.config }
         });
     }
     choices.push({
-        name: "AI-curated — Fern Agent picks tools from your description (requires fern login)\n       resolved after you describe what agents should do",
+        name: `AI-curated — ${chalk.magenta("Fern Agent")} picks tools from your description ${chalk.dim("(requires fern login)")}\n       ${chalk.dim("resolved after you describe what agents should do")}`,
         value: { presetKey: "ai-curated", config: {} }
     });
     const everything = presets.everything;
     choices.push({
-        name: `${everything.label}\n       ${formatVerdictLine(everything.verdict)}`,
+        name: `${everything.label}\n       ${styledVerdictLine(everything.verdict)}`,
         value: { presetKey: "everything", config: everything.config }
     });
 

--- a/packages/cli/cli/src/commands/mcp/prototype/initMcp.ts
+++ b/packages/cli/cli/src/commands/mcp/prototype/initMcp.ts
@@ -14,7 +14,7 @@ import {
 } from "./mcpGeneratorsYml.js";
 import { EndpointSummary } from "./openapiSummary.js";
 import { BuiltinPresetKey, buildBuiltinPresets, PresetResolution } from "./presets.js";
-import { computeVerdict, formatTokens, formatVerdictLine, resolveTools, ToolsConfig, Verdict } from "./toolset.js";
+import { computeVerdict, formatTokens, formatVerdictLine, resolveTools, ToolsConfig } from "./toolset.js";
 import { runTrimLoop } from "./trimLoop.js";
 import {
     banner,
@@ -173,29 +173,20 @@ export async function initMcp(args: InitMcpArgs): Promise<void> {
             toolsConfig = { ...toolsConfig, intent: args.intent };
         }
     } else {
-        const everythingWithinBudget = everythingVerdict.level === "green";
-        const deployEverything =
-            everythingWithinBudget && (await promptForDefaultDeploy({ cliContext, everythingVerdict }));
-        if (deployEverything) {
-            presetKey = "everything";
-            toolsConfig = presets.everything.config;
+        const existingPresets = await loadExistingPresets({ cliContext, absolutePathToWorkspace });
+        const recommendMainResources = everythingVerdict.level !== "green" && presets["main-resources"].available;
+        const choice = await promptForToolsetChoice({
+            cliContext,
+            presets,
+            existingPresets,
+            endpoints,
+            recommendMainResources
+        });
+        presetKey = choice.presetKey;
+        if (choice.presetKey === "ai-curated") {
+            toolsConfig = await promptForAiCuratedConfig({ cliContext, endpoints, initialIntent: undefined });
         } else {
-            if (!everythingWithinBudget) {
-                cliContext.logger.info(`${ICONS.warning} All ${styledVerdictLine(everythingVerdict)}`);
-                cliContext.logger.info(
-                    hint(
-                        "Recommended: Main resources — a smaller surface agents handle well. Everything is still an option."
-                    )
-                );
-            }
-            const existingPresets = await loadExistingPresets({ cliContext, absolutePathToWorkspace });
-            const choice = await promptForToolsetChoice({ cliContext, presets, existingPresets, endpoints });
-            presetKey = choice.presetKey;
-            if (choice.presetKey === "ai-curated") {
-                toolsConfig = await promptForAiCuratedConfig({ cliContext, endpoints, initialIntent: undefined });
-            } else {
-                toolsConfig = choice.config;
-            }
+            toolsConfig = choice.config;
         }
     }
 
@@ -292,32 +283,6 @@ async function loadExistingPresets({
     return existing;
 }
 
-async function promptForDefaultDeploy({
-    cliContext,
-    everythingVerdict
-}: {
-    cliContext: CliContext;
-    everythingVerdict: Verdict;
-}): Promise<boolean> {
-    cliContext.logger.info("");
-    return await select<boolean>({
-        message: `Create MCP with all endpoints? (${everythingVerdict.toolCount} tools)`,
-        choices: [
-            {
-                name: radioChoice(`Create MCP — ${chalk.bold(everythingVerdict.toolCount)} tools`),
-                short: "Create MCP",
-                value: true
-            },
-            {
-                name: `${radioChoice("Customize toolset")}\n         ${hint("pick Read-only / Main resources / AI-curated")}`,
-                short: "Customize toolset",
-                value: false
-            }
-        ],
-        theme: selectTheme
-    });
-}
-
 interface ToolsetChoice {
     presetKey: string;
     config: ToolsConfig;
@@ -327,12 +292,14 @@ async function promptForToolsetChoice({
     cliContext,
     presets,
     existingPresets,
-    endpoints
+    endpoints,
+    recommendMainResources
 }: {
     cliContext: CliContext;
     presets: Record<BuiltinPresetKey, PresetResolution>;
     existingPresets: { name: string; config: ToolsConfig }[];
     endpoints: EndpointSummary[];
+    recommendMainResources: boolean;
 }): Promise<ToolsetChoice> {
     interface Choice {
         name: string;
@@ -361,8 +328,10 @@ async function promptForToolsetChoice({
             continue;
         }
         const noteSuffix = preset.notes.length > 0 ? `\n         ${chalk.dim(preset.notes.join(" · "))}` : "";
+        const recommendedSuffix =
+            key === "main-resources" && recommendMainResources ? ` ${chalk.green("(recommended)")}` : "";
         choices.push({
-            name: `${radioChoice(preset.label)}\n         ${budgetLine(preset.verdict)}${noteSuffix}`,
+            name: `${radioChoice(`${preset.label}${recommendedSuffix}`)}\n         ${budgetLine(preset.verdict)}${noteSuffix}`,
             short: preset.label,
             value: { presetKey: key, config: preset.config }
         });

--- a/packages/cli/cli/src/commands/mcp/prototype/initMcp.ts
+++ b/packages/cli/cli/src/commands/mcp/prototype/initMcp.ts
@@ -16,7 +16,7 @@ import { EndpointSummary } from "./openapiSummary.js";
 import { BuiltinPresetKey, buildBuiltinPresets, PresetResolution } from "./presets.js";
 import { computeVerdict, formatTokens, formatVerdictLine, resolveTools, ToolsConfig } from "./toolset.js";
 import { runTrimLoop } from "./trimLoop.js";
-import { banner, command, hint, ICONS, sleep, styledVerdictLine, withSpinner } from "./ui.js";
+import { banner, command, hint, ICONS, radioChoice, selectTheme, sleep, styledVerdictLine, withSpinner } from "./ui.js";
 import { pickWorkspaceAndLoadSpec } from "./workspace.js";
 
 const AI_SPINNER_DELAY_MS = 1200;
@@ -287,7 +287,7 @@ async function promptForToolsetChoice({
     for (const existing of existingPresets) {
         const verdict = computeVerdict(resolveTools(endpoints, existing.config));
         choices.push({
-            name: `${existing.name}\n       ${styledVerdictLine(verdict)}`,
+            name: `${radioChoice(existing.name)}\n         ${styledVerdictLine(verdict)}`,
             value: { presetKey: existing.name, config: existing.config }
         });
     }
@@ -295,25 +295,25 @@ async function promptForToolsetChoice({
         const preset = presets[key];
         if (!preset.available) {
             choices.push({
-                name: preset.label,
+                name: radioChoice(preset.label),
                 value: { presetKey: key, config: preset.config },
                 disabled: `(${preset.unavailableReason ?? "unavailable"})`
             });
             continue;
         }
-        const noteSuffix = preset.notes.length > 0 ? `\n       ${chalk.dim(preset.notes.join(" · "))}` : "";
+        const noteSuffix = preset.notes.length > 0 ? `\n         ${chalk.dim(preset.notes.join(" · "))}` : "";
         choices.push({
-            name: `${preset.label}\n       ${styledVerdictLine(preset.verdict)}${noteSuffix}`,
+            name: `${radioChoice(preset.label)}\n         ${styledVerdictLine(preset.verdict)}${noteSuffix}`,
             value: { presetKey: key, config: preset.config }
         });
     }
     choices.push({
-        name: `AI-curated — ${chalk.magenta("Fern Agent")} picks tools from your description ${chalk.dim("(requires fern login)")}\n       ${chalk.dim("resolved after you describe what agents should do")}`,
+        name: `${radioChoice(`AI-curated — ${chalk.magenta("Fern Agent")} picks tools from your description ${chalk.dim("(requires fern login)")}`)}\n         ${chalk.dim("resolved after you describe what agents should do")}`,
         value: { presetKey: "ai-curated", config: {} }
     });
     const everything = presets.everything;
     choices.push({
-        name: `${everything.label}\n       ${styledVerdictLine(everything.verdict)}`,
+        name: `${radioChoice(everything.label)}\n         ${styledVerdictLine(everything.verdict)}`,
         value: { presetKey: "everything", config: everything.config }
     });
 
@@ -321,6 +321,7 @@ async function promptForToolsetChoice({
     return await select<ToolsetChoice>({
         message: "Which tools should this server expose?",
         choices,
-        pageSize: 12
+        pageSize: 12,
+        theme: selectTheme
     });
 }

--- a/packages/cli/cli/src/commands/mcp/prototype/initMcp.ts
+++ b/packages/cli/cli/src/commands/mcp/prototype/initMcp.ts
@@ -280,6 +280,7 @@ async function promptForToolsetChoice({
 }): Promise<ToolsetChoice> {
     interface Choice {
         name: string;
+        short?: string;
         value: ToolsetChoice;
         disabled?: string | boolean;
     }
@@ -288,6 +289,7 @@ async function promptForToolsetChoice({
         const verdict = computeVerdict(resolveTools(endpoints, existing.config));
         choices.push({
             name: `${radioChoice(existing.name)}\n         ${styledVerdictLine(verdict)}`,
+            short: existing.name,
             value: { presetKey: existing.name, config: existing.config }
         });
     }
@@ -296,6 +298,7 @@ async function promptForToolsetChoice({
         if (!preset.available) {
             choices.push({
                 name: radioChoice(preset.label),
+                short: preset.label,
                 value: { presetKey: key, config: preset.config },
                 disabled: `(${preset.unavailableReason ?? "unavailable"})`
             });
@@ -304,16 +307,19 @@ async function promptForToolsetChoice({
         const noteSuffix = preset.notes.length > 0 ? `\n         ${chalk.dim(preset.notes.join(" · "))}` : "";
         choices.push({
             name: `${radioChoice(preset.label)}\n         ${styledVerdictLine(preset.verdict)}${noteSuffix}`,
+            short: preset.label,
             value: { presetKey: key, config: preset.config }
         });
     }
     choices.push({
         name: `${radioChoice(`AI-curated — ${chalk.magenta("Fern Agent")} picks tools from your description ${chalk.dim("(requires fern login)")}`)}\n         ${chalk.dim("resolved after you describe what agents should do")}`,
+        short: `AI-curated — ${chalk.magenta("Fern Agent")} picks tools from your description`,
         value: { presetKey: "ai-curated", config: {} }
     });
     const everything = presets.everything;
     choices.push({
         name: `${radioChoice(everything.label)}\n         ${styledVerdictLine(everything.verdict)}`,
+        short: everything.label,
         value: { presetKey: "everything", config: everything.config }
     });
 

--- a/packages/cli/cli/src/commands/mcp/prototype/initMcp.ts
+++ b/packages/cli/cli/src/commands/mcp/prototype/initMcp.ts
@@ -10,8 +10,8 @@ import { proposeAiRuleset } from "./aiCurated.js";
 import {
     DEFAULT_MCP_GROUP_NAME,
     getMcpGeneratorEntries,
-    writeMcpGroupToGeneratorsYml,
-    WriteMcpGroupResult
+    WriteMcpGroupResult,
+    writeMcpGroupToGeneratorsYml
 } from "./mcpGeneratorsYml.js";
 import { EndpointSummary } from "./openapiSummary.js";
 import { BuiltinPresetKey, buildBuiltinPresets, PresetResolution } from "./presets.js";
@@ -62,17 +62,22 @@ async function sleep(milliseconds: number): Promise<void> {
 async function promptForAiCuratedConfig({
     cliContext,
     endpoints,
-    initialIntent
+    initialIntent,
+    quiet = false
 }: {
     cliContext: CliContext;
     endpoints: EndpointSummary[];
     initialIntent: string | undefined;
+    quiet?: boolean;
 }): Promise<ToolsConfig> {
     const intent =
         initialIntent ??
         (await cliContext.getInput({
             message: "Describe what this MCP should let an agent do (and anything it must never touch)"
         }));
+    if (quiet) {
+        return proposeAiRuleset(intent, endpoints).config;
+    }
     cliContext.logger.info(chalk.dim("✦ Fern Agent is proposing a ruleset… (stubbed locally in this prototype)"));
     await sleep(AI_SPINNER_DELAY_MS);
     const proposal = proposeAiRuleset(intent, endpoints);
@@ -149,7 +154,12 @@ export async function initMcp(args: InitMcpArgs): Promise<void> {
 
     if (args.intent != null && args.preset == null) {
         presetKey = "ai-curated";
-        toolsConfig = await promptForAiCuratedConfig({ cliContext, endpoints, initialIntent: args.intent });
+        toolsConfig = await promptForAiCuratedConfig({
+            cliContext,
+            endpoints,
+            initialIntent: args.intent,
+            quiet: json
+        });
     } else if (!interactive || args.preset != null) {
         presetKey = args.preset ?? "read-only";
         const resolution = presets[args.preset ?? "read-only"];

--- a/packages/cli/cli/src/commands/mcp/prototype/initMcp.ts
+++ b/packages/cli/cli/src/commands/mcp/prototype/initMcp.ts
@@ -3,7 +3,6 @@ import { AbsoluteFilePath } from "@fern-api/fs-utils";
 import { Project } from "@fern-api/project-loader";
 import { select } from "@inquirer/prompts";
 import chalk from "chalk";
-import path from "path";
 
 import { CliContext } from "../../../cli-context/CliContext.js";
 import { proposeAiRuleset } from "./aiCurated.js";
@@ -18,10 +17,9 @@ import { BuiltinPresetKey, buildBuiltinPresets, PresetResolution } from "./prese
 import { computeVerdict, formatTokens, formatVerdictLine, resolveTools, ToolsConfig } from "./toolset.js";
 import { runTrimLoop } from "./trimLoop.js";
 import { banner, command, hint, ICONS, radioChoice, selectTheme, sleep, styledVerdictLine, withSpinner } from "./ui.js";
-import { pickWorkspaceAndLoadSpec } from "./workspace.js";
+import { announceSpecDiscovery, pickWorkspaceAndLoadSpec } from "./workspace.js";
 
 const AI_SPINNER_DELAY_MS = 1200;
-const SPEC_SCAN_DELAY_MS = 600;
 
 export interface InitMcpArgs {
     project: Project;
@@ -105,11 +103,6 @@ export async function initMcp(args: InitMcpArgs): Promise<void> {
     const { project, cliContext, yes, json } = args;
     const interactive = !yes && !json;
 
-    if (!json) {
-        cliContext.logger.info("");
-        await withSpinner("Scanning workspace for API specs…", () => sleep(SPEC_SCAN_DELAY_MS));
-    }
-
     const workspaceSpec = await pickWorkspaceAndLoadSpec({
         project,
         cliContext,
@@ -119,6 +112,9 @@ export async function initMcp(args: InitMcpArgs): Promise<void> {
     if (workspaceSpec == null) {
         return;
     }
+    if (!json) {
+        await announceSpecDiscovery({ cliContext, workspaceSpec });
+    }
     const { spec, workspaceName, absolutePathToWorkspace } = workspaceSpec;
     const endpoints = spec.endpoints;
     const allTools = resolveTools(endpoints, {});
@@ -127,10 +123,6 @@ export async function initMcp(args: InitMcpArgs): Promise<void> {
     if (!json) {
         const title = spec.title ?? workspaceName;
         const tagless = endpoints.every((endpoint) => endpoint.tags.length === 0);
-        const relativeSpecPath = path.relative(absolutePathToWorkspace, spec.absoluteFilePath);
-        cliContext.logger.info(
-            `${ICONS.success} Found spec ${chalk.bold(relativeSpecPath)} ${hint(`${ICONS.bullet} ${title} ${ICONS.bullet} ${endpoints.length} endpoints`)}`
-        );
         cliContext.logger.info("");
         cliContext.logger.info(
             banner("Create an MCP server", [

--- a/packages/cli/cli/src/commands/mcp/prototype/listMcp.ts
+++ b/packages/cli/cli/src/commands/mcp/prototype/listMcp.ts
@@ -1,0 +1,82 @@
+import { loadRawGeneratorsConfiguration } from "@fern-api/configuration-loader";
+import { Project } from "@fern-api/project-loader";
+import chalk from "chalk";
+
+import { CliContext } from "../../../cli-context/CliContext.js";
+import { getMcpGeneratorEntries } from "./mcpGeneratorsYml.js";
+import { loadSpecSummaries } from "./openapiSummary.js";
+import { computeVerdict, formatVerdictLine, resolveTools } from "./toolset.js";
+
+interface McpListRow {
+    api: string;
+    group: string;
+    serverName: string;
+    presets: string[];
+    output: string;
+    toolCount: number;
+    estimatedTokens: number;
+    verdict: string;
+}
+
+export async function listMcp({
+    project,
+    cliContext,
+    json
+}: {
+    project: Project;
+    cliContext: CliContext;
+    json: boolean;
+}): Promise<void> {
+    const rows: McpListRow[] = [];
+    for (const workspace of project.apiWorkspaces) {
+        await cliContext.runTaskForWorkspace(workspace, async (context) => {
+            const rawConfiguration = await loadRawGeneratorsConfiguration({
+                absolutePathToWorkspace: workspace.absoluteFilePath,
+                context
+            });
+            if (rawConfiguration == null) {
+                return;
+            }
+            const entries = getMcpGeneratorEntries(rawConfiguration);
+            if (entries.length === 0) {
+                return;
+            }
+            const specs = await loadSpecSummaries(workspace.absoluteFilePath);
+            const endpoints = specs[0]?.endpoints ?? [];
+            for (const entry of entries) {
+                const tools = resolveTools(endpoints, entry.config.tools ?? {});
+                const verdict = computeVerdict(tools);
+                rows.push({
+                    api: workspace.workspaceName ?? "api",
+                    group: entry.groupName,
+                    serverName: entry.config["server-name"],
+                    presets: Object.keys(entry.config.tools?.presets ?? {}),
+                    output: entry.outputLocation ?? "local-file-system",
+                    toolCount: verdict.toolCount,
+                    estimatedTokens: verdict.estimatedTokens,
+                    verdict: formatVerdictLine(verdict)
+                });
+            }
+        });
+    }
+
+    if (json) {
+        cliContext.logger.info(JSON.stringify(rows, null, 2));
+        return;
+    }
+    if (rows.length === 0) {
+        cliContext.logger.info("No MCP servers are configured yet. Run `fern mcp init` to create one.");
+        return;
+    }
+    cliContext.logger.info("");
+    for (const row of rows) {
+        cliContext.logger.info(chalk.bold(`${row.group} (${row.api})`));
+        cliContext.logger.info(`  server-name: ${row.serverName}`);
+        cliContext.logger.info(`  output:      ${row.output}`);
+        if (row.presets.length > 0) {
+            cliContext.logger.info(`  presets:     ${row.presets.join(", ")}`);
+        }
+        cliContext.logger.info(`  tools:       ${row.verdict}`);
+        cliContext.logger.info("");
+    }
+}

--- a/packages/cli/cli/src/commands/mcp/prototype/listMcp.ts
+++ b/packages/cli/cli/src/commands/mcp/prototype/listMcp.ts
@@ -5,7 +5,8 @@ import chalk from "chalk";
 import { CliContext } from "../../../cli-context/CliContext.js";
 import { getMcpGeneratorEntries } from "./mcpGeneratorsYml.js";
 import { loadSpecSummaries } from "./openapiSummary.js";
-import { computeVerdict, formatVerdictLine, resolveTools } from "./toolset.js";
+import { computeVerdict, resolveTools, Verdict } from "./toolset.js";
+import { command, hint, keyValueRows, styledVerdictLine } from "./ui.js";
 
 interface McpListRow {
     api: string;
@@ -15,7 +16,7 @@ interface McpListRow {
     output: string;
     toolCount: number;
     estimatedTokens: number;
-    verdict: string;
+    verdict: Verdict;
 }
 
 export async function listMcp({
@@ -54,29 +55,40 @@ export async function listMcp({
                     output: entry.outputLocation ?? "local-file-system",
                     toolCount: verdict.toolCount,
                     estimatedTokens: verdict.estimatedTokens,
-                    verdict: formatVerdictLine(verdict)
+                    verdict
                 });
             }
         });
     }
 
     if (json) {
-        cliContext.logger.info(JSON.stringify(rows, null, 2));
+        cliContext.logger.info(
+            JSON.stringify(
+                rows.map((row) => ({ ...row, verdict: row.verdict.level })),
+                null,
+                2
+            )
+        );
         return;
     }
     if (rows.length === 0) {
-        cliContext.logger.info("No MCP servers are configured yet. Run `fern mcp init` to create one.");
+        cliContext.logger.info(`No MCP servers are configured yet. Run ${command("fern mcp init")} to create one.`);
         return;
     }
     cliContext.logger.info("");
     for (const row of rows) {
-        cliContext.logger.info(chalk.bold(`${row.group} (${row.api})`));
-        cliContext.logger.info(`  server-name: ${row.serverName}`);
-        cliContext.logger.info(`  output:      ${row.output}`);
+        cliContext.logger.info(`${chalk.bold.green(row.group)} ${hint(`(${row.api})`)}`);
+        const kvRows: [string, string][] = [
+            ["server", chalk.bold(row.serverName)],
+            ["output", row.output]
+        ];
         if (row.presets.length > 0) {
-            cliContext.logger.info(`  presets:     ${row.presets.join(", ")}`);
+            kvRows.push(["presets", row.presets.map((preset) => chalk.cyan(preset)).join(", ")]);
         }
-        cliContext.logger.info(`  tools:       ${row.verdict}`);
+        kvRows.push(["tools", styledVerdictLine(row.verdict)]);
+        for (const line of keyValueRows(kvRows)) {
+            cliContext.logger.info(line);
+        }
         cliContext.logger.info("");
     }
 }

--- a/packages/cli/cli/src/commands/mcp/prototype/mcpGeneratorsYml.ts
+++ b/packages/cli/cli/src/commands/mcp/prototype/mcpGeneratorsYml.ts
@@ -256,7 +256,13 @@ export async function writeMcpGroupToGeneratorsYml({
 
     const configurationAsRecord: Record<string, unknown> = isRecord(parsedFile) ? { ...parsedFile } : {};
     const groups = isRecord(configurationAsRecord.groups) ? { ...configurationAsRecord.groups } : {};
-    groups[groupName] = { generators: [generatorEntry] };
+    const existingGroupValue = groups[groupName];
+    const existingGroup = isRecord(existingGroupValue) ? existingGroupValue : undefined;
+    const existingGenerators: unknown[] = Array.isArray(existingGroup?.generators) ? existingGroup.generators : [];
+    const otherGenerators = existingGenerators.filter(
+        (generator) => !(isRecord(generator) && generator.name === MCP_GENERATOR_NAME)
+    );
+    groups[groupName] = { ...existingGroup, generators: [...otherGenerators, generatorEntry] };
     configurationAsRecord.groups = groups;
 
     await writeFile(

--- a/packages/cli/cli/src/commands/mcp/prototype/mcpGeneratorsYml.ts
+++ b/packages/cli/cli/src/commands/mcp/prototype/mcpGeneratorsYml.ts
@@ -1,0 +1,271 @@
+import { generatorsYml } from "@fern-api/configuration";
+import { getPathToGeneratorsConfiguration, loadRawGeneratorsConfiguration } from "@fern-api/configuration-loader";
+import { AbsoluteFilePath } from "@fern-api/fs-utils";
+import { TaskContext } from "@fern-api/task-context";
+
+import { readFile, writeFile } from "fs/promises";
+import yaml from "js-yaml";
+
+import { ToolSelector, ToolsConfig } from "./toolset.js";
+
+export const MCP_GENERATOR_NAME = "fernapi/fern-mcp-server";
+export const MCP_GENERATOR_VERSION = "0.1.0";
+export const DEFAULT_MCP_GROUP_NAME = "mcp";
+export const GENERATORS_YML_SCHEMA_COMMENT =
+    "# yaml-language-server: $schema=https://schema.buildwithfern.dev/generators-yml.json\n";
+
+/** The `config:` block written on a `fernapi/fern-mcp-server` generator entry. */
+export interface McpGeneratorConfig {
+    "server-name": string;
+    instructions?: string;
+    tools?: McpToolsBlock;
+}
+
+export interface McpToolsBlock extends ToolsConfig {
+    presets?: Record<string, ToolsConfig>;
+}
+
+export interface McpGeneratorEntry {
+    groupName: string;
+    config: McpGeneratorConfig;
+    outputLocation: string | undefined;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+    return typeof value === "object" && value != null && !Array.isArray(value);
+}
+
+function asOptionalString(value: unknown): string | undefined {
+    return typeof value === "string" ? value : undefined;
+}
+
+function parseSelectors(value: unknown): ToolSelector[] | undefined {
+    if (!Array.isArray(value)) {
+        return undefined;
+    }
+    const selectors: ToolSelector[] = [];
+    for (const entry of value) {
+        if (!isRecord(entry)) {
+            continue;
+        }
+        selectors.push({
+            tag: asOptionalString(entry.tag),
+            method: asOptionalString(entry.method),
+            "operation-id": asOptionalString(entry["operation-id"]),
+            "path-prefix": asOptionalString(entry["path-prefix"]),
+            endpoint: asOptionalString(entry.endpoint)
+        });
+    }
+    return selectors;
+}
+
+export function parseToolsConfig(value: unknown): ToolsConfig {
+    if (!isRecord(value)) {
+        return {};
+    }
+    return {
+        intent: asOptionalString(value.intent),
+        instructions: asOptionalString(value.instructions),
+        include: parseSelectors(value.include),
+        exclude: parseSelectors(value.exclude)
+    };
+}
+
+function parsePresets(value: unknown): Record<string, ToolsConfig> | undefined {
+    if (!isRecord(value)) {
+        return undefined;
+    }
+    const presets: Record<string, ToolsConfig> = {};
+    for (const [name, presetValue] of Object.entries(value)) {
+        presets[name] = parseToolsConfig(presetValue);
+    }
+    return Object.keys(presets).length > 0 ? presets : undefined;
+}
+
+export function parseMcpGeneratorConfig(value: unknown): McpGeneratorConfig | undefined {
+    if (!isRecord(value)) {
+        return undefined;
+    }
+    const serverName = asOptionalString(value["server-name"]);
+    if (serverName == null) {
+        return undefined;
+    }
+    const toolsValue = isRecord(value.tools) ? value.tools : undefined;
+    return {
+        "server-name": serverName,
+        instructions: asOptionalString(value.instructions),
+        tools:
+            toolsValue != null
+                ? { ...parseToolsConfig(toolsValue), presets: parsePresets(toolsValue.presets) }
+                : undefined
+    };
+}
+
+function getOutputPath(output: generatorsYml.GeneratorOutputSchema | undefined): string | undefined {
+    if (output == null) {
+        return undefined;
+    }
+    return output.location === "local-file-system" ? output.path : output.location;
+}
+
+export function getMcpGeneratorEntries(
+    rawConfiguration: generatorsYml.GeneratorsConfigurationSchema
+): McpGeneratorEntry[] {
+    const entries: McpGeneratorEntry[] = [];
+    for (const [groupName, group] of Object.entries(rawConfiguration.groups ?? {})) {
+        for (const generator of group.generators) {
+            if (!("name" in generator) || generator.name !== MCP_GENERATOR_NAME) {
+                continue;
+            }
+            const config = parseMcpGeneratorConfig(generator.config);
+            if (config == null) {
+                continue;
+            }
+            entries.push({
+                groupName,
+                config,
+                outputLocation: getOutputPath(generator.output)
+            });
+        }
+    }
+    return entries;
+}
+
+function selectorToPlainObject(selector: ToolSelector): Record<string, string> {
+    const plain: Record<string, string> = {};
+    if (selector.tag != null) {
+        plain.tag = selector.tag;
+    }
+    if (selector.method != null) {
+        plain.method = selector.method;
+    }
+    if (selector["operation-id"] != null) {
+        plain["operation-id"] = selector["operation-id"];
+    }
+    if (selector["path-prefix"] != null) {
+        plain["path-prefix"] = selector["path-prefix"];
+    }
+    if (selector.endpoint != null) {
+        plain.endpoint = selector.endpoint;
+    }
+    return plain;
+}
+
+export function toolsConfigToPlainObject(config: ToolsConfig): Record<string, unknown> {
+    const plain: Record<string, unknown> = {};
+    if (config.intent != null) {
+        plain.intent = config.intent;
+    }
+    if (config.instructions != null) {
+        plain.instructions = config.instructions;
+    }
+    if (config.include != null && config.include.length > 0) {
+        plain.include = config.include.map(selectorToPlainObject);
+    }
+    if (config.exclude != null && config.exclude.length > 0) {
+        plain.exclude = config.exclude.map(selectorToPlainObject);
+    }
+    return plain;
+}
+
+export interface FoundMcpGroup {
+    config: McpGeneratorConfig;
+    outputLocation: string | undefined;
+    absolutePathToGeneratorsConfiguration: AbsoluteFilePath;
+}
+
+/** Loads generators.yml and finds the MCP generator entry in the given group. */
+export async function findMcpGroup({
+    context,
+    absolutePathToWorkspace,
+    groupName
+}: {
+    context: TaskContext;
+    absolutePathToWorkspace: AbsoluteFilePath;
+    groupName: string;
+}): Promise<FoundMcpGroup | undefined> {
+    const absolutePathToGeneratorsConfiguration = await getPathToGeneratorsConfiguration({ absolutePathToWorkspace });
+    if (absolutePathToGeneratorsConfiguration == null) {
+        return undefined;
+    }
+    const rawConfiguration = await loadRawGeneratorsConfiguration({ absolutePathToWorkspace, context });
+    if (rawConfiguration == null) {
+        return undefined;
+    }
+    const entry = getMcpGeneratorEntries(rawConfiguration).find((candidate) => candidate.groupName === groupName);
+    if (entry == null) {
+        return undefined;
+    }
+    return {
+        config: entry.config,
+        outputLocation: entry.outputLocation,
+        absolutePathToGeneratorsConfiguration
+    };
+}
+
+export interface WriteMcpGroupResult {
+    absolutePathToGeneratorsConfiguration: AbsoluteFilePath;
+    yamlBlock: string;
+}
+
+export async function writeMcpGroupToGeneratorsYml({
+    absolutePathToWorkspace,
+    context,
+    groupName,
+    serverName,
+    toolsConfig,
+    presets
+}: {
+    absolutePathToWorkspace: AbsoluteFilePath;
+    context: TaskContext;
+    groupName: string;
+    serverName: string;
+    toolsConfig: ToolsConfig;
+    presets?: Record<string, ToolsConfig>;
+}): Promise<WriteMcpGroupResult | undefined> {
+    const absolutePathToGeneratorsConfiguration = await getPathToGeneratorsConfiguration({ absolutePathToWorkspace });
+    if (absolutePathToGeneratorsConfiguration == null) {
+        return undefined;
+    }
+    // Validate the existing configuration (fails loudly on malformed YAML),
+    // then mutate a plain parsed copy so unrelated keys are preserved verbatim.
+    await loadRawGeneratorsConfiguration({ absolutePathToWorkspace, context });
+    const parsedFile = yaml.load(await readFile(absolutePathToGeneratorsConfiguration, "utf-8"));
+
+    const toolsBlock = toolsConfigToPlainObject({ ...toolsConfig, instructions: undefined });
+    if (presets != null && Object.keys(presets).length > 0) {
+        const presetsBlock: Record<string, unknown> = {};
+        for (const [name, preset] of Object.entries(presets)) {
+            presetsBlock[name] = toolsConfigToPlainObject(preset);
+        }
+        toolsBlock.presets = presetsBlock;
+    }
+    const generatorEntry: Record<string, unknown> = {
+        name: MCP_GENERATOR_NAME,
+        version: MCP_GENERATOR_VERSION,
+        output: {
+            location: "local-file-system",
+            path: `../../generated/${groupName}`
+        },
+        config: {
+            "server-name": serverName,
+            ...(toolsConfig.instructions != null ? { instructions: toolsConfig.instructions } : {}),
+            tools: toolsBlock
+        }
+    };
+
+    const configurationAsRecord: Record<string, unknown> = isRecord(parsedFile) ? { ...parsedFile } : {};
+    const groups = isRecord(configurationAsRecord.groups) ? { ...configurationAsRecord.groups } : {};
+    groups[groupName] = { generators: [generatorEntry] };
+    configurationAsRecord.groups = groups;
+
+    await writeFile(
+        absolutePathToGeneratorsConfiguration,
+        GENERATORS_YML_SCHEMA_COMMENT + yaml.dump(configurationAsRecord)
+    );
+
+    return {
+        absolutePathToGeneratorsConfiguration,
+        yamlBlock: yaml.dump({ groups: { [groupName]: { generators: [generatorEntry] } } })
+    };
+}

--- a/packages/cli/cli/src/commands/mcp/prototype/openapiSummary.ts
+++ b/packages/cli/cli/src/commands/mcp/prototype/openapiSummary.ts
@@ -1,0 +1,141 @@
+import { readdir, readFile } from "fs/promises";
+import yaml from "js-yaml";
+import path from "path";
+
+export interface EndpointSummary {
+    method: string;
+    path: string;
+    operationId: string | undefined;
+    tags: string[];
+    summary: string | undefined;
+    description: string | undefined;
+    /** Rough estimate of the tokens this endpoint costs as a tool definition. */
+    estimatedTokens: number;
+}
+
+export interface SpecSummary {
+    absoluteFilePath: string;
+    title: string | undefined;
+    endpoints: EndpointSummary[];
+    securitySchemeNames: string[];
+}
+
+/** Baseline token overhead per tool (name, wrapper JSON, annotations). */
+const PER_TOOL_TOKEN_OVERHEAD = 60;
+/** Rough chars-per-token ratio for JSON schema content. */
+const CHARS_PER_TOKEN = 4;
+
+const HTTP_METHODS = ["get", "post", "put", "patch", "delete", "head", "options"] as const;
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+    return typeof value === "object" && value != null && !Array.isArray(value);
+}
+
+function asStringArray(value: unknown): string[] {
+    if (!Array.isArray(value)) {
+        return [];
+    }
+    return value.filter((item): item is string => typeof item === "string");
+}
+
+function asOptionalString(value: unknown): string | undefined {
+    return typeof value === "string" ? value : undefined;
+}
+
+function parseSpecDocument(contents: string, filepath: string): Record<string, unknown> | undefined {
+    try {
+        const parsed = filepath.endsWith(".json") ? JSON.parse(contents) : yaml.load(contents);
+        return isRecord(parsed) ? parsed : undefined;
+    } catch {
+        return undefined;
+    }
+}
+
+function isOpenApiDocument(document: Record<string, unknown>): boolean {
+    return (document.openapi != null || document.swagger != null) && isRecord(document.paths);
+}
+
+function summarizeEndpoints(document: Record<string, unknown>): EndpointSummary[] {
+    const endpoints: EndpointSummary[] = [];
+    const paths = isRecord(document.paths) ? document.paths : {};
+    for (const [endpointPath, pathItem] of Object.entries(paths)) {
+        if (!isRecord(pathItem)) {
+            continue;
+        }
+        for (const method of HTTP_METHODS) {
+            const operation = pathItem[method];
+            if (!isRecord(operation)) {
+                continue;
+            }
+            const operationSize = JSON.stringify(operation).length;
+            endpoints.push({
+                method: method.toUpperCase(),
+                path: endpointPath,
+                operationId: asOptionalString(operation.operationId),
+                tags: asStringArray(operation.tags),
+                summary: asOptionalString(operation.summary),
+                description: asOptionalString(operation.description),
+                estimatedTokens: Math.round(operationSize / CHARS_PER_TOKEN) + PER_TOOL_TOKEN_OVERHEAD
+            });
+        }
+    }
+    return endpoints;
+}
+
+function getSecuritySchemeNames(document: Record<string, unknown>): string[] {
+    const components = isRecord(document.components) ? document.components : {};
+    const securitySchemes = isRecord(components.securitySchemes) ? components.securitySchemes : {};
+    return Object.keys(securitySchemes);
+}
+
+function getTitle(document: Record<string, unknown>): string | undefined {
+    const info = isRecord(document.info) ? document.info : {};
+    return asOptionalString(info.title);
+}
+
+async function listCandidateSpecFiles(workspaceDirectory: string): Promise<string[]> {
+    const candidates: string[] = [];
+    const directoriesToScan = [workspaceDirectory, path.join(workspaceDirectory, "openapi")];
+    for (const directory of directoriesToScan) {
+        let entries;
+        try {
+            entries = await readdir(directory, { withFileTypes: true });
+        } catch {
+            continue;
+        }
+        for (const entry of entries) {
+            if (entry.isFile() && /\.(ya?ml|json)$/.test(entry.name) && !entry.name.startsWith("generators")) {
+                candidates.push(path.join(directory, entry.name));
+            }
+        }
+    }
+    return candidates;
+}
+
+/**
+ * Finds and summarizes the OpenAPI spec(s) in a fern workspace directory.
+ * Scans the workspace directory (and an `openapi/` subdirectory) for
+ * YAML/JSON files that look like OpenAPI documents.
+ */
+export async function loadSpecSummaries(workspaceDirectory: string): Promise<SpecSummary[]> {
+    const summaries: SpecSummary[] = [];
+    for (const filepath of await listCandidateSpecFiles(workspaceDirectory)) {
+        let contents: string;
+        try {
+            contents = await readFile(filepath, "utf-8");
+        } catch {
+            continue;
+        }
+        const document = parseSpecDocument(contents, filepath);
+        if (document == null || !isOpenApiDocument(document)) {
+            continue;
+        }
+        summaries.push({
+            absoluteFilePath: filepath,
+            title: getTitle(document),
+            endpoints: summarizeEndpoints(document),
+            securitySchemeNames: getSecuritySchemeNames(document)
+        });
+    }
+    return summaries;
+}

--- a/packages/cli/cli/src/commands/mcp/prototype/presets.ts
+++ b/packages/cli/cli/src/commands/mcp/prototype/presets.ts
@@ -1,0 +1,151 @@
+import { EndpointSummary } from "./openapiSummary.js";
+import { computeVerdict, resolveTools, ToolsConfig, Verdict } from "./toolset.js";
+
+export type BuiltinPresetKey = "read-only" | "main-resources" | "everything";
+
+export const BUILTIN_PRESET_KEYS: BuiltinPresetKey[] = ["read-only", "main-resources", "everything"];
+
+export interface PresetResolution {
+    key: BuiltinPresetKey;
+    label: string;
+    config: ToolsConfig;
+    verdict: Verdict;
+    available: boolean;
+    unavailableReason?: string;
+    notes: string[];
+}
+
+const READ_LIKE_OPERATION_PATTERN = /^(list|search|query|find|lookup|fetch|read|get)[_\-A-Z]?/;
+const READ_LIKE_PATH_SEGMENTS = new Set(["search", "query", "list", "lookup"]);
+const AMBIGUOUS_READ_PATTERN = /(search|query|list|find|lookup)/i;
+const EXCLUDED_TAG_PATTERN = /(admin|internal|webhook|legacy|deprecated|beta|debug|test)/i;
+
+function lastPathSegment(endpointPath: string): string {
+    const segments = endpointPath.split("/").filter((segment) => segment.length > 0);
+    return segments[segments.length - 1] ?? "";
+}
+
+export function isReadLikePost(endpoint: EndpointSummary): boolean {
+    if (endpoint.method !== "POST") {
+        return false;
+    }
+    if (endpoint.operationId != null && READ_LIKE_OPERATION_PATTERN.test(endpoint.operationId)) {
+        return true;
+    }
+    if (endpoint.summary != null && READ_LIKE_OPERATION_PATTERN.test(endpoint.summary.toLowerCase())) {
+        return true;
+    }
+    return READ_LIKE_PATH_SEGMENTS.has(lastPathSegment(endpoint.path).toLowerCase());
+}
+
+export function isAmbiguousReadPost(endpoint: EndpointSummary): boolean {
+    if (endpoint.method !== "POST" || isReadLikePost(endpoint)) {
+        return false;
+    }
+    const haystack = `${endpoint.operationId ?? ""} ${endpoint.summary ?? ""}`;
+    return AMBIGUOUS_READ_PATTERN.test(haystack);
+}
+
+export function buildReadOnlyPreset(endpoints: EndpointSummary[]): PresetResolution {
+    const readLikePosts = endpoints.filter(isReadLikePost);
+    const ambiguousPosts = endpoints.filter(isAmbiguousReadPost);
+    const config: ToolsConfig = {
+        include: [
+            { method: "GET" },
+            ...readLikePosts.map((endpoint) => ({ endpoint: `${endpoint.method} ${endpoint.path}` }))
+        ]
+    };
+    const notes: string[] = [];
+    if (readLikePosts.length > 0) {
+        notes.push(`${readLikePosts.length} read-like POST endpoint(s) included (search/query/list behind POST)`);
+    }
+    if (ambiguousPosts.length > 0) {
+        notes.push(
+            `${ambiguousPosts.length} ambiguous read-like POST endpoint(s) excluded — review with fern mcp tools`
+        );
+    }
+    return {
+        key: "read-only",
+        label: "Read-only — lookups and searches, nothing that writes",
+        config,
+        verdict: computeVerdict(resolveTools(endpoints, config)),
+        available: true,
+        notes
+    };
+}
+
+interface TagStats {
+    tag: string;
+    endpointCount: number;
+    methodVariety: number;
+}
+
+function rankTags(endpoints: EndpointSummary[]): TagStats[] {
+    const byTag = new Map<string, EndpointSummary[]>();
+    for (const endpoint of endpoints) {
+        for (const tag of endpoint.tags) {
+            const existing = byTag.get(tag) ?? [];
+            existing.push(endpoint);
+            byTag.set(tag, existing);
+        }
+    }
+    return [...byTag.entries()]
+        .map(([tag, tagged]) => ({
+            tag,
+            endpointCount: tagged.length,
+            methodVariety: new Set(tagged.map((endpoint) => endpoint.method)).size
+        }))
+        .sort((a, b) => b.endpointCount + b.methodVariety * 2 - (a.endpointCount + a.methodVariety * 2));
+}
+
+export function buildMainResourcesPreset(endpoints: EndpointSummary[]): PresetResolution {
+    const ranked = rankTags(endpoints);
+    const usable = ranked.filter((stats) => !EXCLUDED_TAG_PATTERN.test(stats.tag));
+    const excluded = ranked.filter((stats) => EXCLUDED_TAG_PATTERN.test(stats.tag));
+    if (usable.length === 0) {
+        return {
+            key: "main-resources",
+            label: "Main resources — unavailable",
+            config: {},
+            verdict: computeVerdict([]),
+            available: false,
+            unavailableReason: "spec lacks tags — use AI-curated or trim by path prefix instead",
+            notes: []
+        };
+    }
+    const primary = usable.slice(0, 3);
+    const config: ToolsConfig = {
+        include: primary.map((stats) => ({ tag: stats.tag })),
+        exclude: excluded.length > 0 ? excluded.map((stats) => ({ tag: stats.tag })) : undefined
+    };
+    const resourceNames = primary.map((stats) => stats.tag).join(", ");
+    const notes = excluded.length > 0 ? [`excluded tags: ${excluded.map((stats) => stats.tag).join(", ")}`] : [];
+    return {
+        key: "main-resources",
+        label: `Main resources — ${resourceNames} (detected from your spec)`,
+        config,
+        verdict: computeVerdict(resolveTools(endpoints, config)),
+        available: true,
+        notes
+    };
+}
+
+export function buildEverythingPreset(endpoints: EndpointSummary[]): PresetResolution {
+    const config: ToolsConfig = {};
+    return {
+        key: "everything",
+        label: `Everything — all ${endpoints.length} endpoints`,
+        config,
+        verdict: computeVerdict(resolveTools(endpoints, config)),
+        available: true,
+        notes: []
+    };
+}
+
+export function buildBuiltinPresets(endpoints: EndpointSummary[]): Record<BuiltinPresetKey, PresetResolution> {
+    return {
+        "read-only": buildReadOnlyPreset(endpoints),
+        "main-resources": buildMainResourcesPreset(endpoints),
+        everything: buildEverythingPreset(endpoints)
+    };
+}

--- a/packages/cli/cli/src/commands/mcp/prototype/toolsMcp.ts
+++ b/packages/cli/cli/src/commands/mcp/prototype/toolsMcp.ts
@@ -1,0 +1,118 @@
+import { Project } from "@fern-api/project-loader";
+import chalk from "chalk";
+
+import { CliContext } from "../../../cli-context/CliContext.js";
+import { findMcpGroup, parseToolsConfig, writeMcpGroupToGeneratorsYml } from "./mcpGeneratorsYml.js";
+import { computeVerdict, formatVerdictLine, resolveTools, ToolsConfig } from "./toolset.js";
+import { runTrimLoop } from "./trimLoop.js";
+import { pickWorkspaceAndLoadSpec } from "./workspace.js";
+
+export async function toolsMcp({
+    project,
+    cliContext,
+    api,
+    group,
+    preset,
+    json,
+    refine
+}: {
+    project: Project;
+    cliContext: CliContext;
+    api: string | undefined;
+    group: string;
+    preset: string | undefined;
+    json: boolean;
+    refine: boolean;
+}): Promise<void> {
+    const workspaceSpec = await pickWorkspaceAndLoadSpec({
+        project,
+        cliContext,
+        apiFilter: api,
+        interactive: false
+    });
+    if (workspaceSpec == null) {
+        return;
+    }
+    const { spec, absolutePathToWorkspace } = workspaceSpec;
+
+    const found = await cliContext.runTask((context) =>
+        findMcpGroup({ context, absolutePathToWorkspace, groupName: group })
+    );
+    if (found == null) {
+        cliContext.failAndThrow(
+            `No MCP generator found in group "${group}". Run \`fern mcp init\` to create one, or pass --group.`
+        );
+        return;
+    }
+
+    let toolsConfig: ToolsConfig = found.config.tools ?? {};
+    let presetLabel = group;
+    if (preset != null) {
+        const presetConfig = found.config.tools?.presets?.[preset];
+        if (presetConfig == null) {
+            cliContext.failAndThrow(
+                `Preset "${preset}" not found in group "${group}". Available presets: ${Object.keys(found.config.tools?.presets ?? {}).join(", ") || "(none)"}`
+            );
+            return;
+        }
+        toolsConfig = parseToolsConfig(presetConfig);
+        presetLabel = `${group} (preset: ${preset})`;
+    }
+
+    if (refine) {
+        toolsConfig = await runTrimLoop({
+            cliContext,
+            endpoints: spec.endpoints,
+            initialConfig: toolsConfig
+        });
+        await cliContext.runTaskForWorkspace(workspaceSpec.workspace, async (context) => {
+            await writeMcpGroupToGeneratorsYml({
+                absolutePathToWorkspace,
+                context,
+                groupName: group,
+                serverName: found.config["server-name"],
+                toolsConfig,
+                presets: found.config.tools?.presets
+            });
+        });
+        cliContext.logger.info(chalk.green(`Updated group "${group}" in generators.yml.`));
+    }
+
+    const tools = resolveTools(spec.endpoints, toolsConfig);
+    const verdict = computeVerdict(tools);
+
+    if (json) {
+        cliContext.logger.info(
+            JSON.stringify(
+                {
+                    group,
+                    preset: preset ?? null,
+                    serverName: found.config["server-name"],
+                    tools: tools.map((tool) => ({
+                        name: tool.name,
+                        method: tool.endpoint.method,
+                        path: tool.endpoint.path,
+                        estimatedTokens: tool.endpoint.estimatedTokens
+                    })),
+                    toolCount: verdict.toolCount,
+                    estimatedTokens: verdict.estimatedTokens,
+                    verdict: verdict.level
+                },
+                null,
+                2
+            )
+        );
+        return;
+    }
+
+    cliContext.logger.info("");
+    cliContext.logger.info(chalk.bold(`Tool surface for ${presetLabel} — ${found.config["server-name"]}`));
+    cliContext.logger.info("");
+    for (const tool of tools) {
+        cliContext.logger.info(
+            `  ${tool.name}  ${chalk.dim(`${tool.endpoint.method} ${tool.endpoint.path} · ~${tool.endpoint.estimatedTokens} tokens`)}`
+        );
+    }
+    cliContext.logger.info("");
+    cliContext.logger.info(formatVerdictLine(verdict));
+}

--- a/packages/cli/cli/src/commands/mcp/prototype/toolsMcp.ts
+++ b/packages/cli/cli/src/commands/mcp/prototype/toolsMcp.ts
@@ -6,7 +6,7 @@ import { findMcpGroup, parseToolsConfig, writeMcpGroupToGeneratorsYml } from "./
 import { computeVerdict, resolveTools, ToolsConfig } from "./toolset.js";
 import { runTrimLoop } from "./trimLoop.js";
 import { hint, ICONS, styledVerdictLine, toolTable } from "./ui.js";
-import { pickWorkspaceAndLoadSpec } from "./workspace.js";
+import { announceSpecDiscovery, pickWorkspaceAndLoadSpec } from "./workspace.js";
 
 export async function toolsMcp({
     project,
@@ -33,6 +33,9 @@ export async function toolsMcp({
     });
     if (workspaceSpec == null) {
         return;
+    }
+    if (!json) {
+        await announceSpecDiscovery({ cliContext, workspaceSpec });
     }
     const { spec, absolutePathToWorkspace } = workspaceSpec;
 

--- a/packages/cli/cli/src/commands/mcp/prototype/toolsMcp.ts
+++ b/packages/cli/cli/src/commands/mcp/prototype/toolsMcp.ts
@@ -65,14 +65,18 @@ export async function toolsMcp({
             endpoints: spec.endpoints,
             initialConfig: toolsConfig
         });
+        const refinedConfig = toolsConfig;
+        const groupToolsConfig = preset != null ? (found.config.tools ?? {}) : refinedConfig;
+        const updatedPresets =
+            preset != null ? { ...found.config.tools?.presets, [preset]: refinedConfig } : found.config.tools?.presets;
         await cliContext.runTaskForWorkspace(workspaceSpec.workspace, async (context) => {
             await writeMcpGroupToGeneratorsYml({
                 absolutePathToWorkspace,
                 context,
                 groupName: group,
                 serverName: found.config["server-name"],
-                toolsConfig,
-                presets: found.config.tools?.presets
+                toolsConfig: groupToolsConfig,
+                presets: updatedPresets
             });
         });
         cliContext.logger.info(chalk.green(`Updated group "${group}" in generators.yml.`));

--- a/packages/cli/cli/src/commands/mcp/prototype/toolsMcp.ts
+++ b/packages/cli/cli/src/commands/mcp/prototype/toolsMcp.ts
@@ -3,8 +3,9 @@ import chalk from "chalk";
 
 import { CliContext } from "../../../cli-context/CliContext.js";
 import { findMcpGroup, parseToolsConfig, writeMcpGroupToGeneratorsYml } from "./mcpGeneratorsYml.js";
-import { computeVerdict, formatVerdictLine, resolveTools, ToolsConfig } from "./toolset.js";
+import { computeVerdict, resolveTools, ToolsConfig } from "./toolset.js";
 import { runTrimLoop } from "./trimLoop.js";
+import { hint, ICONS, styledVerdictLine, toolTable } from "./ui.js";
 import { pickWorkspaceAndLoadSpec } from "./workspace.js";
 
 export async function toolsMcp({
@@ -79,7 +80,7 @@ export async function toolsMcp({
                 presets: updatedPresets
             });
         });
-        cliContext.logger.info(chalk.green(`Updated group "${group}" in generators.yml.`));
+        cliContext.logger.info(`${ICONS.success} Updated group ${chalk.bold(`"${group}"`)} in generators.yml.`);
     }
 
     const tools = resolveTools(spec.endpoints, toolsConfig);
@@ -110,13 +111,16 @@ export async function toolsMcp({
     }
 
     cliContext.logger.info("");
-    cliContext.logger.info(chalk.bold(`Tool surface for ${presetLabel} — ${found.config["server-name"]}`));
+    cliContext.logger.info(
+        `${chalk.bold("Tool surface")} ${hint(`for ${presetLabel}`)} — ${chalk.bold.green(found.config["server-name"])}`
+    );
     cliContext.logger.info("");
-    for (const tool of tools) {
-        cliContext.logger.info(
-            `  ${tool.name}  ${chalk.dim(`${tool.endpoint.method} ${tool.endpoint.path} · ~${tool.endpoint.estimatedTokens} tokens`)}`
-        );
+    if (tools.length === 0) {
+        cliContext.logger.info(hint("  (no tools resolved — the config excludes everything)"));
+    }
+    for (const line of toolTable(tools)) {
+        cliContext.logger.info(line);
     }
     cliContext.logger.info("");
-    cliContext.logger.info(formatVerdictLine(verdict));
+    cliContext.logger.info(styledVerdictLine(verdict));
 }

--- a/packages/cli/cli/src/commands/mcp/prototype/toolset.ts
+++ b/packages/cli/cli/src/commands/mcp/prototype/toolset.ts
@@ -1,0 +1,148 @@
+import { EndpointSummary } from "./openapiSummary.js";
+
+/**
+ * A declarative endpoint selector. Fields within one selector are ANDed;
+ * selectors across an include/exclude list are ORed.
+ */
+export interface ToolSelector {
+    tag?: string;
+    method?: string;
+    /** Glob pattern matched against the operationId (e.g. `list_*`). */
+    "operation-id"?: string;
+    "path-prefix"?: string;
+    /** Explicit escape hatch, e.g. `POST /v1/refunds`. */
+    endpoint?: string;
+}
+
+export interface ToolsConfig {
+    intent?: string;
+    instructions?: string;
+    include?: ToolSelector[];
+    exclude?: ToolSelector[];
+}
+
+export interface ResolvedTool {
+    name: string;
+    endpoint: EndpointSummary;
+}
+
+export interface ToolBudget {
+    maxTools: number;
+    maxTokens: number;
+}
+
+export const DEFAULT_BUDGET: ToolBudget = { maxTools: 40, maxTokens: 60_000 };
+
+export type VerdictLevel = "green" | "amber" | "red";
+
+export interface Verdict {
+    level: VerdictLevel;
+    toolCount: number;
+    estimatedTokens: number;
+    label: string;
+}
+
+function globToRegExp(glob: string): RegExp {
+    const escaped = glob.replace(/[.+^${}()|[\]\\]/g, "\\$&").replace(/\*/g, ".*");
+    return new RegExp(`^${escaped}$`);
+}
+
+function matchesSelector(endpoint: EndpointSummary, selector: ToolSelector): boolean {
+    if (selector.tag != null && !endpoint.tags.includes(selector.tag)) {
+        return false;
+    }
+    if (selector.method != null && endpoint.method !== selector.method.toUpperCase()) {
+        return false;
+    }
+    if (selector["operation-id"] != null) {
+        if (endpoint.operationId == null || !globToRegExp(selector["operation-id"]).test(endpoint.operationId)) {
+            return false;
+        }
+    }
+    if (selector["path-prefix"] != null && !endpoint.path.startsWith(selector["path-prefix"])) {
+        return false;
+    }
+    if (selector.endpoint != null && selector.endpoint !== `${endpoint.method} ${endpoint.path}`) {
+        return false;
+    }
+    return true;
+}
+
+function matchesAnySelector(endpoint: EndpointSummary, selectors: ToolSelector[] | undefined): boolean {
+    return (selectors ?? []).some((selector) => matchesSelector(endpoint, selector));
+}
+
+export function toolNameForEndpoint(endpoint: EndpointSummary): string {
+    if (endpoint.operationId != null) {
+        return endpoint.operationId
+            .replace(/([a-z0-9])([A-Z])/g, "$1_$2")
+            .replace(/[^a-zA-Z0-9]+/g, "_")
+            .toLowerCase();
+    }
+    const pathSlug = endpoint.path
+        .replace(/[{}]/g, "")
+        .replace(/[^a-zA-Z0-9]+/g, "_")
+        .replace(/^_|_$/g, "");
+    return `${endpoint.method.toLowerCase()}_${pathSlug}`;
+}
+
+/**
+ * Resolves a tools config against the spec's endpoints.
+ * Omitted/empty `include` means all endpoints; `exclude` always wins.
+ */
+export function resolveTools(endpoints: EndpointSummary[], config: ToolsConfig): ResolvedTool[] {
+    return endpoints
+        .filter((endpoint) => {
+            const included =
+                config.include == null || config.include.length === 0 || matchesAnySelector(endpoint, config.include);
+            return included && !matchesAnySelector(endpoint, config.exclude);
+        })
+        .map((endpoint) => ({ name: toolNameForEndpoint(endpoint), endpoint }));
+}
+
+export function estimateTokens(tools: ResolvedTool[]): number {
+    return tools.reduce((total, tool) => total + tool.endpoint.estimatedTokens, 0);
+}
+
+export function formatTokens(tokens: number): string {
+    return tokens >= 1000 ? `${Math.round(tokens / 1000)}k` : `${tokens}`;
+}
+
+/**
+ * The two-clause verdict function: tool count and token cost are judged
+ * independently and the overall verdict is the worst of the two.
+ */
+export function computeVerdict(tools: ResolvedTool[], budget: ToolBudget = DEFAULT_BUDGET): Verdict {
+    const toolCount = tools.length;
+    const estimatedTokens = estimateTokens(tools);
+
+    const countLevel: VerdictLevel =
+        toolCount <= budget.maxTools ? "green" : toolCount <= budget.maxTools * 3 ? "amber" : "red";
+    const tokenLevel: VerdictLevel =
+        estimatedTokens <= budget.maxTokens ? "green" : estimatedTokens <= budget.maxTokens * 3 ? "amber" : "red";
+    const level: VerdictLevel =
+        countLevel === "red" || tokenLevel === "red"
+            ? "red"
+            : countLevel === "amber" || tokenLevel === "amber"
+              ? "amber"
+              : "green";
+
+    let label: string;
+    if (level === "green") {
+        label = "✓ within budget";
+    } else {
+        const reasons: string[] = [];
+        if (countLevel !== "green") {
+            reasons.push(`tool count ~${Math.ceil(toolCount / budget.maxTools)}× over`);
+        }
+        if (tokenLevel !== "green") {
+            reasons.push(`token cost ~${Math.ceil(estimatedTokens / budget.maxTokens)}× over`);
+        }
+        label = `${level === "red" ? "✗" : "⚠"} ${reasons.join(" · ")} budget`;
+    }
+    return { level, toolCount, estimatedTokens, label };
+}
+
+export function formatVerdictLine(verdict: Verdict): string {
+    return `${verdict.toolCount} tools · ${formatTokens(verdict.estimatedTokens)} tokens — ${verdict.label}`;
+}

--- a/packages/cli/cli/src/commands/mcp/prototype/trimLoop.ts
+++ b/packages/cli/cli/src/commands/mcp/prototype/trimLoop.ts
@@ -1,0 +1,87 @@
+import { assertNever } from "@fern-api/core-utils";
+import { select } from "@inquirer/prompts";
+import chalk from "chalk";
+
+import { CliContext } from "../../../cli-context/CliContext.js";
+import { EndpointSummary } from "./openapiSummary.js";
+import { computeVerdict, formatVerdictLine, resolveTools, ToolsConfig } from "./toolset.js";
+
+type TrimAction = "tag" | "method" | "path-prefix" | "keep";
+
+function uniqueTags(endpoints: EndpointSummary[]): string[] {
+    return [...new Set(endpoints.flatMap((endpoint) => endpoint.tags))];
+}
+
+/**
+ * The interactive trim step: entered when a verdict is amber/red during
+ * `fern mcp init`, or any time via `fern mcp tools --refine`. Offers
+ * remove-by-tag / remove-by-method / remove-by-path-prefix until the user
+ * keeps the toolset as-is.
+ */
+export async function runTrimLoop({
+    cliContext,
+    endpoints,
+    initialConfig
+}: {
+    cliContext: CliContext;
+    endpoints: EndpointSummary[];
+    initialConfig: ToolsConfig;
+}): Promise<ToolsConfig> {
+    let config: ToolsConfig = { ...initialConfig, exclude: [...(initialConfig.exclude ?? [])] };
+    const tags = uniqueTags(endpoints);
+
+    while (true) {
+        const verdict = computeVerdict(resolveTools(endpoints, config));
+        cliContext.logger.info("");
+        cliContext.logger.info(`Verdict: ${formatVerdictLine(verdict)}`);
+        if (verdict.level !== "green") {
+            cliContext.logger.info(chalk.dim("Agents handle ~40 tools well — let's trim it (or keep it as-is)."));
+        }
+
+        const action = await select<TrimAction>({
+            message: "Trim the toolset?",
+            choices: [
+                ...(tags.length > 0 ? [{ name: "Remove endpoints by tag…", value: "tag" as const }] : []),
+                { name: "Remove endpoints by method…", value: "method" as const },
+                { name: "Remove endpoints by path prefix…", value: "path-prefix" as const },
+                { name: "Keep as-is", value: "keep" as const }
+            ]
+        });
+
+        switch (action) {
+            case "keep":
+                return config;
+            case "tag": {
+                const tag = await select<string>({
+                    message: "Which tag should be removed?",
+                    choices: tags.map((candidate) => ({ name: candidate, value: candidate }))
+                });
+                config = { ...config, exclude: [...(config.exclude ?? []), { tag }] };
+                cliContext.logger.info(chalk.dim(`Removed: ${tag}`));
+                break;
+            }
+            case "method": {
+                const method = await select<string>({
+                    message: "Which method should be removed?",
+                    choices: ["GET", "POST", "PUT", "PATCH", "DELETE"].map((candidate) => ({
+                        name: candidate,
+                        value: candidate
+                    }))
+                });
+                config = { ...config, exclude: [...(config.exclude ?? []), { method }] };
+                cliContext.logger.info(chalk.dim(`Removed: ${method} endpoints`));
+                break;
+            }
+            case "path-prefix": {
+                const prefix = await cliContext.getInput({
+                    message: "Which path prefix should be removed? (e.g. /v1/admin)"
+                });
+                config = { ...config, exclude: [...(config.exclude ?? []), { "path-prefix": prefix }] };
+                cliContext.logger.info(chalk.dim(`Removed: ${prefix}*`));
+                break;
+            }
+            default:
+                assertNever(action);
+        }
+    }
+}

--- a/packages/cli/cli/src/commands/mcp/prototype/trimLoop.ts
+++ b/packages/cli/cli/src/commands/mcp/prototype/trimLoop.ts
@@ -5,7 +5,7 @@ import chalk from "chalk";
 import { CliContext } from "../../../cli-context/CliContext.js";
 import { EndpointSummary } from "./openapiSummary.js";
 import { computeVerdict, resolveTools, ToolsConfig } from "./toolset.js";
-import { hint, ICONS, styledVerdictLine } from "./ui.js";
+import { hint, ICONS, radioChoice, selectTheme, styledVerdictLine } from "./ui.js";
 
 type TrimAction = "tag" | "method" | "path-prefix" | "keep";
 
@@ -42,11 +42,12 @@ export async function runTrimLoop({
         const action = await select<TrimAction>({
             message: "Trim the toolset?",
             choices: [
-                ...(tags.length > 0 ? [{ name: "Remove endpoints by tag…", value: "tag" as const }] : []),
-                { name: "Remove endpoints by method…", value: "method" as const },
-                { name: "Remove endpoints by path prefix…", value: "path-prefix" as const },
-                { name: "Keep as-is", value: "keep" as const }
-            ]
+                ...(tags.length > 0 ? [{ name: radioChoice("Remove endpoints by tag…"), value: "tag" as const }] : []),
+                { name: radioChoice("Remove endpoints by method…"), value: "method" as const },
+                { name: radioChoice("Remove endpoints by path prefix…"), value: "path-prefix" as const },
+                { name: radioChoice("Keep as-is"), value: "keep" as const }
+            ],
+            theme: selectTheme
         });
 
         switch (action) {
@@ -55,7 +56,8 @@ export async function runTrimLoop({
             case "tag": {
                 const tag = await select<string>({
                     message: "Which tag should be removed?",
-                    choices: tags.map((candidate) => ({ name: candidate, value: candidate }))
+                    choices: tags.map((candidate) => ({ name: radioChoice(candidate), value: candidate })),
+                    theme: selectTheme
                 });
                 config = { ...config, exclude: [...(config.exclude ?? []), { tag }] };
                 cliContext.logger.info(`${ICONS.success} Removed ${chalk.bold(tag)}`);
@@ -65,9 +67,10 @@ export async function runTrimLoop({
                 const method = await select<string>({
                     message: "Which method should be removed?",
                     choices: ["GET", "POST", "PUT", "PATCH", "DELETE"].map((candidate) => ({
-                        name: candidate,
+                        name: radioChoice(candidate),
                         value: candidate
-                    }))
+                    })),
+                    theme: selectTheme
                 });
                 config = { ...config, exclude: [...(config.exclude ?? []), { method }] };
                 cliContext.logger.info(`${ICONS.success} Removed ${chalk.bold(method)} endpoints`);

--- a/packages/cli/cli/src/commands/mcp/prototype/trimLoop.ts
+++ b/packages/cli/cli/src/commands/mcp/prototype/trimLoop.ts
@@ -42,10 +42,26 @@ export async function runTrimLoop({
         const action = await select<TrimAction>({
             message: "Trim the toolset?",
             choices: [
-                ...(tags.length > 0 ? [{ name: radioChoice("Remove endpoints by tag…"), value: "tag" as const }] : []),
-                { name: radioChoice("Remove endpoints by method…"), value: "method" as const },
-                { name: radioChoice("Remove endpoints by path prefix…"), value: "path-prefix" as const },
-                { name: radioChoice("Keep as-is"), value: "keep" as const }
+                ...(tags.length > 0
+                    ? [
+                          {
+                              name: radioChoice("Remove endpoints by tag…"),
+                              short: "Remove endpoints by tag…",
+                              value: "tag" as const
+                          }
+                      ]
+                    : []),
+                {
+                    name: radioChoice("Remove endpoints by method…"),
+                    short: "Remove endpoints by method…",
+                    value: "method" as const
+                },
+                {
+                    name: radioChoice("Remove endpoints by path prefix…"),
+                    short: "Remove endpoints by path prefix…",
+                    value: "path-prefix" as const
+                },
+                { name: radioChoice("Keep as-is"), short: "Keep as-is", value: "keep" as const }
             ],
             theme: selectTheme
         });
@@ -56,7 +72,11 @@ export async function runTrimLoop({
             case "tag": {
                 const tag = await select<string>({
                     message: "Which tag should be removed?",
-                    choices: tags.map((candidate) => ({ name: radioChoice(candidate), value: candidate })),
+                    choices: tags.map((candidate) => ({
+                        name: radioChoice(candidate),
+                        short: candidate,
+                        value: candidate
+                    })),
                     theme: selectTheme
                 });
                 config = { ...config, exclude: [...(config.exclude ?? []), { tag }] };
@@ -68,6 +88,7 @@ export async function runTrimLoop({
                     message: "Which method should be removed?",
                     choices: ["GET", "POST", "PUT", "PATCH", "DELETE"].map((candidate) => ({
                         name: radioChoice(candidate),
+                        short: candidate,
                         value: candidate
                     })),
                     theme: selectTheme

--- a/packages/cli/cli/src/commands/mcp/prototype/trimLoop.ts
+++ b/packages/cli/cli/src/commands/mcp/prototype/trimLoop.ts
@@ -4,7 +4,8 @@ import chalk from "chalk";
 
 import { CliContext } from "../../../cli-context/CliContext.js";
 import { EndpointSummary } from "./openapiSummary.js";
-import { computeVerdict, formatVerdictLine, resolveTools, ToolsConfig } from "./toolset.js";
+import { computeVerdict, resolveTools, ToolsConfig } from "./toolset.js";
+import { hint, ICONS, styledVerdictLine } from "./ui.js";
 
 type TrimAction = "tag" | "method" | "path-prefix" | "keep";
 
@@ -33,9 +34,9 @@ export async function runTrimLoop({
     while (true) {
         const verdict = computeVerdict(resolveTools(endpoints, config));
         cliContext.logger.info("");
-        cliContext.logger.info(`Verdict: ${formatVerdictLine(verdict)}`);
+        cliContext.logger.info(styledVerdictLine(verdict));
         if (verdict.level !== "green") {
-            cliContext.logger.info(chalk.dim("Agents handle ~40 tools well — let's trim it (or keep it as-is)."));
+            cliContext.logger.info(hint("Agents handle ~40 tools well — let's trim it (or keep it as-is)."));
         }
 
         const action = await select<TrimAction>({
@@ -57,7 +58,7 @@ export async function runTrimLoop({
                     choices: tags.map((candidate) => ({ name: candidate, value: candidate }))
                 });
                 config = { ...config, exclude: [...(config.exclude ?? []), { tag }] };
-                cliContext.logger.info(chalk.dim(`Removed: ${tag}`));
+                cliContext.logger.info(`${ICONS.success} Removed ${chalk.bold(tag)}`);
                 break;
             }
             case "method": {
@@ -69,7 +70,7 @@ export async function runTrimLoop({
                     }))
                 });
                 config = { ...config, exclude: [...(config.exclude ?? []), { method }] };
-                cliContext.logger.info(chalk.dim(`Removed: ${method} endpoints`));
+                cliContext.logger.info(`${ICONS.success} Removed ${chalk.bold(method)} endpoints`);
                 break;
             }
             case "path-prefix": {
@@ -77,7 +78,7 @@ export async function runTrimLoop({
                     message: "Which path prefix should be removed? (e.g. /v1/admin)"
                 });
                 config = { ...config, exclude: [...(config.exclude ?? []), { "path-prefix": prefix }] };
-                cliContext.logger.info(chalk.dim(`Removed: ${prefix}*`));
+                cliContext.logger.info(`${ICONS.success} Removed ${chalk.bold(`${prefix}*`)}`);
                 break;
             }
             default:

--- a/packages/cli/cli/src/commands/mcp/prototype/ui.ts
+++ b/packages/cli/cli/src/commands/mcp/prototype/ui.ts
@@ -83,6 +83,26 @@ export function keyValueRows(rows: [string, string][]): string[] {
     return rows.map(([key, value]) => `  ${chalk.dim(`${key.padEnd(keyWidth)}`)}  ${value}`);
 }
 
+export const RADIO_UNSELECTED = "○";
+
+/**
+ * Radio-style theme for `@inquirer/prompts` select menus: a green `❯` cursor,
+ * a filled green radio dot on the active choice, and a persistent
+ * "↑↓ navigate · ⏎ select" hint.
+ */
+export const selectTheme = {
+    icon: { cursor: chalk.green("❯") },
+    style: {
+        highlight: (text: string): string => text.replace(RADIO_UNSELECTED, chalk.green("●")),
+        help: (text: string): string => chalk.dim(text)
+    },
+    helpMode: "always" as const
+};
+
+export function radioChoice(label: string): string {
+    return `${RADIO_UNSELECTED} ${label}`;
+}
+
 export function command(text: string): string {
     return chalk.cyan(text);
 }

--- a/packages/cli/cli/src/commands/mcp/prototype/ui.ts
+++ b/packages/cli/cli/src/commands/mcp/prototype/ui.ts
@@ -1,0 +1,119 @@
+import { assertNever } from "@fern-api/core-utils";
+import boxen from "boxen";
+import chalk from "chalk";
+
+import { formatTokens, ResolvedTool, Verdict } from "./toolset.js";
+
+const SPINNER_FRAMES = ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"];
+const SPINNER_INTERVAL_MS = 80;
+
+export const ICONS = {
+    success: chalk.green("✓"),
+    warning: chalk.yellow("▲"),
+    error: chalk.red("✗"),
+    agent: chalk.magenta("✦"),
+    bullet: chalk.dim("·"),
+    pointer: chalk.green("➜")
+} as const;
+
+export function banner(title: string, lines: string[]): string {
+    const body = [chalk.bold(title), ...lines].join("\n");
+    return boxen(body, {
+        padding: { top: 0, bottom: 0, left: 1, right: 1 },
+        borderStyle: "round",
+        borderColor: "green"
+    });
+}
+
+export function sectionRule(title: string): string {
+    const label = ` ${title} `;
+    const width = Math.max(8, 56 - label.length);
+    return chalk.dim(`──${chalk.reset(chalk.bold(label))}${chalk.dim("─".repeat(width))}`);
+}
+
+export function methodBadge(method: string): string {
+    const padded = method.padEnd(6);
+    switch (method) {
+        case "GET":
+            return chalk.green(padded);
+        case "POST":
+            return chalk.yellow(padded);
+        case "PUT":
+        case "PATCH":
+            return chalk.blue(padded);
+        case "DELETE":
+            return chalk.red(padded);
+        default:
+            return chalk.dim(padded);
+    }
+}
+
+export function verdictBadge(verdict: Verdict): string {
+    switch (verdict.level) {
+        case "green":
+            return chalk.bgGreen.black(" PASS ");
+        case "amber":
+            return chalk.bgYellow.black(" WARN ");
+        case "red":
+            return chalk.bgRed.white(" OVER ");
+        default:
+            assertNever(verdict.level);
+    }
+}
+
+export function styledVerdictLine(verdict: Verdict): string {
+    const counts = `${chalk.bold(verdict.toolCount)} tools ${ICONS.bullet} ${chalk.bold(formatTokens(verdict.estimatedTokens))} tokens`;
+    const label = verdict.level === "green" ? chalk.green(verdict.label) : chalk.yellow(verdict.label);
+    return `${verdictBadge(verdict)} ${counts} ${chalk.dim("—")} ${verdict.level === "red" ? chalk.red(verdict.label) : label}`;
+}
+
+export function toolTable(tools: ResolvedTool[]): string[] {
+    if (tools.length === 0) {
+        return [];
+    }
+    const nameWidth = Math.max(...tools.map((tool) => tool.name.length), 4);
+    return tools.map((tool) => {
+        const tokens = `~${tool.endpoint.estimatedTokens} tok`.padStart(9);
+        return `  ${chalk.cyan(tool.name.padEnd(nameWidth + 2))}${methodBadge(tool.endpoint.method)} ${tool.endpoint.path.padEnd(28)}${chalk.dim(tokens)}`;
+    });
+}
+
+export function keyValueRows(rows: [string, string][]): string[] {
+    const keyWidth = Math.max(...rows.map(([key]) => key.length));
+    return rows.map(([key, value]) => `  ${chalk.dim(`${key.padEnd(keyWidth)}`)}  ${value}`);
+}
+
+export function command(text: string): string {
+    return chalk.cyan(text);
+}
+
+export function hint(text: string): string {
+    return chalk.dim(text);
+}
+
+/**
+ * Runs `work` while animating a spinner on stdout (TTY only). Falls back to a
+ * single static line when not attached to a terminal.
+ */
+export async function withSpinner<T>(text: string, work: () => Promise<T>): Promise<T> {
+    if (!process.stdout.isTTY) {
+        process.stdout.write(`${text}\n`);
+        return await work();
+    }
+    let frame = 0;
+    process.stdout.write(`${chalk.magenta(SPINNER_FRAMES[0])} ${text}`);
+    const timer = setInterval(() => {
+        frame = (frame + 1) % SPINNER_FRAMES.length;
+        process.stdout.write(`\r${chalk.magenta(SPINNER_FRAMES[frame])} ${text}`);
+    }, SPINNER_INTERVAL_MS);
+    try {
+        return await work();
+    } finally {
+        clearInterval(timer);
+        process.stdout.write(`\r${" ".repeat(text.length + 2)}\r`);
+    }
+}
+
+export async function sleep(milliseconds: number): Promise<void> {
+    await new Promise((resolve) => setTimeout(resolve, milliseconds));
+}

--- a/packages/cli/cli/src/commands/mcp/prototype/workspace.ts
+++ b/packages/cli/cli/src/commands/mcp/prototype/workspace.ts
@@ -2,10 +2,14 @@ import { AbsoluteFilePath } from "@fern-api/fs-utils";
 import { Project } from "@fern-api/project-loader";
 import { AbstractAPIWorkspace } from "@fern-api/workspace-loader";
 import { select } from "@inquirer/prompts";
+import chalk from "chalk";
+import path from "path";
 
 import { CliContext } from "../../../cli-context/CliContext.js";
 import { loadSpecSummaries, SpecSummary } from "./openapiSummary.js";
-import { radioChoice, selectTheme } from "./ui.js";
+import { hint, ICONS, radioChoice, selectTheme, sleep, withSpinner } from "./ui.js";
+
+const SPEC_SCAN_DELAY_MS = 600;
 
 export interface WorkspaceSpec {
     workspace: AbstractAPIWorkspace<unknown>;
@@ -16,6 +20,27 @@ export interface WorkspaceSpec {
 
 function getWorkspaceName(workspace: AbstractAPIWorkspace<unknown>): string {
     return workspace.workspaceName ?? "api";
+}
+
+/**
+ * Prints the spec-discovery step every MCP flow starts with: a brief scan
+ * spinner followed by the spec that was identified.
+ */
+export async function announceSpecDiscovery({
+    cliContext,
+    workspaceSpec
+}: {
+    cliContext: CliContext;
+    workspaceSpec: WorkspaceSpec;
+}): Promise<void> {
+    cliContext.logger.info("");
+    await withSpinner("Scanning workspace for API specs…", () => sleep(SPEC_SCAN_DELAY_MS));
+    const { spec, workspaceName, absolutePathToWorkspace } = workspaceSpec;
+    const relativeSpecPath = path.relative(absolutePathToWorkspace, spec.absoluteFilePath);
+    const title = spec.title ?? workspaceName;
+    cliContext.logger.info(
+        `${ICONS.success} Found spec ${chalk.bold(relativeSpecPath)} ${hint(`${ICONS.bullet} ${title} ${ICONS.bullet} ${spec.endpoints.length} endpoints`)}`
+    );
 }
 
 /**

--- a/packages/cli/cli/src/commands/mcp/prototype/workspace.ts
+++ b/packages/cli/cli/src/commands/mcp/prototype/workspace.ts
@@ -5,6 +5,7 @@ import { select } from "@inquirer/prompts";
 
 import { CliContext } from "../../../cli-context/CliContext.js";
 import { loadSpecSummaries, SpecSummary } from "./openapiSummary.js";
+import { radioChoice, selectTheme } from "./ui.js";
 
 export interface WorkspaceSpec {
     workspace: AbstractAPIWorkspace<unknown>;
@@ -46,9 +47,10 @@ export async function pickWorkspaceAndLoadSpec({
             workspace = await select({
                 message: `Which API? (detected ${workspaces.length})`,
                 choices: workspaces.map((candidate) => ({
-                    name: getWorkspaceName(candidate),
+                    name: radioChoice(getWorkspaceName(candidate)),
                     value: candidate
-                }))
+                })),
+                theme: selectTheme
             });
         } else {
             cliContext.failAndThrow("Multiple APIs found. Specify one with --api <name>.");

--- a/packages/cli/cli/src/commands/mcp/prototype/workspace.ts
+++ b/packages/cli/cli/src/commands/mcp/prototype/workspace.ts
@@ -1,0 +1,77 @@
+import { AbsoluteFilePath } from "@fern-api/fs-utils";
+import { Project } from "@fern-api/project-loader";
+import { AbstractAPIWorkspace } from "@fern-api/workspace-loader";
+import { select } from "@inquirer/prompts";
+
+import { CliContext } from "../../../cli-context/CliContext.js";
+import { loadSpecSummaries, SpecSummary } from "./openapiSummary.js";
+
+export interface WorkspaceSpec {
+    workspace: AbstractAPIWorkspace<unknown>;
+    workspaceName: string;
+    absolutePathToWorkspace: AbsoluteFilePath;
+    spec: SpecSummary;
+}
+
+function getWorkspaceName(workspace: AbstractAPIWorkspace<unknown>): string {
+    return workspace.workspaceName ?? "api";
+}
+
+/**
+ * Picks the API workspace to operate on (prompting when the project has
+ * several and no `--api` was passed) and summarizes its OpenAPI spec.
+ */
+export async function pickWorkspaceAndLoadSpec({
+    project,
+    cliContext,
+    apiFilter,
+    interactive
+}: {
+    project: Project;
+    cliContext: CliContext;
+    apiFilter: string | undefined;
+    interactive: boolean;
+}): Promise<WorkspaceSpec | undefined> {
+    let workspaces = project.apiWorkspaces;
+    if (apiFilter != null) {
+        workspaces = workspaces.filter((workspace) => getWorkspaceName(workspace) === apiFilter);
+        if (workspaces.length === 0) {
+            cliContext.failAndThrow(`No API named "${apiFilter}" was found in this project.`);
+            return undefined;
+        }
+    }
+    let workspace = workspaces[0];
+    if (workspaces.length > 1) {
+        if (interactive) {
+            workspace = await select({
+                message: `Which API? (detected ${workspaces.length})`,
+                choices: workspaces.map((candidate) => ({
+                    name: getWorkspaceName(candidate),
+                    value: candidate
+                }))
+            });
+        } else {
+            cliContext.failAndThrow("Multiple APIs found. Specify one with --api <name>.");
+            return undefined;
+        }
+    }
+    if (workspace == null) {
+        cliContext.failAndThrow("No API workspaces were found in this project.");
+        return undefined;
+    }
+
+    const specs = await loadSpecSummaries(workspace.absoluteFilePath);
+    const spec = specs[0];
+    if (spec == null) {
+        cliContext.failAndThrow(
+            "No OpenAPI spec was found in this workspace. The MCP prototype currently requires an OpenAPI spec."
+        );
+        return undefined;
+    }
+    return {
+        workspace,
+        workspaceName: getWorkspaceName(workspace),
+        absolutePathToWorkspace: workspace.absoluteFilePath,
+        spec
+    };
+}

--- a/packages/cli/cli/src/commands/mcp/prototype/workspace.ts
+++ b/packages/cli/cli/src/commands/mcp/prototype/workspace.ts
@@ -48,6 +48,7 @@ export async function pickWorkspaceAndLoadSpec({
                 message: `Which API? (detected ${workspaces.length})`,
                 choices: workspaces.map((candidate) => ({
                     name: radioChoice(getWorkspaceName(candidate)),
+                    short: getWorkspaceName(candidate),
                     value: candidate
                 })),
                 theme: selectTheme

--- a/packages/cli/cli/src/commands/mcp/prototype/workspace.ts
+++ b/packages/cli/cli/src/commands/mcp/prototype/workspace.ts
@@ -9,7 +9,7 @@ import { CliContext } from "../../../cli-context/CliContext.js";
 import { loadSpecSummaries, SpecSummary } from "./openapiSummary.js";
 import { hint, ICONS, radioChoice, selectTheme, sleep, withSpinner } from "./ui.js";
 
-const SPEC_SCAN_DELAY_MS = 600;
+const SPEC_SCAN_DELAY_MS = 1500;
 
 export interface WorkspaceSpec {
     workspace: AbstractAPIWorkspace<unknown>;


### PR DESCRIPTION
## Description

**UX prototype — all backend functionality is stubbed.** This PR adds a representative stub-mode prototype of the customer-facing MCP creation flow so the full UX path can be demoed end-to-end. Real CLI commands, real OpenAPI spec parsing, and real `generators.yml` writing — but the costing service, AI curation, code generation, and MCP runtime are all stubbed locally. No backend credentials are required.

New subcommands under `fern mcp` (alongside the existing `fern mcp install`):

- `fern mcp init` — wizard: diagnoses the spec (title, endpoint count, token estimate), prompts for a server name, offers toolset presets (Read-only / Main resources / AI-curated / Everything, plus any existing `tools.presets`), shows tool count + token estimate + verdict per choice, routes amber/red verdicts into a trim loop (remove by tag/method/path-prefix), and writes an `mcp` group with a `fernapi/fern-mcp-server` entry into the workspace's real `generators.yml`. Noninteractive flags: `--name`, `--preset`, `--intent`, `--group`, `--yes`, `--json` (verdicts become warnings).
- `fern mcp list` — lists MCP generator entries with group, server-name, output path, and resolved tool count/verdict.
- `fern mcp tools` — prints the resolved tool surface for a group (`--group`, default `mcp`; `--preset`, `--json`), with `--refine` entering the same trim loop and rewriting the config in place.
- `fern mcp generate` — prints a plausible stub generation transcript and writes `tools.lock` next to `generators.yml` (tool names, per-tool token estimates, deterministic local schema hash).
- `fern mcp dev` — prints local dev / MCP Inspector guidance (`npx @modelcontextprotocol/inspector ...`).

All prototype logic lives under `packages/cli/cli/src/commands/mcp/prototype/`:
- `openapiSummary.ts` — scans the workspace (incl. `openapi/`) for OpenAPI YAML/JSON, extracts endpoint summaries and rough token estimates.
- `toolset.ts` — compound include/exclude selectors (fields ANDed within a selector, selectors ORed, exclude wins), tool resolution, and the two-clause verdict (tool count and token cost judged independently; default budget 40 tools / 60k tokens; amber ≤3× budget, red beyond).
- `presets.ts` — read-only preset (GET + read-like POSTs by operationId/path/summary heuristics, ambiguous ones called out), main-resources preset backed by a multi-signal resource scorer (see below).
- `aiCurated.ts` — stubbed "Fern Agent": pattern-matches the intent against tags/methods, presents exclusions first, persists the intent as `intent:` in YAML.
- `mcpGeneratorsYml.ts` — parses/writes the MCP group in `generators.yml` (js-yaml, schema comment header, unrelated groups/keys preserved).
- `trimLoop.ts`, `workspace.ts`, `initMcp.ts`, `listMcp.ts`, `toolsMcp.ts`, `generateMcp.ts` — command implementations.

### Main-resources scorer (multi-signal)

`buildMainResourcesPreset` identifies resources from three signals — tags, first meaningful path segment after version prefixes (`/v1`, `/api`), and component-schema references from request/response bodies — and treats a candidate as credible when ≥2 signals agree (case/plural-insensitive canonical name matching). Each credible resource is scored as:

```
score = crudShapes.size × CRUD_SHAPE_WEIGHT        // list/get/create/update/delete detected from actual operation shapes
      + log2(activeEndpointCount + 1)              // log-scaled so chatty utility tags don't dominate
      + log2(schemaCentrality + 1)                 // other operations referencing the resource's schemas
```

Selection is threshold + budget, not top-N: resources above `SCORE_THRESHOLD_RATIO` (40%) of the top score are included, then the lowest-scoring resources are trimmed until `computeVerdict` is green — the preset is within budget by construction. Selectors are `tag` when tags exist, `path-prefix` compound selectors on untagged specs. Negative signals: name-regex exclusion (admin/internal/webhook/legacy/deprecated/beta/debug/test) plus operation-level `deprecated: true` and `x-internal: true` (captured per-endpoint in `openapiSummary.ts`), excluded via explicit `endpoint` selectors. A confidence gate marks the preset unavailable when no credible resources exist or when scores are flat (top < `FLAT_SCORE_SEPARATION_RATIO` (1.5×) median with no strong-CRUD resource).

### Exception-based budget rendering

Human-facing output only "screams" budget when it's a problem. Within budget (green), option lines, `fern mcp list`, `fern mcp tools`, and the init/generate summaries show only a quiet tool count (e.g. `8 tools`) — no token estimate, no PASS badge. Over budget (amber/red), the full treatment appears: count + token estimate + verdict badge/label, plus the existing routing into the trim/refine loop. The trim/refine loop itself keeps its full live count/token/verdict readout, since budget is the point there. `--json` output is unchanged and unconditionally includes `toolCount`, `estimatedTokens`, and `verdict` — only the human rendering goes quiet (`budgetLine` in `ui.ts`).

The interactive toolset menu always shows all four options with the cursor on the first one — no verdict-driven preselection. The per-option counts (quiet on green) carry the information; the only over-budget difference is that Main resources gets a green `(recommended)` tag and Everything shows its over-budget line inline (still routing into refine if chosen). `--yes`/`--preset` and JSON behavior are unchanged.

## Changes Made
- Extend `addMcpCommand` in `packages/cli/cli/src/cli.ts` with `init`, `list`, `tools`, `generate`, `dev` subcommands
- Add prototype modules under `packages/cli/cli/src/commands/mcp/prototype/`
- Add unreleased changelog entry (`type: feat`)
- Vitest unit tests for spec summarizing, selector resolution, verdict logic, preset inference (tagged happy path, untagged path fallback, version-prefix stripping, schema-centrality rescue, flat-score gate, deprecated/x-internal exclusion, budget trimming), and AI-curated heuristics (27 tests)

## Testing
- [x] Unit tests added/updated — `pnpm vitest run src/commands/mcp/prototype/__test__` → 27 passed
- [x] Manual testing completed — built the dev CLI (`node build.dev.mjs`) and ran the full flow against a scratch petstore workspace (19 endpoints). Full transcript below.

<details>
<summary>End-to-end demo transcript (petstore workspace)</summary>

```text
# fern mcp prototype — end-to-end demo transcript
# workspace: petstore OpenAPI 3.0 spec (19 endpoints), scratch fern workspace

$ fern mcp init --yes

┌ Create an MCP server
│  Swagger Petstore - OpenAPI 3.0: 19 endpoints · ~4k tokens (est.) if all become tools
│  Recommended budget: 40 tools · 60k tokens (adjustable later)


└ Wrote group "mcp" to /home/ubuntu/mcp-demo/fern/generators.yml

groups:
  mcp:
    generators:
      - name: fernapi/fern-mcp-server
        version: 0.1.0
        output:
          location: local-file-system
          path: ../../generated/mcp
        config:
          server-name: swagger-petstore-openapi-3-0-mcp
          tools:
            include:
              - method: GET

Verdict: 8 tools · 2k tokens — ✓ within budget

Next steps:
  fern generate --group mcp     # build it
  fern mcp dev --group mcp      # try it locally with an inspector

$ fern mcp init --name petstore-main --preset main-resources --group mcp-main --yes

┌ Create an MCP server
│  Swagger Petstore - OpenAPI 3.0: 19 endpoints · ~4k tokens (est.) if all become tools
│  Recommended budget: 40 tools · 60k tokens (adjustable later)


└ Wrote group "mcp-main" to /home/ubuntu/mcp-demo/fern/generators.yml

groups:
  mcp-main:
    generators:
      - name: fernapi/fern-mcp-server
        version: 0.1.0
        output:
          location: local-file-system
          path: ../../generated/mcp-main
        config:
          server-name: petstore-main
          tools:
            include:
              - tag: pet
              - tag: user
              - tag: store

Verdict: 19 tools · 4k tokens — ✓ within budget

Next steps:
  fern generate --group mcp-main     # build it
  fern mcp dev --group mcp-main      # try it locally with an inspector

$ fern mcp init --intent let agents look up pets and orders, never delete anything --group mcp-ai --yes

┌ Create an MCP server
│  Swagger Petstore - OpenAPI 3.0: 19 endpoints · ~4k tokens (est.) if all become tools
│  Recommended budget: 40 tools · 60k tokens (adjustable later)

✦ Fern Agent is proposing a ruleset… (stubbed locally in this prototype)

✦ Proposed ruleset (exclusions first — that's the part worth reviewing):
  exclude:
    - { method: DELETE } — "never delete anything"
  include:
    - { tag: pet, method: GET } — read-only pet

└ Wrote group "mcp-ai" to /home/ubuntu/mcp-demo/fern/generators.yml

groups:
  mcp-ai:
    generators:
      - name: fernapi/fern-mcp-server
        version: 0.1.0
        output:
          location: local-file-system
          path: ../../generated/mcp-ai
        config:
          server-name: swagger-petstore-openapi-3-0-mcp
          tools:
            intent: let agents look up pets and orders, never delete anything
            include:
              - tag: pet
                method: GET
            exclude:
              - method: DELETE

Verdict: 3 tools · 730 tokens — ✓ within budget

Next steps:
  fern generate --group mcp-ai     # build it
  fern mcp dev --group mcp-ai      # try it locally with an inspector

$ fern mcp list

mcp (api)
  server-name: swagger-petstore-openapi-3-0-mcp
  output:      ../../generated/mcp
  tools:       8 tools · 2k tokens — ✓ within budget

mcp-main (api)
  server-name: petstore-main
  output:      ../../generated/mcp-main
  tools:       19 tools · 4k tokens — ✓ within budget

mcp-ai (api)
  server-name: swagger-petstore-openapi-3-0-mcp
  output:      ../../generated/mcp-ai
  tools:       3 tools · 730 tokens — ✓ within budget


$ fern mcp tools

Tool surface for mcp — swagger-petstore-openapi-3-0-mcp

  find_pets_by_status  GET /pet/findByStatus · ~260 tokens
  find_pets_by_tags  GET /pet/findByTags · ~247 tokens
  get_pet_by_id  GET /pet/{petId} · ~223 tokens
  get_inventory  GET /store/inventory · ~174 tokens
  get_order_by_id  GET /store/order/{orderId} · ~246 tokens
  login_user  GET /user/login · ~283 tokens
  logout_user  GET /user/logout · ~125 tokens
  get_user_by_name  GET /user/{username} · ~219 tokens

8 tools · 2k tokens — ✓ within budget

$ fern mcp tools --group mcp-ai --json
{
  "group": "mcp-ai",
  "preset": null,
  "serverName": "swagger-petstore-openapi-3-0-mcp",
  "tools": [
    {
      "name": "find_pets_by_status",
      "method": "GET",
      "path": "/pet/findByStatus",
      "estimatedTokens": 260
    },
    {
      "name": "find_pets_by_tags",
      "method": "GET",
      "path": "/pet/findByTags",
      "estimatedTokens": 247
    },
    {
      "name": "get_pet_by_id",
      "method": "GET",
      "path": "/pet/{petId}",
      "estimatedTokens": 223
    }
  ],
  "toolCount": 3,
  "estimatedTokens": 730,
  "verdict": "green"
}

$ fern mcp generate

[mcp] Generating swagger-petstore-openapi-3-0-mcp (group: mcp)
[mcp] NOTE: this is a stubbed prototype — no code is actually generated.
[mcp] Using generator fernapi/fern-mcp-server@0.1.0
[mcp] Parsed spec: 19 endpoints
[mcp] Resolved tool surface: 8 tools · 2k tokens — ✓ within budget
[mcp] Building tool schemas… 8/8
[mcp] Wrote lockfile: /home/ubuntu/mcp-demo/fern/tools.lock
[mcp] Done. 8 tools locked for swagger-petstore-openapi-3-0-mcp.

Next: fern mcp dev --group mcp

$ fern mcp dev

Local dev for swagger-petstore-openapi-3-0-mcp (group: mcp)
This prototype does not start a real MCP runtime — here's how you would:

1. Generate the server (stubbed in this prototype):
     fern mcp generate --group mcp

2. Inspect it with the MCP Inspector:
     npx @modelcontextprotocol/inspector node ../../generated/mcp/server.js

3. Or wire it into your agent (e.g. Claude Desktop / Cursor) with:
     { "command": "node", "args": ["../../generated/mcp/server.js"] }

Tool surface: run `fern mcp tools --group mcp` to review before shipping.

$ cat fern/generators.yml
# yaml-language-server: $schema=https://schema.buildwithfern.dev/generators-yml.json
api:
  specs:
    - openapi: openapi/petstore.yml
groups:
  ts-sdk:
    generators:
      - name: fernapi/fern-typescript-sdk
        version: 3.31.3
        output:
          location: local-file-system
          path: ../generated/ts
  mcp:
    generators:
      - name: fernapi/fern-mcp-server
        version: 0.1.0
        output:
          location: local-file-system
          path: ../../generated/mcp
        config:
          server-name: swagger-petstore-openapi-3-0-mcp
          tools:
            include:
              - method: GET
  mcp-main:
    generators:
      - name: fernapi/fern-mcp-server
        version: 0.1.0
        output:
          location: local-file-system
          path: ../../generated/mcp-main
        config:
          server-name: petstore-main
          tools:
            include:
              - tag: pet
              - tag: user
              - tag: store
  mcp-ai:
    generators:
      - name: fernapi/fern-mcp-server
        version: 0.1.0
        output:
          location: local-file-system
          path: ../../generated/mcp-ai
        config:
          server-name: swagger-petstore-openapi-3-0-mcp
          tools:
            intent: let agents look up pets and orders, never delete anything
            include:
              - tag: pet
                method: GET
            exclude:
              - method: DELETE

$ cat fern/tools.lock
version: 1
group: mcp
server-name: swagger-petstore-openapi-3-0-mcp
generator: fernapi/fern-mcp-server@0.1.0
schema-hash: sha256:57e4e85511bb1275
generated-at: '2026-08-26T19:31:21.685Z'
tool-count: 8
estimated-tokens: 1777
tools:
  - name: find_pets_by_status
    endpoint: GET /pet/findByStatus
    estimated-tokens: 260
  - name: find_pets_by_tags
    endpoint: GET /pet/findByTags
    estimated-tokens: 247
  - name: get_pet_by_id
    endpoint: GET /pet/{petId}
    estimated-tokens: 223
  - name: get_inventory
    endpoint: GET /store/inventory
    estimated-tokens: 174
  - name: get_order_by_id
    endpoint: GET /store/order/{orderId}
    estimated-tokens: 246
  - name: login_user
    endpoint: GET /user/login
    estimated-tokens: 283
  - name: logout_user
    endpoint: GET /user/logout
    estimated-tokens: 125
  - name: get_user_by_name
    endpoint: GET /user/{username}
    estimated-tokens: 219

```

</details>

Notes:
- `pnpm turbo run compile --filter @fern-api/cli` passes for the CLI package; a preexisting, unrelated compile error exists on `main` in `@fern-api/docs-validator` (`valid-changelog-slug.test.ts` TS2322), so the dev CLI was bundled via `node build.dev.mjs` directly.
- The `fernapi/fern-mcp-server@0.1.0` generator referenced in `generators.yml` does not exist — `fern generate` on the written config is out of scope for this prototype; `fern mcp generate` provides the stubbed path.


Link to Devin session: https://app.devin.ai/sessions/9c59da7519e74af1a4a7a78d0e8e2abe
Open in Devin Desktop: https://app.devin.ai/desktop/session/9c59da7519e74af1a4a7a78d0e8e2abe?variant=devin
Requested by: @matlegault
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/17544" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->