### PR TITLE
fix(cli-generator): disclose the flag name for every property in --schema

### DIFF
--- a/generators/cli/changes/unreleased/fix-schema-flag-disclosure.yml
+++ b/generators/cli/changes/unreleased/fix-schema-flag-disclosure.yml
@@ -1,0 +1,15 @@
+# yaml-language-server: $schema=../../../../fern-changes-yml.schema.json
+
+- summary: |
+    Every settable property in `--schema` now discloses the flag to type.
+    Property keys are wire names and diverge from flags more often than they
+    look: a header `Idempotency-Key` becomes `--idempotency-key`, an
+    `x-fern-parameter-name` rename changes it outright, and a name colliding
+    with a builtin gets a `-param` suffix — so a spec parameter called `query`
+    is registered as `--query-param` because `--query` is the JMESPath global.
+    That last case made the contract unfollowable: `required` named `query` and
+    no such flag existed. The name is derived from the same
+    `resolve_param_flag_name` the command builder uses, and is absent only when
+    the name cannot be sanitized into a flag at all — meaning that parameter is
+    reachable via `--params` alone.
+  type: fix

--- a/generators/cli/changes/unreleased/fix-schema-flag-disclosure.yml
+++ b/generators/cli/changes/unreleased/fix-schema-flag-disclosure.yml
@@ -9,7 +9,8 @@
     is registered as `--query-param` because `--query` is the JMESPath global.
     That last case made the contract unfollowable: `required` named `query` and
     no such flag existed. The name is derived from the same
-    `resolve_param_flag_name` the command builder uses, and is absent only when
-    the name cannot be sanitized into a flag at all — meaning that parameter is
-    reachable via `--params` alone.
+    `resolve_param_flag_name` the command builder uses, and is absent when no
+    flag exists for that property — either the name cannot be sanitized into a
+    flag, or another wire name claimed the same flag first and the builder
+    skipped this one — meaning that property is reachable via `--params` alone.
   type: fix

--- a/generators/cli/sdk/src/openapi/commands.rs
+++ b/generators/cli/sdk/src/openapi/commands.rs
@@ -658,8 +658,7 @@ fn build_resource_command(
         // Skip fields whose kebab name collides with a builtin flag,
         // matching the regular-param convention above.
         for field in &method.multipart_fields {
-            let kebab = to_kebab_flag(&field.wire_name);
-            if is_reserved_flag_name(&kebab) {
+            if resolve_multipart_field_flag_name(&field.wire_name).is_none() {
                 continue;
             }
             method_cmd = method_cmd.arg(build_multipart_field_arg(field));
@@ -964,6 +963,19 @@ pub(crate) fn resolve_param_flag_name(param: &MethodParameter, wire_name: &str) 
         flag = format!("{flag}-param");
     }
     Some(flag)
+}
+
+/// Resolve the CLI flag name for a multipart field, replicating what
+/// `build_resource_command` registers. `None` when the kebab name is
+/// reserved by the runtime: the builder skips those args, so no flag
+/// exists and the field is reachable only through `--params`.
+pub(crate) fn resolve_multipart_field_flag_name(wire_name: &str) -> Option<String> {
+    let kebab = to_kebab_flag(wire_name);
+    if is_reserved_flag_name(&kebab) {
+        None
+    } else {
+        Some(kebab)
+    }
 }
 
 /// Whether a parameter-derived flag long name is reserved by the runtime

--- a/generators/cli/sdk/src/openapi/help.rs
+++ b/generators/cli/sdk/src/openapi/help.rs
@@ -174,6 +174,12 @@ fn build_operation_schema(
     let mut properties: Map<String, Value> = Map::new();
     let mut required: Vec<String> = Vec::new();
 
+    // Mirrors `commands::build_resource_command`: when two wire names
+    // sanitize to the same flag only the first in sorted order is
+    // registered, so the loser must not advertise a flag that belongs to
+    // the winner.
+    let mut flag_to_wire: HashMap<String, String> = HashMap::new();
+
     let mut param_names: Vec<_> = method.parameters.keys().collect();
     param_names.sort();
     for name in param_names {
@@ -277,21 +283,21 @@ fn build_operation_schema(
             prop["variable"] = json!(var_name);
             prop["globalFlag"] = json!(format!("--{}", crate::text::to_kebab_flag(var_name)));
             prop["envVar"] = json!(crate::text::to_screaming_snake(var_name));
-        } else {
-            // The flag an agent must actually type. Property keys are wire
-            // names, and the two diverge more often than they look: a header
-            // `Idempotency-Key` becomes `--idempotency-key`, an
-            // `x-fern-parameter-name` rename changes it outright, and a name
-            // colliding with a builtin gets a `-param` suffix — so a spec
-            // parameter called `query` is registered as `--query-param`
-            // because `--query` is the JMESPath global. That last case made
-            // the advertised contract unfollowable: `required` named `query`
-            // and no such flag existed. Derived from the same
-            // `resolve_param_flag_name` the command builder uses, so the two
-            // cannot drift. Absent when the name cannot be sanitized into a
-            // flag at all — that parameter is reachable only via `--params`.
-            if let Some(flag) = crate::openapi::commands::resolve_param_flag_name(param, name) {
-                prop["flag"] = json!(format!("--{flag}"));
+        } else if let Some(flag) = crate::openapi::commands::resolve_param_flag_name(param, name) {
+            // Property keys are wire names, which diverge from the flag an
+            // agent types (header casing, `x-fern-parameter-name` renames, a
+            // `-param` suffix on builtin collisions). Derived from the same
+            // `resolve_param_flag_name` the command builder uses so the two
+            // cannot drift; absent means the parameter is reachable only via
+            // `--params`, because the builder registers no flag for it.
+            match flag_to_wire.entry(flag.clone()) {
+                std::collections::hash_map::Entry::Vacant(slot) => {
+                    slot.insert(name.clone());
+                    prop["flag"] = json!(format!("--{flag}"));
+                }
+                // The builder skipped this parameter: `--{flag}` sets the
+                // wire name that claimed it first, not this one.
+                std::collections::hash_map::Entry::Occupied(_) => {}
             }
         }
         if param.variable_reference.is_none() && (param.required || param.required_by_spec) {
@@ -313,14 +319,16 @@ fn build_operation_schema(
     // undiscoverable, so an agent driving purely from `--schema` could not
     // invoke *any* multipart operation.
     //
-    // Skips fields whose kebab name collides with a builtin flag, mirroring
+    // Skips fields whose kebab name is reserved by the runtime, mirroring
     // `commands::build_resource_command` — those args are never registered, so
-    // advertising them would be the same class of lie.
+    // advertising them would be the same class of lie. Both loops resolve the
+    // name through `resolve_multipart_field_flag_name` so they cannot drift.
     for field in &method.multipart_fields {
-        let kebab = crate::text::to_kebab_flag(&field.wire_name);
-        if crate::openapi::commands::BUILTIN_FLAG_NAMES.contains(&kebab.as_str()) {
+        let Some(kebab) =
+            crate::openapi::commands::resolve_multipart_field_flag_name(&field.wire_name)
+        else {
             continue;
-        }
+        };
         // The flag surface is a string either way: a text part takes its value
         // verbatim, a file part takes a filesystem path (`@path` / `-` for
         // stdin are accepted too — see `--help`). `file: true` is what tells an
@@ -2268,15 +2276,14 @@ mod tests {
     #[test]
     fn every_settable_property_discloses_its_flag() {
         use crate::openapi::discovery::{MethodParameter, MultipartField};
-        let query = |name: &str| MethodParameter {
+        let mut parameters = HashMap::new();
+        // Collides with the JMESPath global -> registered with a `-param` suffix.
+        parameters.insert("query".to_string(), MethodParameter {
             param_type: Some("string".to_string()),
             location: Some("query".to_string()),
             required: true,
             ..Default::default()
-        };
-        let mut parameters = HashMap::new();
-        // Collides with the JMESPath global -> registered with a `-param` suffix.
-        parameters.insert("query".to_string(), query("query"));
+        });
         // Header wire-casing -> kebab flag.
         parameters.insert("Idempotency-Key".to_string(), MethodParameter {
             param_type: Some("string".to_string()),
@@ -2289,6 +2296,16 @@ mod tests {
             location: Some("query".to_string()),
             ..Default::default()
         });
+        // Two wire names sanitizing to `--page-size`: the command builder
+        // registers only the first in sorted order, so the loser must stay
+        // silent rather than point at the winner's flag.
+        for wire in ["pageSize", "page_size"] {
+            parameters.insert(wire.to_string(), MethodParameter {
+                param_type: Some("integer".to_string()),
+                location: Some("query".to_string()),
+                ..Default::default()
+            });
+        }
 
         let mut methods = HashMap::new();
         methods.insert(
@@ -2329,6 +2346,11 @@ mod tests {
         assert_eq!(props["Idempotency-Key"]["flag"], "--idempotency-key");
         assert_eq!(props["limit"]["flag"], "--limit");
         assert_eq!(props["audio_file"]["flag"], "--audio-file");
+        assert_eq!(props["pageSize"]["flag"], "--page-size");
+        assert!(
+            props["page_size"].get("flag").is_none(),
+            "the parameter that lost the flag collision must not advertise it: {props}",
+        );
 
         // The required list still uses wire names (the `--params` route), so
         // both spellings stay usable.

--- a/generators/cli/sdk/src/openapi/help.rs
+++ b/generators/cli/sdk/src/openapi/help.rs
@@ -277,7 +277,24 @@ fn build_operation_schema(
             prop["variable"] = json!(var_name);
             prop["globalFlag"] = json!(format!("--{}", crate::text::to_kebab_flag(var_name)));
             prop["envVar"] = json!(crate::text::to_screaming_snake(var_name));
-        } else if param.required || param.required_by_spec {
+        } else {
+            // The flag an agent must actually type. Property keys are wire
+            // names, and the two diverge more often than they look: a header
+            // `Idempotency-Key` becomes `--idempotency-key`, an
+            // `x-fern-parameter-name` rename changes it outright, and a name
+            // colliding with a builtin gets a `-param` suffix — so a spec
+            // parameter called `query` is registered as `--query-param`
+            // because `--query` is the JMESPath global. That last case made
+            // the advertised contract unfollowable: `required` named `query`
+            // and no such flag existed. Derived from the same
+            // `resolve_param_flag_name` the command builder uses, so the two
+            // cannot drift. Absent when the name cannot be sanitized into a
+            // flag at all — that parameter is reachable only via `--params`.
+            if let Some(flag) = crate::openapi::commands::resolve_param_flag_name(param, name) {
+                prop["flag"] = json!(format!("--{flag}"));
+            }
+        }
+        if param.variable_reference.is_none() && (param.required || param.required_by_spec) {
             // `required_by_spec` catches object-valued body properties whose
             // shorthand flag is deliberately clap-optional (the caller may use
             // dot-notation leaves instead) but which the wire still requires.
@@ -324,6 +341,7 @@ fn build_operation_schema(
         if let Some(content_type) = &field.content_type {
             prop["contentType"] = json!(content_type);
         }
+        prop["flag"] = json!(format!("--{kebab}"));
         if field.required {
             required.push(field.wire_name.clone());
         }
@@ -2239,5 +2257,88 @@ mod tests {
             .map(|v| v.as_str().unwrap())
             .collect();
         assert_eq!(required, vec!["audio"], "only the required part is listed");
+    }
+
+    /// Every settable property must disclose the flag an agent types.
+    ///
+    /// Property keys are wire names and diverge from flags more often than
+    /// they look. The case that made a contract unfollowable: a spec parameter
+    /// named `query` is registered as `--query-param`, because `--query` is the
+    /// JMESPath global — `required` named `query` and no such flag existed.
+    #[test]
+    fn every_settable_property_discloses_its_flag() {
+        use crate::openapi::discovery::{MethodParameter, MultipartField};
+        let query = |name: &str| MethodParameter {
+            param_type: Some("string".to_string()),
+            location: Some("query".to_string()),
+            required: true,
+            ..Default::default()
+        };
+        let mut parameters = HashMap::new();
+        // Collides with the JMESPath global -> registered with a `-param` suffix.
+        parameters.insert("query".to_string(), query("query"));
+        // Header wire-casing -> kebab flag.
+        parameters.insert("Idempotency-Key".to_string(), MethodParameter {
+            param_type: Some("string".to_string()),
+            location: Some("header".to_string()),
+            ..Default::default()
+        });
+        // Ordinary name -> unchanged.
+        parameters.insert("limit".to_string(), MethodParameter {
+            param_type: Some("integer".to_string()),
+            location: Some("query".to_string()),
+            ..Default::default()
+        });
+
+        let mut methods = HashMap::new();
+        methods.insert(
+            "search".to_string(),
+            RestMethod {
+                parameters,
+                multipart_fields: vec![MultipartField {
+                    wire_name: "audio_file".to_string(),
+                    is_file: true,
+                    description: None,
+                    required: true,
+                    content_type: None,
+                    repeated: false,
+                }],
+                ..Default::default()
+            },
+        );
+        let mut resources = HashMap::new();
+        resources.insert(
+            "things".to_string(),
+            crate::openapi::discovery::RestResource {
+                methods,
+                resources: HashMap::new(),
+            },
+        );
+        let doc = RestDescription {
+            resources,
+            ..Default::default()
+        };
+
+        let schema = operation_schema(&doc, &["things"], "search").expect("schema");
+        let props = &schema["input"]["properties"];
+
+        assert_eq!(
+            props["query"]["flag"], "--query-param",
+            "a builtin-colliding name must disclose its suffixed flag: {props}",
+        );
+        assert_eq!(props["Idempotency-Key"]["flag"], "--idempotency-key");
+        assert_eq!(props["limit"]["flag"], "--limit");
+        assert_eq!(props["audio_file"]["flag"], "--audio-file");
+
+        // The required list still uses wire names (the `--params` route), so
+        // both spellings stay usable.
+        let required: Vec<&str> = schema["input"]["required"]
+            .as_array()
+            .expect("required")
+            .iter()
+            .map(|v| v.as_str().unwrap())
+            .collect();
+        assert!(required.contains(&"query"), "{required:?}");
+        assert!(required.contains(&"audio_file"), "{required:?}");
     }
 }


### PR DESCRIPTION
## Description

Linear ticket: Refs

Follow-up to #17545, which merged while this was in flight. Both regression agents that verified #17545 independently reported the same gap, and it left one operation whose advertised contract could not be followed at all.

`--schema` keys properties by **wire name**, and the flag diverges more often than it looks:

| property | actual flag | why |
|---|---|---|
| `Idempotency-Key` | `--idempotency-key` | header wire-casing |
| `query` | `--query-param` | `--query` is the JMESPath global, so the spec param gets a `-param` suffix |
| any `x-fern-parameter-name` rename | the renamed flag | override |

The `query` case made the contract literally unfollowable on `conversational-ai knowledge-base search` — `input.required` named `query`, and no `--query` flag existed for it:

```
$ elevenlabs conversational-ai knowledge-base search --query x --dry-run
Required parameter 'query' is missing. Provide it via --query-param or --params
```

An agent had to reimplement the CLI's own sanitisation to get from a property name to a flag — and get the `-param` suffix and header kebab-casing right. It now reads the flag off the contract:

```json
"query": {"type": "string", "location": "query",
           "description": "The search query text", "flag": "--query-param"}
```

Derived from the same `resolve_param_flag_name` the command builder uses, so the two cannot drift. Multipart fields get the same treatment.

`flag` is **absent exactly when the builder registers no flag**, which is itself the signal that the property is reachable via `--params` alone. That is two cases, both mirroring `build_resource_command`:

- the name cannot be sanitised into a flag at all;
- another wire name claimed the same flag first. The builder keeps the first in sorted order and skips the rest, so the help loop tracks the same `flag_to_wire` map over the same sorted iteration — otherwise the loser would advertise a flag that sets the *winner's* parameter.

This is the parameter-loop counterpart to the builtin-collision skip #17545's multipart commit added: one loop in `build_operation_schema` was honest about builtin collisions and the other was not.

`input.required` still uses wire names, so the `--params` route keeps working unchanged.

## Changes Made

- `sdk/src/openapi/help.rs` — emit `flag` per settable property (parameters and multipart fields); skip it for sdk-variable-bound params, which already advertise `globalFlag`, and for params whose flag was claimed by an earlier wire name.
- `sdk/src/openapi/commands.rs` — new `resolve_multipart_field_flag_name`, called by both the command builder and the help loop. This also closed an existing drift: the builder skipped on `is_reserved_flag_name` (builtins **plus** a customer-configured `userAgentSuffixFlag`) while the help loop only checked `BUILTIN_FLAG_NAMES`, so a field colliding with the suffix flag was advertised with a flag that is never registered.
- Changelog entry under `generators/cli/changes/unreleased/`.
- [x] Updated README.md generator (if applicable) — n/a

## Testing

- [x] Unit tests added/updated
- [x] Manual testing completed

**1945 lib tests pass.** `every_settable_property_discloses_its_flag` covers the builtin-collision suffix, header kebab-casing, an ordinary name, a multipart field, and a cross-parameter collision (`pageSize` / `page_size` both resolving to `--page-size`: the winner discloses it, the loser has no `flag`), and asserts `required` still uses wire names.

Verified by regenerating and building the ElevenLabs CLI: **2364 settable properties across 337 operations, 0 missing a `flag`**, and the previously-unfollowable operation now exits 0 from exactly what the contract advertises (`--query-param x` → `query_params=[['query','x']]`).

Also re-confirmed on the same build: 0 ancestor-prefix violations in any `required` list.


Link to Devin session: https://app.devin.ai/sessions/8d3395b13c124d728dc5d615e2149057
Open in Devin Desktop: https://app.devin.ai/desktop/session/8d3395b13c124d728dc5d615e2149057?variant=devin
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/17554" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->